### PR TITLE
fix: resolve C/C++ bare include paths in graph visualization

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -38,6 +38,14 @@ def _build_name_index(
             mod = fp.replace("/", ".").replace(".py", "")
             if n["kind"] == "File":
                 _add(mod, qn)
+                # Index by every path suffix so C/C++ bare includes resolve.
+                # e.g. "/abs/libs/trading/Foo.hpp" is also indexed as
+                # "Foo.hpp", "trading/Foo.hpp", "libs/trading/Foo.hpp", …
+                parts = fp.replace("\\", "/").split("/")
+                for i in range(len(parts)):
+                    suffix = "/".join(parts[i:])
+                    if suffix:
+                        _add(suffix, qn)
             else:
                 _add(mod + "." + n["name"], qn)
     return index

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -144,6 +144,53 @@ def test_generate_html(store_with_data, tmp_path):
     assert "</html>" in content
 
 
+def test_cpp_include_resolution(tmp_path):
+    """IMPORTS_FROM edges with bare C++ include paths should resolve to File nodes
+    stored under absolute paths — previously these were dropped, leaving the
+    graph almost entirely disconnected for C/C++ projects."""
+    from code_review_graph.visualization import export_graph_data
+
+    db_path = tmp_path / "test.db"
+    store = GraphStore(db_path)
+
+    def _file(name, path, lang="cpp"):
+        return NodeInfo(
+            kind="File", name=name, file_path=path,
+            line_start=1, line_end=10, language=lang,
+            parent_name=None, params=None, return_type=None,
+            modifiers=None, is_test=False, extra={},
+        )
+
+    store.upsert_node(_file("main.cpp",  "/abs/src/main.cpp"))
+    store.upsert_node(_file("Renderer.hpp", "/abs/libs/rendering/Renderer.hpp"))
+    store.upsert_node(_file("Utils.hpp",    "/abs/libs/utils/Utils.hpp"))
+
+    # Parser emits bare include paths as targets — exactly what Tree-sitter sees
+    store.upsert_edge(EdgeInfo(
+        kind="IMPORTS_FROM",
+        source="/abs/src/main.cpp",
+        target="rendering/Renderer.hpp",   # relative, one directory level
+        file_path="/abs/src/main.cpp", line=1, extra={},
+    ))
+    store.upsert_edge(EdgeInfo(
+        kind="IMPORTS_FROM",
+        source="/abs/src/main.cpp",
+        target="Utils.hpp",                # bare filename only
+        file_path="/abs/src/main.cpp", line=2, extra={},
+    ))
+    store.commit()
+
+    data = export_graph_data(store)
+    resolved_targets = {e["target"] for e in data["edges"] if e["kind"] == "IMPORTS_FROM"}
+
+    assert "/abs/libs/rendering/Renderer.hpp" in resolved_targets, (
+        "bare relative include 'rendering/Renderer.hpp' was not resolved to its absolute path"
+    )
+    assert "/abs/libs/utils/Utils.hpp" in resolved_targets, (
+        "bare filename include 'Utils.hpp' was not resolved to its absolute path"
+    )
+
+
 def test_generate_html_overwrites(store_with_data, tmp_path):
     from code_review_graph.visualization import generate_html
 


### PR DESCRIPTION
## What broke

For C/C++ projects, the graph visualization showed almost entirely disconnected nodes. On a real project I tested, only **796 of 4,300 edges (18.5%)** were resolvable — meaning 81.5% of connections were silently dropped and never rendered.

## Root cause

`_build_name_index` in `visualization.py` only indexed files using Python module-style dot paths (e.g. `libs.trading.Foo`). C++ `#include` statements are stored by the parser as **bare relative paths** like `trading/Foo.hpp` or `Foo.hpp`. These never matched the dot-style index, so `_resolve_target` returned `None` for every single C/C++ import edge and dropped them all.

## Fix

For every `File` node, also index all path suffixes:

```
/abs/libs/trading/Foo.hpp  →  also keyed as:
  "Foo.hpp"
  "trading/Foo.hpp"
  "libs/trading/Foo.hpp"
  ...
```

This lets any length of bare relative include path resolve correctly to its File node. The change is 8 lines in `_build_name_index` and is additive — no existing behaviour changes.

## Test

Added `test_cpp_include_resolution` covering:
- bare filename include: `"Utils.hpp"` → `/abs/libs/utils/Utils.hpp`
- relative path include: `"rendering/Renderer.hpp"` → `/abs/libs/rendering/Renderer.hpp`

All 108 existing tests still pass.

## Impact

This also benefits other languages that use path-style imports (e.g. Go, Rust `use` paths) where the import target doesn't exactly match a qualified name.

## Before / After
<img width="1365" height="929" alt="sentinel_code_review html" src="https://github.com/user-attachments/assets/fa879a2e-3d12-4a38-be8c-878e0e62c355" />
---
<img width="1444" height="929" alt="sentinel_code_review_fix html" src="https://github.com/user-attachments/assets/eb1e22bb-8b6e-4a9d-8401-b0ce0e99be4e" />