### PR TITLE
fix: add SRI hash to D3.js CDN script tag

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -156,7 +156,7 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Code Review Graph</title>
-<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   html, body { width: 100%; height: 100%; overflow: hidden; }


### PR DESCRIPTION
## Summary
- Adds `integrity` (sha384) and `crossorigin="anonymous"` attributes to the D3.js `<script>` tag in the generated HTML template
- Mitigates supply-chain risk: if `d3js.org` is compromised, browsers will refuse to execute a tampered script

## Test plan
- [ ] Generate a visualization and confirm D3.js still loads correctly in a browser
- [ ] Inspect the generated HTML to verify the `integrity` and `crossorigin` attributes are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)