### PR TITLE
fix: use cryptographically secure nonce in webview CSP

### DIFF
--- a/code-review-graph-vscode/src/views/graphWebview.ts
+++ b/code-review-graph-vscode/src/views/graphWebview.ts
@@ -8,6 +8,7 @@
 
 import * as vscode from "vscode";
 import * as path from "node:path";
+import * as crypto from "node:crypto";
 import type { SqliteReader, ImpactRadius } from "../backend/sqlite";
 
 export class GraphWebviewPanel {
@@ -536,11 +537,5 @@ export class GraphWebviewPanel {
 }
 
 function getNonce(): string {
-  let text = "";
-  const possible =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  return crypto.randomBytes(16).toString("hex");
 }


### PR DESCRIPTION
## Summary
- Replace `Math.random()` with `crypto.randomBytes()` in the `getNonce()` function used for Content Security Policy headers in the VS Code extension webview
- `Math.random()` is not cryptographically secure and produces predictable values; `crypto.randomBytes()` provides proper entropy for CSP nonces

## Test plan
- [ ] Verify the VS Code extension webview still loads and renders the graph correctly
- [ ] Confirm the CSP nonce is present in the generated HTML
- [ ] Check that no console errors appear related to CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)