### PR TITLE
fix: validate repo_root to prevent arbitrary file read

### DIFF
--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -28,9 +28,29 @@ from .incremental import (
 )
 
 
+def _validate_repo_root(path: Path) -> Path:
+    """Validate that a path is a plausible project root.
+
+    Ensures the path is an existing directory that contains a ``.git``
+    or ``.code-review-graph`` directory, preventing arbitrary file-system
+    traversal via the ``repo_root`` parameter.
+    """
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise ValueError(
+            f"repo_root is not an existing directory: {resolved}"
+        )
+    if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
+        raise ValueError(
+            f"repo_root does not look like a project root (no .git or "
+            f".code-review-graph directory found): {resolved}"
+        )
+    return resolved
+
+
 def _get_store(repo_root: str | None = None) -> tuple[GraphStore, Path]:
     """Resolve repo root and open the graph store."""
-    root = Path(repo_root) if repo_root else find_project_root()
+    root = _validate_repo_root(Path(repo_root)) if repo_root else find_project_root()
     db_path = get_db_path(root)
     return GraphStore(db_path), root
 


### PR DESCRIPTION
## Summary
- Adds `_validate_repo_root()` in `code_review_graph/tools.py` that resolves symlinks, checks the path is an existing directory, and requires a `.git` or `.code-review-graph` directory to be present
- Prevents an attacker from setting `repo_root` to an arbitrary directory (e.g. `/etc`) and using `get_review_context(include_source=True)` to read sensitive files
- Minimal change — only the `_get_store` entry point is affected; no changes to tool signatures or behavior for valid repos

## Test plan
- [ ] Confirm existing tools work when `repo_root` points to a valid git repository
- [ ] Confirm `_get_store("/etc")` raises `ValueError` (no `.git` directory)
- [ ] Confirm `_get_store("/nonexistent")` raises `ValueError` (not a directory)
- [ ] Confirm symlink traversal is resolved before validation (`path.resolve()`)
- [ ] Confirm auto-detection (`repo_root=None`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)