### PR TITLE
fix(vscode): restrict cliPath to machine scope to prevent RCE

### DIFF
--- a/code-review-graph-vscode/package.json
+++ b/code-review-graph-vscode/package.json
@@ -123,6 +123,7 @@
         "codeReviewGraph.cliPath": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "Path to the code-review-graph CLI binary. Leave empty to use the bundled version or the one found on PATH."
         },
         "codeReviewGraph.autoUpdate": {


### PR DESCRIPTION
## Summary
- Adds `"scope": "machine"` to the `codeReviewGraph.cliPath` configuration property in the VS Code extension
- This prevents the setting from being overridden in workspace-level `.vscode/settings.json` files, mitigating an RCE vector where an attacker commits a malicious workspace config pointing `cliPath` to a malicious binary

## Test plan
- [ ] Verify `codeReviewGraph.cliPath` no longer appears in workspace settings UI
- [ ] Verify setting it in `.vscode/settings.json` has no effect
- [ ] Verify it can still be configured in user/machine-level settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)