### PR TITLE
security: sanitize node/edge names against prompt injection

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -481,12 +481,30 @@ class GraphStore:
         )
 
 
+def _sanitize_name(s: str, max_len: int = 256) -> str:
+    """Strip ASCII control characters and truncate to prevent prompt injection.
+
+    Node names extracted from source code could contain adversarial strings
+    (e.g. ``IGNORE_ALL_PREVIOUS_INSTRUCTIONS``).  This function removes control
+    characters (0x00-0x1F except tab and newline) and enforces a length limit so
+    that names flowing through MCP tool responses cannot easily influence AI
+    agent behaviour.
+    """
+    # Strip control chars 0x00-0x1F except \t (0x09) and \n (0x0A)
+    cleaned = "".join(
+        ch for ch in s
+        if ch in ("\t", "\n") or ord(ch) >= 0x20
+    )
+    return cleaned[:max_len]
+
+
 def node_to_dict(n: GraphNode) -> dict:
     return {
-        "id": n.id, "kind": n.kind, "name": n.name,
-        "qualified_name": n.qualified_name, "file_path": n.file_path,
+        "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
+        "qualified_name": _sanitize_name(n.qualified_name), "file_path": n.file_path,
         "line_start": n.line_start, "line_end": n.line_end,
-        "language": n.language, "parent_name": n.parent_name,
+        "language": n.language,
+        "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
     }
 
@@ -494,6 +512,7 @@ def node_to_dict(n: GraphNode) -> dict:
 def edge_to_dict(e: GraphEdge) -> dict:
     return {
         "id": e.id, "kind": e.kind,
-        "source": e.source_qualified, "target": e.target_qualified,
+        "source": _sanitize_name(e.source_qualified),
+        "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
     }


### PR DESCRIPTION
## Summary
- Adds `_sanitize_name()` function in `code_review_graph/graph.py` that strips ASCII control characters (0x00-0x1F except tab/newline) and truncates to 256 characters
- Applied at the serialization boundary in `node_to_dict()` (for `name`, `qualified_name`, `parent_name`) and `edge_to_dict()` (for `source`, `target`)
- Mitigates graph-laundered prompt injection where malicious function/class names in source code could influence AI agent behavior through MCP tool responses

## Test plan
- [ ] Verify existing tests still pass (`pytest`)
- [ ] Manually test with node names containing control characters to confirm they are stripped
- [ ] Manually test with node names exceeding 256 characters to confirm truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)