### PR TITLE
fix: eliminate TOCTOU race between file hashing and parsing

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -7,6 +7,7 @@ and updates the graph accordingly. Also supports CLI invocation for hooks.
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import logging
 import subprocess
 import time
@@ -14,7 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 from .graph import GraphStore
-from .parser import CodeParser, file_hash
+from .parser import CodeParser
 
 logger = logging.getLogger(__name__)
 
@@ -264,8 +265,9 @@ def full_build(repo_root: Path, store: GraphStore) -> dict:
     for i, rel_path in enumerate(files, 1):
         full_path = repo_root / rel_path
         try:
-            fhash = file_hash(full_path)
-            nodes, edges = parser.parse_file(full_path)
+            source = full_path.read_bytes()
+            fhash = hashlib.sha256(source).hexdigest()
+            nodes, edges = parser.parse_bytes(full_path, source)
             store.store_file_nodes_edges(str(full_path), nodes, edges, fhash)
             total_nodes += len(nodes)
             total_edges += len(edges)
@@ -343,14 +345,15 @@ def incremental_update(
             continue
 
         try:
-            fhash = file_hash(abs_path)
+            source = abs_path.read_bytes()
+            fhash = hashlib.sha256(source).hexdigest()
             # Check if file actually changed (compare against stored file_hash column)
             existing_nodes = store.get_nodes_by_file(str(abs_path))
             if existing_nodes and existing_nodes[0].file_hash == fhash:
                 # Skip unchanged files (hash match)
                 continue
 
-            nodes, edges = parser.parse_file(abs_path)
+            nodes, edges = parser.parse_bytes(abs_path, source)
             store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
             total_nodes += len(nodes)
             total_edges += len(edges)
@@ -466,8 +469,9 @@ def watch(repo_root: Path, store: GraphStore) -> None:
             if _is_binary(path):
                 return
             try:
-                fhash = file_hash(path)
-                nodes, edges = parser.parse_file(path)
+                source = path.read_bytes()
+                fhash = hashlib.sha256(source).hexdigest()
+                nodes, edges = parser.parse_bytes(path, source)
                 store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
                 store.set_metadata(
                     "last_updated", time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -207,17 +207,24 @@ class CodeParser:
 
     def parse_file(self, path: Path) -> tuple[list[NodeInfo], list[EdgeInfo]]:
         """Parse a single file and return extracted nodes and edges."""
+        try:
+            source = path.read_bytes()
+        except (OSError, PermissionError):
+            return [], []
+        return self.parse_bytes(path, source)
+
+    def parse_bytes(self, path: Path, source: bytes) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse pre-read bytes and return extracted nodes and edges.
+
+        This avoids re-reading the file from disk, eliminating TOCTOU gaps
+        when the caller has already read the bytes (e.g. for hashing).
+        """
         language = self.detect_language(path)
         if not language:
             return [], []
 
         parser = self._get_parser(language)
         if not parser:
-            return [], []
-
-        try:
-            source = path.read_bytes()
-        except (OSError, PermissionError):
             return [], []
 
         tree = parser.parse(source)


### PR DESCRIPTION
## Summary
- **TOCTOU fix**: Read file bytes once and reuse for both SHA-256 hashing and tree-sitter parsing, eliminating the race window where the file could change between hash computation and parse.
- **New method**: Added `CodeParser.parse_bytes(path, source)` that accepts pre-read bytes instead of reading from disk. `parse_file` now delegates to it.
- **Updated callers**: `full_build`, `incremental_update`, and `watch` mode in `incremental.py` all use the single-read pattern with `hashlib.sha256` directly, removing the now-unused `file_hash` import.

## Test plan
- [x] All 108 existing tests pass (3 skipped)
- [ ] Verify incremental update correctly detects changed files with `crg build` followed by file edit and `crg update`
- [ ] Verify full rebuild produces identical graph output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)