### PR TITLE
fix: skip symlinks to prevent parsing files outside the repository

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -212,6 +212,8 @@ def collect_all_files(repo_root: Path) -> list[str]:
         full_path = repo_root / rel_path
         if not full_path.is_file():
             continue
+        if full_path.is_symlink():
+            continue
         if parser.detect_language(full_path) is None:
             continue
         if _is_binary(full_path):
@@ -402,6 +404,8 @@ def watch(repo_root: Path, store: GraphStore) -> None:
             self._timer: threading.Timer | None = None
 
         def _should_handle(self, path: str) -> bool:
+            if Path(path).is_symlink():
+                return False
             try:
                 rel = str(Path(path).relative_to(repo_root))
             except ValueError:
@@ -462,6 +466,8 @@ def watch(repo_root: Path, store: GraphStore) -> None:
         def _update_file(self, abs_path: str):
             path = Path(abs_path)
             if not path.is_file():
+                return
+            if path.is_symlink():
                 return
             if _is_binary(path):
                 return


### PR DESCRIPTION
## Summary
- Adds `is_symlink()` checks in three locations within `code_review_graph/incremental.py` to prevent symlink traversal attacks
- `collect_all_files`: skips symlinked files during full builds
- `GraphUpdateHandler._should_handle`: rejects symlinks in watch mode event filtering
- `GraphUpdateHandler._update_file`: rejects symlinks before parsing in watch mode updates

## Security context
An attacker could create a symlink inside a repository (e.g., `secrets.py` -> `~/.aws/credentials`) causing sensitive files outside the repo to be parsed and stored in the graph.

## Test plan
- [ ] Verify that regular files are still parsed normally during full build and watch mode
- [ ] Create a symlink to a file outside the repo and confirm it is skipped during `collect_all_files`
- [ ] Confirm watch mode ignores symlink creation/modification events

🤖 Generated with [Claude Code](https://claude.com/claude-code)