### PR TITLE
fix: add --repo to serve so get_docs_section works via uvx

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -181,7 +181,8 @@ def main() -> None:
     vis_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
 
     # serve
-    sub.add_parser("serve", help="Start MCP server (stdio transport)")
+    serve_cmd = sub.add_parser("serve", help="Start MCP server (stdio transport)")
+    serve_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
 
     args = ap.parse_args()
 
@@ -195,7 +196,7 @@ def main() -> None:
 
     if args.command == "serve":
         from .main import main as serve_main
-        serve_main()
+        serve_main(repo_root=args.repo)
         return
 
     if args.command in ("init", "install"):

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -21,6 +21,8 @@ from .tools import (
     semantic_search_nodes,
 )
 
+_default_repo_root: str | None = None
+
 mcp = FastMCP(
     "code-review-graph",
     instructions=(
@@ -204,11 +206,13 @@ def get_docs_section_tool(
     Args:
         section_name: The section to retrieve (e.g. "review-delta", "usage").
     """
-    return get_docs_section(section_name=section_name)
+    return get_docs_section(section_name=section_name, repo_root=_default_repo_root)
 
 
-def main() -> None:
+def main(repo_root: str | None = None) -> None:
     """Run the MCP server via stdio."""
+    global _default_repo_root
+    _default_repo_root = repo_root
     mcp.run(transport="stdio")
 
 

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -712,13 +712,7 @@ def embed_graph(repo_root: str | None = None) -> dict[str, Any]:
 # Tool 8: get_docs_section
 # ---------------------------------------------------------------------------
 
-# Search paths for the LLM-optimized reference file
-_REFERENCE_PATHS = [
-    "docs/LLM-OPTIMIZED-REFERENCE.md",
-]
-
-
-def get_docs_section(section_name: str) -> dict[str, Any]:
+def get_docs_section(section_name: str, repo_root: str | None = None) -> dict[str, Any]:
     """Return a specific section from the LLM-optimized reference.
 
     Used by skills and Claude Code to load only the exact documentation
@@ -728,41 +722,41 @@ def get_docs_section(section_name: str) -> dict[str, Any]:
         section_name: Exact section name. One of: usage, review-delta,
                       review-pr, commands, legal, watch, embeddings,
                       languages, troubleshooting.
+        repo_root: Repository root path. Auto-detected from current directory if omitted.
 
     Returns:
         The section content, or an error if not found.
     """
     import re as _re
 
-    # Try package-relative path first (works even outside a git repo)
-    pkg_dir = Path(__file__).resolve().parent.parent
-    search_roots = [pkg_dir]
+    search_roots: list[Path] = []
 
-    # Also try repo root if inside a git repo
+    if repo_root:
+        search_roots.append(Path(repo_root))
+
     try:
-        _, root = _get_store()
+        _, root = _get_store(repo_root)
         if root not in search_roots:
             search_roots.append(root)
-    except RuntimeError:
+    except (RuntimeError, ValueError):
         pass
 
     for search_root in search_roots:
-        for rel_path in _REFERENCE_PATHS:
-            full_path = search_root / rel_path
-            if full_path.exists():
-                content = full_path.read_text()
-                match = _re.search(
-                    rf'<section name="{_re.escape(section_name)}">'
-                    r"(.*?)</section>",
-                    content,
-                    _re.DOTALL | _re.IGNORECASE,
-                )
-                if match:
-                    return {
-                        "status": "ok",
-                        "section": section_name,
-                        "content": match.group(1).strip(),
-                    }
+        candidate = search_root / "docs" / "LLM-OPTIMIZED-REFERENCE.md"
+        if candidate.exists():
+            content = candidate.read_text(encoding="utf-8")
+            match = _re.search(
+                rf'<section name="{_re.escape(section_name)}">'
+                r"(.*?)</section>",
+                content,
+                _re.DOTALL | _re.IGNORECASE,
+            )
+            if match:
+                return {
+                    "status": "ok",
+                    "section": section_name,
+                    "content": match.group(1).strip(),
+                }
 
     available = [
         "usage", "review-delta", "review-pr", "commands",


### PR DESCRIPTION
## Problem

`get_docs_section_tool` always returns `{"status": "not_found"}` when the MCP server runs via `uvx`. The root cause is that the existing auto-detection relies on the current working directory being inside the repo, which is not the case under `uvx`.

The `serve` subcommand was also the only one without a `--repo` argument — every other subcommand (`build`, `update`, `watch`, `status`, `visualize`, `install`, `init`) accepts `--repo` for explicit repo root specification.

## Solution

Add `--repo` to the `serve` subcommand, consistent with all other subcommands. Thread the value through `main()` via a module-level default, then pass it to `get_docs_section` so the tool can locate `docs/LLM-OPTIMIZED-REFERENCE.md`.

**No files are bundled into the wheel** — docs stay in `docs/` in the source tree.

## Usage

```bash
# Standard install via uvx — now works correctly:
uvx code-review-graph serve --repo /path/to/your/repo
```

In `.mcp.json`:
```json
{
  "mcpServers": {
    "code-review-graph": {
      "command": "uvx",
      "args": ["code-review-graph", "serve", "--repo", "/path/to/your/repo"]
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `code_review_graph/cli.py` | Add `--repo` to `serve` subparser; pass to `serve_main()` |
| `code_review_graph/main.py` | Accept `repo_root` in `main()`; store as module-level default; pass to `get_docs_section` |
| `code_review_graph/tools.py` | Add `repo_root` param to `get_docs_section`; use explicit path first, then auto-detect |

## Test Plan

- [x] `uv run --with pytest pytest` — 111 passed
- [x] `get_docs_section('troubleshooting', repo_root='.')` returns section content
- [x] `code-review-graph serve --help` shows `--repo` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)