### PR TITLE
fix: use PostToolUse instead of invalid PostEdit/PostGit hook events

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "PostEdit and PostGit are custom Claude Code hook events (confirmed working as of v1.6.4).",
   "hooks": {
     "SessionStart": [
       {
@@ -11,20 +10,9 @@
         ]
       }
     ],
-    "PostEdit": [
+    "PostToolUse": [
       {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "code-review-graph update 2>/dev/null || true"
-          }
-        ]
-      }
-    ],
-    "PostGit": [
-      {
-        "matcher": "commit",
+        "matcher": "Write|Edit|Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Problem

`hooks/hooks.json` uses `PostEdit` and `PostGit` as hook event types, but these are not valid Claude Code hook events. They cause a validation error on the plugins page, preventing the hooks from loading at all.

Closes #25

## Fix

Replace both invalid entries with a single `PostToolUse` entry:

- `PostEdit` (matcher: `Write|Edit`) → `PostToolUse` (matcher: `Write|Edit`) — file edits still go through the Write/Edit tools
- `PostGit` (matcher: `commit`) → `PostToolUse` (matcher: `Bash`) — git commits go through the Bash tool

Since both now use `PostToolUse`, they're merged into one entry with matcher `Write|Edit|Bash`. The `update` command is idempotent, so triggering on all Bash calls is safe.

Also removes the `_comment` field that claimed these were "confirmed working as of v1.6.4" — they are not valid in current Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)