### PR TITLE
feat: add find_large_functions tool for size-based node queries

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -413,6 +413,52 @@ class GraphStore:
             last_updated=last_updated,
         )
 
+    def get_nodes_by_size(
+        self,
+        min_lines: int = 50,
+        max_lines: int | None = None,
+        kind: str | None = None,
+        file_path_pattern: str | None = None,
+        limit: int = 50,
+    ) -> list[GraphNode]:
+        """Find nodes within a line-count range, ordered largest first.
+
+        Args:
+            min_lines: Minimum line count threshold (inclusive).
+            max_lines: Maximum line count threshold (inclusive). None = no upper bound.
+            kind: Filter by node kind (Function, Class, File, etc.).
+            file_path_pattern: SQL LIKE pattern to filter by file path.
+            limit: Maximum results to return.
+
+        Returns:
+            List of GraphNode objects, ordered by line count descending.
+        """
+        conditions = [
+            "line_start IS NOT NULL",
+            "line_end IS NOT NULL",
+            "(line_end - line_start + 1) >= ?",
+        ]
+        params: list = [min_lines]
+
+        if max_lines is not None:
+            conditions.append("(line_end - line_start + 1) <= ?")
+            params.append(max_lines)
+        if kind:
+            conditions.append("kind = ?")
+            params.append(kind)
+        if file_path_pattern:
+            conditions.append("file_path LIKE ?")
+            params.append(f"%{file_path_pattern}%")
+
+        params.append(limit)
+        where = " AND ".join(conditions)
+        rows = self._conn.execute(
+            f"SELECT * FROM nodes WHERE {where} "  # nosec B608
+            "ORDER BY (line_end - line_start) DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
     # --- Public edge access (for visualization etc.) ---
 
     def get_all_edges(self) -> list[GraphEdge]:

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -13,6 +13,7 @@ from fastmcp import FastMCP
 from .tools import (
     build_or_update_graph,
     embed_graph,
+    find_large_functions,
     get_docs_section,
     get_impact_radius,
     get_review_context,
@@ -205,6 +206,32 @@ def get_docs_section_tool(
         section_name: The section to retrieve (e.g. "review-delta", "usage").
     """
     return get_docs_section(section_name=section_name)
+
+
+@mcp.tool()
+def find_large_functions_tool(
+    min_lines: int = 50,
+    kind: Optional[str] = None,
+    file_path_pattern: Optional[str] = None,
+    limit: int = 50,
+    repo_root: Optional[str] = None,
+) -> dict:
+    """Find functions, classes, or files exceeding a line-count threshold.
+
+    Useful for decomposition audits, code quality checks, and enforcing
+    size limits during code review. Results are ordered by line count.
+
+    Args:
+        min_lines: Minimum line count to flag. Default: 50.
+        kind: Optional filter: Function, Class, File, or Test.
+        file_path_pattern: Filter by file path substring (e.g. "components/").
+        limit: Maximum results. Default: 50.
+        repo_root: Repository root path. Auto-detected if omitted.
+    """
+    return find_large_functions(
+        min_lines=min_lines, kind=kind, file_path_pattern=file_path_pattern,
+        limit=limit, repo_root=repo_root,
+    )
 
 
 def main() -> None:

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -1,6 +1,6 @@
 """MCP tool definitions for the Code Review Graph server.
 
-Exposes 8 tools:
+Exposes 9 tools:
 1. build_or_update_graph  - full or incremental build
 2. get_impact_radius      - blast radius from changed files
 3. query_graph            - predefined graph queries
@@ -9,6 +9,7 @@ Exposes 8 tools:
 6. list_graph_stats       - aggregate statistics
 7. embed_graph            - compute vector embeddings for semantic search
 8. get_docs_section       - token-optimized documentation retrieval
+9. find_large_functions   - find oversized functions/classes by line count
 """
 
 from __future__ import annotations
@@ -775,3 +776,75 @@ def get_docs_section(section_name: str) -> dict[str, Any]:
             f"Available: {', '.join(available)}"
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# Tool 9: find_large_functions
+# ---------------------------------------------------------------------------
+
+
+def find_large_functions(
+    min_lines: int = 50,
+    kind: str | None = None,
+    file_path_pattern: str | None = None,
+    limit: int = 50,
+    repo_root: str | None = None,
+) -> dict[str, Any]:
+    """Find functions, classes, or files exceeding a line-count threshold.
+
+    Useful for identifying decomposition targets, code-quality audits,
+    and enforcing size limits during code review.
+
+    Args:
+        min_lines: Minimum line count to flag (default: 50).
+        kind: Filter by node kind: Function, Class, File, or Test.
+        file_path_pattern: Filter by file path substring (e.g. "components/").
+        limit: Maximum results (default: 50).
+        repo_root: Repository root path. Auto-detected if omitted.
+
+    Returns:
+        Oversized nodes with line counts, ordered largest first.
+    """
+    store, root = _get_store(repo_root)
+    try:
+        nodes = store.get_nodes_by_size(
+            min_lines=min_lines,
+            kind=kind,
+            file_path_pattern=file_path_pattern,
+            limit=limit,
+        )
+
+        results = []
+        for n in nodes:
+            d = node_to_dict(n)
+            d["line_count"] = (n.line_end - n.line_start + 1) if n.line_start and n.line_end else 0
+            # Make file_path relative for readability
+            try:
+                d["relative_path"] = str(Path(n.file_path).relative_to(root))
+            except ValueError:
+                d["relative_path"] = n.file_path
+            results.append(d)
+
+        summary_parts = [
+            f"Found {len(results)} node(s) with >= {min_lines} lines"
+            + (f" (kind={kind})" if kind else "")
+            + (f" matching '{file_path_pattern}'" if file_path_pattern else "")
+            + ":",
+        ]
+        for r in results[:10]:
+            summary_parts.append(
+                f"  {r['line_count']:>4} lines | {r['kind']:>8} | "
+                f"{r['name']} ({r['relative_path']}:{r['line_start']})"
+            )
+        if len(results) > 10:
+            summary_parts.append(f"  ... and {len(results) - 10} more")
+
+        return {
+            "status": "ok",
+            "summary": "\n".join(summary_parts),
+            "total_found": len(results),
+            "min_lines": min_lines,
+            "results": results,
+        }
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Adds a new MCP tool (`find_large_functions_tool`) that queries the graph for nodes exceeding a line-count threshold. This enables size-based code quality audits directly from the graph's AST data.

**Use cases:**
- Find all functions over 100 lines for decomposition planning
- Audit a codebase for oversized classes or files
- Filter by node kind (`Function`, `Class`, `File`) and file path pattern
- Enforce size limits during code review

## Changes

### `graph.py` — `GraphStore.get_nodes_by_size()`
New method that builds a parameterized SQL query with optional filters for `min_lines`, `max_lines`, `kind`, and `file_path_pattern`. Results are ordered by line count descending.

### `tools.py` — `find_large_functions()`
Tool 9 function that calls `get_nodes_by_size()`, enriches results with `line_count` and `relative_path`, and produces a human-readable summary.

### `main.py` — `find_large_functions_tool`
MCP tool wrapper registered with `@mcp.tool()`.

## Example Output

```
Found 20 node(s) with >= 100 lines (kind=Function):
  1401 lines | Function | ModelPlayground (apps/web/src/components/admin/model-playground.tsx:292)
   956 lines | Function | processDiagnosticRequest (src/lib/ai/diagnostic-orchestrator.ts:817)
   949 lines | Function | EnhancedSignupForm (src/components/connected/EnhancedSignupForm.tsx:50)
   ...
```

## Design Notes

- Follows existing patterns exactly (`_get_store()`, `node_to_dict()`, `# nosec B608`)
- No new dependencies
- Parameterized SQL prevents injection
- ~50 lines of new code across 3 files
- Uses existing `line_start`/`line_end` data — no parser changes needed

## Test Plan

- [ ] Verify `find_large_functions_tool(min_lines=50)` returns expected results on a built graph
- [ ] Verify `kind` filter works (e.g., `kind="Function"` vs `kind="Class"`)
- [ ] Verify `file_path_pattern` filter works (e.g., `"components/"`)
- [ ] Verify `limit` caps results correctly
- [ ] Verify empty graph returns `total_found: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)