### PR TITLE
fix: filter JS/TS builtins, enable callers_of, improve multi-word search

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -268,6 +268,21 @@ class GraphStore:
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
 
+    def search_edges_by_target_name(self, name: str, kind: str = "CALLS") -> list[GraphEdge]:
+        """Search for edges where target_qualified matches an unqualified name.
+
+        CALLS edges often store unqualified target names (e.g. ``generateTestCode``)
+        rather than fully qualified ones (``file.ts::generateTestCode``).  This
+        method finds those edges by exact match on the plain function name so that
+        reverse call tracing (callers_of) works even when qualified-name lookup
+        returns nothing.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM edges WHERE target_qualified = ? AND kind = ?",
+            (name, kind),
+        ).fetchall()
+        return [self._row_to_edge(r) for r in rows]
+
     def get_all_files(self) -> list[str]:
         rows = self._conn.execute(
             "SELECT DISTINCT file_path FROM nodes WHERE kind = 'File'"
@@ -275,13 +290,40 @@ class GraphStore:
         return [r["file_path"] for r in rows]
 
     def search_nodes(self, query: str, limit: int = 20) -> list[GraphNode]:
-        """Simple keyword search across node names."""
-        pattern = f"%{query}%"
-        rows = self._conn.execute(
-            "SELECT * FROM nodes WHERE name LIKE ? OR qualified_name LIKE ? LIMIT ?",
-            (pattern, pattern, limit),
-        ).fetchall()
-        return [self._row_to_node(r) for r in rows]
+        """Simple keyword search across node names.
+
+        Multi-word queries match nodes containing ANY of the terms, ranked by
+        the number of terms matched (more matches first).  Single-word queries
+        behave exactly as before.
+        """
+        terms = query.strip().split()
+        if len(terms) <= 1:
+            # Original single-term behavior
+            pattern = f"%{query}%"
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE name LIKE ? OR qualified_name LIKE ? LIMIT ?",
+                (pattern, pattern, limit),
+            ).fetchall()
+            return [self._row_to_node(r) for r in rows]
+
+        # Multi-term: match any term, rank by number of terms matched
+        seen: dict[str, tuple[GraphNode, int]] = {}
+        for term in terms:
+            pattern = f"%{term}%"
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE name LIKE ? OR qualified_name LIKE ? LIMIT ?",
+                (pattern, pattern, limit * 3),
+            ).fetchall()
+            for r in rows:
+                node = self._row_to_node(r)
+                if node.qualified_name in seen:
+                    seen[node.qualified_name] = (node, seen[node.qualified_name][1] + 1)
+                else:
+                    seen[node.qualified_name] = (node, 1)
+
+        # Sort: more matches first, then by name relevance
+        items = sorted(seen.values(), key=lambda x: -x[1])
+        return [node for node, _ in items[:limit]]
 
     # --- Impact / Graph traversal ---
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -166,6 +166,100 @@ _TEST_FILE_PATTERNS = [
     re.compile(r"tests?/"),
 ]
 
+# JS/TS builtin method names to exclude from CALLS edges.
+# These are Array, String, Object, Promise, Console, Math, DOM, Timer,
+# JSON, Date, encoding, Function.prototype, EventEmitter, Stream,
+# Express-style, Map/Set, Prisma/ORM, and test-framework methods that
+# produce noise rather than meaningful cross-function call relationships.
+_JS_BUILTIN_CALL_NAMES: set[str] = {
+    # Array.prototype & Array static
+    "map", "filter", "reduce", "reduceRight", "forEach", "find", "findIndex",
+    "some", "every", "includes", "indexOf", "lastIndexOf",
+    "push", "pop", "shift", "unshift", "splice", "slice",
+    "concat", "join", "flat", "flatMap", "sort", "reverse", "fill",
+    "keys", "values", "entries", "from", "isArray", "of", "at",
+    "copyWithin", "findLast", "findLastIndex", "toReversed", "toSorted", "toSpliced", "with",
+    # String.prototype
+    "trim", "trimStart", "trimEnd", "split", "replace", "replaceAll",
+    "match", "matchAll", "search", "substring", "substr",
+    "toLowerCase", "toUpperCase", "toLocaleLowerCase", "toLocaleUpperCase",
+    "startsWith", "endsWith", "padStart", "padEnd", "repeat",
+    "charAt", "charCodeAt", "codePointAt", "normalize", "localeCompare",
+    # Object static & prototype
+    "assign", "freeze", "defineProperty", "defineProperties",
+    "getOwnPropertyNames", "getOwnPropertyDescriptor", "getPrototypeOf",
+    "hasOwnProperty", "create", "is", "fromEntries", "getOwnPropertySymbols",
+    # Console / logging
+    "log", "warn", "error", "info", "debug", "trace", "dir", "table",
+    "time", "timeEnd", "timeLog", "group", "groupEnd", "groupCollapsed",
+    "assert", "clear", "count", "countReset",
+    # Promise / async
+    "then", "catch", "finally", "resolve", "reject", "all", "allSettled", "race", "any",
+    # JSON
+    "parse", "stringify",
+    # Math
+    "floor", "ceil", "round", "random", "max", "min", "abs", "pow", "sqrt",
+    "sign", "trunc", "log2", "log10", "hypot", "clz32", "fround", "imul",
+    # DOM / Node / Event
+    "addEventListener", "removeEventListener",
+    "querySelector", "querySelectorAll", "getElementById",
+    "getElementsByClassName", "getElementsByTagName",
+    "createElement", "createTextNode", "appendChild", "removeChild",
+    "insertBefore", "replaceChild", "cloneNode",
+    "setAttribute", "getAttribute", "removeAttribute", "hasAttribute",
+    "contains", "remove", "add", "toggle",
+    "preventDefault", "stopPropagation", "stopImmediatePropagation",
+    "dispatchEvent", "focus", "blur", "click", "scrollTo", "scrollIntoView",
+    # classList (overlaps with Set-like: add, remove, toggle, contains)
+    # Timer
+    "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+    "requestAnimationFrame", "cancelAnimationFrame",
+    # Common Object / conversion
+    "toString", "valueOf", "toJSON", "toISOString", "toLocaleDateString",
+    "toLocaleString", "toLocaleTimeString", "toDateString", "toTimeString",
+    # Date
+    "getTime", "getFullYear", "getMonth", "getDate", "getDay",
+    "getHours", "getMinutes", "getSeconds", "getMilliseconds",
+    "setFullYear", "setMonth", "setDate", "setHours", "setMinutes", "setSeconds",
+    "now", "toUTCString", "getTimezoneOffset",
+    # Number / globals
+    "isNaN", "isFinite", "isInteger", "isSafeInteger",
+    "parseInt", "parseFloat", "toFixed", "toPrecision", "toExponential",
+    # Encoding
+    "encodeURIComponent", "decodeURIComponent", "encodeURI", "decodeURI",
+    "btoa", "atob",
+    # Function.prototype
+    "call", "apply", "bind",
+    # Iteration / Generator
+    "next", "return", "throw",
+    # EventEmitter (Node)
+    "emit", "on", "off", "once", "removeListener", "removeAllListeners",
+    "listenerCount", "prependListener",
+    # Stream / IO (Node)
+    "pipe", "write", "read", "end", "close", "destroy", "cork", "uncork",
+    "resume", "pause", "unshift",
+    # Express-style response/request
+    "send", "status", "json", "redirect", "render", "cookie", "header",
+    "type", "format", "attachment", "download", "jsonp",
+    # Map / Set / WeakMap / WeakSet
+    "set", "get", "delete", "has", "clear", "size",
+    # Prisma / ORM
+    "findUnique", "findFirst", "findMany", "createMany",
+    "update", "updateMany", "deleteMany", "upsert",
+    "count", "aggregate", "groupBy", "transaction",
+    # Test frameworks (jest, mocha, vitest, playwright)
+    "describe", "it", "test", "expect", "beforeEach", "afterEach",
+    "beforeAll", "afterAll", "mock", "spyOn", "fn",
+    "toBe", "toEqual", "toBeTruthy", "toBeFalsy", "toContain",
+    "toHaveBeenCalled", "toHaveBeenCalledWith", "toThrow", "toMatch",
+    "toHaveLength", "toBeNull", "toBeUndefined", "toBeDefined",
+    "toBeGreaterThan", "toBeLessThan", "toHaveProperty",
+    # Misc utilities
+    "require", "fetch", "Symbol", "WeakRef", "FinalizationRegistry",
+}
+
+_JS_LANGUAGES = frozenset({"javascript", "typescript", "tsx"})
+
 
 def _is_test_file(path: str) -> bool:
     return any(p.search(path) for p in _TEST_FILE_PATTERNS)
@@ -373,14 +467,19 @@ class CodeParser:
             if node_type in call_types:
                 call_name = self._get_call_name(child, language, source)
                 if call_name and enclosing_func:
-                    caller = self._qualify(enclosing_func, file_path, enclosing_class)
-                    edges.append(EdgeInfo(
-                        kind="CALLS",
-                        source=caller,
-                        target=call_name,
-                        file_path=file_path,
-                        line=child.start_point[0] + 1,
-                    ))
+                    # Skip JS/TS builtin method calls (map, filter, push, etc.)
+                    # — they add noise, not meaningful cross-function edges.
+                    if language in _JS_LANGUAGES and call_name in _JS_BUILTIN_CALL_NAMES:
+                        pass
+                    else:
+                        caller = self._qualify(enclosing_func, file_path, enclosing_class)
+                        edges.append(EdgeInfo(
+                            kind="CALLS",
+                            source=caller,
+                            target=call_name,
+                            file_path=file_path,
+                            line=child.start_point[0] + 1,
+                        ))
 
             # Recurse for other node types
             self._extract_from_tree(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -166,101 +166,6 @@ _TEST_FILE_PATTERNS = [
     re.compile(r"tests?/"),
 ]
 
-# JS/TS builtin method names to exclude from CALLS edges.
-# These are Array, String, Object, Promise, Console, Math, DOM, Timer,
-# JSON, Date, encoding, Function.prototype, EventEmitter, Stream,
-# Express-style, Map/Set, Prisma/ORM, and test-framework methods that
-# produce noise rather than meaningful cross-function call relationships.
-_JS_BUILTIN_CALL_NAMES: set[str] = {
-    # Array.prototype & Array static
-    "map", "filter", "reduce", "reduceRight", "forEach", "find", "findIndex",
-    "some", "every", "includes", "indexOf", "lastIndexOf",
-    "push", "pop", "shift", "unshift", "splice", "slice",
-    "concat", "join", "flat", "flatMap", "sort", "reverse", "fill",
-    "keys", "values", "entries", "from", "isArray", "of", "at",
-    "copyWithin", "findLast", "findLastIndex", "toReversed", "toSorted", "toSpliced", "with",
-    # String.prototype
-    "trim", "trimStart", "trimEnd", "split", "replace", "replaceAll",
-    "match", "matchAll", "search", "substring", "substr",
-    "toLowerCase", "toUpperCase", "toLocaleLowerCase", "toLocaleUpperCase",
-    "startsWith", "endsWith", "padStart", "padEnd", "repeat",
-    "charAt", "charCodeAt", "codePointAt", "normalize", "localeCompare",
-    # Object static & prototype
-    "assign", "freeze", "defineProperty", "defineProperties",
-    "getOwnPropertyNames", "getOwnPropertyDescriptor", "getPrototypeOf",
-    "hasOwnProperty", "create", "is", "fromEntries", "getOwnPropertySymbols",
-    # Console / logging
-    "log", "warn", "error", "info", "debug", "trace", "dir", "table",
-    "time", "timeEnd", "timeLog", "group", "groupEnd", "groupCollapsed",
-    "assert", "clear", "count", "countReset",
-    # Promise / async
-    "then", "catch", "finally", "resolve", "reject", "all", "allSettled", "race", "any",
-    # JSON
-    "parse", "stringify",
-    # Math
-    "floor", "ceil", "round", "random", "max", "min", "abs", "pow", "sqrt",
-    "sign", "trunc", "log2", "log10", "hypot", "clz32", "fround", "imul",
-    # DOM / Node / Event
-    "addEventListener", "removeEventListener",
-    "querySelector", "querySelectorAll", "getElementById",
-    "getElementsByClassName", "getElementsByTagName",
-    "createElement", "createTextNode", "appendChild", "removeChild",
-    "insertBefore", "replaceChild", "cloneNode",
-    "setAttribute", "getAttribute", "removeAttribute", "hasAttribute",
-    "contains", "remove", "add", "toggle",
-    "preventDefault", "stopPropagation", "stopImmediatePropagation",
-    "dispatchEvent", "focus", "blur", "click", "scrollTo", "scrollIntoView",
-    # classList (overlaps with Set-like: add, remove, toggle, contains)
-    # Timer
-    "setTimeout", "clearTimeout", "setInterval", "clearInterval",
-    "requestAnimationFrame", "cancelAnimationFrame",
-    # Common Object / conversion
-    "toString", "valueOf", "toJSON", "toISOString", "toLocaleDateString",
-    "toLocaleString", "toLocaleTimeString", "toDateString", "toTimeString",
-    # Date
-    "getTime", "getFullYear", "getMonth", "getDate", "getDay",
-    "getHours", "getMinutes", "getSeconds", "getMilliseconds",
-    "setFullYear", "setMonth", "setDate", "setHours", "setMinutes", "setSeconds",
-    "now", "toUTCString", "getTimezoneOffset",
-    # Number / globals
-    "isNaN", "isFinite", "isInteger", "isSafeInteger",
-    "parseInt", "parseFloat", "toFixed", "toPrecision", "toExponential",
-    # Encoding
-    "encodeURIComponent", "decodeURIComponent", "encodeURI", "decodeURI",
-    "btoa", "atob",
-    # Function.prototype
-    "call", "apply", "bind",
-    # Iteration / Generator
-    "next", "return", "throw",
-    # EventEmitter (Node)
-    "emit", "on", "off", "once", "removeListener", "removeAllListeners",
-    "listenerCount", "prependListener",
-    # Stream / IO (Node)
-    "pipe", "write", "read", "end", "close", "destroy", "cork", "uncork",
-    "resume", "pause", "unshift",
-    # Express-style response/request
-    "send", "status", "json", "redirect", "render", "cookie", "header",
-    "type", "format", "attachment", "download", "jsonp",
-    # Map / Set / WeakMap / WeakSet
-    "set", "get", "delete", "has", "clear", "size",
-    # Prisma / ORM
-    "findUnique", "findFirst", "findMany", "createMany",
-    "update", "updateMany", "deleteMany", "upsert",
-    "count", "aggregate", "groupBy", "transaction",
-    # Test frameworks (jest, mocha, vitest, playwright)
-    "describe", "it", "test", "expect", "beforeEach", "afterEach",
-    "beforeAll", "afterAll", "mock", "spyOn", "fn",
-    "toBe", "toEqual", "toBeTruthy", "toBeFalsy", "toContain",
-    "toHaveBeenCalled", "toHaveBeenCalledWith", "toThrow", "toMatch",
-    "toHaveLength", "toBeNull", "toBeUndefined", "toBeDefined",
-    "toBeGreaterThan", "toBeLessThan", "toHaveProperty",
-    # Misc utilities
-    "require", "fetch", "Symbol", "WeakRef", "FinalizationRegistry",
-}
-
-_JS_LANGUAGES = frozenset({"javascript", "typescript", "tsx"})
-
-
 def _is_test_file(path: str) -> bool:
     return any(p.search(path) for p in _TEST_FILE_PATTERNS)
 
@@ -467,19 +372,14 @@ class CodeParser:
             if node_type in call_types:
                 call_name = self._get_call_name(child, language, source)
                 if call_name and enclosing_func:
-                    # Skip JS/TS builtin method calls (map, filter, push, etc.)
-                    # — they add noise, not meaningful cross-function edges.
-                    if language in _JS_LANGUAGES and call_name in _JS_BUILTIN_CALL_NAMES:
-                        pass
-                    else:
-                        caller = self._qualify(enclosing_func, file_path, enclosing_class)
-                        edges.append(EdgeInfo(
-                            kind="CALLS",
-                            source=caller,
-                            target=call_name,
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                        ))
+                    caller = self._qualify(enclosing_func, file_path, enclosing_class)
+                    edges.append(EdgeInfo(
+                        kind="CALLS",
+                        source=caller,
+                        target=call_name,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1,
+                    ))
 
             # Recurse for other node types
             self._extract_from_tree(

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -256,6 +256,15 @@ def query_graph(
                     if caller:
                         results.append(node_to_dict(caller))
                     edges_out.append(edge_to_dict(e))
+            # Fallback: CALLS edges often store unqualified target names
+            # (e.g. "generateTestCode") while qn is fully qualified
+            # (e.g. "file.ts::generateTestCode"). Search by plain name too.
+            if not results and node:
+                for e in store.search_edges_by_target_name(node.name):
+                    caller = store.get_node(e.source_qualified)
+                    if caller:
+                        results.append(node_to_dict(caller))
+                    edges_out.append(edge_to_dict(e))
 
         elif pattern == "callees_of":
             for e in store.get_edges_by_source(qn):

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -27,6 +27,48 @@ from .incremental import (
     incremental_update,
 )
 
+# Common JS/TS builtin method names filtered from callers_of results.
+# "Who calls .map()?" returns hundreds of hits and is never useful.
+# These are kept in the graph (callees_of still shows them) but excluded
+# when doing reverse call tracing to reduce noise.
+_BUILTIN_CALL_NAMES: set[str] = {
+    "map", "filter", "reduce", "reduceRight", "forEach", "find", "findIndex",
+    "some", "every", "includes", "indexOf", "lastIndexOf",
+    "push", "pop", "shift", "unshift", "splice", "slice",
+    "concat", "join", "flat", "flatMap", "sort", "reverse", "fill",
+    "keys", "values", "entries", "from", "isArray", "of", "at",
+    "trim", "trimStart", "trimEnd", "split", "replace", "replaceAll",
+    "match", "matchAll", "search", "substring", "substr",
+    "toLowerCase", "toUpperCase", "startsWith", "endsWith",
+    "padStart", "padEnd", "repeat", "charAt", "charCodeAt",
+    "assign", "freeze", "defineProperty", "getOwnPropertyNames",
+    "hasOwnProperty", "create", "is", "fromEntries",
+    "log", "warn", "error", "info", "debug", "trace", "dir", "table",
+    "time", "timeEnd", "assert", "clear", "count",
+    "then", "catch", "finally", "resolve", "reject", "all", "allSettled", "race", "any",
+    "parse", "stringify",
+    "floor", "ceil", "round", "random", "max", "min", "abs", "pow", "sqrt",
+    "addEventListener", "removeEventListener", "querySelector", "querySelectorAll",
+    "getElementById", "createElement", "appendChild", "removeChild",
+    "setAttribute", "getAttribute", "preventDefault", "stopPropagation",
+    "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+    "toString", "valueOf", "toJSON", "toISOString",
+    "getTime", "getFullYear", "now",
+    "isNaN", "parseInt", "parseFloat", "toFixed",
+    "encodeURIComponent", "decodeURIComponent",
+    "call", "apply", "bind", "next",
+    "emit", "on", "off", "once",
+    "pipe", "write", "read", "end", "close", "destroy",
+    "send", "status", "json", "redirect",
+    "set", "get", "delete", "has",
+    "findUnique", "findFirst", "findMany", "createMany",
+    "update", "updateMany", "deleteMany", "upsert",
+    "aggregate", "groupBy", "transaction",
+    "describe", "it", "test", "expect", "beforeEach", "afterEach",
+    "beforeAll", "afterAll", "mock", "spyOn",
+    "require", "fetch",
+}
+
 
 def _validate_repo_root(path: Path) -> Path:
     """Validate that a path is a plausible project root.
@@ -223,6 +265,16 @@ def query_graph(
         results: list[dict] = []
         edges_out: list[dict] = []
 
+        # For callers_of, skip common builtins early (before node resolution)
+        # "Who calls .map()?" returns hundreds of useless hits.
+        if pattern == "callers_of" and target in _BUILTIN_CALL_NAMES:
+            return {
+                "status": "ok", "pattern": pattern, "target": target,
+                "description": _QUERY_PATTERNS[pattern],
+                "summary": f"'{target}' is a common builtin — callers_of skipped to avoid noise.",
+                "results": [], "edges": [],
+            }
+
         # Resolve target - try as-is, then as absolute path, then search
         node = store.get_node(target)
         if not node:
@@ -256,7 +308,7 @@ def query_graph(
                     if caller:
                         results.append(node_to_dict(caller))
                     edges_out.append(edge_to_dict(e))
-            # Fallback: CALLS edges often store unqualified target names
+            # Fallback: CALLS edges store unqualified target names
             # (e.g. "generateTestCode") while qn is fully qualified
             # (e.g. "file.ts::generateTestCode"). Search by plain name too.
             if not results and node:


### PR DESCRIPTION
Three fixes that make the graph more useful for JavaScript/TypeScript projects:

  1. callers_of now works — Was broken for all users. CALLS edges store unqualified names (generateTestCode) but
  callers_of searched by fully qualified name (file.ts::generateTestCode), so it always returned 0 results. Added
   fallback that matches by plain function name.
  2. Builtin noise filtered at query-time, not parse-time — Asking "who calls .map()?" returns hundreds of
  useless hits. Common JS/TS builtins are now skipped in callers_of queries. But they're kept in the graph so
  callees_of still shows them — knowing a function calls .map() and .filter() helps the AI understand what it
  does.
  3. Multi-word keyword search — "whisper transcribe" returned 0 results because it searched for the exact
  string. Now splits into individual terms and matches ANY, ranked by match count.

  What changed

  - graph.py — Added search_edges_by_target_name() + multi-word search_nodes
  - tools.py — callers_of fallback to unqualified name + builtin skip list
  - parser.py — No changes (builtins kept in graph)