### PR TITLE
fix: use valid PostToolUse hooks and remove duplicate MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "code-review-graph": {
-      "command": "uvx",
-      "args": ["code-review-graph", "serve"]
-    }
-  }
-}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "PostEdit and PostGit are custom Claude Code hook events (confirmed working as of v1.6.4).",
+  "_comment": "Auto-update knowledge graph after file edits and git commits via PostToolUse hooks.",
   "hooks": {
     "SessionStart": [
       {
@@ -11,7 +11,7 @@
         ]
       }
     ],
-    "PostEdit": [
+    "PostToolUse": [
       {
         "matcher": "Write|Edit",
         "hooks": [
@@ -20,11 +20,9 @@
             "command": "code-review-graph update 2>/dev/null || true"
           }
         ]
-      }
-    ],
-    "PostGit": [
+      },
       {
-        "matcher": "commit",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Fixes two plugin issues that cause errors in Claude Code `/doctor`:

- **Invalid hook events**: `PostEdit` and `PostGit` are not valid Claude Code hook event types. Replaced with `PostToolUse` — the standard event for post-tool callbacks.
- **Duplicate MCP server**: `.mcp.json` at repo root duplicates the MCP server already declared in `.claude-plugin/plugin.json` `mcpServers` field. Removed `.mcp.json` since `plugin.json` is the canonical source for plugin installs. The CLI `install` command creates `.mcp.json` in the **user's project root** (not this repo), so non-plugin installs are unaffected.

Closes #25
Closes #23

## Details

### Hook event mapping

| Before (invalid) | After (valid) | Matcher |
|---|---|---|
| `PostEdit` | `PostToolUse` | `Write\|Edit` |
| `PostGit` | `PostToolUse` | `Bash` |

### Why .mcp.json removal is safe

When installed as a **plugin** (\`/plugin install\`), Claude Code reads MCP server config from \`plugin.json\` → \`mcpServers\` field. The standalone \`.mcp.json\` is only needed for non-plugin installs via \`code-review-graph install\`, which creates \`.mcp.json\` in the user's **project directory**, not from this repo's copy.

Having both causes Claude Code to log:
\`\`\`
MCP server "code-review-graph" skipped — same command/URL as already-configured "code-review-graph"
\`\`\`

### Supersedes

This PR supersedes #26 by also fixing the duplicate MCP issue in addition to the hooks fix.

## Test plan

- [ ] Install plugin via \`claude plugin marketplace add tirth8205/code-review-graph && claude plugin install code-review-graph@code-review-graph\`
- [ ] Run \`/reload-plugins\` — should show \`6 hooks\` (not 3)
- [ ] Run \`/doctor\` — should show no errors
- [ ] Edit a file — verify \`code-review-graph update\` runs via PostToolUse hook
- [ ] Run \`git commit\` via Bash — verify graph update triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)