### PR TITLE
fix: resolve same-file call targets to qualified names

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -247,7 +247,49 @@ class CodeParser:
             tree.root_node, source, language, file_path_str, nodes, edges
         )
 
+        # Resolve bare call targets to qualified names using same-file definitions
+        edges = self._resolve_call_targets(nodes, edges, file_path_str)
+
         return nodes, edges
+
+    def _resolve_call_targets(
+        self,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        file_path: str,
+    ) -> list[EdgeInfo]:
+        """Resolve bare call targets to qualified names using same-file definitions.
+
+        After parsing, CALLS edges store bare function names (e.g. ``FirebaseAuth``)
+        as targets. This method builds a symbol table from the parsed nodes and
+        qualifies any bare target that matches a local definition, so that
+        ``callers_of`` / ``callees_of`` queries produce correct results.
+
+        External calls (names not defined in this file) remain bare.
+        """
+        # Build symbol table: bare_name -> qualified_name
+        symbols: dict[str, str] = {}
+        for node in nodes:
+            if node.kind in ("Function", "Class", "Type", "Test"):
+                bare = node.name
+                qualified = self._qualify(bare, file_path, node.parent_name)
+                if bare not in symbols:
+                    symbols[bare] = qualified
+
+        resolved: list[EdgeInfo] = []
+        for edge in edges:
+            if edge.kind == "CALLS" and "::" not in edge.target:
+                if edge.target in symbols:
+                    edge = EdgeInfo(
+                        kind=edge.kind,
+                        source=edge.source,
+                        target=symbols[edge.target],
+                        file_path=edge.file_path,
+                        line=edge.line,
+                        extra=edge.extra,
+                    )
+            resolved.append(edge)
+        return resolved
 
     def _extract_from_tree(
         self,


### PR DESCRIPTION
## Summary

Fixes #20.

`callers_of` and `callees_of` queries return empty results because the parser stores CALLS edges with **bare** target names (e.g. `FirebaseAuth`) while graph queries look up **qualified** names (e.g. `main.go::FirebaseAuth`).

This PR adds a post-parse resolution step that builds a symbol table from parsed nodes and qualifies bare call targets that match local definitions.

**Before:** `callers_of("main.go::FirebaseAuth")` returns 0 results, even though `setupRoutes()` calls `FirebaseAuth()` in the same file.

**After:** The CALLS edge target is resolved from `FirebaseAuth` to `main.go::FirebaseAuth`, so `callers_of` correctly returns `setupRoutes`.

External calls (names not defined in the file) remain bare -- this is correct since they reference symbols in other files or libraries.

## Changes

- `code_review_graph/parser.py`:
  - Added `_resolve_call_targets()` method that builds a symbol table and qualifies bare targets
  - Called at the end of `parse_bytes()` after tree extraction

## Test plan

- [ ] Go file with `func FirebaseAuth()` and `func setupRoutes() { FirebaseAuth() }` produces a CALLS edge with qualified target `main.go::FirebaseAuth`
- [ ] Python file with local function calls produces qualified CALLS targets
- [ ] External library calls (e.g. `json.loads()`) remain bare (no `::` in target)
- [ ] Existing tests pass