### PR TITLE
feat: add output pagination to impact radius

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -346,11 +346,17 @@ class GraphStore:
             if node:
                 impacted_nodes.append(node)
 
+        # Truncation: cap impacted nodes and report total
+        total_impacted = len(impacted_nodes)
+        truncated = total_impacted > max_nodes
+        if truncated:
+            impacted_nodes = impacted_nodes[:max_nodes]
+
         impacted_files = list({n.file_path for n in impacted_nodes})
 
         # Collect relevant edges in a single batch query
         relevant_edges = []
-        all_qns = seeds | impacted
+        all_qns = seeds | {n.qualified_name for n in impacted_nodes}
         if all_qns:
             relevant_edges = self.get_edges_among(all_qns)
 
@@ -359,6 +365,8 @@ class GraphStore:
             "impacted_nodes": impacted_nodes,
             "impacted_files": impacted_files,
             "edges": relevant_edges,
+            "truncated": truncated,
+            "total_impacted": total_impacted,
         }
 
     def get_subgraph(self, qualified_names: list[str]) -> dict[str, Any]:

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -121,6 +121,7 @@ def build_or_update_graph(
 def get_impact_radius(
     changed_files: list[str] | None = None,
     max_depth: int = 2,
+    max_results: int = 500,
     repo_root: str | None = None,
     base: str = "HEAD~1",
 ) -> dict[str, Any]:
@@ -130,11 +131,13 @@ def get_impact_radius(
         changed_files: Explicit list of changed file paths (relative to repo root).
                        If omitted, auto-detects from git diff.
         max_depth: How many hops to traverse in the graph (default: 2).
+        max_results: Maximum impacted nodes to return (default: 500).
         repo_root: Repository root path. Auto-detected if omitted.
         base: Git ref for auto-detecting changes (default: HEAD~1).
 
     Returns:
-        Changed nodes, impacted nodes, impacted files, and connecting edges.
+        Changed nodes, impacted nodes, impacted files, connecting edges,
+        plus ``truncated`` flag and ``total_impacted`` count.
     """
     store, root = _get_store(repo_root)
     try:
@@ -150,15 +153,21 @@ def get_impact_radius(
                 "changed_nodes": [],
                 "impacted_nodes": [],
                 "impacted_files": [],
+                "truncated": False,
+                "total_impacted": 0,
             }
 
         # Convert to absolute paths for graph lookup
         abs_files = [str(root / f) for f in changed_files]
-        result = store.get_impact_radius(abs_files, max_depth=max_depth)
+        result = store.get_impact_radius(
+            abs_files, max_depth=max_depth, max_nodes=max_results
+        )
 
         changed_dicts = [node_to_dict(n) for n in result["changed_nodes"]]
         impacted_dicts = [node_to_dict(n) for n in result["impacted_nodes"]]
         edge_dicts = [edge_to_dict(e) for e in result["edges"]]
+        truncated = result["truncated"]
+        total_impacted = result["total_impacted"]
 
         summary_parts = [
             f"Blast radius for {len(changed_files)} changed file(s):",
@@ -166,6 +175,11 @@ def get_impact_radius(
             f"  - {len(impacted_dicts)} nodes impacted (within {max_depth} hops)",
             f"  - {len(result['impacted_files'])} additional files affected",
         ]
+        if truncated:
+            summary_parts.append(
+                f"  - TRUNCATED: results capped at {max_results} nodes"
+                f" ({total_impacted} total impacted)"
+            )
 
         return {
             "status": "ok",
@@ -175,6 +189,8 @@ def get_impact_radius(
             "impacted_nodes": impacted_dicts,
             "impacted_files": result["impacted_files"],
             "edges": edge_dicts,
+            "truncated": truncated,
+            "total_impacted": total_impacted,
         }
     finally:
         store.close()


### PR DESCRIPTION
## Summary

On large codebases, `get_impact_radius` can return thousands of nodes, producing 500K+ character MCP responses that blow up context windows and cause timeouts.

This PR adds output pagination with truncation metadata:
- `max_results` parameter (default: 500) caps impacted nodes returned
- `truncated` boolean flag indicates when results are incomplete
- `total_impacted` integer shows the full count before truncation
- Summary includes truncation notice when active

The BFS traversal itself already had a `max_nodes` parameter in `graph.py` but it was not exposed to the tools layer, and the results lacked truncation metadata.

## Changes

- `code_review_graph/graph.py`: `get_impact_radius()` now returns `truncated` and `total_impacted` in results dict
- `code_review_graph/tools.py`: `get_impact_radius()` adds `max_results` parameter, passes to graph layer, includes truncation info in summary and response

## Test plan

- [ ] Impact radius with 100+ impacted nodes and `max_results=10` returns exactly 10 nodes with `truncated=True`
- [ ] Impact radius with few impacted nodes returns all with `truncated=False`
- [ ] Default `max_results=500` does not change behavior for small codebases
- [ ] Existing tests pass