### PR TITLE
feat: add Vue SFC parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ On every git commit or file save, a hook fires. The graph diffs changed files, f
 </details>
 
 <details>
-<summary><strong>12 supported languages</strong></summary>
+<summary><strong>13 supported languages</strong></summary>
 <br>
 
-Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
+Python, TypeScript, JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
 
 Each language has full Tree-sitter grammar support for functions, classes, imports, call sites, inheritance, and test detection.
 
@@ -209,7 +209,7 @@ Claude uses these automatically once the graph is built.
 | Feature | Details |
 |---------|---------|
 | **Incremental updates** | Re-parses only changed files. Subsequent updates complete in under 2 seconds. |
-| **12 languages** | Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++ |
+| **13 languages** | Python, TypeScript, JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++ |
 | **Blast-radius analysis** | Shows exactly which functions, classes, and files are affected by any change |
 | **Auto-update hooks** | Graph updates on every file edit and git commit without manual intervention |
 | **Semantic search** | Optional vector embeddings via sentence-transformers |

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -73,6 +73,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".swift": "swift",
     ".php": "php",
     ".sol": "solidity",
+    ".vue": "vue",
 }
 
 # Tree-sitter node type mappings per language
@@ -215,6 +216,8 @@ def file_hash(path: Path) -> str:
 class CodeParser:
     """Parses source files using Tree-sitter and extracts structural information."""
 
+    _MODULE_CACHE_MAX = 15_000  # Evict cache to cap memory on huge monorepos
+
     def __init__(self) -> None:
         self._parsers: dict[str, object] = {}
         self._module_file_cache: dict[str, Optional[str]] = {}
@@ -247,6 +250,10 @@ class CodeParser:
         language = self.detect_language(path)
         if not language:
             return [], []
+
+        # Vue SFCs: parse with vue parser, then delegate script blocks to JS/TS
+        if language == "vue":
+            return self._parse_vue(path, source)
 
         parser = self._get_parser(language)
         if not parser:
@@ -300,6 +307,119 @@ class CodeParser:
 
         return nodes, edges
 
+    def _parse_vue(
+        self, path: Path, source: bytes,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a Vue SFC by extracting <script> blocks and delegating to JS/TS."""
+        vue_parser = self._get_parser("vue")
+        if not vue_parser:
+            return [], []
+
+        tree = vue_parser.parse(source)
+        file_path_str = str(path)
+        test_file = _is_test_file(file_path_str)
+
+        all_nodes: list[NodeInfo] = [NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1,
+            line_end=source.count(b"\n") + 1,
+            language="vue",
+            is_test=test_file,
+        )]
+        all_edges: list[EdgeInfo] = []
+
+        # Find script_element blocks in the Vue AST
+        for child in tree.root_node.children:
+            if child.type != "script_element":
+                continue
+
+            # Detect language from lang="ts" attribute
+            script_lang = "javascript"
+            start_tag = None
+            raw_text_node = None
+            for sub in child.children:
+                if sub.type == "start_tag":
+                    start_tag = sub
+                elif sub.type == "raw_text":
+                    raw_text_node = sub
+
+            if start_tag:
+                for attr in start_tag.children:
+                    if attr.type == "attribute":
+                        attr_name = None
+                        attr_value = None
+                        for a in attr.children:
+                            if a.type == "attribute_name":
+                                attr_name = a.text.decode("utf-8", errors="replace")
+                            elif a.type == "quoted_attribute_value":
+                                for v in a.children:
+                                    if v.type == "attribute_value":
+                                        attr_value = v.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                        if attr_name == "lang" and attr_value in ("ts", "typescript"):
+                            script_lang = "typescript"
+
+            if not raw_text_node:
+                continue
+
+            script_source = raw_text_node.text
+            line_offset = raw_text_node.start_point[0]  # 0-based line of raw_text start
+
+            # Parse the script block with the appropriate JS/TS parser
+            script_parser = self._get_parser(script_lang)
+            if not script_parser:
+                continue
+
+            script_tree = script_parser.parse(script_source)
+
+            # Collect imports and defined names from the script block
+            import_map, defined_names = self._collect_file_scope(
+                script_tree.root_node, script_lang, script_source,
+            )
+
+            nodes: list[NodeInfo] = []
+            edges: list[EdgeInfo] = []
+            self._extract_from_tree(
+                script_tree.root_node, script_source, script_lang,
+                file_path_str, nodes, edges,
+                import_map=import_map, defined_names=defined_names,
+            )
+
+            # Adjust line numbers to account for position within the .vue file
+            for node in nodes:
+                node.line_start += line_offset
+                node.line_end += line_offset
+                node.language = "vue"
+            for edge in edges:
+                edge.line += line_offset
+
+            all_nodes.extend(nodes)
+            all_edges.extend(edges)
+
+        # Generate TESTED_BY edges
+        if test_file:
+            test_qnames = set()
+            for n in all_nodes:
+                if n.is_test:
+                    qn = self._qualify(n.name, n.file_path, n.parent_name)
+                    test_qnames.add(qn)
+            for edge in list(all_edges):
+                if edge.kind == "CALLS" and edge.source in test_qnames:
+                    all_edges.append(EdgeInfo(
+                        kind="TESTED_BY",
+                        source=edge.target,
+                        target=edge.source,
+                        file_path=edge.file_path,
+                        line=edge.line,
+                    ))
+
+        return all_nodes, all_edges
+
+    _MAX_AST_DEPTH = 180  # Guard against pathologically nested source files
+
     def _extract_from_tree(
         self,
         root,
@@ -312,8 +432,11 @@ class CodeParser:
         enclosing_func: Optional[str] = None,
         import_map: Optional[dict[str, str]] = None,
         defined_names: Optional[set[str]] = None,
+        _depth: int = 0,
     ) -> None:
         """Recursively walk the AST and extract nodes/edges."""
+        if _depth > self._MAX_AST_DEPTH:
+            return
         class_types = set(_CLASS_TYPES.get(language, []))
         func_types = set(_FUNCTION_TYPES.get(language, []))
         import_types = set(_IMPORT_TYPES.get(language, []))
@@ -362,6 +485,7 @@ class CodeParser:
                         child, source, language, file_path, nodes, edges,
                         enclosing_class=name, enclosing_func=None,
                         import_map=import_map, defined_names=defined_names,
+                        _depth=_depth + 1,
                     )
                     continue
 
@@ -425,6 +549,7 @@ class CodeParser:
                         child, source, language, file_path, nodes, edges,
                         enclosing_class=enclosing_class, enclosing_func=name,
                         import_map=import_map, defined_names=defined_names,
+                        _depth=_depth + 1,
                     )
                     continue
 
@@ -589,6 +714,7 @@ class CodeParser:
                 child, source, language, file_path, nodes, edges,
                 enclosing_class=enclosing_class, enclosing_func=enclosing_func,
                 import_map=import_map, defined_names=defined_names,
+                _depth=_depth + 1,
             )
 
     def _collect_file_scope(
@@ -711,6 +837,8 @@ class CodeParser:
             return self._module_file_cache[cache_key]
 
         resolved = self._do_resolve_module(module, file_path, language)
+        if len(self._module_file_cache) >= self._MODULE_CACHE_MAX:
+            self._module_file_cache.clear()
         self._module_file_cache[cache_key] = resolved
         return resolved
 
@@ -734,11 +862,11 @@ class CodeParser:
                     break
                 current = current.parent
 
-        elif language in ("javascript", "typescript", "tsx"):
+        elif language in ("javascript", "typescript", "tsx", "vue"):
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx"]
+                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue"]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -44,7 +44,7 @@ Model: all-MiniLM-L6-v2 (384-dim, fast).
 </section>
 
 <section name="languages">
-Supported: Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
+Supported: Python, TypeScript, JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
 Parser: Tree-sitter via tree-sitter-language-pack
 </section>
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -61,7 +61,7 @@ Then use `embed_graph_tool` to compute vectors. `semantic_search_nodes_tool` aut
 
 ## Supported Languages
 
-Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
+Python, TypeScript, JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
 
 ## What Gets Indexed
 

--- a/skills/build-graph/SKILL.md
+++ b/skills/build-graph/SKILL.md
@@ -35,4 +35,4 @@ Build or incrementally update the persistent code knowledge graph for this repos
 
 - The graph is stored as a SQLite database (`.code-review-graph/graph.db`) in the repo root
 - Binary files, generated files, and patterns in `.code-review-graphignore` are skipped
-- Supported languages: Python, TypeScript/JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
+- Supported languages: Python, TypeScript/JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++

--- a/tests/fixtures/sample_vue.vue
+++ b/tests/fixtures/sample_vue.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="app">
+    <h1>{{ title }}</h1>
+    <UserList :users="users" @select="onSelectUser" />
+    <button @click="increment">Count: {{ count }}</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import UserList from './UserList.vue'
+
+interface User {
+  id: number
+  name: string
+}
+
+const count = ref(0)
+const title = ref('My App')
+const users = ref<User[]>([])
+
+function increment() {
+  count.value++
+}
+
+function onSelectUser(user: User) {
+  console.log(user.name)
+}
+
+const doubled = computed(() => count.value * 2)
+
+function fetchUsers() {
+  return fetch('/api/users')
+}
+</script>

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1,4 +1,4 @@
-"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, and Solidity parsing."""
+"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Solidity, and Vue parsing."""
 
 from pathlib import Path
 
@@ -463,3 +463,37 @@ class TestSolidityParsing:
             if n.kind == "Function" and n.parent_name == "RewardMath"
         }
         assert "uint256" in funcs["mulPrecise"].return_type
+
+
+class TestVueParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("App.vue")) == "vue"
+
+    def test_finds_functions(self):
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        assert "increment" in names
+        assert "onSelectUser" in names
+        assert "fetchUsers" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "vue" in targets
+        assert "./UserList.vue" in targets
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 3
+
+    def test_nodes_have_vue_language(self):
+        for node in self.nodes:
+            assert node.language == "vue"
+
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        assert len(calls) >= 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from code_review_graph.parser import CodeParser, NodeInfo, EdgeInfo
+from code_review_graph.parser import CodeParser
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -150,3 +150,125 @@ class TestCodeParser:
         nodes, edges = self.parser.parse_file(Path("readme.txt"))
         assert nodes == []
         assert edges == []
+
+    def test_tested_by_edges_generated(self):
+        """Test files should produce TESTED_BY edges when tests call production code."""
+        nodes, edges = self.parser.parse_file(FIXTURES / "test_sample.py")
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1
+
+    def test_recursion_depth_guard(self):
+        """Parser should not crash on deeply nested code."""
+        # Generate Python code with many nested functions (> _MAX_AST_DEPTH)
+        depth = 200
+        lines = []
+        for i in range(depth):
+            indent = "    " * i
+            lines.append(f"{indent}def func_{i}():")
+        lines.append("    " * depth + "pass")
+        source = "\n".join(lines).encode("utf-8")
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            f.write(source)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            # Should NOT raise RecursionError
+            nodes, edges = self.parser.parse_bytes(path, source)
+            # We should get some functions but not all 200 due to depth cap
+            funcs = [n for n in nodes if n.kind == "Function"]
+            assert len(funcs) > 0
+            assert len(funcs) < depth  # capped by _MAX_AST_DEPTH
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_module_file_cache_bounded(self):
+        """Module file cache should not grow unboundedly."""
+        parser = CodeParser()
+        # Fill the cache up to the limit
+        for i in range(parser._MODULE_CACHE_MAX + 100):
+            parser._module_file_cache[f"key_{i}"] = f"/path/to/mod_{i}.py"
+        # Trigger a resolve which should clear the cache
+        parser._resolve_module_to_file("os", "/test/file.py", "python")
+        assert len(parser._module_file_cache) <= parser._MODULE_CACHE_MAX
+
+    # --- Vue SFC tests ---
+
+    def test_detect_language_vue(self):
+        assert self.parser.detect_language(Path("App.vue")) == "vue"
+
+    def test_parse_vue_file(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+
+        # Should have File node with language=vue
+        file_nodes = [n for n in nodes if n.kind == "File"]
+        assert len(file_nodes) == 1
+        assert file_nodes[0].language == "vue"
+
+        # Should find functions from <script setup>
+        funcs = [n for n in nodes if n.kind == "Function"]
+        func_names = {f.name for f in funcs}
+        assert "increment" in func_names
+        assert "onSelectUser" in func_names
+        assert "fetchUsers" in func_names
+
+    def test_parse_vue_imports(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        import_targets = {e.target for e in imports}
+        assert "vue" in import_targets
+        assert "./UserList.vue" in import_targets
+
+    def test_parse_vue_calls(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+        calls = [e for e in edges if e.kind == "CALLS"]
+        call_targets = {e.target for e in calls}
+        assert "log" in call_targets or "console.log" in call_targets or any(
+            "log" in t for t in call_targets
+        )
+
+    def test_parse_vue_contains_edges(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+        contains = [e for e in edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 1
+
+    def test_parse_vue_line_numbers_offset(self):
+        """Line numbers should be offset to reflect position in the .vue file."""
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+        funcs = [n for n in nodes if n.kind == "Function" and n.name == "increment"]
+        assert len(funcs) == 1
+        # increment() is on line 22 of the .vue file (inside <script setup> starting at line 9)
+        assert funcs[0].line_start > 9
+
+    def test_parse_vue_nodes_have_vue_language(self):
+        """All extracted nodes from Vue SFC should have language='vue'."""
+        nodes, _ = self.parser.parse_file(FIXTURES / "sample_vue.vue")
+        for node in nodes:
+            assert node.language == "vue"
+
+    def test_parse_vue_empty_script(self):
+        """Vue file with no script block should still produce a File node."""
+        source = b"<template><div>Hello</div></template>\n"
+        path = Path("empty_script.vue")
+        nodes, edges = self.parser.parse_bytes(path, source)
+        assert len(nodes) == 1
+        assert nodes[0].kind == "File"
+
+    def test_parse_vue_js_default(self):
+        """Vue file without lang attr should parse script as JavaScript."""
+        source = (
+            b"<script>\n"
+            b"export default {\n"
+            b"  methods: {\n"
+            b"    greet() { return 'hi' }\n"
+            b"  }\n"
+            b"}\n"
+            b"</script>\n"
+        )
+        path = Path("js_default.vue")
+        nodes, edges = self.parser.parse_bytes(path, source)
+        funcs = [n for n in nodes if n.kind == "Function"]
+        func_names = {f.name for f in funcs}
+        assert "greet" in func_names


### PR DESCRIPTION
## Summary
- Adds Vue Single File Component (.vue) parsing via tree-sitter
- Extracts `<script>` and `<script setup>` blocks, detects `lang="ts"` for TypeScript
- Offsets line numbers correctly within the .vue file
- Includes parser hardening: recursion depth guard (180) and module cache eviction (15k cap)
- Updates language count from 12 to 13 across all docs

## Test plan
- [x] `tests/test_multilang.py::TestVueParsing` — 6 tests covering functions, imports, contains, calls, language tag
- [x] `tests/test_parser.py` — Vue-specific tests + recursion depth guard + cache bound tests
- [x] All 176 existing tests still pass
- [ ] Manual: `code-review-graph build` on a Vue project

🤖 Generated with [Claude Code](https://claude.com/claude-code)