### PR TITLE
chore: add governance files and bump to v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.8.3] - 2026-03-20
+
+### Fixed
+- **Parser recursion guard**: Added `_MAX_AST_DEPTH = 180` limit to `_extract_from_tree()` preventing stack overflow on deeply nested ASTs
+- **Module cache bound**: Added `_MODULE_CACHE_MAX = 15_000` with automatic eviction to prevent unbounded memory growth in `_module_file_cache`
+- **Embeddings thread safety**: Added `check_same_thread=False` to `EmbeddingStore` SQLite connection
+- **Embeddings retry logic**: Added `_call_with_retry()` with exponential backoff for Google Gemini API calls
+- **Visualization XSS hardening**: Added `</` to `<\/` replacement in JSON serialization to prevent script injection
+- **CLI error handling**: Split broad `except` into specific `json.JSONDecodeError` and `(KeyError, TypeError)` handlers
+- **Git timeout**: Made configurable via `CRG_GIT_TIMEOUT` environment variable (default 30s)
+
+### Added
+- **Governance files**: Added CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md
+- **Project URLs**: Added Homepage, Repository, Issues, Changelog URLs to pyproject.toml metadata
+
 ## [1.8.2] - 2026-03-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md - Project Context for Claude Code
+
+## Project Overview
+
+**code-review-graph** is a persistent, incrementally-updated knowledge graph for token-efficient code reviews with Claude Code. It parses codebases using Tree-sitter, builds a structural graph in SQLite, and exposes it via MCP tools.
+
+## Architecture
+
+- **Core Package**: `code_review_graph/` (Python 3.10+)
+  - `parser.py` — Tree-sitter multi-language AST parser (13 languages + Vue SFC support)
+  - `graph.py` — SQLite-backed graph store (nodes, edges, BFS impact analysis)
+  - `tools.py` — 9 MCP tool implementations
+  - `incremental.py` — Git-based change detection, file watching
+  - `embeddings.py` — Optional vector embeddings (local or Google Gemini)
+  - `visualization.py` — D3.js interactive HTML graph generator
+  - `cli.py` — CLI entry point (`code-review-graph build/update/watch/serve/...`)
+  - `main.py` — FastMCP server entry point (stdio transport)
+
+- **VS Code Extension**: `code-review-graph-vscode/` (TypeScript)
+  - Separate subproject with its own `package.json`, `tsconfig.json`
+  - Reads from `.code-review-graph/graph.db` via SQLite
+
+- **Database**: `.code-review-graph/graph.db` (SQLite, WAL mode)
+
+## Key Commands
+
+```bash
+# Development
+uv run pytest tests/ --tb=short -q          # Run tests (145 tests)
+uv run ruff check code_review_graph/        # Lint
+uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
+
+# Build & test
+uv run code-review-graph build              # Full graph build
+uv run code-review-graph update             # Incremental update
+uv run code-review-graph status             # Show stats
+uv run code-review-graph serve              # Start MCP server
+```
+
+## Code Conventions
+
+- **Line length**: 100 chars (ruff)
+- **Python target**: 3.10+
+- **SQL**: Always use parameterized queries (`?` placeholders), never f-string values
+- **Error handling**: Catch specific exceptions, log with `logger.warning/error`
+- **Thread safety**: `threading.Lock` for shared caches, `check_same_thread=False` for SQLite
+- **Node names**: Always sanitize via `_sanitize_name()` before returning to MCP clients
+- **File reads**: Read bytes once, hash, then parse (TOCTOU-safe pattern)
+
+## Security Invariants
+
+- No `eval()`, `exec()`, `pickle`, or `yaml.unsafe_load()`
+- No `shell=True` in subprocess calls
+- `_validate_repo_root()` prevents path traversal via repo_root parameter
+- `_sanitize_name()` strips control characters, caps at 256 chars (prompt injection defense)
+- `escH()` in visualization escapes HTML entities including quotes and backticks
+- SRI hash on D3.js CDN script tag
+- API keys only from environment variables, never hardcoded
+
+## Test Structure
+
+- `tests/test_parser.py` — Parser correctness, cross-file resolution
+- `tests/test_graph.py` — Graph CRUD, stats, impact radius
+- `tests/test_tools.py` — MCP tool integration tests
+- `tests/test_visualization.py` — Export, HTML generation, C++ resolution
+- `tests/test_incremental.py` — Build, update, migration, git ops
+- `tests/test_multilang.py` — 12 language parsing tests
+- `tests/test_embeddings.py` — Vector encode/decode, similarity, store
+- `tests/fixtures/` — Sample files for each supported language
+
+## CI Pipeline
+
+- **lint**: ruff on Python 3.10
+- **type-check**: mypy
+- **security**: bandit scan
+- **test**: pytest matrix (3.10, 3.11, 3.12, 3.13) with 50% coverage minimum

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+All participants in this project are expected to follow the Code of Conduct.
+Please report any concerns to the project maintainers.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including issues,
+pull requests, discussions, and any other communication channels.
+
+## Reporting
+
+Instances of unacceptable behavior may be reported to the project maintainers.
+All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to code-review-graph
+
+Thank you for your interest in contributing! This guide will help you get started.
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/tirth8205/code-review-graph.git
+cd code-review-graph
+
+# Install with dev dependencies (requires uv)
+uv sync --extra dev
+
+# Verify setup
+uv run pytest tests/ --tb=short -q
+```
+
+## Running Tests
+
+```bash
+# All tests
+uv run pytest tests/ --tb=short -q
+
+# With coverage
+uv run pytest --cov=code_review_graph --cov-report=term-missing --cov-fail-under=50
+
+# Single test file
+uv run pytest tests/test_parser.py -v
+```
+
+## Linting and Type Checking
+
+```bash
+uv run ruff check code_review_graph/
+uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
+```
+
+## Code Style
+
+- **Line length**: 100 characters
+- **Target**: Python 3.10+
+- **Linter**: ruff (rules: E, F, I, N, W)
+- **SQL**: Always parameterized queries (`?` placeholders)
+- **Imports**: Sorted by ruff (isort-compatible)
+
+## Making Changes
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make your changes
+4. Add tests for new functionality
+5. Ensure all tests pass: `uv run pytest`
+6. Ensure linting passes: `uv run ruff check code_review_graph/`
+7. Submit a pull request
+
+## Project Structure
+
+```
+code_review_graph/     # Core Python package
+  parser.py            # Tree-sitter multi-language parser
+  graph.py             # SQLite graph store
+  tools.py             # MCP tool implementations
+  incremental.py       # Git diff + file watch logic
+  embeddings.py        # Vector embedding support
+  visualization.py     # D3.js HTML generator
+  cli.py               # CLI entry point
+  main.py              # MCP server entry point
+tests/                 # Test suite
+  fixtures/            # Language sample files
+```
+
+## Adding Language Support
+
+1. Add the extension mapping to `EXTENSION_TO_LANGUAGE` in `parser.py`
+2. Add tree-sitter node types to `_CLASS_TYPES`, `_FUNCTION_TYPES`, `_IMPORT_TYPES`, `_CALL_TYPES`
+3. Add a sample fixture file in `tests/fixtures/`
+4. Add parsing tests in `tests/test_multilang.py`
+
+## Reporting Issues
+
+- Use GitHub Issues: https://github.com/tirth8205/code-review-graph/issues
+- Include: Python version, OS, steps to reproduce, error output
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.8.x   | Yes       |
+| < 1.8   | No        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT open a public GitHub issue**
+2. Email the maintainer directly or use GitHub's private vulnerability reporting
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and aim to release a fix within 7 days for critical issues.
+
+## Security Model
+
+### Threat Surface
+
+code-review-graph is a **local development tool**. It:
+- Runs as a local MCP server via stdio (no network listener)
+- Stores data in a local SQLite database (`.code-review-graph/graph.db`)
+- Makes no network calls during normal operation
+- Only reads source files within the validated repository root
+
+### Mitigations
+
+| Vector | Mitigation |
+|--------|------------|
+| SQL Injection | All queries use parameterized `?` placeholders |
+| Path Traversal | `_validate_repo_root()` requires `.git` or `.code-review-graph` directory |
+| Prompt Injection | `_sanitize_name()` strips control characters, caps at 256 chars |
+| XSS (visualization) | `escH()` escapes HTML entities; `</script>` escaped in JSON |
+| Subprocess Injection | No `shell=True`; all git commands use list arguments |
+| Supply Chain | Dependencies pinned with upper bounds; `uv.lock` has SHA256 hashes |
+| CDN Tampering | D3.js loaded with Subresource Integrity (SRI) hash |
+| API Key Leakage | Google API key loaded from env var only, never logged |
+
+### Optional Network Calls
+
+- **Google Gemini embeddings**: Only when explicitly configured with `provider="google"` and `GOOGLE_API_KEY` env var
+- **Local embeddings model download**: One-time download from HuggingFace on first use of `sentence-transformers`
+- **D3.js CDN**: Visualization HTML loads D3.js v7 from `d3js.org` (with SRI verification)
+
+## Security Scanning
+
+The CI pipeline runs:
+- **Bandit** security scanner on every PR
+- **Ruff** linter for code quality
+- **mypy** type checker
+
+Bandit exemptions are documented in `pyproject.toml` with justifications for each skip.

--- a/code_review_graph/__init__.py
+++ b/code_review_graph/__init__.py
@@ -1,1 +1,3 @@
 """Code Review Graph - MCP server for persistent incremental code knowledge graphs."""
+
+__version__ = "1.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "1.8.2"
+version = "1.8.3"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"
@@ -32,6 +32,13 @@ dependencies = [
     "networkx>=3.2,<4",
     "watchdog>=4.0.0,<6",
 ]
+
+[project.urls]
+Homepage = "https://github.com/tirth8205/code-review-graph"
+Repository = "https://github.com/tirth8205/code-review-graph"
+Documentation = "https://github.com/tirth8205/code-review-graph/blob/main/docs/INDEX.md"
+Changelog = "https://github.com/tirth8205/code-review-graph/blob/main/CHANGELOG.md"
+Issues = "https://github.com/tirth8205/code-review-graph/issues"
 
 [project.scripts]
 code-review-graph = "code_review_graph.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -43,11 +43,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Add project governance files: CLAUDE.md, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md
- Add `[project.urls]` metadata to pyproject.toml for PyPI
- Bump version to 1.8.3 with full CHANGELOG entry

## Test plan
- [x] No code changes — governance/metadata only
- [x] `uv run pytest` still passes (no functional changes)
- [ ] Verify PyPI page shows project URLs after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)