### PR TITLE
feat: add R language parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ On every git commit or file save, a hook fires. The graph diffs changed files, f
 </details>
 
 <details>
-<summary><strong>12 supported languages</strong></summary>
+<summary><strong>13 supported languages</strong></summary>
 <br>
 
-Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++
+Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++, R
 
 Each language has full Tree-sitter grammar support for functions, classes, imports, call sites, inheritance, and test detection.
 
@@ -209,7 +209,7 @@ Claude uses these automatically once the graph is built.
 | Feature | Details |
 |---------|---------|
 | **Incremental updates** | Re-parses only changed files. Subsequent updates complete in under 2 seconds. |
-| **12 languages** | Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++ |
+| **13 languages** | Python, TypeScript, JavaScript, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, C/C++, R |
 | **Blast-radius analysis** | Shows exactly which functions, classes, and files are affected by any change |
 | **Auto-update hooks** | Graph updates on every file edit and git commit without manual intervention |
 | **Semantic search** | Optional vector embeddings via sentence-transformers |

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -73,6 +73,8 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".swift": "swift",
     ".php": "php",
     ".sol": "solidity",
+    ".r": "r",
+    ".R": "r",
 }
 
 # Tree-sitter node type mappings per language
@@ -92,6 +94,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
         "enum_declaration", "struct_declaration",
     ],
     "ruby": ["class", "module"],
+    "r": [],  # Classes detected via call pattern-matching (setClass/setRefClass)
     "kotlin": ["class_declaration", "object_declaration"],
     "swift": ["class_declaration", "struct_declaration", "protocol_declaration"],
     "php": ["class_declaration", "interface_declaration"],
@@ -114,6 +117,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "cpp": ["function_definition"],
     "csharp": ["method_declaration", "constructor_declaration"],
     "ruby": ["method", "singleton_method"],
+    "r": ["function_definition"],
     "kotlin": ["function_declaration"],
     "swift": ["function_declaration"],
     "php": ["function_definition", "method_declaration"],
@@ -139,6 +143,7 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "cpp": ["preproc_include"],
     "csharp": ["using_directive"],
     "ruby": ["call"],  # require/require_relative
+    "r": ["call"],  # library(), require(), source() — filtered downstream
     "kotlin": ["import_header"],
     "swift": ["import_declaration"],
     "php": ["namespace_use_declaration"],
@@ -157,6 +162,7 @@ _CALL_TYPES: dict[str, list[str]] = {
     "cpp": ["call_expression"],
     "csharp": ["invocation_expression", "object_creation_expression"],
     "ruby": ["call", "method_call"],
+    "r": ["call"],
     "kotlin": ["call_expression"],
     "swift": ["call_expression"],
     "php": ["function_call_expression", "member_call_expression"],
@@ -180,6 +186,8 @@ _TEST_FILE_PATTERNS = [
     re.compile(r".*\.spec\.[jt]sx?$"),
     re.compile(r".*_test\.go$"),
     re.compile(r"tests?/"),
+    re.compile(r"test[_-].*\.[rR]$"),
+    re.compile(r"tests/testthat/"),
 ]
 
 
@@ -321,6 +329,26 @@ class CodeParser:
 
         for child in root.children:
             node_type = child.type
+
+            # --- R: function definitions via assignment ---
+            if language == "r" and node_type == "binary_operator":
+                handled = self._handle_r_binary_operator(
+                    child, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names,
+                )
+                if handled:
+                    continue
+
+            # --- R: setClass/setRefClass/setGeneric calls → Class nodes ---
+            if language == "r" and node_type == "call":
+                handled = self._handle_r_call(
+                    child, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names,
+                )
+                if handled:
+                    continue
 
             # --- Classes ---
             if node_type in class_types:
@@ -623,6 +651,18 @@ class CodeParser:
                         break
 
             target_type = target.type
+
+            # R: function names live on the left side of binary_operator
+            if language == "r" and target_type == "binary_operator":
+                r_children = target.children
+                if (
+                    len(r_children) >= 3
+                    and r_children[0].type == "identifier"
+                    and r_children[2].type == "function_definition"
+                ):
+                    name = r_children[0].text.decode("utf-8", errors="replace")
+                    defined_names.add(name)
+                continue
 
             # Collect defined function/class names
             if target_type in func_types or target_type in class_types:
@@ -953,6 +993,26 @@ class CodeParser:
                     val = child.text.decode("utf-8", errors="replace").strip('"')
                     if val:
                         imports.append(val)
+        elif language == "r":
+            # library(pkg), require(pkg), source("file.R")
+            func_name = None
+            for child in node.children:
+                if child.type == "identifier":
+                    func_name = child.text.decode("utf-8", errors="replace")
+                    break
+            if func_name in ("library", "require", "source"):
+                for child in node.children:
+                    if child.type == "arguments":
+                        for arg in child.children:
+                            if arg.type == "argument":
+                                for sub in arg.children:
+                                    if sub.type == "identifier":
+                                        imports.append(sub.text.decode("utf-8", errors="replace"))
+                                    elif sub.type == "string":
+                                        for sc in sub.children:
+                                            if sc.type == "string_content":
+                                                val = sc.text.decode("utf-8", errors="replace")
+                                                imports.append(val)
         elif language == "ruby":
             # require 'module' or require_relative 'path'
             if "require" in text:
@@ -999,4 +1059,278 @@ class CodeParser:
         if first.type in ("scoped_identifier", "qualified_name"):
             return first.text.decode("utf-8", errors="replace")
 
+        # R namespace-qualified call: dplyr::filter()
+        if first.type == "namespace_operator":
+            return first.text.decode("utf-8", errors="replace")
+
         return None
+
+    # ------------------------------------------------------------------
+    # R-specific handlers
+    # ------------------------------------------------------------------
+
+    def _handle_r_binary_operator(
+        self, node, source: bytes, language: str, file_path: str,
+        nodes: list[NodeInfo], edges: list[EdgeInfo],
+        enclosing_class: Optional[str], enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+    ) -> bool:
+        """Handle R binary_operator nodes: name <- function(...) { ... }.
+
+        Returns True if the node was handled (a function definition), False otherwise.
+        """
+        children = node.children
+        if len(children) < 3:
+            return False
+
+        left, op, right = children[0], children[1], children[2]
+        if op.type not in ("<-", "="):
+            return False
+
+        # name <- function(...) { ... }
+        if right.type == "function_definition" and left.type == "identifier":
+            name = left.text.decode("utf-8", errors="replace")
+            is_test = _is_test_function(name, file_path)
+            kind = "Test" if is_test else "Function"
+            qualified = self._qualify(name, file_path, enclosing_class)
+            params = self._get_params(right, language, source)
+
+            nodes.append(NodeInfo(
+                kind=kind,
+                name=name,
+                file_path=file_path,
+                line_start=right.start_point[0] + 1,
+                line_end=right.end_point[0] + 1,
+                language=language,
+                parent_name=enclosing_class,
+                params=params,
+                is_test=is_test,
+            ))
+
+            container = (
+                self._qualify(enclosing_class, file_path, None)
+                if enclosing_class else file_path
+            )
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=container,
+                target=qualified,
+                file_path=file_path,
+                line=right.start_point[0] + 1,
+            ))
+
+            # Recurse into function body for calls
+            self._extract_from_tree(
+                right, source, language, file_path, nodes, edges,
+                enclosing_class=enclosing_class, enclosing_func=name,
+                import_map=import_map, defined_names=defined_names,
+            )
+            return True
+
+        # name <- setRefClass(...) / setClass(...) — handled by _handle_r_call
+        # but the call is wrapped in a binary_operator, so delegate
+        if right.type == "call" and left.type == "identifier":
+            call_func = None
+            for child in right.children:
+                if child.type == "identifier":
+                    call_func = child.text.decode("utf-8", errors="replace")
+                    break
+            if call_func in ("setRefClass", "setClass", "setGeneric"):
+                assign_name = left.text.decode("utf-8", errors="replace")
+                return self._handle_r_class_call(
+                    right, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names,
+                    assign_name=assign_name,
+                )
+
+        return False
+
+    def _handle_r_call(
+        self, node, source: bytes, language: str, file_path: str,
+        nodes: list[NodeInfo], edges: list[EdgeInfo],
+        enclosing_class: Optional[str], enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+    ) -> bool:
+        """Handle R call nodes for imports and class definitions.
+
+        Returns True if the node was fully handled, False to let generic logic proceed.
+        """
+        func_name = None
+        for child in node.children:
+            if child.type == "identifier":
+                func_name = child.text.decode("utf-8", errors="replace")
+                break
+            if child.type == "namespace_operator":
+                # dplyr::filter() — not an import, treat as a regular call
+                func_name = child.text.decode("utf-8", errors="replace")
+                break
+
+        if not func_name:
+            return False
+
+        # Import calls: library(), require(), source()
+        if func_name in ("library", "require", "source"):
+            imports = self._extract_import(node, language, source)
+            for imp_target in imports:
+                edges.append(EdgeInfo(
+                    kind="IMPORTS_FROM",
+                    source=file_path,
+                    target=imp_target,
+                    file_path=file_path,
+                    line=node.start_point[0] + 1,
+                ))
+            return True
+
+        # Bare setRefClass/setClass/setGeneric (without assignment)
+        if func_name in ("setRefClass", "setClass", "setGeneric"):
+            return self._handle_r_class_call(
+                node, source, language, file_path, nodes, edges,
+                enclosing_class, enclosing_func,
+                import_map, defined_names,
+            )
+
+        # Regular call inside a function body → CALLS edge
+        if enclosing_func:
+            call_name = self._get_call_name(node, language, source)
+            if call_name:
+                caller = self._qualify(enclosing_func, file_path, enclosing_class)
+                target = self._resolve_call_target(
+                    call_name, file_path, language,
+                    import_map or {}, defined_names or set(),
+                )
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=caller,
+                    target=target,
+                    file_path=file_path,
+                    line=node.start_point[0] + 1,
+                ))
+
+        # Recurse into call arguments for nested calls
+        self._extract_from_tree(
+            node, source, language, file_path, nodes, edges,
+            enclosing_class=enclosing_class, enclosing_func=enclosing_func,
+            import_map=import_map, defined_names=defined_names,
+        )
+        return True
+
+    def _handle_r_class_call(
+        self, node, source: bytes, language: str, file_path: str,
+        nodes: list[NodeInfo], edges: list[EdgeInfo],
+        enclosing_class: Optional[str], enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        assign_name: Optional[str] = None,
+    ) -> bool:
+        """Handle setClass/setRefClass/setGeneric calls → Class nodes."""
+        # Extract class name from first string argument
+        class_name = None
+        for child in node.children:
+            if child.type == "arguments":
+                for arg in child.children:
+                    if arg.type == "argument":
+                        for sub in arg.children:
+                            if sub.type == "string":
+                                for sc in sub.children:
+                                    if sc.type == "string_content":
+                                        class_name = sc.text.decode("utf-8", errors="replace")
+                                        break
+                        if class_name:
+                            break
+                break
+
+        if not class_name:
+            class_name = assign_name
+        if not class_name:
+            return False
+
+        qualified = self._qualify(class_name, file_path, enclosing_class)
+        nodes.append(NodeInfo(
+            kind="Class",
+            name=class_name,
+            file_path=file_path,
+            line_start=node.start_point[0] + 1,
+            line_end=node.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=file_path,
+            target=qualified,
+            file_path=file_path,
+            line=node.start_point[0] + 1,
+        ))
+
+        # For setRefClass, extract methods
+        for child in node.children:
+            if child.type == "arguments":
+                for arg in child.children:
+                    if arg.type == "argument":
+                        # Look for methods = list(...)
+                        arg_name = None
+                        arg_value = None
+                        for sub in arg.children:
+                            if sub.type == "identifier":
+                                arg_name = sub.text.decode("utf-8", errors="replace")
+                            elif sub.type == "call":
+                                arg_value = sub
+                        if arg_name == "methods" and arg_value is not None:
+                            self._extract_r_methods(
+                                arg_value, source, language, file_path,
+                                nodes, edges, class_name,
+                                import_map, defined_names,
+                            )
+
+        return True
+
+    def _extract_r_methods(
+        self, list_call, source: bytes, language: str, file_path: str,
+        nodes: list[NodeInfo], edges: list[EdgeInfo],
+        class_name: str,
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+    ) -> None:
+        """Extract methods from a setRefClass methods = list(...) call."""
+        for child in list_call.children:
+            if child.type == "arguments":
+                for arg in child.children:
+                    if arg.type == "argument":
+                        method_name = None
+                        func_def = None
+                        for sub in arg.children:
+                            if sub.type == "identifier":
+                                method_name = sub.text.decode("utf-8", errors="replace")
+                            elif sub.type == "function_definition":
+                                func_def = sub
+                        if method_name and func_def:
+                            qualified = self._qualify(method_name, file_path, class_name)
+                            params = self._get_params(func_def, language, source)
+                            nodes.append(NodeInfo(
+                                kind="Function",
+                                name=method_name,
+                                file_path=file_path,
+                                line_start=func_def.start_point[0] + 1,
+                                line_end=func_def.end_point[0] + 1,
+                                language=language,
+                                parent_name=class_name,
+                                params=params,
+                            ))
+                            edges.append(EdgeInfo(
+                                kind="CONTAINS",
+                                source=self._qualify(class_name, file_path, None),
+                                target=qualified,
+                                file_path=file_path,
+                                line=func_def.start_point[0] + 1,
+                            ))
+                            # Recurse into method body for calls
+                            self._extract_from_tree(
+                                func_def, source, language, file_path, nodes, edges,
+                                enclosing_class=class_name,
+                                enclosing_func=method_name,
+                                import_map=import_map,
+                                defined_names=defined_names,
+                            )

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -994,24 +994,16 @@ class CodeParser:
                         imports.append(val)
         elif language == "r":
             # library(pkg), require(pkg), source("file.R")
-            func_name = None
-            for child in node.children:
-                if child.type == "identifier":
-                    func_name = child.text.decode("utf-8", errors="replace")
-                    break
+            func_name = self._r_call_func_name(node)
             if func_name in ("library", "require", "source"):
-                for child in node.children:
-                    if child.type == "arguments":
-                        for arg in child.children:
-                            if arg.type == "argument":
-                                for sub in arg.children:
-                                    if sub.type == "identifier":
-                                        imports.append(sub.text.decode("utf-8", errors="replace"))
-                                    elif sub.type == "string":
-                                        for sc in sub.children:
-                                            if sc.type == "string_content":
-                                                val = sc.text.decode("utf-8", errors="replace")
-                                                imports.append(val)
+                for _name, value in self._r_iter_args(node):
+                    if value.type == "identifier":
+                        imports.append(value.text.decode("utf-8", errors="replace"))
+                    elif value.type == "string":
+                        val = self._r_first_string_arg(node)
+                        if val:
+                            imports.append(val)
+                    break  # Only first argument matters
         elif language == "ruby":
             # require 'module' or require_relative 'path'
             if "require" in text:
@@ -1062,6 +1054,74 @@ class CodeParser:
         if first.type == "namespace_operator":
             return first.text.decode("utf-8", errors="replace")
 
+        return None
+
+    # ------------------------------------------------------------------
+    # R-specific helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _r_call_func_name(call_node) -> Optional[str]:
+        """Extract the function name from an R call node."""
+        for child in call_node.children:
+            if child.type in ("identifier", "namespace_operator"):
+                return child.text.decode("utf-8", errors="replace")
+        return None
+
+    @staticmethod
+    def _r_first_string_arg(call_node) -> Optional[str]:
+        """Extract the first string argument value from an R call node."""
+        for child in call_node.children:
+            if child.type == "arguments":
+                for arg in child.children:
+                    if arg.type == "argument":
+                        for sub in arg.children:
+                            if sub.type == "string":
+                                for sc in sub.children:
+                                    if sc.type == "string_content":
+                                        return sc.text.decode("utf-8", errors="replace")
+                break
+        return None
+
+    @staticmethod
+    def _r_iter_args(call_node):
+        """Yield (name_str, value_node) pairs from an R call's arguments.
+
+        For named arguments like ``methods = list(...)``, yields
+        ``("methods", <call node>)``.  For positional arguments like
+        ``library(dplyr)``, yields ``(None, <identifier/string node>)``.
+        """
+        for child in call_node.children:
+            if child.type != "arguments":
+                continue
+            for arg in child.children:
+                if arg.type != "argument":
+                    continue
+                # Check if this is a named arg (has '=' child)
+                has_eq = any(sub.type == "=" for sub in arg.children)
+                if has_eq:
+                    name = None
+                    value = None
+                    for sub in arg.children:
+                        if sub.type == "identifier" and name is None:
+                            name = sub.text.decode("utf-8", errors="replace")
+                        elif sub.type not in ("=", ","):
+                            value = sub
+                    yield (name, value)
+                else:
+                    # Positional arg — first non-punctuation child is the value
+                    for sub in arg.children:
+                        if sub.type not in (",",):
+                            yield (None, sub)
+                            break
+            break
+
+    @classmethod
+    def _r_find_named_arg(cls, call_node, arg_name: str):
+        """Find a named argument's value node in an R call."""
+        for name, value in cls._r_iter_args(call_node):
+            if name == arg_name:
+                return value
         return None
 
     # ------------------------------------------------------------------
@@ -1127,14 +1187,9 @@ class CodeParser:
             )
             return True
 
-        # name <- setRefClass(...) / setClass(...) — handled by _handle_r_call
-        # but the call is wrapped in a binary_operator, so delegate
+        # name <- setRefClass(...) / setClass(...) — delegate to class handler
         if right.type == "call" and left.type == "identifier":
-            call_func = None
-            for child in right.children:
-                if child.type == "identifier":
-                    call_func = child.text.decode("utf-8", errors="replace")
-                    break
+            call_func = self._r_call_func_name(right)
             if call_func in ("setRefClass", "setClass", "setGeneric"):
                 assign_name = left.text.decode("utf-8", errors="replace")
                 return self._handle_r_class_call(
@@ -1157,16 +1212,7 @@ class CodeParser:
 
         Returns True if the node was fully handled, False to let generic logic proceed.
         """
-        func_name = None
-        for child in node.children:
-            if child.type == "identifier":
-                func_name = child.text.decode("utf-8", errors="replace")
-                break
-            if child.type == "namespace_operator":
-                # dplyr::filter() — not an import, treat as a regular call
-                func_name = child.text.decode("utf-8", errors="replace")
-                break
-
+        func_name = self._r_call_func_name(node)
         if not func_name:
             return False
 
@@ -1225,24 +1271,7 @@ class CodeParser:
         assign_name: Optional[str] = None,
     ) -> bool:
         """Handle setClass/setRefClass/setGeneric calls → Class nodes."""
-        # Extract class name from first string argument
-        class_name = None
-        for child in node.children:
-            if child.type == "arguments":
-                for arg in child.children:
-                    if arg.type == "argument":
-                        for sub in arg.children:
-                            if sub.type == "string":
-                                for sc in sub.children:
-                                    if sc.type == "string_content":
-                                        class_name = sc.text.decode("utf-8", errors="replace")
-                                        break
-                        if class_name:
-                            break
-                break
-
-        if not class_name:
-            class_name = assign_name
+        class_name = self._r_first_string_arg(node) or assign_name
         if not class_name:
             return False
 
@@ -1264,25 +1293,14 @@ class CodeParser:
             line=node.start_point[0] + 1,
         ))
 
-        # For setRefClass, extract methods
-        for child in node.children:
-            if child.type == "arguments":
-                for arg in child.children:
-                    if arg.type == "argument":
-                        # Look for methods = list(...)
-                        arg_name = None
-                        arg_value = None
-                        for sub in arg.children:
-                            if sub.type == "identifier":
-                                arg_name = sub.text.decode("utf-8", errors="replace")
-                            elif sub.type == "call":
-                                arg_value = sub
-                        if arg_name == "methods" and arg_value is not None:
-                            self._extract_r_methods(
-                                arg_value, source, language, file_path,
-                                nodes, edges, class_name,
-                                import_map, defined_names,
-                            )
+        # For setRefClass, extract methods from methods = list(...)
+        methods_list = self._r_find_named_arg(node, "methods")
+        if methods_list is not None:
+            self._extract_r_methods(
+                methods_list, source, language, file_path,
+                nodes, edges, class_name,
+                import_map, defined_names,
+            )
 
         return True
 
@@ -1294,42 +1312,36 @@ class CodeParser:
         defined_names: Optional[set[str]],
     ) -> None:
         """Extract methods from a setRefClass methods = list(...) call."""
-        for child in list_call.children:
-            if child.type == "arguments":
-                for arg in child.children:
-                    if arg.type == "argument":
-                        method_name = None
-                        func_def = None
-                        for sub in arg.children:
-                            if sub.type == "identifier":
-                                method_name = sub.text.decode("utf-8", errors="replace")
-                            elif sub.type == "function_definition":
-                                func_def = sub
-                        if method_name and func_def:
-                            qualified = self._qualify(method_name, file_path, class_name)
-                            params = self._get_params(func_def, language, source)
-                            nodes.append(NodeInfo(
-                                kind="Function",
-                                name=method_name,
-                                file_path=file_path,
-                                line_start=func_def.start_point[0] + 1,
-                                line_end=func_def.end_point[0] + 1,
-                                language=language,
-                                parent_name=class_name,
-                                params=params,
-                            ))
-                            edges.append(EdgeInfo(
-                                kind="CONTAINS",
-                                source=self._qualify(class_name, file_path, None),
-                                target=qualified,
-                                file_path=file_path,
-                                line=func_def.start_point[0] + 1,
-                            ))
-                            # Recurse into method body for calls
-                            self._extract_from_tree(
-                                func_def, source, language, file_path, nodes, edges,
-                                enclosing_class=class_name,
-                                enclosing_func=method_name,
-                                import_map=import_map,
-                                defined_names=defined_names,
-                            )
+        for method_name, func_def in self._r_iter_args(list_call):
+            if not method_name or func_def is None:
+                continue
+            if func_def.type != "function_definition":
+                continue
+
+            qualified = self._qualify(method_name, file_path, class_name)
+            params = self._get_params(func_def, language, source)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=method_name,
+                file_path=file_path,
+                line_start=func_def.start_point[0] + 1,
+                line_end=func_def.end_point[0] + 1,
+                language=language,
+                parent_name=class_name,
+                params=params,
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=self._qualify(class_name, file_path, None),
+                target=qualified,
+                file_path=file_path,
+                line=func_def.start_point[0] + 1,
+            ))
+            # Recurse into method body for calls
+            self._extract_from_tree(
+                func_def, source, language, file_path, nodes, edges,
+                enclosing_class=class_name,
+                enclosing_func=method_name,
+                import_map=import_map,
+                defined_names=defined_names,
+            )

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -73,8 +73,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".swift": "swift",
     ".php": "php",
     ".sol": "solidity",
-    ".r": "r",
-    ".R": "r",
+    ".r": "r",  # .lower() in detect_language handles .R → .r
 }
 
 # Tree-sitter node type mappings per language
@@ -662,7 +661,7 @@ class CodeParser:
                 ):
                     name = r_children[0].text.decode("utf-8", errors="replace")
                     defined_names.add(name)
-                continue
+                    continue
 
             # Collect defined function/class names
             if target_type in func_types or target_type in class_types:

--- a/docs/superpowers/specs/2026-03-20-r-language-notebook-support-design.md
+++ b/docs/superpowers/specs/2026-03-20-r-language-notebook-support-design.md
@@ -1,0 +1,226 @@
+# R Language + Jupyter Notebook Support
+
+**Date**: 2026-03-20
+**Status**: Proposed
+
+## Overview
+
+Add R language parsing and Jupyter notebook (.ipynb) support to code-review-graph. R support includes functions, S4/R5 classes, imports, and calls. Notebook support extracts code cells from .ipynb files and parses them with the existing Python parser.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| R class support level | S4/R5 via `setClass`/`setRefClass` | Covers formal OO; S3 too heuristic-dependent |
+| R import handling | `_IMPORT_TYPES["r"] = ["call"]` with filtering | Follows Ruby precedent in the codebase |
+| Notebook parsing strategy | Concatenate code cells, parse as single source | Reuses existing Python parser; offset tracking maps back to cells |
+| Notebook line reporting | Concatenated line numbers + `cell_index` in `extra` | Keeps schema uniform; cell-aware consumers use `extra` |
+| Notebook language scope | Python only (phase 1) | Databricks multi-language support deferred to phase 2 |
+| Databricks multi-language | Phase 2 follow-up | Multi-language cell routing and SQL table detection are non-trivial scope expansions |
+
+## R Language Support
+
+### File Extensions
+
+`.r`, `.R` map to language `"r"` in `EXTENSION_TO_LANGUAGE`.
+
+### Type Mappings
+
+```python
+_CLASS_TYPES["r"] = []  # Classes detected via call pattern-matching, not AST node types
+_FUNCTION_TYPES["r"] = ["function_definition"]
+_IMPORT_TYPES["r"] = ["call"]  # library(), require(), source() — filtered downstream
+_CALL_TYPES["r"] = ["call"]
+```
+
+### Function Extraction
+
+R functions are defined via assignment: `name <- function(x, y) { ... }`. Tree-sitter parses this as:
+
+```
+binary_operator
+  identifier ("name")
+  <-
+  function_definition
+    parameters (...)
+    braced_expression { ... }
+```
+
+The `function_definition` node is listed in `_FUNCTION_TYPES["r"]`, but it has no `identifier` child — the name lives on the left side of the enclosing `binary_operator`. Special handling in `_extract_from_tree`:
+
+1. When visiting a `binary_operator` node in R, check if the right child is a `function_definition`
+2. If so, extract the name from the left child (identifier)
+3. Emit a `Function` node using the `function_definition` child's span for line numbers
+4. Recurse into the function body for nested calls
+
+Also handle `=` assignment (`name = function(...)`) — tree-sitter parses this identically as `binary_operator` with `=` instead of `<-`.
+
+### S4/R5 Class Detection
+
+Pattern-match on `call` nodes where the function name is `setClass`, `setRefClass`, or `setGeneric`:
+
+- Extract the class/generic name from the first string argument
+- Emit a `Class` kind node
+- For `setRefClass`, the `methods` argument contains `function_definition` nodes — recurse into these as methods with `enclosing_class` set
+
+Example:
+```r
+MyClass <- setRefClass("MyClass",
+  fields = list(name = "character"),
+  methods = list(
+    greet = function() { cat(paste("Hello", name)) }
+  )
+)
+```
+
+Produces:
+- `Class` node: `MyClass`
+- `Function` node: `greet` with `parent_name = "MyClass"`
+
+### Import Extraction
+
+`_IMPORT_TYPES["r"] = ["call"]` means all `call` nodes are candidates. Filter in `_extract_import` and `_collect_import_names`:
+
+| R Call | Import Target |
+|--------|--------------|
+| `library(dplyr)` | `"dplyr"` |
+| `require(ggplot2)` | `"ggplot2"` |
+| `source("utils.R")` | `"utils.R"` |
+
+Extract the first argument. For `library`/`require`, the argument is typically an unquoted identifier. For `source`, it's a string.
+
+Non-import `call` nodes are ignored by the import extraction path (filtered by function name).
+
+### Call Extraction
+
+`_CALL_TYPES["r"] = ["call"]`. The existing `_get_call_name` handles simple `identifier` first-child calls (covers `func(args)`).
+
+R namespace-qualified calls use `::` operator: `dplyr::filter(data, x > 5)`. Tree-sitter parses this with a `namespace_operator` node. Add a branch in `_get_call_name`:
+
+```
+call
+  namespace_operator
+    identifier ("dplyr")
+    ::
+    identifier ("filter")
+  arguments (...)
+```
+
+Extract as `"dplyr::filter"` — take the full text of the `namespace_operator` node.
+
+### Test Detection
+
+R's testthat framework uses:
+- Files named `test-*.R` or `test_*.R` in a `tests/testthat/` directory
+- `test_that("description", { ... })` calls
+
+Add to `_TEST_FILE_PATTERNS`:
+```python
+re.compile(r"test[_-].*\.[rR]$"),
+re.compile(r"tests/testthat/"),
+```
+
+Add to `_TEST_PATTERNS` or handle in `_is_test_function`: detect functions defined inside `test_that()` calls, or flag the `test_that` call itself.
+
+## Jupyter Notebook Support (.ipynb)
+
+### Detection
+
+Add `".ipynb": "notebook"` to `EXTENSION_TO_LANGUAGE`.
+
+### Parsing Flow
+
+New `_parse_notebook` method called from `parse_bytes` when language is `"notebook"`:
+
+1. **Parse JSON**: `json.loads(source)` to get the notebook structure
+2. **Check kernel language**: Read `metadata.kernelspec.language` (or `metadata.language_info.name`). If not `"python"`, return empty (phase 1 — Python only)
+3. **Extract code cells**: Iterate `cells` array, collect cells where `cell_type == "code"`
+4. **Filter magic commands**: Skip lines starting with `%` or `!` (IPython magics, shell commands)
+5. **Concatenate with offset tracking**: Join cell sources with single blank line separators. Build a mapping: `[(cell_index, start_line, end_line), ...]`
+6. **Parse concatenated source**: Pass to `_get_parser("python")` and run `_extract_from_tree` as normal
+7. **Post-process nodes**: For each `NodeInfo`, look up which cell it belongs to via the offset mapping. Set `extra["cell_index"]` to the 0-based cell index
+
+### Line Offset Mapping
+
+```python
+# Example: 3 code cells with 5, 3, 8 lines
+# Cell 0: lines 1-5    (concat lines 1-5)
+# Cell 1: lines 1-3    (concat lines 7-9, after 1 blank separator)
+# Cell 2: lines 1-8    (concat lines 11-18)
+
+cell_offsets = [
+    (0, 1, 5),    # (cell_index, concat_start, concat_end)
+    (1, 7, 9),
+    (2, 11, 18),
+]
+```
+
+### Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Magic commands (`%pip`, `%matplotlib`, `!ls`) | Skip lines starting with `%` or `!` |
+| Empty notebooks / no code cells | Return just the File node |
+| Malformed JSON | Return empty `([], [])` |
+| Missing kernel metadata | Default to Python |
+| Markdown cells | Skipped (code cells only) |
+| Raw cells | Skipped |
+
+### File Node
+
+The notebook gets a single `File` node with:
+- `kind = "File"`
+- `name = "<path>.ipynb"`
+- `language = "python"` (the actual parsing language, not `"notebook"`)
+
+## Test Plan
+
+### R Language Tests (`tests/test_multilang.py`)
+
+New `TestRParsing` class following the existing pattern:
+
+| Test | Assertion |
+|------|-----------|
+| `test_detects_language` | `.r` and `.R` map to `"r"` |
+| `test_finds_functions` | Detects `add`, `multiply` (both `<-` and `=` assignment) |
+| `test_finds_s4_classes` | Detects `MyClass` from `setRefClass` |
+| `test_finds_class_methods` | Detects `greet` with `parent_name = "MyClass"` |
+| `test_finds_imports` | Detects `library(dplyr)`, `require(ggplot2)`, `source("utils.R")` |
+| `test_finds_calls` | Detects function calls including `dplyr::filter` |
+| `test_finds_params` | Parameters extracted from function definitions |
+| `test_detects_test_functions` | testthat patterns detected |
+
+### Notebook Tests (`tests/test_notebook.py`)
+
+| Test | Assertion |
+|------|-----------|
+| `test_detects_notebook` | `.ipynb` maps to `"notebook"` |
+| `test_parses_python_notebook` | Extracts functions/classes from code cells |
+| `test_cell_index_tracking` | `extra["cell_index"]` correctly maps to source cell |
+| `test_cross_cell_calls` | CALLS edges connect functions across cells |
+| `test_imports_from_cells` | Import statements in cells produce IMPORTS_FROM edges |
+| `test_skips_magic_commands` | `%pip`, `!ls` lines don't break parsing |
+| `test_empty_notebook` | Returns only File node |
+| `test_non_python_kernel` | Non-Python notebooks return empty |
+
+### Test Fixtures
+
+- `tests/fixtures/sample.R` — R code exercising all detected constructs
+- `tests/fixtures/sample_notebook.ipynb` — Python notebook with multiple code cells, imports, functions, cross-cell calls, and magic commands
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `code_review_graph/parser.py` | Extension mapping, type dicts, R-specific extraction in `_extract_from_tree`, `_extract_import`, `_collect_import_names`, `_get_call_name`; new `_parse_notebook` method; notebook handling in `parse_bytes` |
+| `tests/test_multilang.py` | New `TestRParsing` class |
+| `tests/test_notebook.py` (new) | Notebook parsing tests |
+| `tests/fixtures/sample.R` (new) | R test fixture |
+| `tests/fixtures/sample_notebook.ipynb` (new) | Notebook test fixture |
+
+## Future Work (Phase 2)
+
+- Databricks multi-language notebooks: route cells to per-language parsers based on `%sql`, `%r`, `%python` magic prefixes
+- SQL cell support: extract table references as `DEPENDS_ON` edges
+- R notebook support: use R parser for IRkernel notebooks
+- S3 class heuristics (if demand warrants)

--- a/tests/fixtures/sample.R
+++ b/tests/fixtures/sample.R
@@ -1,0 +1,30 @@
+library(dplyr)
+require(ggplot2)
+source("utils.R")
+
+add <- function(x, y) {
+  x + y
+}
+
+multiply = function(a, b) {
+  a * b
+}
+
+MyClass <- setRefClass("MyClass",
+  fields = list(name = "character", age = "numeric"),
+  methods = list(
+    greet = function() {
+      cat(paste("Hello", name))
+    },
+    get_age = function() {
+      return(age)
+    }
+  )
+)
+
+process_data <- function(data) {
+  result <- dplyr::filter(data, x > 5)
+  summary <- dplyr::summarize(result, mean_x = mean(x))
+  add(1, 2)
+  summary
+}

--- a/tests/fixtures/test_sample.R
+++ b/tests/fixtures/test_sample.R
@@ -1,0 +1,9 @@
+library(testthat)
+
+test_that("addition works", {
+  expect_equal(add(1, 2), 3)
+})
+
+test_add <- function() {
+  stopifnot(add(1, 2) == 3)
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -518,3 +518,14 @@ class TestRParsing:
         assert "multiply" in targets
         assert "MyClass" in targets
         assert "MyClass.greet" in targets
+
+    def test_detects_test_functions(self):
+        parser = CodeParser()
+        nodes, _edges = parser.parse_file(FIXTURES / "test_sample.R")
+        # File should be detected as a test file
+        file_node = [n for n in nodes if n.kind == "File"][0]
+        assert file_node.is_test is True
+        # test_add should be detected as a test function
+        test_funcs = [n for n in nodes if n.is_test and n.kind == "Test"]
+        names = {f.name for f in test_funcs}
+        assert "test_add" in names

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -463,3 +463,58 @@ class TestSolidityParsing:
             if n.kind == "Function" and n.parent_name == "RewardMath"
         }
         assert "uint256" in funcs["mulPrecise"].return_type
+
+
+class TestRParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.R")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("script.r")) == "r"
+        assert self.parser.detect_language(Path("script.R")) == "r"
+
+    def test_finds_functions(self):
+        funcs = [n for n in self.nodes if n.kind == "Function" and n.parent_name is None]
+        names = {f.name for f in funcs}
+        assert "add" in names
+        assert "multiply" in names
+        assert "process_data" in names
+
+    def test_finds_s4_classes(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "MyClass" in names
+
+    def test_finds_class_methods(self):
+        methods = [n for n in self.nodes if n.kind == "Function" and n.parent_name == "MyClass"]
+        names = {m.name for m in methods}
+        assert "greet" in names
+        assert "get_age" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "dplyr" in targets
+        assert "ggplot2" in targets
+        assert "utils.R" in targets
+
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert "dplyr::filter" in targets
+        assert "dplyr::summarize" in targets
+
+    def test_finds_params(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        assert funcs["add"].params is not None
+        assert "x" in funcs["add"].params
+        assert "y" in funcs["add"].params
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target.split("::")[-1] for e in contains}
+        assert "add" in targets
+        assert "multiply" in targets
+        assert "MyClass" in targets
+        assert "MyClass.greet" in targets


### PR DESCRIPTION
## Summary
- Add tree-sitter based R language parsing: functions (via `<-`/`=` assignment), S4/R5 classes (`setClass`/`setRefClass`/`setGeneric`), imports (`library`/`require`/`source`), namespace-qualified calls (`dplyr::filter`), and testthat test detection
- R-specific helpers (`_r_call_func_name`, `_r_first_string_arg`, `_r_iter_args`, `_r_find_named_arg`) keep AST traversal flat and readable
- Dedicated handlers: `_handle_r_binary_operator`, `_handle_r_call`, `_handle_r_class_call`, `_extract_r_methods`
- Update README to list R as 14th supported language (alongside Vue from #40)
- Include design spec, test fixtures (`sample.R`, `test_sample.R`), and 9 tests in `TestRParsing`

## Test Plan
- [x] All 9 R parsing tests pass (language detection, functions, classes, methods, imports, calls, params, contains, test detection)
- [x] All 191 tests pass (no regressions, includes upstream Vue + security changes)
- [x] Ruff lint clean