### PR TITLE
Add MiniMax embo-01 as third embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Claude uses these automatically once the graph is built.
 | **14 languages** | Python, TypeScript, JavaScript, Vue, Go, Rust, Java, C#, Ruby, Kotlin, Swift, PHP, Solidity, C/C++ |
 | **Blast-radius analysis** | Shows exactly which functions, classes, and files are affected by any change |
 | **Auto-update hooks** | Graph updates on every file edit and git commit without manual intervention |
-| **Semantic search** | Optional vector embeddings via sentence-transformers |
+| **Semantic search** | Optional vector embeddings via sentence-transformers, Google Gemini, or [MiniMax](https://www.minimaxi.com/) |
 | **Interactive visualisation** | D3.js force-directed graph with edge-type toggles and search |
 | **Local storage** | SQLite file in `.code-review-graph/`. No external database, no cloud dependency. |
 | **Watch mode** | Continuous graph updates as you work |
@@ -235,6 +235,17 @@ For semantic search, install the optional embeddings dependencies:
 
 ```bash
 pip install code-review-graph[embeddings]
+```
+
+Alternatively, use a cloud embedding provider:
+
+```bash
+# Google Gemini embeddings
+pip install code-review-graph[google-embeddings]
+export GOOGLE_API_KEY=your-key
+
+# MiniMax embo-01 embeddings (1536 dimensions, no extra dependency needed)
+export MINIMAX_API_KEY=your-key
 ```
 
 </details>

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -3,6 +3,7 @@
 Supports multiple providers:
 1. Local (sentence-transformers) - Private, fast, offline.
 2. Google Gemini - High-quality, cloud-based. Requires explicit opt-in.
+3. MiniMax (embo-01) - High-quality 1536-dim cloud embeddings. Requires MINIMAX_API_KEY.
 """
 
 from __future__ import annotations
@@ -153,12 +154,102 @@ class GoogleEmbeddingProvider(EmbeddingProvider):
         return f"google:{self.model}"
 
 
+class MiniMaxEmbeddingProvider(EmbeddingProvider):
+    """MiniMax embo-01 embedding provider (1536 dimensions).
+
+    Uses the MiniMax Embeddings API (https://api.minimax.io/v1/embeddings)
+    with the embo-01 model. Supports distinct task types for indexing ("db")
+    and search queries ("query").
+
+    Requires the MINIMAX_API_KEY environment variable.
+    """
+
+    _ENDPOINT = "https://api.minimax.io/v1/embeddings"
+    _MODEL = "embo-01"
+    _DIMENSION = 1536
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def _call_api(self, texts: list[str], task_type: str) -> list[list[float]]:
+        """Call the MiniMax embedding API.
+
+        Args:
+            texts: List of texts to embed.
+            task_type: "db" for indexing, "query" for search queries.
+        """
+        import json as _json
+        import urllib.request
+
+        payload = _json.dumps({
+            "model": self._MODEL,
+            "texts": texts,
+            "type": task_type,
+        }).encode("utf-8")
+
+        req = urllib.request.Request(
+            self._ENDPOINT,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._api_key}",
+            },
+        )
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    body = _json.loads(resp.read().decode("utf-8"))
+
+                base_resp = body.get("base_resp", {})
+                if base_resp.get("status_code", 0) != 0:
+                    raise RuntimeError(
+                        f"MiniMax API error: {base_resp.get('status_msg', 'unknown')}"
+                    )
+
+                return body["vectors"]
+            except Exception as e:
+                err_str = str(e)
+                is_retryable = "429" in err_str or "500" in err_str or "503" in err_str
+                if not is_retryable or attempt == max_retries - 1:
+                    raise
+                wait = 2 ** attempt
+                logger.warning(
+                    "MiniMax API error (attempt %d/%d), retrying in %ds: %s",
+                    attempt + 1, max_retries, wait, e,
+                )
+                time.sleep(wait)
+
+        return []  # unreachable, but keeps mypy happy
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        batch_size = 100
+        results: list[list[float]] = []
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i:i + batch_size]
+            results.extend(self._call_api(batch, "db"))
+        return results
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._call_api([text], "query")[0]
+
+    @property
+    def dimension(self) -> int:
+        return self._DIMENSION
+
+    @property
+    def name(self) -> str:
+        return f"minimax:{self._MODEL}"
+
+
 def get_provider(provider: str | None = None) -> EmbeddingProvider | None:
     """Get an embedding provider by name.
 
     Args:
-        provider: Provider name. One of "local", "google", or None for local.
+        provider: Provider name. One of "local", "google", "minimax", or None for local.
                   Google requires GOOGLE_API_KEY env var and explicit opt-in.
+                  MiniMax requires MINIMAX_API_KEY env var and explicit opt-in.
     """
     if provider == "google":
         api_key = os.environ.get("GOOGLE_API_KEY")
@@ -171,6 +262,15 @@ def get_provider(provider: str | None = None) -> EmbeddingProvider | None:
             return GoogleEmbeddingProvider(api_key=api_key)
         except ImportError:
             return None
+
+    if provider == "minimax":
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "MINIMAX_API_KEY environment variable is required for "
+                "the MiniMax embedding provider."
+            )
+        return MiniMaxEmbeddingProvider(api_key=api_key)
 
     # Default: local
     try:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,13 +1,18 @@
 """Tests for the embeddings module."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from code_review_graph.embeddings import (
     EmbeddingStore,
+    MiniMaxEmbeddingProvider,
     _cosine_similarity,
     _decode_vector,
     _encode_vector,
     _node_to_text,
+    get_provider,
 )
 from code_review_graph.graph import GraphNode
 
@@ -133,3 +138,232 @@ class TestEmbeddingStore:
             # Should not raise even if node doesn't exist
             store.remove_node("nonexistent::func")
             store.close()
+
+
+class TestMiniMaxEmbeddingProvider:
+    """Unit tests for MiniMaxEmbeddingProvider."""
+
+    def test_name(self):
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        assert provider.name == "minimax:embo-01"
+
+    def test_dimension(self):
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        assert provider.dimension == 1536
+
+    def test_embed_calls_api_with_db_type(self):
+        """embed() should call the API with type='db' for indexing."""
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        mock_vectors = [[0.1] * 1536, [0.2] * 1536]
+        mock_response = json.dumps({
+            "vectors": mock_vectors,
+            "total_tokens": 10,
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode("utf-8")
+
+        mock_resp_obj = MagicMock()
+        mock_resp_obj.read.return_value = mock_response
+        mock_resp_obj.__enter__ = MagicMock(return_value=mock_resp_obj)
+        mock_resp_obj.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp_obj) as mock_urlopen:
+            result = provider.embed(["hello", "world"])
+
+        assert len(result) == 2
+        assert len(result[0]) == 1536
+        # Verify the request payload
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        payload = json.loads(req.data.decode("utf-8"))
+        assert payload["type"] == "db"
+        assert payload["model"] == "embo-01"
+        assert payload["texts"] == ["hello", "world"]
+
+    def test_embed_query_calls_api_with_query_type(self):
+        """embed_query() should call the API with type='query' for search."""
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        mock_vectors = [[0.5] * 1536]
+        mock_response = json.dumps({
+            "vectors": mock_vectors,
+            "total_tokens": 5,
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode("utf-8")
+
+        mock_resp_obj = MagicMock()
+        mock_resp_obj.read.return_value = mock_response
+        mock_resp_obj.__enter__ = MagicMock(return_value=mock_resp_obj)
+        mock_resp_obj.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp_obj) as mock_urlopen:
+            result = provider.embed_query("search term")
+
+        assert len(result) == 1536
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        payload = json.loads(req.data.decode("utf-8"))
+        assert payload["type"] == "query"
+        assert payload["texts"] == ["search term"]
+
+    def test_embed_sets_authorization_header(self):
+        """API calls should include the Bearer token."""
+        provider = MiniMaxEmbeddingProvider(api_key="sk-test-123")
+        mock_response = json.dumps({
+            "vectors": [[0.1] * 1536],
+            "total_tokens": 1,
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode("utf-8")
+
+        mock_resp_obj = MagicMock()
+        mock_resp_obj.read.return_value = mock_response
+        mock_resp_obj.__enter__ = MagicMock(return_value=mock_resp_obj)
+        mock_resp_obj.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp_obj) as mock_urlopen:
+            provider.embed_query("test")
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer sk-test-123"
+
+    def test_embed_api_error_raises(self):
+        """Non-zero status_code in base_resp should raise RuntimeError."""
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        mock_response = json.dumps({
+            "vectors": [],
+            "base_resp": {"status_code": 1001, "status_msg": "invalid api key"},
+        }).encode("utf-8")
+
+        mock_resp_obj = MagicMock()
+        mock_resp_obj.read.return_value = mock_response
+        mock_resp_obj.__enter__ = MagicMock(return_value=mock_resp_obj)
+        mock_resp_obj.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp_obj):
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                provider.embed_query("test")
+
+    def test_embed_batches_large_input(self):
+        """Inputs larger than batch_size=100 should be split into batches."""
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+        texts = [f"text_{i}" for i in range(150)]
+
+        call_count = 0
+
+        def mock_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            payload = json.loads(req.data.decode("utf-8"))
+            n = len(payload["texts"])
+            mock_response = json.dumps({
+                "vectors": [[0.1] * 1536] * n,
+                "total_tokens": n,
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }).encode("utf-8")
+            resp = MagicMock()
+            resp.read.return_value = mock_response
+            resp.__enter__ = MagicMock(return_value=resp)
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            result = provider.embed(texts)
+
+        assert len(result) == 150
+        assert call_count == 2  # 100 + 50
+
+    def test_embed_retries_on_429(self):
+        """Should retry on rate-limit (429) errors."""
+        provider = MiniMaxEmbeddingProvider(api_key="test-key")
+
+        attempt = 0
+
+        def mock_urlopen(req, timeout=None):
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                raise Exception("HTTP Error 429: Too Many Requests")
+            mock_response = json.dumps({
+                "vectors": [[0.1] * 1536],
+                "total_tokens": 1,
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }).encode("utf-8")
+            resp = MagicMock()
+            resp.read.return_value = mock_response
+            resp.__enter__ = MagicMock(return_value=resp)
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+            with patch("time.sleep"):  # Skip actual sleep
+                result = provider.embed_query("test")
+
+        assert len(result) == 1536
+        assert attempt == 2
+
+    def test_embed_no_retry_on_auth_error(self):
+        """Should NOT retry on authentication errors (non-retryable)."""
+        provider = MiniMaxEmbeddingProvider(api_key="bad-key")
+
+        with patch("urllib.request.urlopen", side_effect=Exception("HTTP Error 401: Unauthorized")):
+            with pytest.raises(Exception, match="401"):
+                provider.embed_query("test")
+
+
+class TestGetProviderMiniMax:
+    """Tests for get_provider() with MiniMax."""
+
+    def test_get_provider_minimax_with_key(self):
+        with patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"}):
+            provider = get_provider("minimax")
+        assert isinstance(provider, MiniMaxEmbeddingProvider)
+        assert provider.name == "minimax:embo-01"
+
+    def test_get_provider_minimax_without_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+                get_provider("minimax")
+
+    def test_get_provider_none_returns_local(self):
+        """Default provider (None) should attempt local."""
+        # We just verify it doesn't return MiniMax
+        result = get_provider(None)
+        if result is not None:
+            assert "minimax" not in result.name
+
+    def test_get_provider_unknown_falls_to_local(self):
+        """Unknown provider name should fall through to local."""
+        result = get_provider("unknown_provider")
+        # Should try local (may return None if sentence-transformers not installed)
+        if result is not None:
+            assert "minimax" not in result.name
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax embedding provider (require MINIMAX_API_KEY)."""
+
+    @pytest.fixture
+    def api_key(self):
+        import os
+        key = os.environ.get("MINIMAX_API_KEY")
+        if not key:
+            pytest.skip("MINIMAX_API_KEY not set")
+        return key
+
+    def test_embed_single_text(self, api_key):
+        provider = MiniMaxEmbeddingProvider(api_key=api_key)
+        result = provider.embed(["hello world"])
+        assert len(result) == 1
+        assert len(result[0]) == 1536
+        assert all(isinstance(v, float) for v in result[0])
+
+    def test_embed_query_returns_vector(self, api_key):
+        provider = MiniMaxEmbeddingProvider(api_key=api_key)
+        result = provider.embed_query("search for functions")
+        assert len(result) == 1536
+        assert all(isinstance(v, float) for v in result)
+
+    def test_embed_multiple_texts(self, api_key):
+        provider = MiniMaxEmbeddingProvider(api_key=api_key)
+        result = provider.embed(["hello", "world", "test"])
+        assert len(result) == 3
+        for vec in result:
+            assert len(vec) == 1536


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com/) embo-01 as the third embedding provider for semantic code search, alongside the existing Local (sentence-transformers) and Google Gemini providers.

### Key changes:
- **`MiniMaxEmbeddingProvider`** class in `embeddings.py` — calls the MiniMax Embeddings API (`https://api.minimax.io/v1/embeddings`) with the `embo-01` model (1536 dimensions)
- **Zero extra dependencies** — uses Python stdlib `urllib.request`, no new packages needed
- **Distinct task types**: `type="db"` for indexing, `type="query"` for search queries (matches the MiniMax API spec)
- **Retry with exponential backoff** for rate-limit (429) and server errors (500/503)
- **Factory registration**: `get_provider("minimax")` with `MINIMAX_API_KEY` env var auto-detection
- **README update**: documents the MiniMax provider alongside Google Gemini

## Test plan
- [x] 13 new unit tests covering provider properties, API call format, auth header, batching, retry, error handling, and factory registration
- [x] 3 integration tests (require `MINIMAX_API_KEY` env var, skip when not set)
- [x] All 30 unit tests pass (`pytest tests/test_embeddings.py -k 'not Integration'`)
- [x] Existing tests unaffected
- [x] `ruff check` passes with no issues

### Usage
```bash
export MINIMAX_API_KEY=your-key
# Then use provider="minimax" in EmbeddingStore or get_provider("minimax")
```