### PR TITLE
feat(parser): add Dart language support

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -74,6 +74,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".php": "php",
     ".sol": "solidity",
     ".vue": "vue",
+    ".dart": "dart",
 }
 
 # Tree-sitter node type mappings per language
@@ -101,6 +102,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
         "struct_declaration", "enum_declaration", "error_declaration",
         "user_defined_type_definition",
     ],
+    "dart": ["class_definition", "mixin_declaration", "enum_declaration"],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -126,6 +128,11 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
         "function_definition", "constructor_definition", "modifier_definition",
         "event_definition", "fallback_receive_definition",
     ],
+    # Dart: function_signature covers both top-level functions and class methods
+    # (class methods appear as method_signature > function_signature pairs;
+    # the parser recurses into method_signature generically and then matches
+    # function_signature inside it).
+    "dart": ["function_signature"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -144,6 +151,8 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "swift": ["import_declaration"],
     "php": ["namespace_use_declaration"],
     "solidity": ["import_directive"],
+    # Dart: import_or_export wraps library_import > import_specification > configurable_uri
+    "dart": ["import_or_export"],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -181,6 +190,7 @@ _TEST_FILE_PATTERNS = [
     re.compile(r".*\.spec\.[jt]sx?$"),
     re.compile(r".*_test\.go$"),
     re.compile(r"tests?/"),
+    re.compile(r".*_test\.dart$"),
 ]
 
 
@@ -924,6 +934,17 @@ class CodeParser:
                         if target.is_file():
                             return str(target.resolve())
 
+        elif language == "dart":
+            if module.startswith("."):
+                # Dart relative imports include the .dart extension
+                base = caller_dir / module
+                if base.is_file():
+                    return str(base.resolve())
+                # Fallback: try appending .dart
+                target = base.with_suffix(".dart")
+                if target.is_file():
+                    return str(target.resolve())
+
         return None
 
     def _resolve_call_target(
@@ -953,6 +974,13 @@ class CodeParser:
 
     def _get_name(self, node, language: str, kind: str) -> Optional[str]:
         """Extract the name from a class/function definition node."""
+        # Dart: function_signature has a return-type node before the identifier;
+        # search only for 'identifier' to avoid returning the return type name.
+        if language == "dart" and node.type == "function_signature":
+            for child in node.children:
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
+            return None
         # Solidity: constructor and receive/fallback have no identifier child
         if language == "solidity":
             if node.type == "constructor_definition":
@@ -986,7 +1014,7 @@ class CodeParser:
     def _get_params(self, node, language: str, source: bytes) -> Optional[str]:
         """Extract parameter list as a string."""
         for child in node.children:
-            if child.type in ("parameters", "formal_parameters", "parameter_list"):
+            if child.type in ("parameters", "formal_parameters", "parameter_list", "formal_parameter_list"):
                 return child.text.decode("utf-8", errors="replace")
         # Solidity: parameters are direct children between ( and )
         if language == "solidity":
@@ -1064,6 +1092,23 @@ class CodeParser:
                                     for f in field_node.children:
                                         if f.type == "type_identifier":
                                             bases.append(f.text.decode("utf-8", errors="replace"))
+        elif language == "dart":
+            # class Foo extends Bar with Mixin implements Iface { ... }
+            # AST: superclass contains type_identifier (base) and mixins (with clause);
+            #      interfaces is a sibling of superclass.
+            for child in node.children:
+                if child.type == "superclass":
+                    for sub in child.children:
+                        if sub.type == "type_identifier":
+                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                        elif sub.type == "mixins":
+                            for m in sub.children:
+                                if m.type == "type_identifier":
+                                    bases.append(m.text.decode("utf-8", errors="replace"))
+                elif child.type == "interfaces":
+                    for sub in child.children:
+                        if sub.type == "type_identifier":
+                            bases.append(sub.text.decode("utf-8", errors="replace"))
         return bases
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:
@@ -1129,6 +1174,21 @@ class CodeParser:
                 match = re.search(r"""['"](.*?)['"]""", text)
                 if match:
                     imports.append(match.group(1))
+        elif language == "dart":
+            # import 'dart:async' or import 'package:flutter/material.dart'
+            # Node structure: import_or_export > library_import > import_specification
+            #                 > configurable_uri > uri > string_literal
+            def _find_string_literal(n) -> Optional[str]:
+                if n.type == "string_literal":
+                    return n.text.decode("utf-8", errors="replace").strip("'\"")
+                for c in n.children:
+                    result = _find_string_literal(c)
+                    if result is not None:
+                        return result
+                return None
+            val = _find_string_literal(node)
+            if val:
+                imports.append(val)
         else:
             # Fallback: just record the text
             imports.append(text)

--- a/tests/fixtures/sample.dart
+++ b/tests/fixtures/sample.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+abstract class Animal {
+  String get name;
+  void speak();
+}
+
+mixin SwimmingMixin {
+  void swim() => print('swimming');
+}
+
+enum PetType { dog, cat, bird }
+
+class Dog extends Animal with SwimmingMixin {
+  final String name;
+  final PetType type;
+
+  Dog(this.name) : type = PetType.dog;
+
+  @override
+  void speak() {
+    print('Woof! I am $name');
+  }
+
+  Future<void> fetch(String item) async {
+    await _run();
+    print('Fetched $item');
+  }
+
+  void _run() {
+    print('running');
+  }
+
+  static Dog create(String name) {
+    return Dog(name);
+  }
+}
+
+Dog createDog(String name) {
+  return Dog(name);
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -273,3 +273,73 @@ class TestCodeParser:
         funcs = [n for n in nodes if n.kind == "Function"]
         func_names = {f.name for f in funcs}
         assert "greet" in func_names
+
+    # --- Dart tests ---
+
+    def test_detect_language_dart(self):
+        assert self.parser.detect_language(Path("main.dart")) == "dart"
+
+    def test_parse_dart_file(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+
+        file_nodes = [n for n in nodes if n.kind == "File"]
+        assert len(file_nodes) == 1
+        assert file_nodes[0].language == "dart"
+
+        classes = [n for n in nodes if n.kind == "Class"]
+        class_names = {c.name for c in classes}
+        assert "Animal" in class_names
+        assert "Dog" in class_names
+        assert "SwimmingMixin" in class_names
+        assert "PetType" in class_names
+
+        funcs = [n for n in nodes if n.kind == "Function"]
+        func_names = {f.name for f in funcs}
+        assert "speak" in func_names
+        assert "fetch" in func_names
+        assert "_run" in func_names
+        assert "create" in func_names
+        assert "createDog" in func_names
+        assert "swim" in func_names
+
+    def test_parse_dart_imports(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        import_targets = {e.target for e in imports}
+        assert "dart:async" in import_targets
+        assert "package:flutter/material.dart" in import_targets
+
+    def test_parse_dart_inheritance(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+        inherits = [e for e in edges if e.kind == "INHERITS"]
+        assert any("Dog" in e.source and "Animal" in e.target for e in inherits)
+        assert any("Dog" in e.source and "SwimmingMixin" in e.target for e in inherits)
+
+    def test_parse_dart_contains_edges(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+        contains = [e for e in edges if e.kind == "CONTAINS"]
+        # File should contain top-level classes and functions
+        file_path = str(FIXTURES / "sample.dart")
+        file_contains = [e for e in contains if e.source == file_path]
+        assert len(file_contains) >= 1
+        # Dog class should contain its methods
+        dog_contains = [e for e in contains if "Dog" in e.source]
+        dog_targets = {e.target for e in dog_contains}
+        assert any("speak" in t for t in dog_targets)
+        assert any("fetch" in t for t in dog_targets)
+
+    def test_parse_dart_method_parent(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+        funcs = [n for n in nodes if n.kind == "Function"]
+        # Both Animal and Dog define speak(); check Dog's specifically
+        dog_speak = next(
+            (f for f in funcs if f.name == "speak" and f.parent_name == "Dog"), None,
+        )
+        assert dog_speak is not None
+
+    def test_parse_dart_top_level_function_no_parent(self):
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
+        funcs = [n for n in nodes if n.kind == "Function"]
+        create_dog = next((f for f in funcs if f.name == "createDog"), None)
+        assert create_dog is not None
+        assert create_dog.parent_name is None


### PR DESCRIPTION
## Summary

- Adds `.dart` to `EXTENSION_TO_LANGUAGE`, enabling the graph to parse Flutter/Dart codebases
- Populates `_CLASS_TYPES`, `_FUNCTION_TYPES`, and `_IMPORT_TYPES` for Dart
- Extends `_get_name`, `_get_params`, `_get_bases`, `_extract_import`, and `_do_resolve_module` with Dart-specific logic
- Adds `*_test.dart` to `_TEST_FILE_PATTERNS`
- Adds `tests/fixtures/sample.dart` and 7 new test cases (all 35 parser tests pass)

## What's extracted

| Node type | Dart AST nodes |
|-----------|---------------|
| `Class`   | `class_definition`, `mixin_declaration`, `enum_declaration` |
| `Function` | `function_signature` (top-level and class methods via `method_signature` recursion) |
| `IMPORTS_FROM` | `import_or_export` → walks to `string_literal` URI |
| `INHERITS` | `extends`, `with` (mixins), `implements` clauses |
| `CONTAINS` | file→class, class→method |

## Known limitation

Dart's AST represents method bodies as `function_body` siblings of `method_signature`, rather than children. The current walker architecture attributes calls to `enclosing_func` via parent-node recursion, so CALLS edges inside method bodies are not attributed in this initial pass. A follow-up can add a Dart-specific sibling-lookahead in `_extract_from_tree`.

## Test plan

- [x] `test_detect_language_dart`
- [x] `test_parse_dart_file` — Class, Function nodes extracted correctly
- [x] `test_parse_dart_imports` — `dart:async`, `package:flutter/material.dart`
- [x] `test_parse_dart_inheritance` — `extends Animal`, `with SwimmingMixin`
- [x] `test_parse_dart_contains_edges` — file→class and class→method CONTAINS
- [x] `test_parse_dart_method_parent` — method `parent_name` set to enclosing class
- [x] `test_parse_dart_top_level_function_no_parent` — top-level fns have `parent_name=None`
- [x] All 28 pre-existing tests continue to pass