### PR TITLE
feat: allow configurable embedding model for local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,25 @@ For semantic search, install the optional embeddings dependencies:
 pip install code-review-graph[embeddings]
 ```
 
+By default, the `all-MiniLM-L6-v2` model is used. To use a different [sentence-transformers](https://www.sbert.net/) model, set `CRG_EMBEDDING_MODEL` in your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "uvx",
+      "args": ["code-review-graph", "serve"],
+      "env": {
+        "CRG_EMBEDDING_MODEL": "BAAI/bge-small-en-v1.5"
+      }
+    }
+  }
+}
+```
+
+Or pass the `model` parameter directly to the `embed_graph` MCP tool.
+Changing the model re-embeds all nodes automatically.
+
 </details>
 
 ---

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -47,15 +47,21 @@ class EmbeddingProvider(ABC):
         pass
 
 
+LOCAL_DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+
 class LocalEmbeddingProvider(EmbeddingProvider):
-    def __init__(self) -> None:
+    def __init__(self, model_name: str | None = None) -> None:
+        self._model_name = model_name or os.environ.get(
+            "CRG_EMBEDDING_MODEL", LOCAL_DEFAULT_MODEL
+        )
         self._model = None  # Lazy-loaded
 
     def _get_model(self):
         if self._model is None:
             try:
                 from sentence_transformers import SentenceTransformer
-                self._model = SentenceTransformer("all-MiniLM-L6-v2")
+                self._model = SentenceTransformer(self._model_name)
             except ImportError:
                 raise ImportError(
                     "sentence-transformers not installed. "
@@ -78,7 +84,7 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 
     @property
     def name(self) -> str:
-        return "local:all-MiniLM-L6-v2"
+        return f"local:{self._model_name}"
 
 
 class GoogleEmbeddingProvider(EmbeddingProvider):
@@ -153,12 +159,19 @@ class GoogleEmbeddingProvider(EmbeddingProvider):
         return f"google:{self.model}"
 
 
-def get_provider(provider: str | None = None) -> EmbeddingProvider | None:
+def get_provider(
+    provider: str | None = None,
+    model: str | None = None,
+) -> EmbeddingProvider | None:
     """Get an embedding provider by name.
 
     Args:
         provider: Provider name. One of "local", "google", or None for local.
                   Google requires GOOGLE_API_KEY env var and explicit opt-in.
+        model: Model name/path to use. For local provider this is any
+               sentence-transformers compatible model (HuggingFace ID or local
+               path). Falls back to CRG_EMBEDDING_MODEL env var, then to
+               all-MiniLM-L6-v2. For Google provider this is a Gemini model ID.
     """
     if provider == "google":
         api_key = os.environ.get("GOOGLE_API_KEY")
@@ -168,13 +181,16 @@ def get_provider(provider: str | None = None) -> EmbeddingProvider | None:
                 "the Google embedding provider."
             )
         try:
-            return GoogleEmbeddingProvider(api_key=api_key)
+            return GoogleEmbeddingProvider(
+                api_key=api_key,
+                model=model or "gemini-embedding-001",
+            )
         except ImportError:
             return None
 
     # Default: local
     try:
-        return LocalEmbeddingProvider()
+        return LocalEmbeddingProvider(model_name=model)
     except ImportError:
         return None
 
@@ -244,8 +260,13 @@ def _node_to_text(node: GraphNode) -> str:
 class EmbeddingStore:
     """Manages vector embeddings for graph nodes in SQLite."""
 
-    def __init__(self, db_path: str | Path, provider: str | None = None) -> None:
-        self.provider = get_provider(provider)
+    def __init__(
+        self,
+        db_path: str | Path,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        self.provider = get_provider(provider, model=model)
         self.available = self.provider is not None
         self.db_path = Path(db_path)
         self._conn = sqlite3.connect(str(self.db_path), timeout=30, check_same_thread=False)

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -183,7 +183,7 @@ def get_provider(
         try:
             return GoogleEmbeddingProvider(
                 api_key=api_key,
-                model=model or "gemini-embedding-001",
+                **({"model": model} if model else {}),
             )
         except ImportError:
             return None

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -143,6 +143,7 @@ def semantic_search_nodes_tool(
     kind: Optional[str] = None,
     limit: int = 20,
     repo_root: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> dict:
     """Search for code entities by name, keyword, or semantic similarity.
 
@@ -154,29 +155,36 @@ def semantic_search_nodes_tool(
         kind: Optional filter: File, Class, Function, Type, or Test.
         limit: Maximum results. Default: 20.
         repo_root: Repository root path. Auto-detected if omitted.
+        model: Embedding model for query vectors. Must match the model used
+               during embed_graph. Falls back to CRG_EMBEDDING_MODEL env var,
+               then all-MiniLM-L6-v2.
     """
     return semantic_search_nodes(
-        query=query, kind=kind, limit=limit, repo_root=repo_root
+        query=query, kind=kind, limit=limit, repo_root=repo_root, model=model
     )
 
 
 @mcp.tool()
 def embed_graph_tool(
     repo_root: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> dict:
     """Compute vector embeddings for all graph nodes to enable semantic search.
 
     Requires: pip install code-review-graph[embeddings]
-    Uses the all-MiniLM-L6-v2 model (fast, 384-dim vectors).
-    Only computes embeddings for nodes that don't already have them.
+    Default model: all-MiniLM-L6-v2. Override via `model` param or
+    CRG_EMBEDDING_MODEL env var (any sentence-transformers compatible model).
+    Changing the model re-embeds all nodes automatically.
 
     After running this, semantic_search_nodes_tool will use vector similarity
     instead of keyword matching for much better results.
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        model: Embedding model name (HuggingFace ID or local path).
+               Falls back to CRG_EMBEDDING_MODEL env var, then all-MiniLM-L6-v2.
     """
-    return embed_graph(repo_root=repo_root)
+    return embed_graph(repo_root=repo_root, model=model)
 
 
 @mcp.tool()

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -742,23 +742,31 @@ def list_graph_stats(repo_root: str | None = None) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def embed_graph(repo_root: str | None = None) -> dict[str, Any]:
+def embed_graph(
+    repo_root: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
     """Compute vector embeddings for all graph nodes to enable semantic search.
 
     Requires: `pip install code-review-graph[embeddings]`
-    Uses the all-MiniLM-L6-v2 model (fast, 384-dim).
 
     Only embeds nodes that don't already have up-to-date embeddings.
+    Changing the model will re-embed all nodes automatically.
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        model: Embedding model to use. Any sentence-transformers compatible
+               model name (HuggingFace ID or local path). Falls back to
+               CRG_EMBEDDING_MODEL env var, then to all-MiniLM-L6-v2.
+               Examples: "all-MiniLM-L6-v2", "BAAI/bge-small-en-v1.5",
+               "intfloat/multilingual-e5-small".
 
     Returns:
         Number of nodes embedded and total embedding count.
     """
     store, root = _get_store(repo_root)
     db_path = get_db_path(root)
-    emb_store = EmbeddingStore(db_path)
+    emb_store = EmbeddingStore(db_path, model=model)
     try:
         if not emb_store.available:
             return {

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -603,6 +603,7 @@ def semantic_search_nodes(
     kind: str | None = None,
     limit: int = 20,
     repo_root: str | None = None,
+    model: str | None = None,
 ) -> dict[str, Any]:
     """Search for nodes by name, keyword, or semantic similarity.
 
@@ -615,6 +616,9 @@ def semantic_search_nodes(
         kind: Optional filter by node kind (File, Class, Function, Type, Test).
         limit: Maximum results to return (default: 20).
         repo_root: Repository root path. Auto-detected if omitted.
+        model: Embedding model to use for query vectors. Must match the model
+               used during embed_graph. Falls back to CRG_EMBEDDING_MODEL env
+               var, then to all-MiniLM-L6-v2.
 
     Returns:
         Ranked list of matching nodes.
@@ -622,7 +626,7 @@ def semantic_search_nodes(
     store, root = _get_store(repo_root)
     try:
         db_path = get_db_path(root)
-        emb_store = EmbeddingStore(db_path)
+        emb_store = EmbeddingStore(db_path, model=model)
         search_mode = "keyword"
 
         try:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,13 +1,17 @@
 """Tests for the embeddings module."""
 
-from unittest.mock import patch
+import os
+from unittest.mock import MagicMock, patch
 
 from code_review_graph.embeddings import (
+    LOCAL_DEFAULT_MODEL,
     EmbeddingStore,
+    LocalEmbeddingProvider,
     _cosine_similarity,
     _decode_vector,
     _encode_vector,
     _node_to_text,
+    get_provider,
 )
 from code_review_graph.graph import GraphNode
 
@@ -132,4 +136,116 @@ class TestEmbeddingStore:
             store = EmbeddingStore(db)
             # Should not raise even if node doesn't exist
             store.remove_node("nonexistent::func")
+            store.close()
+
+
+class TestLocalEmbeddingProviderModelName:
+    """Tests for configurable model name on LocalEmbeddingProvider."""
+
+    def test_default_model_name(self):
+        """Without args or env var, uses LOCAL_DEFAULT_MODEL."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CRG_EMBEDDING_MODEL", None)
+            provider = LocalEmbeddingProvider()
+            assert provider._model_name == LOCAL_DEFAULT_MODEL
+            assert provider.name == f"local:{LOCAL_DEFAULT_MODEL}"
+
+    def test_explicit_model_name(self):
+        """Explicit model_name param takes priority over env var."""
+        with patch.dict(os.environ, {"CRG_EMBEDDING_MODEL": "should-be-ignored"}):
+            provider = LocalEmbeddingProvider(model_name="custom/model")
+            assert provider._model_name == "custom/model"
+            assert provider.name == "local:custom/model"
+
+    def test_env_var_fallback(self):
+        """CRG_EMBEDDING_MODEL env var is used when model_name is None."""
+        with patch.dict(os.environ, {"CRG_EMBEDDING_MODEL": "BAAI/bge-small-en-v1.5"}):
+            provider = LocalEmbeddingProvider()
+            assert provider._model_name == "BAAI/bge-small-en-v1.5"
+            assert provider.name == "local:BAAI/bge-small-en-v1.5"
+
+    def test_env_var_not_used_when_explicit(self):
+        """Explicit model_name='' is falsy but falls through to env var."""
+        with patch.dict(os.environ, {"CRG_EMBEDDING_MODEL": "from-env"}):
+            provider = LocalEmbeddingProvider(model_name="")
+            assert provider._model_name == "from-env"
+
+
+class TestGetProviderModel:
+    """Tests for model parameter in get_provider()."""
+
+    @patch("code_review_graph.embeddings.LocalEmbeddingProvider")
+    def test_local_passes_model(self, mock_cls):
+        mock_cls.return_value = MagicMock()
+        get_provider(provider=None, model="custom/model")
+        mock_cls.assert_called_once_with(model_name="custom/model")
+
+    @patch("code_review_graph.embeddings.LocalEmbeddingProvider")
+    def test_local_default_passes_none(self, mock_cls):
+        mock_cls.return_value = MagicMock()
+        get_provider(provider=None, model=None)
+        mock_cls.assert_called_once_with(model_name=None)
+
+
+class TestEmbeddingStoreModelPassthrough:
+    """Tests that EmbeddingStore passes model to get_provider."""
+
+    def test_model_forwarded_to_get_provider(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+        with patch("code_review_graph.embeddings.get_provider", return_value=None) as mock_gp:
+            EmbeddingStore(db, model="custom/model").close()
+            mock_gp.assert_called_once_with(None, model="custom/model")
+
+    def test_provider_and_model_forwarded(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+        with patch("code_review_graph.embeddings.get_provider", return_value=None) as mock_gp:
+            EmbeddingStore(db, provider="local", model="custom/model").close()
+            mock_gp.assert_called_once_with("local", model="custom/model")
+
+
+class TestReEmbedOnProviderChange:
+    """Tests that changing the model triggers re-embedding."""
+
+    def _make_node(self, name="my_func", qn="file.py::my_func"):
+        return GraphNode(
+            id=1, kind="Function", name=name,
+            qualified_name=qn, file_path="file.py",
+            line_start=1, line_end=10, language="python",
+            parent_name=None, params=None, return_type=None,
+            is_test=False, file_hash=None, extra={},
+        )
+
+    def _make_mock_provider(self, name="local:model-a", dim=3):
+        provider = MagicMock()
+        provider.name = name
+        provider.dimension = dim
+        provider.embed.return_value = [[1.0, 0.0, 0.0]]
+        provider.embed_query.return_value = [1.0, 0.0, 0.0]
+        return provider
+
+    def test_same_provider_skips_reembed(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+        provider = self._make_mock_provider("local:model-a")
+        node = self._make_node()
+
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider):
+            store = EmbeddingStore(db)
+            assert store.embed_nodes([node]) == 1  # first time
+            assert store.embed_nodes([node]) == 0  # cached, skip
+            store.close()
+
+    def test_different_provider_triggers_reembed(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+        node = self._make_node()
+
+        provider_a = self._make_mock_provider("local:model-a")
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider_a):
+            store = EmbeddingStore(db)
+            assert store.embed_nodes([node]) == 1
+            store.close()
+
+        provider_b = self._make_mock_provider("local:model-b")
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider_b):
+            store = EmbeddingStore(db)
+            assert store.embed_nodes([node]) == 1  # re-embedded!
             store.close()


### PR DESCRIPTION
## Summary

- Allow users to specify any sentence-transformers compatible model for local embeddings instead of the hardcoded `all-MiniLM-L6-v2`
- Model can be configured via `model` parameter on MCP tool, `CRG_EMBEDDING_MODEL` env var, or falls back to the default
- Changing the model automatically re-embeds all nodes (provider name in DB acts as cache key)

## Changes

- **`embeddings.py`**: `LocalEmbeddingProvider` accepts `model_name`; `get_provider()` and `EmbeddingStore` forward new `model` kwarg; removed redundant default in Google provider passthrough
- **`tools.py`**: `embed_graph` and `semantic_search_nodes` accept `model` parameter — ensures query vectors use the same model as indexing
- **`main.py`**: Both MCP tool wrappers (`embed_graph_tool`, `semantic_search_nodes_tool`) expose and forward the `model` parameter; updated docstrings
- **`README.md`**: Configuration section documents custom model setup via `.mcp.json` env
- **`tests/test_embeddings.py`**: +10 tests covering model_name priority chain, env var fallback, get_provider/EmbeddingStore passthrough, re-embed on provider change

## Configuration

Via `.mcp.json` (recommended — applies to all MCP tool calls):

```json
{
  "mcpServers": {
    "code-review-graph": {
      "command": "uvx",
      "args": ["code-review-graph", "serve"],
      "env": {
        "CRG_EMBEDDING_MODEL": "BAAI/bge-small-en-v1.5"
      }
    }
  }
}
```

Or directly via MCP tool parameter:

```
embed_graph(model="intfloat/multilingual-e5-small")
```

