### PR TITLE
feat: CSS/SCSS/LESS parsing with cross-language STYLES edges and conflict detection

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1,7 +1,8 @@
 """SQLite-backed knowledge graph storage and query engine.
 
 Stores code structure as nodes (File, Class, Function, Type, Test) and
-edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON).
+edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON,
+OVERRIDES, STYLES, POTENTIAL_CONFLICT).
 Supports impact-radius queries and subgraph extraction.
 """
 
@@ -531,6 +532,32 @@ class GraphStore:
                     results.append(edge)
         return results
 
+    def delete_edges_by_kind(self, kind: str) -> int:
+        """Delete all edges of the given kind. Returns count of deleted rows."""
+        cur = self._conn.execute("DELETE FROM edges WHERE kind = ?", (kind,))
+        self._invalidate_cache()
+        return cur.rowcount
+
+    def get_nodes_by_extra_pattern(
+        self, pattern: str, kind: str | None = None,
+    ) -> list[GraphNode]:
+        """Find nodes where extra JSON matches a LIKE pattern.
+
+        Args:
+            pattern: SQL LIKE pattern, e.g. '%"css_kind":"selector"%'.
+            kind: Optional node kind filter (Class, Function, etc.).
+        """
+        if kind:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ? AND kind = ?",
+                (pattern, kind),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ?", (pattern,),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
     # --- Internal helpers ---
 
     def _build_networkx_graph(self) -> nx.DiGraph:
@@ -599,6 +626,21 @@ def _sanitize_name(s: str, max_len: int = 256) -> str:
     return cleaned[:max_len]
 
 
+def _sanitize_extra(extra: dict) -> dict:
+    """Sanitize string values in extra dict for safe display."""
+    if not extra:
+        return {}
+
+    def _sanitize_value(v):  # type: ignore[no-untyped-def]
+        if isinstance(v, str):
+            return _sanitize_name(v)
+        if isinstance(v, list):
+            return [_sanitize_value(item) for item in v]
+        return v
+
+    return {k: _sanitize_value(v) for k, v in extra.items()}
+
+
 def node_to_dict(n: GraphNode) -> dict:
     return {
         "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
@@ -607,6 +649,7 @@ def node_to_dict(n: GraphNode) -> dict:
         "language": n.language,
         "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
+        "extra": _sanitize_extra(n.extra),
     }
 
 
@@ -616,4 +659,5 @@ def edge_to_dict(e: GraphEdge) -> dict:
         "source": _sanitize_name(e.source_qualified),
         "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
+        "extra": _sanitize_extra(e.extra),
     }

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1,7 +1,8 @@
 """SQLite-backed knowledge graph storage and query engine.
 
 Stores code structure as nodes (File, Class, Function, Type, Test) and
-edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON, REFERENCES).
+edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON,
+REFERENCES, OVERRIDES, STYLES, POTENTIAL_CONFLICT).
 Supports impact-radius queries and subgraph extraction.
 """
 
@@ -371,6 +372,32 @@ class GraphStore:
             (name, kind),
         ).fetchall()
         return [self._row_to_edge(r) for r in rows]
+
+    def delete_edges_by_kind(self, kind: str) -> int:
+        """Delete all edges of the given kind. Returns count of deleted rows."""
+        cur = self._conn.execute("DELETE FROM edges WHERE kind = ?", (kind,))
+        self._invalidate_cache()
+        return cur.rowcount
+
+    def get_nodes_by_extra_pattern(
+        self, pattern: str, kind: str | None = None,
+    ) -> list[GraphNode]:
+        """Find nodes where extra JSON matches a LIKE pattern.
+
+        Args:
+            pattern: SQL LIKE pattern, e.g. '%"css_kind":"selector"%'.
+            kind: Optional node kind filter (Class, Function, etc.).
+        """
+        if kind:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ? AND kind = ?",
+                (pattern, kind),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ?", (pattern,),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
 
     def get_transitive_tests(
         self, qualified_name: str, max_depth: int = 1, max_frontier: int | None = None,
@@ -1352,6 +1379,21 @@ def _sanitize_name(s: str, max_len: int = 256) -> str:
     return cleaned[:max_len]
 
 
+def _sanitize_extra(extra: dict) -> dict:
+    """Sanitize string values in extra dict for safe display."""
+    if not extra:
+        return {}
+
+    def _sanitize_value(v):  # type: ignore[no-untyped-def]
+        if isinstance(v, str):
+            return _sanitize_name(v)
+        if isinstance(v, list):
+            return [_sanitize_value(item) for item in v]
+        return v
+
+    return {k: _sanitize_value(v) for k, v in extra.items()}
+
+
 def node_to_dict(n: GraphNode) -> dict:
     return {
         "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
@@ -1360,6 +1402,7 @@ def node_to_dict(n: GraphNode) -> dict:
         "language": n.language,
         "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
+        "extra": _sanitize_extra(n.extra),
     }
 
 
@@ -1370,4 +1413,5 @@ def edge_to_dict(e: GraphEdge) -> dict:
         "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
         "confidence": e.confidence, "confidence_tier": e.confidence_tier,
+        "extra": _sanitize_extra(e.extra),
     }

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -246,11 +246,214 @@ def find_dependents(store: GraphStore, file_path: str) -> list[str]:
     nodes = store.get_nodes_by_file(file_path)
     for node in nodes:
         for e in store.get_edges_by_target(node.qualified_name):
-            if e.kind in ("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"):
+            if e.kind in (
+                "CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS", "STYLES",
+            ):
                 dependents.add(e.file_path)
 
     dependents.discard(file_path)
     return list(dependents)
+
+
+def link_css_styles(store: GraphStore) -> int:
+    """Create STYLES edges between class references and CSS selectors.
+
+    Queries the graph for:
+    1. All CSS selector nodes (css_kind == "selector")
+    2. All nodes with css_classes or vue_template_classes in extra
+
+    Creates STYLES edges from the referencing component/function to
+    the matching CSS selector node.
+
+    Returns count of STYLES edges created.
+    """
+    from .parser import CodeParser, EdgeInfo  # noqa: F811 (avoid circular)
+
+    # Clean up previous STYLES edges
+    store.delete_edges_by_kind("STYLES")
+
+    # Build selector index: bare class name → list of (qualified_name, file_path)
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+    selector_index: dict[str, list[tuple[str, str]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        # Only index class selectors (starting with .)
+        if sel_name.startswith("."):
+            bare = sel_name.lstrip(".")
+            selector_index.setdefault(bare, []).append(
+                (sel.qualified_name, sel.file_path),
+            )
+        # For compound selectors, also index by last class segment
+        parts = sel_name.split()
+        if len(parts) > 1:
+            last = parts[-1].strip()
+            if last.startswith("."):
+                bare = last.lstrip(".")
+                selector_index.setdefault(bare, []).append(
+                    (sel.qualified_name, sel.file_path),
+                )
+
+    if not selector_index:
+        store.commit()
+        return 0
+
+    count = 0
+
+    # Link static css_classes references
+    class_nodes = store.get_nodes_by_extra_pattern('%"css_classes"%')
+    for node in class_nodes:
+        classes = node.extra.get("css_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link Vue template class references
+    vue_nodes = store.get_nodes_by_extra_pattern('%"vue_template_classes"%')
+    for node in vue_nodes:
+        classes = node.extra.get("vue_template_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link CSS Module references
+    module_nodes = store.get_nodes_by_extra_pattern('%"css_module_refs"%')
+    for node in module_nodes:
+        refs = node.extra.get("css_module_refs", [])
+        # Find the File node for CSS module imports
+        file_nodes = store.get_nodes_by_extra_pattern(
+            '%"css_module_imports"%', kind="File",
+        )
+        # Build a map of import names → module paths per file
+        file_mod_imports: dict[str, dict[str, str]] = {}
+        for fn in file_nodes:
+            file_mod_imports[fn.file_path] = fn.extra.get(
+                "css_module_imports", {},
+            )
+
+        mod_imports = file_mod_imports.get(node.file_path, {})
+        for ref in refs:
+            imp_name = ref.get("import", "")
+            prop_name = ref.get("property", "")
+            if not imp_name or not prop_name:
+                continue
+            # Find the module path
+            if imp_name not in mod_imports:
+                continue
+            # Convert camelCase to kebab-case for selector lookup
+            kebab = CodeParser._camel_to_kebab(prop_name)
+            matches = selector_index.get(kebab, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": kebab,
+                        "resolution": "css_module",
+                        "import_name": imp_name,
+                        "property": prop_name,
+                    },
+                ))
+                count += 1
+
+    store.commit()
+    return count
+
+
+def detect_cross_file_conflicts(store: GraphStore) -> int:
+    """Detect potential CSS conflicts across files.
+
+    Scans for CSS selectors across different files that target the same
+    class name. Creates POTENTIAL_CONFLICT edges when found.
+
+    Returns count of conflict edges created.
+    """
+    from .parser import EdgeInfo  # noqa: F811
+
+    store.delete_edges_by_kind("POTENTIAL_CONFLICT")
+
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+
+    # Group by bare class name
+    by_class: dict[str, list[tuple[str, str, list]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        if not sel_name.startswith("."):
+            continue
+        bare = sel_name.lstrip(".")
+        specificity = sel.extra.get("specificity", [0, 0, 0])
+        by_class.setdefault(bare, []).append(
+            (sel.qualified_name, sel.file_path, specificity),
+        )
+
+    count = 0
+    max_pairs_per_class = 50
+
+    for bare, entries in by_class.items():
+        # Only flag if selectors appear in 2+ different files
+        files_seen = {fp for _, fp, _ in entries}
+        if len(files_seen) < 2:
+            continue
+
+        pairs = 0
+        for i, (src_qn, src_fp, src_spec) in enumerate(entries):
+            for tgt_qn, tgt_fp, tgt_spec in entries[i + 1:]:
+                if src_fp == tgt_fp:
+                    continue
+                if pairs >= max_pairs_per_class:
+                    break
+                # Determine confidence
+                confidence = "high"  # same bare class name
+                store.upsert_edge(EdgeInfo(
+                    kind="POTENTIAL_CONFLICT",
+                    source=src_qn,
+                    target=tgt_qn,
+                    file_path="<cross-file>",
+                    line=0,
+                    extra={
+                        "class_name": f".{bare}",
+                        "source_specificity": src_spec,
+                        "target_specificity": tgt_spec,
+                        "confidence": confidence,
+                    },
+                ))
+                count += 1
+                pairs += 1
+            if pairs >= max_pairs_per_class:
+                break
+
+    store.commit()
+    return count
 
 
 def full_build(repo_root: Path, store: GraphStore) -> dict:
@@ -286,6 +489,14 @@ def full_build(repo_root: Path, store: GraphStore) -> dict:
         if i % 50 == 0 or i == file_count:
             logger.info("Progress: %d/%d files parsed", i, file_count)
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+    logger.info(
+        "CSS linking: %d STYLES edges, %d POTENTIAL_CONFLICT edges",
+        styles_count, conflicts_count,
+    )
+
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
     store.commit()
@@ -294,6 +505,8 @@ def full_build(repo_root: Path, store: GraphStore) -> dict:
         "files_parsed": len(files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
         "errors": errors,
     }
 
@@ -370,6 +583,10 @@ def incremental_update(
             logger.warning("Error parsing %s: %s", rel_path, e)
             errors.append({"file": rel_path, "error": str(e)})
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")
     store.commit()
@@ -378,6 +595,8 @@ def incremental_update(
         "files_updated": len(all_files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
         "changed_files": list(changed_files),
         "dependent_files": list(dependent_files),
         "errors": errors,

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -728,7 +728,9 @@ def _single_hop_dependents(store: GraphStore, file_path: str) -> set[str]:
     nodes = store.get_nodes_by_file(file_path)
     for node in nodes:
         for e in store.get_edges_by_target(node.qualified_name):
-            if e.kind in ("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"):
+            if e.kind in (
+                "CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS", "STYLES",
+            ):
                 dependents.add(e.file_path)
 
     dependents.discard(file_path)
@@ -815,6 +817,212 @@ def _parse_single_file(
         return (rel_path, nodes, edges, None, fhash)
     except Exception as e:
         return (rel_path, [], [], str(e), "")
+
+
+def link_css_styles(store: GraphStore) -> int:
+    """Create STYLES edges between class references and CSS selectors.
+
+    Queries the graph for:
+    1. All CSS selector nodes (css_kind == "selector")
+    2. All nodes with css_classes or vue_template_classes in extra
+
+    Creates STYLES edges from the referencing component/function to
+    the matching CSS selector node.
+
+    Returns count of STYLES edges created.
+    """
+    from .parser import CodeParser, EdgeInfo  # noqa: F811 (avoid circular)
+
+    # Clean up previous STYLES edges
+    store.delete_edges_by_kind("STYLES")
+
+    # Build selector index: bare class name → list of (qualified_name, file_path)
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+    selector_index: dict[str, list[tuple[str, str]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        # Only index class selectors (starting with .)
+        if sel_name.startswith("."):
+            bare = sel_name.lstrip(".")
+            selector_index.setdefault(bare, []).append(
+                (sel.qualified_name, sel.file_path),
+            )
+        # For compound selectors, also index by last class segment
+        parts = sel_name.split()
+        if len(parts) > 1:
+            last = parts[-1].strip()
+            if last.startswith("."):
+                bare = last.lstrip(".")
+                selector_index.setdefault(bare, []).append(
+                    (sel.qualified_name, sel.file_path),
+                )
+
+    if not selector_index:
+        store.commit()
+        return 0
+
+    count = 0
+
+    # Link static css_classes references
+    class_nodes = store.get_nodes_by_extra_pattern('%"css_classes"%')
+    for node in class_nodes:
+        classes = node.extra.get("css_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link Vue template class references
+    vue_nodes = store.get_nodes_by_extra_pattern('%"vue_template_classes"%')
+    for node in vue_nodes:
+        classes = node.extra.get("vue_template_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link CSS Module references
+    module_nodes = store.get_nodes_by_extra_pattern('%"css_module_refs"%')
+    for node in module_nodes:
+        refs = node.extra.get("css_module_refs", [])
+        # Find the File node for CSS module imports
+        file_nodes = store.get_nodes_by_extra_pattern(
+            '%"css_module_imports"%', kind="File",
+        )
+        # Build a map of import names → module paths per file
+        file_mod_imports: dict[str, dict[str, str]] = {}
+        for fn in file_nodes:
+            file_mod_imports[fn.file_path] = fn.extra.get(
+                "css_module_imports", {},
+            )
+
+        mod_imports = file_mod_imports.get(node.file_path, {})
+        for ref in refs:
+            imp_name = ref.get("import", "")
+            prop_name = ref.get("property", "")
+            if not imp_name or not prop_name:
+                continue
+            # Find the module path
+            if imp_name not in mod_imports:
+                continue
+            # Convert camelCase to kebab-case for selector lookup
+            kebab = CodeParser._camel_to_kebab(prop_name)
+            matches = selector_index.get(kebab, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": kebab,
+                        "resolution": "css_module",
+                        "import_name": imp_name,
+                        "property": prop_name,
+                    },
+                ))
+                count += 1
+
+    store.commit()
+    return count
+
+
+def detect_cross_file_conflicts(store: GraphStore) -> int:
+    """Detect potential CSS conflicts across files.
+
+    Scans for CSS selectors across different files that target the same
+    class name. Creates POTENTIAL_CONFLICT edges when found.
+
+    Returns count of conflict edges created.
+    """
+    from .parser import EdgeInfo  # noqa: F811
+
+    store.delete_edges_by_kind("POTENTIAL_CONFLICT")
+
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+
+    # Group by bare class name
+    by_class: dict[str, list[tuple[str, str, list]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        if not sel_name.startswith("."):
+            continue
+        bare = sel_name.lstrip(".")
+        specificity = sel.extra.get("specificity", [0, 0, 0])
+        by_class.setdefault(bare, []).append(
+            (sel.qualified_name, sel.file_path, specificity),
+        )
+
+    count = 0
+    max_pairs_per_class = 50
+
+    for bare, entries in by_class.items():
+        # Only flag if selectors appear in 2+ different files
+        files_seen = {fp for _, fp, _ in entries}
+        if len(files_seen) < 2:
+            continue
+
+        pairs = 0
+        for i, (src_qn, src_fp, src_spec) in enumerate(entries):
+            for tgt_qn, tgt_fp, tgt_spec in entries[i + 1:]:
+                if src_fp == tgt_fp:
+                    continue
+                if pairs >= max_pairs_per_class:
+                    break
+                # Determine confidence. Named "conflict_confidence" (not
+                # "confidence") because GraphEdge/upsert_edge now reserve the
+                # "confidence" extra key for a float 0.0-1.0 score consumed by
+                # the confidence/confidence_tier columns added upstream since
+                # this feature was written; a qualitative "high"/"medium"
+                # string there breaks float(...) coercion in upsert_edge.
+                conflict_confidence = "high"  # same bare class name
+                store.upsert_edge(EdgeInfo(
+                    kind="POTENTIAL_CONFLICT",
+                    source=src_qn,
+                    target=tgt_qn,
+                    file_path="<cross-file>",
+                    line=0,
+                    extra={
+                        "class_name": f".{bare}",
+                        "source_specificity": src_spec,
+                        "target_specificity": tgt_spec,
+                        "conflict_confidence": conflict_confidence,
+                    },
+                ))
+                count += 1
+                pairs += 1
+            if pairs >= max_pairs_per_class:
+                break
+
+    store.commit()
+    return count
 
 
 def full_build(
@@ -905,6 +1113,14 @@ def full_build(
     spring_stats = _run_spring_resolver(store)
     temporal_stats = _run_temporal_resolver(store)
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+    logger.info(
+        "CSS linking: %d STYLES edges, %d POTENTIAL_CONFLICT edges",
+        styles_count, conflicts_count,
+    )
+
     return {
         "files_parsed": len(files),
         "total_nodes": total_nodes,
@@ -913,6 +1129,8 @@ def full_build(
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
         "temporal_resolution": temporal_stats,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
     }
 
 
@@ -1043,6 +1261,10 @@ def incremental_update(
     spring_stats = _run_spring_resolver(store) if spring_changed else None
     temporal_stats = _run_temporal_resolver(store) if spring_changed else None
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+
     return {
         "files_updated": len(all_files),
         "total_nodes": total_nodes,
@@ -1053,6 +1275,8 @@ def incremental_update(
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
         "temporal_resolution": temporal_stats,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
     }
 
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -819,6 +819,11 @@ def _parse_single_file(
         return (rel_path, [], [], str(e), "")
 
 
+# Bare class tokens in a CSS selector: every ``.name`` occurrence, ignoring
+# tags, ids, pseudo-classes/elements and attribute selectors.
+_CSS_CLASS_TOKEN_RE = re.compile(r"\.([A-Za-z_-][\w-]*)")
+
+
 def link_css_styles(store: GraphStore) -> int:
     """Create STYLES edges between class references and CSS selectors.
 
@@ -842,36 +847,44 @@ def link_css_styles(store: GraphStore) -> int:
     )
     selector_index: dict[str, list[tuple[str, str]]] = {}
     for sel in selectors:
-        sel_name = sel.name.strip()
-        # Only index class selectors (starting with .)
-        if sel_name.startswith("."):
-            bare = sel_name.lstrip(".")
+        # Index the selector under every bare class token it contains, so
+        # compound (.btn.active), descendant (.card .title) and pseudo
+        # (.btn:hover, .btn::before) selectors all match a plain className.
+        for bare in _CSS_CLASS_TOKEN_RE.findall(sel.name):
             selector_index.setdefault(bare, []).append(
                 (sel.qualified_name, sel.file_path),
             )
-        # For compound selectors, also index by last class segment
-        parts = sel_name.split()
-        if len(parts) > 1:
-            last = parts[-1].strip()
-            if last.startswith("."):
-                bare = last.lstrip(".")
-                selector_index.setdefault(bare, []).append(
-                    (sel.qualified_name, sel.file_path),
-                )
 
     if not selector_index:
         store.commit()
         return 0
 
+    # file_path -> set of stylesheet paths that file imports, for scoping.
+    css_import_map: dict[str, set[str]] = {}
+    for fn in store.get_nodes_by_extra_pattern(
+        '%"css_import_files"%', kind="File",
+    ):
+        files = fn.extra.get("css_import_files", [])
+        if files:
+            css_import_map[fn.file_path] = set(files)
+
+    def _in_scope(node_file: str, sel_file: str) -> bool:
+        # A component links to a selector only when the selector is defined
+        # in the same file or in a stylesheet the component's file imports.
+        return sel_file == node_file or sel_file in css_import_map.get(
+            node_file, (),
+        )
+
     count = 0
 
-    # Link static css_classes references
+    # Link static css_classes references, scoped to imported/same-file sheets
     class_nodes = store.get_nodes_by_extra_pattern('%"css_classes"%')
     for node in class_nodes:
         classes = node.extra.get("css_classes", [])
         for cls_name in classes:
-            matches = selector_index.get(cls_name, [])
-            for sel_qn, sel_file in matches:
+            for sel_qn, sel_file in selector_index.get(cls_name, []):
+                if not _in_scope(node.file_path, sel_file):
+                    continue
                 store.upsert_edge(EdgeInfo(
                     kind="STYLES",
                     source=node.qualified_name,
@@ -885,13 +898,14 @@ def link_css_styles(store: GraphStore) -> int:
                 ))
                 count += 1
 
-    # Link Vue template class references
+    # Link Vue template class references (SFC <style> lives in the same file)
     vue_nodes = store.get_nodes_by_extra_pattern('%"vue_template_classes"%')
     for node in vue_nodes:
         classes = node.extra.get("vue_template_classes", [])
         for cls_name in classes:
-            matches = selector_index.get(cls_name, [])
-            for sel_qn, sel_file in matches:
+            for sel_qn, sel_file in selector_index.get(cls_name, []):
+                if not _in_scope(node.file_path, sel_file):
+                    continue
                 store.upsert_edge(EdgeInfo(
                     kind="STYLES",
                     source=node.qualified_name,
@@ -905,21 +919,17 @@ def link_css_styles(store: GraphStore) -> int:
                 ))
                 count += 1
 
-    # Link CSS Module references
+    # Link CSS Module references. Map import names → module paths per file
+    # once, not per module node.
+    file_mod_imports: dict[str, dict[str, str]] = {}
+    for fn in store.get_nodes_by_extra_pattern(
+        '%"css_module_imports"%', kind="File",
+    ):
+        file_mod_imports[fn.file_path] = fn.extra.get("css_module_imports", {})
+
     module_nodes = store.get_nodes_by_extra_pattern('%"css_module_refs"%')
     for node in module_nodes:
         refs = node.extra.get("css_module_refs", [])
-        # Find the File node for CSS module imports
-        file_nodes = store.get_nodes_by_extra_pattern(
-            '%"css_module_imports"%', kind="File",
-        )
-        # Build a map of import names → module paths per file
-        file_mod_imports: dict[str, dict[str, str]] = {}
-        for fn in file_nodes:
-            file_mod_imports[fn.file_path] = fn.extra.get(
-                "css_module_imports", {},
-            )
-
         mod_imports = file_mod_imports.get(node.file_path, {})
         for ref in refs:
             imp_name = ref.get("import", "")
@@ -931,8 +941,9 @@ def link_css_styles(store: GraphStore) -> int:
                 continue
             # Convert camelCase to kebab-case for selector lookup
             kebab = CodeParser._camel_to_kebab(prop_name)
-            matches = selector_index.get(kebab, [])
-            for sel_qn, sel_file in matches:
+            for sel_qn, sel_file in selector_index.get(kebab, []):
+                if not _in_scope(node.file_path, sel_file):
+                    continue
                 store.upsert_edge(EdgeInfo(
                     kind="STYLES",
                     source=node.qualified_name,

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -98,6 +98,8 @@ def query_graph_tool(
     - children_of: Find nodes contained in a file or class
     - tests_for: Find tests for the target
     - inheritors_of: Find classes inheriting from the target
+    - overrides_of: Find CSS selectors that the target overrides
+    - overridden_by: Find CSS selectors that override the target
     - file_summary: Get all nodes in a file
 
     Args:

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -229,6 +229,11 @@ def query_graph_tool(
     - children_of: Find nodes contained in a file or class
     - tests_for: Find tests for the target
     - inheritors_of: Find classes inheriting from the target
+    - overrides_of: Find CSS selectors that the target overrides
+    - overridden_by: Find CSS selectors that override the target
+    - styles_of: Find CSS selectors that style the target
+    - styled_by: Find components/functions that use the target selector
+    - conflicts_of: Find potential cross-file CSS conflicts for the target
     - file_summary: Get all nodes in a file
 
     Args:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -40,7 +40,7 @@ class NodeInfo:
 
 @dataclass
 class EdgeInfo:
-    kind: str  # CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON
+    kind: str  # CALLS, IMPORTS_FROM, INHERITS, ..., DEPENDS_ON, OVERRIDES
     source: str  # qualified name or path
     target: str  # qualified name or path
     file_path: str
@@ -74,6 +74,9 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".php": "php",
     ".sol": "solidity",
     ".vue": "vue",
+    ".css": "css",
+    ".scss": "scss",
+    ".less": "less",
 }
 
 # Tree-sitter node type mappings per language
@@ -255,6 +258,14 @@ class CodeParser:
         if language == "vue":
             return self._parse_vue(path, source)
 
+        # CSS/SCSS: dedicated parser for stylesheet languages
+        if language in ("css", "scss"):
+            return self._parse_css(path, source, language)
+
+        # LESS: regex-based fallback (no tree-sitter grammar available)
+        if language == "less":
+            return self._parse_less(path, source)
+
         parser = self._get_parser(language)
         if not parser:
             return [], []
@@ -281,11 +292,41 @@ class CodeParser:
             tree.root_node, language, source,
         )
 
-        # Walk the tree
+        # Walk the tree (with JSX class collection for JSX-capable languages)
+        jsx_class_collector: dict[str, dict] = {}
         self._extract_from_tree(
             tree.root_node, source, language, file_path_str, nodes, edges,
             import_map=import_map, defined_names=defined_names,
+            jsx_class_collector=jsx_class_collector,
         )
+
+        # Attach collected JSX class refs to their enclosing function nodes
+        if jsx_class_collector:
+            node_by_qn: dict[str, NodeInfo] = {}
+            for n in nodes:
+                qn = self._qualify(n.name, n.file_path, n.parent_name)
+                node_by_qn[qn] = n
+            for func_qn, refs in jsx_class_collector.items():
+                target_node = node_by_qn.get(func_qn)
+                if target_node:
+                    if refs.get("classes"):
+                        target_node.extra["css_classes"] = sorted(
+                            set(refs["classes"]),
+                        )
+                    if refs.get("module_refs"):
+                        target_node.extra["css_module_refs"] = [
+                            {"import": imp, "property": prop}
+                            for imp, prop in refs["module_refs"]
+                        ]
+
+        # Detect CSS Module imports and store on File node
+        if import_map:
+            css_mod_imports = {
+                name: mod for name, mod in import_map.items()
+                if ".module.css" in mod or ".module.scss" in mod
+            }
+            if css_mod_imports:
+                nodes[0].extra["css_module_imports"] = css_mod_imports
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -402,6 +443,65 @@ class CodeParser:
             all_nodes.extend(nodes)
             all_edges.extend(edges)
 
+        # Extract <style> blocks and delegate to CSS/SCSS parser
+        for child in tree.root_node.children:
+            if child.type != "style_element":
+                continue
+
+            style_lang = "css"
+            raw_text_node = None
+            start_tag = None
+            for sub in child.children:
+                if sub.type == "start_tag":
+                    start_tag = sub
+                elif sub.type == "raw_text":
+                    raw_text_node = sub
+
+            if start_tag:
+                for attr in start_tag.children:
+                    if attr.type == "attribute":
+                        attr_name = None
+                        attr_value = None
+                        for a in attr.children:
+                            if a.type == "attribute_name":
+                                attr_name = a.text.decode("utf-8", errors="replace")
+                            elif a.type == "quoted_attribute_value":
+                                for v in a.children:
+                                    if v.type == "attribute_value":
+                                        attr_value = v.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                        if attr_name == "lang" and attr_value in ("scss", "sass"):
+                            style_lang = "scss"
+
+            if not raw_text_node:
+                continue
+
+            style_source = raw_text_node.text
+            style_line_offset = raw_text_node.start_point[0]
+
+            style_nodes, style_edges = self._parse_css(
+                path, style_source, style_lang, line_offset=style_line_offset,
+            )
+
+            # Remove the File node that _parse_css creates (we already have one)
+            style_nodes = [n for n in style_nodes if n.kind != "File"]
+            for sn in style_nodes:
+                sn.language = "vue"
+
+            all_nodes.extend(style_nodes)
+            all_edges.extend(style_edges)
+
+        # Extract static class names from <template> elements
+        for child in tree.root_node.children:
+            if child.type == "template_element":
+                template_classes = self._extract_vue_template_classes(child)
+                if template_classes:
+                    all_nodes[0].extra["vue_template_classes"] = sorted(
+                        set(template_classes),
+                    )
+                break  # Only one <template> per SFC
+
         # Generate TESTED_BY edges
         if test_file:
             test_qnames = set()
@@ -420,6 +520,955 @@ class CodeParser:
                     ))
 
         return all_nodes, all_edges
+
+    # -------------------------------------------------------------------
+    # CSS / SCSS parsing
+    # -------------------------------------------------------------------
+
+    @dataclass
+    class _SelectorRecord:
+        """Ephemeral record for CSS override detection within a single file."""
+
+        selector_text: str
+        qualified_name: str
+        specificity: tuple[int, int, int]
+        properties: dict[str, int]          # property_name -> line
+        has_important: dict[str, bool]      # property_name -> has !important
+        line_start: int
+        line_end: int
+        source_order: int
+
+    def _parse_css(
+        self,
+        path: Path,
+        source: bytes,
+        language: str = "css",
+        line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a CSS/SCSS file and extract selectors, custom properties,
+        mixins, variables, @import, var() usage, and override relationships."""
+        css_parser = self._get_parser(language)
+        if not css_parser:
+            return [], []
+
+        tree = css_parser.parse(source)
+        file_path_str = str(path)
+
+        nodes: list[NodeInfo] = [NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=source.count(b"\n") + 1 + line_offset,
+            language=language,
+        )]
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        self._walk_css(
+            tree.root_node, source, language, file_path_str,
+            nodes, edges, selector_records,
+            enclosing_context=None, line_offset=line_offset,
+        )
+
+        # Override detection (post-processing after all selectors collected)
+        override_edges = self._detect_css_overrides(selector_records, file_path_str)
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    def _walk_css(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str] = None,
+        line_offset: int = 0,
+        _depth: int = 0,
+    ) -> None:
+        """Recursively walk CSS/SCSS AST extracting nodes and edges."""
+        if _depth > self._MAX_AST_DEPTH:
+            return
+
+        for child in node.children:
+            node_type = child.type
+
+            # --- @import / @use ---
+            if node_type in ("import_statement", "use_statement"):
+                target = self._extract_css_import(child)
+                if target:
+                    edges.append(EdgeInfo(
+                        kind="IMPORTS_FROM",
+                        source=file_path,
+                        target=target,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- rule_set (selector + block) ---
+            if node_type == "rule_set":
+                self._handle_css_ruleset(
+                    child, source, language, file_path,
+                    nodes, edges, selector_records,
+                    enclosing_context, line_offset, _depth,
+                )
+                continue
+
+            # --- @media ---
+            if node_type == "media_statement":
+                media_text = self._get_css_media_text(child)
+                media_name = f"@media({media_text})"
+                qualified = self._qualify(media_name, file_path, None)
+
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=media_name,
+                    file_path=file_path,
+                    line_start=child.start_point[0] + 1 + line_offset,
+                    line_end=child.end_point[0] + 1 + line_offset,
+                    language=language,
+                    extra={"css_kind": "media_query"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path,
+                    target=qualified,
+                    file_path=file_path,
+                    line=child.start_point[0] + 1 + line_offset,
+                ))
+
+                for sub in child.children:
+                    if sub.type == "block":
+                        self._walk_css(
+                            sub, source, language, file_path,
+                            nodes, edges, selector_records,
+                            enclosing_context=media_name,
+                            line_offset=line_offset,
+                            _depth=_depth + 1,
+                        )
+                continue
+
+            # --- @keyframes ---
+            if node_type == "keyframes_statement":
+                kf_name = None
+                for sub in child.children:
+                    if sub.type == "keyframes_name":
+                        kf_name = sub.text.decode("utf-8", errors="replace")
+                if kf_name:
+                    name = f"@keyframes({kf_name})"
+                    nodes.append(NodeInfo(
+                        kind="Class",
+                        name=name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "keyframes"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: top-level $variable declarations ---
+            if language == "scss" and node_type == "declaration":
+                prop_name = self._get_css_property_name(child)
+                if prop_name and prop_name.startswith("$"):
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=prop_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "scss_variable"},
+                    ))
+                    container = (
+                        self._qualify(enclosing_context, file_path, None)
+                        if enclosing_context
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=self._qualify(prop_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: @mixin ---
+            if language == "scss" and node_type == "mixin_statement":
+                mixin_name = None
+                for sub in child.children:
+                    if sub.type == "identifier":
+                        mixin_name = sub.text.decode("utf-8", errors="replace")
+                        break
+                if mixin_name:
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=mixin_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "mixin"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(mixin_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- Recurse into other nodes ---
+            self._walk_css(
+                child, source, language, file_path,
+                nodes, edges, selector_records,
+                enclosing_context=enclosing_context,
+                line_offset=line_offset,
+                _depth=_depth + 1,
+            )
+
+    def _handle_css_ruleset(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str],
+        line_offset: int,
+        _depth: int,
+    ) -> None:
+        """Process a CSS rule_set: extract selectors, properties, var() refs."""
+        selectors_node = None
+        block_node = None
+        for sub in node.children:
+            if sub.type == "selectors":
+                selectors_node = sub
+            elif sub.type == "block":
+                block_node = sub
+
+        if not selectors_node:
+            return
+
+        # Extract properties and var() refs from the block
+        properties: dict[str, int] = {}
+        has_important: dict[str, bool] = {}
+        var_refs: list[tuple[str, int]] = []   # (var_name, line)
+        include_refs: list[tuple[str, int]] = []  # (mixin_name, line)
+        custom_prop_defs: list[tuple[str, int, int]] = []  # (name, line_start, line_end)
+
+        if block_node:
+            for decl in block_node.children:
+                if decl.type == "declaration":
+                    prop = self._get_css_property_name(decl)
+                    if prop:
+                        line = decl.start_point[0] + 1 + line_offset
+                        if prop.startswith("--"):
+                            # Custom property definition
+                            custom_prop_defs.append((
+                                prop, line, decl.end_point[0] + 1 + line_offset,
+                            ))
+                        else:
+                            properties[prop] = line
+                            has_important[prop] = self._has_important(decl)
+                        # Check for var() references in value
+                        for var_name in self._find_var_refs(decl):
+                            var_refs.append((var_name, line))
+                elif decl.type == "include_statement" and language == "scss":
+                    # @include mixin_name
+                    for sub in decl.children:
+                        if sub.type == "identifier":
+                            include_refs.append((
+                                sub.text.decode("utf-8", errors="replace"),
+                                decl.start_point[0] + 1 + line_offset,
+                            ))
+                            break
+
+        # Split comma-separated selectors into individual nodes
+        individual_selectors = self._split_css_selectors(selectors_node)
+
+        # Create custom property nodes once (not per selector in comma groups)
+        seen_custom_props: set[str] = set()
+        first_qualified: Optional[str] = None
+
+        for sel_text, sel_node in individual_selectors:
+            # Resolve SCSS nesting selector (&)
+            if language == "scss" and enclosing_context and "&" in sel_text:
+                # For BEM: &-primary → .btn-primary (parent is .btn)
+                parent_sel = enclosing_context
+                if parent_sel.startswith("@"):
+                    parent_sel = ""  # Don't resolve & against @media
+                sel_text = sel_text.replace("&", parent_sel)
+
+            specificity = self._compute_specificity(sel_node)
+            qualified = self._qualify(sel_text, file_path, enclosing_context)
+            if first_qualified is None:
+                first_qualified = qualified
+
+            nodes.append(NodeInfo(
+                kind="Class",
+                name=sel_text,
+                file_path=file_path,
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                language=language,
+                parent_name=enclosing_context,
+                extra={"css_kind": "selector", "specificity": list(specificity)},
+            ))
+
+            # CONTAINS edge
+            container = (
+                self._qualify(enclosing_context, file_path, None)
+                if enclosing_context
+                else file_path
+            )
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=container,
+                target=qualified,
+                file_path=file_path,
+                line=node.start_point[0] + 1 + line_offset,
+            ))
+
+            # Custom property definitions — only create once, parent to first selector
+            for cp_name, cp_start, cp_end in custom_prop_defs:
+                if cp_name in seen_custom_props:
+                    continue
+                seen_custom_props.add(cp_name)
+                cp_qualified = self._qualify(cp_name, file_path, None)
+                nodes.append(NodeInfo(
+                    kind="Function",
+                    name=cp_name,
+                    file_path=file_path,
+                    line_start=cp_start,
+                    line_end=cp_end,
+                    language=language,
+                    parent_name=sel_text,
+                    extra={"css_kind": "custom_property"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=first_qualified,
+                    target=cp_qualified,
+                    file_path=file_path,
+                    line=cp_start,
+                ))
+
+            # var() references → CALLS edges
+            for var_name, var_line in var_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=var_name,
+                    file_path=file_path,
+                    line=var_line,
+                ))
+
+            # SCSS @include → CALLS edges
+            for mixin_name, inc_line in include_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=mixin_name,
+                    file_path=file_path,
+                    line=inc_line,
+                ))
+
+            # Record for override detection
+            selector_records.append(CodeParser._SelectorRecord(
+                selector_text=sel_text,
+                qualified_name=qualified,
+                specificity=specificity,
+                properties=dict(properties),
+                has_important=dict(has_important),
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                source_order=len(selector_records),
+            ))
+
+        # Recurse into nested rule_sets (SCSS nesting / CSS nesting)
+        if block_node:
+            for sub in block_node.children:
+                if sub.type == "rule_set":
+                    # Use the first selector as enclosing context for nesting
+                    ctx = individual_selectors[0][0] if individual_selectors else enclosing_context
+                    self._handle_css_ruleset(
+                        sub, source, language, file_path,
+                        nodes, edges, selector_records,
+                        enclosing_context=ctx,
+                        line_offset=line_offset,
+                        _depth=_depth + 1,
+                    )
+
+    def _compute_specificity(self, selector_node) -> tuple[int, int, int]:
+        """Compute CSS specificity (a, b, c) from a selector AST node.
+
+        a = ID selectors, b = class/pseudo-class/attribute, c = type/pseudo-element.
+        """
+        a = b = c = 0
+        stack = [selector_node]
+        while stack:
+            n = stack.pop()
+            t = n.type
+            if t == "id_selector":
+                a += 1
+            elif t in ("class_selector", "pseudo_class_selector", "attribute_selector"):
+                b += 1
+            elif t == "pseudo_element_selector":
+                c += 1
+            elif t == "tag_name":
+                # Don't count tag_name inside pseudo_element_selector (already counted)
+                if not (n.parent and n.parent.type == "pseudo_element_selector"):
+                    c += 1
+            for child in n.children:
+                stack.append(child)
+        return (a, b, c)
+
+    def _detect_css_overrides(
+        self,
+        records: list[_SelectorRecord],
+        file_path: str,
+    ) -> list[EdgeInfo]:
+        """Detect CSS override relationships between selectors in a file."""
+        if len(records) < 2:
+            return []
+
+        # Build property → record indices
+        prop_index: dict[str, list[int]] = {}
+        for i, rec in enumerate(records):
+            for prop in rec.properties:
+                prop_index.setdefault(prop, []).append(i)
+
+        seen_pairs: set[tuple[str, str, str]] = set()
+        raw_edges: list[EdgeInfo] = []
+
+        max_override_candidates = 50  # Cap pairwise comparisons per property
+
+        for prop, rec_indices in prop_index.items():
+            if len(rec_indices) < 2:
+                continue
+            # Cap to avoid O(n²) blow-up on large files with common properties
+            candidates = rec_indices[:max_override_candidates]
+            for i in range(len(candidates)):
+                for j in range(i + 1, len(candidates)):
+                    ri = records[rec_indices[i]]
+                    rj = records[rec_indices[j]]
+                    result = self._check_override(ri, rj, prop)
+                    if result is None:
+                        continue
+                    winner, loser, mechanism = result
+                    pair_key = (winner.qualified_name, loser.qualified_name, prop)
+                    if pair_key in seen_pairs:
+                        continue
+                    seen_pairs.add(pair_key)
+                    raw_edges.append(EdgeInfo(
+                        kind="OVERRIDES",
+                        source=winner.qualified_name,
+                        target=loser.qualified_name,
+                        file_path=file_path,
+                        line=winner.line_start,
+                        extra={
+                            "properties": [prop],
+                            "source_specificity": list(winner.specificity),
+                            "target_specificity": list(loser.specificity),
+                            "mechanism": mechanism,
+                        },
+                    ))
+
+        # Consolidate: merge edges between same (source, target) pair
+        consolidated: dict[tuple[str, str], EdgeInfo] = {}
+        for edge in raw_edges:
+            key = (edge.source, edge.target)
+            if key in consolidated:
+                consolidated[key].extra["properties"].extend(edge.extra["properties"])
+            else:
+                consolidated[key] = edge
+
+        return list(consolidated.values())
+
+    def _check_override(
+        self,
+        a: _SelectorRecord,
+        b: _SelectorRecord,
+        prop: str,
+    ) -> Optional[tuple[_SelectorRecord, _SelectorRecord, str]]:
+        """Check if two selectors override each other for a property.
+
+        Returns (winner, loser, mechanism) or None.
+        """
+        a_imp = a.has_important.get(prop, False)
+        b_imp = b.has_important.get(prop, False)
+        if a_imp and not b_imp:
+            return (a, b, "important")
+        if b_imp and not a_imp:
+            return (b, a, "important")
+
+        # BEM refinement
+        if self._is_bem_refinement(a.selector_text, b.selector_text):
+            return (a, b, "bem_refinement")
+        if self._is_bem_refinement(b.selector_text, a.selector_text):
+            return (b, a, "bem_refinement")
+
+        # Same selector, source order
+        if a.selector_text == b.selector_text:
+            if a.source_order > b.source_order:
+                return (a, b, "source_order")
+            return (b, a, "source_order")
+
+        # Key selector match with different specificity
+        key_a = self._extract_key_selector(a.selector_text)
+        key_b = self._extract_key_selector(b.selector_text)
+        if key_a and key_b and key_a == key_b:
+            if a.specificity > b.specificity:
+                return (a, b, "specificity")
+            elif b.specificity > a.specificity:
+                return (b, a, "specificity")
+
+        return None
+
+    @staticmethod
+    def _is_bem_refinement(candidate: str, base: str) -> bool:
+        """Check if candidate is a BEM refinement of base.
+
+        Only applies to simple class selectors (e.g. .btn → .btn-primary).
+        """
+        candidate = candidate.strip()
+        base = base.strip()
+        if not base or not candidate or len(candidate) <= len(base):
+            return False
+        # Only match simple class selectors (no spaces, combinators, etc.)
+        if " " in base or ">" in base or "+" in base or "~" in base:
+            return False
+        if candidate.startswith(base):
+            next_char = candidate[len(base)]
+            return next_char in ("-", "_", ".")
+        return False
+
+    @staticmethod
+    def _extract_key_selector(selector_text: str) -> Optional[str]:
+        """Extract the rightmost simple selector (key selector)."""
+        parts = re.split(r"\s*[>+~]\s*|\s+", selector_text.strip())
+        return parts[-1] if parts else None
+
+    def _split_css_selectors(
+        self, selectors_node,
+    ) -> list[tuple[str, object]]:
+        """Split comma-separated selectors into (text, AST node) tuples."""
+        result: list[tuple[str, object]] = []
+        current_parts: list = []
+        for child in selectors_node.children:
+            if child.type == ",":
+                if current_parts:
+                    sel_text = self._normalize_selector_text(current_parts)
+                    result.append((sel_text, current_parts[-1]))
+                    current_parts = []
+            else:
+                current_parts.append(child)
+        if current_parts:
+            sel_text = self._normalize_selector_text(current_parts)
+            result.append((sel_text, current_parts[-1]))
+        return result
+
+    @staticmethod
+    def _normalize_selector_text(parts: list) -> str:
+        """Build normalized selector text from AST node parts."""
+        texts = []
+        for part in parts:
+            raw = part.text.decode("utf-8", errors="replace").strip()
+            raw = re.sub(r"\s+", " ", raw)
+            texts.append(raw)
+        return " ".join(texts)
+
+    @staticmethod
+    def _extract_css_import(node) -> Optional[str]:
+        """Extract the import target from a CSS @import statement."""
+        for child in node.children:
+            if child.type == "string_value":
+                raw = child.text.decode("utf-8", errors="replace")
+                return raw.strip("'\"")
+            if child.type == "call_expression":
+                # url('path')
+                for sub in child.children:
+                    if sub.type == "arguments":
+                        for arg in sub.children:
+                            if arg.type == "string_value":
+                                raw = arg.text.decode("utf-8", errors="replace")
+                                return raw.strip("'\"")
+        return None
+
+    @staticmethod
+    def _get_css_media_text(node) -> str:
+        """Extract normalized media query text from a media_statement node."""
+        parts = []
+        for child in node.children:
+            if child.type in ("feature_query", "keyword_query", "binary_query"):
+                raw = child.text.decode("utf-8", errors="replace")
+                parts.append(re.sub(r"\s+", "", raw))
+        return ",".join(parts) if parts else "unknown"
+
+    @staticmethod
+    def _get_css_property_name(decl_node) -> Optional[str]:
+        """Extract property name from a CSS declaration node."""
+        for child in decl_node.children:
+            if child.type == "property_name":
+                return child.text.decode("utf-8", errors="replace")
+            if child.type == "variable_name":
+                return child.text.decode("utf-8", errors="replace")
+        return None
+
+    @staticmethod
+    def _find_var_refs(decl_node) -> list[str]:
+        """Find all var(--name) references in a declaration value."""
+        refs: list[str] = []
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "call_expression":
+                fn_name = None
+                for child in n.children:
+                    if child.type == "function_name":
+                        fn_name = child.text.decode("utf-8", errors="replace")
+                    elif child.type == "arguments" and fn_name == "var":
+                        for arg in child.children:
+                            if arg.type in ("plain_value", "identifier"):
+                                val = arg.text.decode("utf-8", errors="replace")
+                                if val.startswith("--"):
+                                    refs.append(val)
+            for child in n.children:
+                stack.append(child)
+        return refs
+
+    @staticmethod
+    def _has_important(decl_node) -> bool:
+        """Check if a CSS declaration has !important."""
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "important":
+                return True
+            for child in n.children:
+                stack.append(child)
+        return False
+
+    # --- LESS regex-based parser (v2) ---
+
+    # Regex patterns for LESS parsing (no tree-sitter grammar available)
+    _LESS_SELECTOR_RE = re.compile(
+        r"^([.#\w][\w\-\s>+~,.:[\]=*^$|\"'()]*?)\s*\{", re.MULTILINE,
+    )
+    _LESS_VARIABLE_RE = re.compile(r"^(@[\w-]+)\s*:\s*(.+?);", re.MULTILINE)
+    _LESS_IMPORT_RE = re.compile(
+        r'@import\s+(?:\([^)]+\)\s+)?["\']([^"\']+)["\']', re.MULTILINE,
+    )
+    _LESS_MIXIN_DEF_RE = re.compile(
+        r"^([.#][\w-]+)\s*\(([^)]*)\)\s*\{", re.MULTILINE,
+    )
+    _LESS_MIXIN_CALL_RE = re.compile(
+        r"^\s*([.#][\w-]+)\s*\(([^)]*)\)\s*;", re.MULTILINE,
+    )
+
+    @staticmethod
+    def _less_specificity(selector_text: str) -> tuple[int, int, int]:
+        """Compute CSS specificity from selector text using regex.
+
+        Returns (a, b, c) where a=IDs, b=classes/attrs/pseudo-classes,
+        c=type selectors/pseudo-elements.
+        """
+        # Strip pseudo-elements first (::before, ::after, etc.)
+        stripped = re.sub(r"::[a-zA-Z-]+", "", selector_text)
+        a = len(re.findall(r"#[\w-]+", stripped))
+        b = len(re.findall(r"\.[\w-]+", stripped))
+        b += len(re.findall(r"\[[\w-]+", stripped))
+        b += len(re.findall(r":[\w-]+", stripped))
+        # Type selectors: standalone word not preceded by . # : [
+        c = len(re.findall(r"(?<![.#:\[])(?:^|[\s>+~])([a-zA-Z][\w]*)", stripped))
+        return (a, b, c)
+
+    def _parse_less(
+        self, path: Path, source: bytes, line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a LESS file using regex-based extraction.
+
+        Creates same NodeInfo/EdgeInfo structures as _parse_css().
+        Supports selectors, @variables, @import, mixins, and mixin calls.
+        Note: nesting is not fully resolved (top-level selectors only).
+        """
+        file_path_str = str(path)
+        text = source.decode("utf-8", errors="replace")
+        nodes: list[NodeInfo] = []
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        # File node
+        nodes.append(NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=text.count("\n") + 1 + line_offset,
+            language="less",
+        ))
+
+        source_order = 0
+
+        # Extract @import statements
+        for m in self._LESS_IMPORT_RE.finditer(text):
+            target = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="IMPORTS_FROM",
+                source=file_path_str,
+                target=target,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract @variable declarations
+        for m in self._LESS_VARIABLE_RE.finditer(text):
+            var_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            qualified = self._qualify(var_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=var_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                extra={"css_kind": "less_variable"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract mixin definitions (before selectors to avoid double-matching)
+        mixin_names: set[str] = set()
+        for m in self._LESS_MIXIN_DEF_RE.finditer(text):
+            mixin_name = m.group(1)
+            params = m.group(2).strip()
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            mixin_names.add(mixin_name)
+            qualified = self._qualify(mixin_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=mixin_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                params=params if params else None,
+                extra={"css_kind": "mixin"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract selectors (skip lines that are mixin definitions)
+        for m in self._LESS_SELECTOR_RE.finditer(text):
+            sel_text = m.group(1).strip()
+            if not sel_text:
+                continue
+            # Skip if this is a mixin definition (has parens)
+            full_line = text[m.start():m.end()]
+            if re.search(r"\(", full_line.split("{")[0]):
+                continue
+            # Skip @-rules
+            if sel_text.startswith("@"):
+                continue
+
+            line_start = text[:m.start()].count("\n") + 1 + line_offset
+            # Split comma-separated selectors
+            for individual in sel_text.split(","):
+                individual = individual.strip()
+                if not individual:
+                    continue
+                specificity = self._less_specificity(individual)
+                qualified = self._qualify(individual, file_path_str, None)
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=individual,
+                    file_path=file_path_str,
+                    line_start=line_start,
+                    line_end=line_start,
+                    language="less",
+                    extra={
+                        "css_kind": "selector",
+                        "specificity": list(specificity),
+                    },
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path_str,
+                    target=qualified,
+                    file_path=file_path_str,
+                    line=line_start,
+                ))
+                # Collect for override detection
+                selector_records.append(self._SelectorRecord(
+                    selector_text=individual,
+                    qualified_name=qualified,
+                    specificity=specificity,
+                    properties={},
+                    has_important={},
+                    line_start=line_start,
+                    line_end=line_start,
+                    source_order=source_order,
+                ))
+                source_order += 1
+
+        # Extract mixin calls
+        for m in self._LESS_MIXIN_CALL_RE.finditer(text):
+            call_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="CALLS",
+                source=file_path_str,
+                target=self._qualify(call_name, file_path_str, None),
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Detect overrides among selectors
+        override_edges = self._detect_css_overrides(
+            selector_records, file_path_str,
+        )
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    # --- JSX / Vue template class extraction (v2) ---
+
+    @staticmethod
+    def _camel_to_kebab(name: str) -> str:
+        """Convert camelCase to kebab-case for CSS Modules resolution.
+
+        Examples: btnPrimary → btn-primary, navItem → nav-item
+        """
+        return re.sub(r"(?<=[a-z0-9])([A-Z])", r"-\1", name).lower()
+
+    def _extract_jsx_class_refs(
+        self, attr_node, source: bytes,
+    ) -> tuple[list[str], list[tuple[str, str]]]:
+        """Extract class names from a jsx_attribute node.
+
+        Returns (static_classes, module_refs) where module_refs are
+        (import_name, property_name) tuples for CSS Modules.
+        """
+        static_classes: list[str] = []
+        module_refs: list[tuple[str, str]] = []
+
+        # Check this is a className or class attribute
+        attr_name = None
+        value_node = None
+        for child in attr_node.children:
+            if child.type == "property_identifier":
+                attr_name = child.text.decode("utf-8", errors="replace")
+            elif child.type == "string":
+                value_node = child
+            elif child.type == "jsx_expression":
+                value_node = child
+
+        if attr_name not in ("className", "class"):
+            return static_classes, module_refs
+
+        if value_node is None:
+            return static_classes, module_refs
+
+        if value_node.type == "string":
+            # className="btn btn-primary"
+            text = value_node.text.decode("utf-8", errors="replace")
+            text = text.strip("'\"")
+            static_classes.extend(text.split())
+        elif value_node.type == "jsx_expression":
+            # Look inside the expression
+            for expr_child in value_node.children:
+                if expr_child.type == "string":
+                    # className={"btn btn-primary"}
+                    text = expr_child.text.decode("utf-8", errors="replace")
+                    text = text.strip("'\"")
+                    static_classes.extend(text.split())
+                elif expr_child.type == "template_string":
+                    # className={`btn ${...}`} — extract literal parts
+                    for frag in expr_child.children:
+                        if frag.type == "string_fragment":
+                            for part in frag.text.decode(
+                                "utf-8", errors="replace",
+                            ).split():
+                                if part and not part.startswith("$"):
+                                    static_classes.append(part)
+                elif expr_child.type == "member_expression":
+                    # className={styles.btnPrimary}
+                    obj_name = None
+                    prop_name = None
+                    for me_child in expr_child.children:
+                        if me_child.type == "identifier":
+                            obj_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                        elif me_child.type == "property_identifier":
+                            prop_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                    if obj_name and prop_name:
+                        module_refs.append((obj_name, prop_name))
+
+        return static_classes, module_refs
+
+    def _extract_vue_template_classes(self, node) -> list[str]:
+        """Recursively walk Vue template AST, extract class='...' values.
+
+        Only extracts static class attributes, skips :class dynamic bindings.
+        """
+        classes: list[str] = []
+        stack = [node]
+        while stack:
+            n = stack.pop()
+            if n.type == "attribute":
+                attr_name = None
+                attr_value = None
+                for child in n.children:
+                    if child.type == "attribute_name":
+                        attr_name = child.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                    elif child.type == "quoted_attribute_value":
+                        for v in child.children:
+                            if v.type == "attribute_value":
+                                attr_value = v.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                if attr_name == "class" and attr_value:
+                    classes.extend(attr_value.split())
+            # Skip directive_attribute (:class bindings)
+            elif n.type == "directive_attribute":
+                continue
+            for child in n.children:
+                stack.append(child)
+        return classes
 
     def _resolve_call_targets(
         self,
@@ -475,6 +1524,7 @@ class CodeParser:
         import_map: Optional[dict[str, str]] = None,
         defined_names: Optional[set[str]] = None,
         _depth: int = 0,
+        jsx_class_collector: Optional[dict[str, dict]] = None,
     ) -> None:
         """Recursively walk the AST and extract nodes/edges."""
         if _depth > self._MAX_AST_DEPTH:
@@ -528,6 +1578,7 @@ class CodeParser:
                         enclosing_class=name, enclosing_func=None,
                         import_map=import_map, defined_names=defined_names,
                         _depth=_depth + 1,
+                        jsx_class_collector=jsx_class_collector,
                     )
                     continue
 
@@ -592,6 +1643,7 @@ class CodeParser:
                         enclosing_class=enclosing_class, enclosing_func=name,
                         import_map=import_map, defined_names=defined_names,
                         _depth=_depth + 1,
+                        jsx_class_collector=jsx_class_collector,
                     )
                     continue
 
@@ -624,6 +1676,27 @@ class CodeParser:
                         file_path=file_path,
                         line=child.start_point[0] + 1,
                     ))
+
+            # --- JSX className extraction ---
+            if (
+                node_type == "jsx_attribute"
+                and language in ("javascript", "typescript", "tsx")
+                and jsx_class_collector is not None
+            ):
+                static_cls, mod_refs = self._extract_jsx_class_refs(
+                    child, source,
+                )
+                func_key = self._qualify(
+                    enclosing_func or "<module>", file_path, enclosing_class,
+                )
+                if static_cls or mod_refs:
+                    if func_key not in jsx_class_collector:
+                        jsx_class_collector[func_key] = {
+                            "classes": [], "module_refs": [],
+                        }
+                    entry = jsx_class_collector[func_key]
+                    entry["classes"].extend(static_cls)
+                    entry["module_refs"].extend(mod_refs)
 
             # --- Solidity-specific constructs ---
             if language == "solidity":
@@ -757,6 +1830,7 @@ class CodeParser:
                 enclosing_class=enclosing_class, enclosing_func=enclosing_func,
                 import_map=import_map, defined_names=defined_names,
                 _depth=_depth + 1,
+                jsx_class_collector=jsx_class_collector,
             )
 
     def _collect_file_scope(
@@ -908,7 +1982,7 @@ class CodeParser:
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue"]
+                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue", ".css", ".scss"]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
@@ -923,6 +1997,23 @@ class CodeParser:
                         target = base / f"index{ext}"
                         if target.is_file():
                             return str(target.resolve())
+
+        elif language in ("css", "scss"):
+            if module.startswith(".") or module.startswith("/"):
+                base = caller_dir / module
+                extensions = [".css", ".scss"]
+                if base.is_file():
+                    return str(base.resolve())
+                for ext in extensions:
+                    target = base.with_suffix(ext)
+                    if target.is_file():
+                        return str(target.resolve())
+                # SCSS partial: _filename.scss
+                base_name = base.name
+                for ext in extensions:
+                    partial = base.parent / f"_{base_name}{ext}"
+                    if partial.is_file():
+                        return str(partial.resolve())
 
         return None
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -68,7 +68,7 @@ class NodeInfo:
 @dataclass
 class EdgeInfo:
     # CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS,
-    # TESTED_BY, DEPENDS_ON, REFERENCES
+    # TESTED_BY, DEPENDS_ON, REFERENCES, OVERRIDES, STYLES, POTENTIAL_CONFLICT
     kind: str
     source: str  # qualified name or path
     target: str  # qualified name or path
@@ -105,6 +105,9 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".scala": "scala",
     ".sol": "solidity",
     ".vue": "vue",
+    ".css": "css",
+    ".scss": "scss",
+    ".less": "less",
     ".dart": "dart",
     ".r": "r",  # .lower() in detect_language handles .R → .r
     ".mjs": "javascript",
@@ -807,6 +810,13 @@ class CodeParser:
         self._tsconfig_resolver = TsconfigResolver()
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
+        # Per-parse scratch space collecting JSX className/CSS-module refs,
+        # keyed by the qualified name of the enclosing function. Reset at the
+        # start of every parse_bytes() call; not threaded through
+        # _extract_from_tree's recursion (22 call sites) since it is only
+        # ever written by the JSX-attribute branch and read back once parsing
+        # of the current file/script-block finishes.
+        self._jsx_class_collector: dict[str, dict] = {}
         # Config-driven custom languages (.code-review-graph/languages.toml).
         # The built-in tables stay shared module-level constants; only when a
         # repo defines custom languages does this parser switch to merged
@@ -989,6 +999,14 @@ class CodeParser:
         if language == "sql":
             return self._parse_sql(path, source)
 
+        # CSS/SCSS: dedicated parser for stylesheet languages
+        if language in ("css", "scss"):
+            return self._parse_css(path, source, language)
+
+        # LESS: regex-based fallback (no tree-sitter grammar available)
+        if language == "less":
+            return self._parse_less(path, source)
+
         parser = self._get_parser(language)
         if not parser:
             return [], []
@@ -1015,11 +1033,41 @@ class CodeParser:
             tree.root_node, language, source,
         )
 
-        # Walk the tree
+        # Walk the tree (jsx_class_collector is reset per parse and populated
+        # by the jsx_attribute branch inside _extract_from_tree)
+        self._jsx_class_collector = {}
         self._extract_from_tree(
             tree.root_node, source, language, file_path_str, nodes, edges,
             import_map=import_map, defined_names=defined_names,
         )
+
+        # Attach collected JSX class refs to their enclosing function nodes
+        if self._jsx_class_collector:
+            node_by_qn: dict[str, NodeInfo] = {}
+            for n in nodes:
+                qn = self._qualify(n.name, n.file_path, n.parent_name)
+                node_by_qn[qn] = n
+            for func_qn, refs in self._jsx_class_collector.items():
+                target_node = node_by_qn.get(func_qn)
+                if target_node:
+                    if refs.get("classes"):
+                        target_node.extra["css_classes"] = sorted(
+                            set(refs["classes"]),
+                        )
+                    if refs.get("module_refs"):
+                        target_node.extra["css_module_refs"] = [
+                            {"import": imp, "property": prop}
+                            for imp, prop in refs["module_refs"]
+                        ]
+
+        # Detect CSS Module imports and store on File node
+        if import_map:
+            css_mod_imports = {
+                name: mod for name, mod in import_map.items()
+                if ".module.css" in mod or ".module.scss" in mod
+            }
+            if css_mod_imports:
+                nodes[0].extra["css_module_imports"] = css_mod_imports
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -1135,6 +1183,65 @@ class CodeParser:
 
             all_nodes.extend(nodes)
             all_edges.extend(edges)
+
+        # Extract <style> blocks and delegate to CSS/SCSS parser
+        for child in tree.root_node.children:
+            if child.type != "style_element":
+                continue
+
+            style_lang = "css"
+            raw_text_node = None
+            start_tag = None
+            for sub in child.children:
+                if sub.type == "start_tag":
+                    start_tag = sub
+                elif sub.type == "raw_text":
+                    raw_text_node = sub
+
+            if start_tag:
+                for attr in start_tag.children:
+                    if attr.type == "attribute":
+                        attr_name = None
+                        attr_value = None
+                        for a in attr.children:
+                            if a.type == "attribute_name":
+                                attr_name = a.text.decode("utf-8", errors="replace")
+                            elif a.type == "quoted_attribute_value":
+                                for v in a.children:
+                                    if v.type == "attribute_value":
+                                        attr_value = v.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                        if attr_name == "lang" and attr_value in ("scss", "sass"):
+                            style_lang = "scss"
+
+            if not raw_text_node:
+                continue
+
+            style_source = raw_text_node.text
+            style_line_offset = raw_text_node.start_point[0]
+
+            style_nodes, style_edges = self._parse_css(
+                path, style_source, style_lang, line_offset=style_line_offset,
+            )
+
+            # Remove the File node that _parse_css creates (we already have one)
+            style_nodes = [n for n in style_nodes if n.kind != "File"]
+            for sn in style_nodes:
+                sn.language = "vue"
+
+            all_nodes.extend(style_nodes)
+            all_edges.extend(style_edges)
+
+        # Extract static class names from <template> elements
+        for child in tree.root_node.children:
+            if child.type == "template_element":
+                template_classes = self._extract_vue_template_classes(child)
+                if template_classes:
+                    all_nodes[0].extra["vue_template_classes"] = sorted(
+                        set(template_classes),
+                    )
+                break  # Only one <template> per SFC
 
         # Generate TESTED_BY edges
         if test_file:
@@ -2160,6 +2267,955 @@ class CodeParser:
             line=line_start,
         ))
 
+    # -------------------------------------------------------------------
+    # CSS / SCSS parsing
+    # -------------------------------------------------------------------
+
+    @dataclass
+    class _SelectorRecord:
+        """Ephemeral record for CSS override detection within a single file."""
+
+        selector_text: str
+        qualified_name: str
+        specificity: tuple[int, int, int]
+        properties: dict[str, int]          # property_name -> line
+        has_important: dict[str, bool]      # property_name -> has !important
+        line_start: int
+        line_end: int
+        source_order: int
+
+    def _parse_css(
+        self,
+        path: Path,
+        source: bytes,
+        language: str = "css",
+        line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a CSS/SCSS file and extract selectors, custom properties,
+        mixins, variables, @import, var() usage, and override relationships."""
+        css_parser = self._get_parser(language)
+        if not css_parser:
+            return [], []
+
+        tree = css_parser.parse(source)
+        file_path_str = str(path)
+
+        nodes: list[NodeInfo] = [NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=source.count(b"\n") + 1 + line_offset,
+            language=language,
+        )]
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        self._walk_css(
+            tree.root_node, source, language, file_path_str,
+            nodes, edges, selector_records,
+            enclosing_context=None, line_offset=line_offset,
+        )
+
+        # Override detection (post-processing after all selectors collected)
+        override_edges = self._detect_css_overrides(selector_records, file_path_str)
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    def _walk_css(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str] = None,
+        line_offset: int = 0,
+        _depth: int = 0,
+    ) -> None:
+        """Recursively walk CSS/SCSS AST extracting nodes and edges."""
+        if _depth > self._MAX_AST_DEPTH:
+            return
+
+        for child in node.children:
+            node_type = child.type
+
+            # --- @import / @use ---
+            if node_type in ("import_statement", "use_statement"):
+                target = self._extract_css_import(child)
+                if target:
+                    edges.append(EdgeInfo(
+                        kind="IMPORTS_FROM",
+                        source=file_path,
+                        target=target,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- rule_set (selector + block) ---
+            if node_type == "rule_set":
+                self._handle_css_ruleset(
+                    child, source, language, file_path,
+                    nodes, edges, selector_records,
+                    enclosing_context, line_offset, _depth,
+                )
+                continue
+
+            # --- @media ---
+            if node_type == "media_statement":
+                media_text = self._get_css_media_text(child)
+                media_name = f"@media({media_text})"
+                qualified = self._qualify(media_name, file_path, None)
+
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=media_name,
+                    file_path=file_path,
+                    line_start=child.start_point[0] + 1 + line_offset,
+                    line_end=child.end_point[0] + 1 + line_offset,
+                    language=language,
+                    extra={"css_kind": "media_query"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path,
+                    target=qualified,
+                    file_path=file_path,
+                    line=child.start_point[0] + 1 + line_offset,
+                ))
+
+                for sub in child.children:
+                    if sub.type == "block":
+                        self._walk_css(
+                            sub, source, language, file_path,
+                            nodes, edges, selector_records,
+                            enclosing_context=media_name,
+                            line_offset=line_offset,
+                            _depth=_depth + 1,
+                        )
+                continue
+
+            # --- @keyframes ---
+            if node_type == "keyframes_statement":
+                kf_name = None
+                for sub in child.children:
+                    if sub.type == "keyframes_name":
+                        kf_name = sub.text.decode("utf-8", errors="replace")
+                if kf_name:
+                    name = f"@keyframes({kf_name})"
+                    nodes.append(NodeInfo(
+                        kind="Class",
+                        name=name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "keyframes"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: top-level $variable declarations ---
+            if language == "scss" and node_type == "declaration":
+                prop_name = self._get_css_property_name(child)
+                if prop_name and prop_name.startswith("$"):
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=prop_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "scss_variable"},
+                    ))
+                    container = (
+                        self._qualify(enclosing_context, file_path, None)
+                        if enclosing_context
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=self._qualify(prop_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: @mixin ---
+            if language == "scss" and node_type == "mixin_statement":
+                mixin_name = None
+                for sub in child.children:
+                    if sub.type == "identifier":
+                        mixin_name = sub.text.decode("utf-8", errors="replace")
+                        break
+                if mixin_name:
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=mixin_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "mixin"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(mixin_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- Recurse into other nodes ---
+            self._walk_css(
+                child, source, language, file_path,
+                nodes, edges, selector_records,
+                enclosing_context=enclosing_context,
+                line_offset=line_offset,
+                _depth=_depth + 1,
+            )
+
+    def _handle_css_ruleset(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str],
+        line_offset: int,
+        _depth: int,
+    ) -> None:
+        """Process a CSS rule_set: extract selectors, properties, var() refs."""
+        selectors_node = None
+        block_node = None
+        for sub in node.children:
+            if sub.type == "selectors":
+                selectors_node = sub
+            elif sub.type == "block":
+                block_node = sub
+
+        if not selectors_node:
+            return
+
+        # Extract properties and var() refs from the block
+        properties: dict[str, int] = {}
+        has_important: dict[str, bool] = {}
+        var_refs: list[tuple[str, int]] = []   # (var_name, line)
+        include_refs: list[tuple[str, int]] = []  # (mixin_name, line)
+        custom_prop_defs: list[tuple[str, int, int]] = []  # (name, line_start, line_end)
+
+        if block_node:
+            for decl in block_node.children:
+                if decl.type == "declaration":
+                    prop = self._get_css_property_name(decl)
+                    if prop:
+                        line = decl.start_point[0] + 1 + line_offset
+                        if prop.startswith("--"):
+                            # Custom property definition
+                            custom_prop_defs.append((
+                                prop, line, decl.end_point[0] + 1 + line_offset,
+                            ))
+                        else:
+                            properties[prop] = line
+                            has_important[prop] = self._has_important(decl)
+                        # Check for var() references in value
+                        for var_name in self._find_var_refs(decl):
+                            var_refs.append((var_name, line))
+                elif decl.type == "include_statement" and language == "scss":
+                    # @include mixin_name
+                    for sub in decl.children:
+                        if sub.type == "identifier":
+                            include_refs.append((
+                                sub.text.decode("utf-8", errors="replace"),
+                                decl.start_point[0] + 1 + line_offset,
+                            ))
+                            break
+
+        # Split comma-separated selectors into individual nodes
+        individual_selectors = self._split_css_selectors(selectors_node)
+
+        # Create custom property nodes once (not per selector in comma groups)
+        seen_custom_props: set[str] = set()
+        first_qualified: Optional[str] = None
+
+        for sel_text, sel_node in individual_selectors:
+            # Resolve SCSS nesting selector (&)
+            if language == "scss" and enclosing_context and "&" in sel_text:
+                # For BEM: &-primary → .btn-primary (parent is .btn)
+                parent_sel = enclosing_context
+                if parent_sel.startswith("@"):
+                    parent_sel = ""  # Don't resolve & against @media
+                sel_text = sel_text.replace("&", parent_sel)
+
+            specificity = self._compute_specificity(sel_node)
+            qualified = self._qualify(sel_text, file_path, enclosing_context)
+            if first_qualified is None:
+                first_qualified = qualified
+
+            nodes.append(NodeInfo(
+                kind="Class",
+                name=sel_text,
+                file_path=file_path,
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                language=language,
+                parent_name=enclosing_context,
+                extra={"css_kind": "selector", "specificity": list(specificity)},
+            ))
+
+            # CONTAINS edge
+            container = (
+                self._qualify(enclosing_context, file_path, None)
+                if enclosing_context
+                else file_path
+            )
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=container,
+                target=qualified,
+                file_path=file_path,
+                line=node.start_point[0] + 1 + line_offset,
+            ))
+
+            # Custom property definitions — only create once, parent to first selector
+            for cp_name, cp_start, cp_end in custom_prop_defs:
+                if cp_name in seen_custom_props:
+                    continue
+                seen_custom_props.add(cp_name)
+                cp_qualified = self._qualify(cp_name, file_path, None)
+                nodes.append(NodeInfo(
+                    kind="Function",
+                    name=cp_name,
+                    file_path=file_path,
+                    line_start=cp_start,
+                    line_end=cp_end,
+                    language=language,
+                    parent_name=sel_text,
+                    extra={"css_kind": "custom_property"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=first_qualified,
+                    target=cp_qualified,
+                    file_path=file_path,
+                    line=cp_start,
+                ))
+
+            # var() references → CALLS edges
+            for var_name, var_line in var_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=var_name,
+                    file_path=file_path,
+                    line=var_line,
+                ))
+
+            # SCSS @include → CALLS edges
+            for mixin_name, inc_line in include_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=mixin_name,
+                    file_path=file_path,
+                    line=inc_line,
+                ))
+
+            # Record for override detection
+            selector_records.append(CodeParser._SelectorRecord(
+                selector_text=sel_text,
+                qualified_name=qualified,
+                specificity=specificity,
+                properties=dict(properties),
+                has_important=dict(has_important),
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                source_order=len(selector_records),
+            ))
+
+        # Recurse into nested rule_sets (SCSS nesting / CSS nesting)
+        if block_node:
+            for sub in block_node.children:
+                if sub.type == "rule_set":
+                    # Use the first selector as enclosing context for nesting
+                    ctx = individual_selectors[0][0] if individual_selectors else enclosing_context
+                    self._handle_css_ruleset(
+                        sub, source, language, file_path,
+                        nodes, edges, selector_records,
+                        enclosing_context=ctx,
+                        line_offset=line_offset,
+                        _depth=_depth + 1,
+                    )
+
+    def _compute_specificity(self, selector_node) -> tuple[int, int, int]:
+        """Compute CSS specificity (a, b, c) from a selector AST node.
+
+        a = ID selectors, b = class/pseudo-class/attribute, c = type/pseudo-element.
+        """
+        a = b = c = 0
+        stack = [selector_node]
+        while stack:
+            n = stack.pop()
+            t = n.type
+            if t == "id_selector":
+                a += 1
+            elif t in ("class_selector", "pseudo_class_selector", "attribute_selector"):
+                b += 1
+            elif t == "pseudo_element_selector":
+                c += 1
+            elif t == "tag_name":
+                # Don't count tag_name inside pseudo_element_selector (already counted)
+                if not (n.parent and n.parent.type == "pseudo_element_selector"):
+                    c += 1
+            for child in n.children:
+                stack.append(child)
+        return (a, b, c)
+
+    def _detect_css_overrides(
+        self,
+        records: list[_SelectorRecord],
+        file_path: str,
+    ) -> list[EdgeInfo]:
+        """Detect CSS override relationships between selectors in a file."""
+        if len(records) < 2:
+            return []
+
+        # Build property → record indices
+        prop_index: dict[str, list[int]] = {}
+        for i, rec in enumerate(records):
+            for prop in rec.properties:
+                prop_index.setdefault(prop, []).append(i)
+
+        seen_pairs: set[tuple[str, str, str]] = set()
+        raw_edges: list[EdgeInfo] = []
+
+        max_override_candidates = 50  # Cap pairwise comparisons per property
+
+        for prop, rec_indices in prop_index.items():
+            if len(rec_indices) < 2:
+                continue
+            # Cap to avoid O(n²) blow-up on large files with common properties
+            candidates = rec_indices[:max_override_candidates]
+            for i in range(len(candidates)):
+                for j in range(i + 1, len(candidates)):
+                    ri = records[rec_indices[i]]
+                    rj = records[rec_indices[j]]
+                    result = self._check_override(ri, rj, prop)
+                    if result is None:
+                        continue
+                    winner, loser, mechanism = result
+                    pair_key = (winner.qualified_name, loser.qualified_name, prop)
+                    if pair_key in seen_pairs:
+                        continue
+                    seen_pairs.add(pair_key)
+                    raw_edges.append(EdgeInfo(
+                        kind="OVERRIDES",
+                        source=winner.qualified_name,
+                        target=loser.qualified_name,
+                        file_path=file_path,
+                        line=winner.line_start,
+                        extra={
+                            "properties": [prop],
+                            "source_specificity": list(winner.specificity),
+                            "target_specificity": list(loser.specificity),
+                            "mechanism": mechanism,
+                        },
+                    ))
+
+        # Consolidate: merge edges between same (source, target) pair
+        consolidated: dict[tuple[str, str], EdgeInfo] = {}
+        for edge in raw_edges:
+            key = (edge.source, edge.target)
+            if key in consolidated:
+                consolidated[key].extra["properties"].extend(edge.extra["properties"])
+            else:
+                consolidated[key] = edge
+
+        return list(consolidated.values())
+
+    def _check_override(
+        self,
+        a: _SelectorRecord,
+        b: _SelectorRecord,
+        prop: str,
+    ) -> Optional[tuple[_SelectorRecord, _SelectorRecord, str]]:
+        """Check if two selectors override each other for a property.
+
+        Returns (winner, loser, mechanism) or None.
+        """
+        a_imp = a.has_important.get(prop, False)
+        b_imp = b.has_important.get(prop, False)
+        if a_imp and not b_imp:
+            return (a, b, "important")
+        if b_imp and not a_imp:
+            return (b, a, "important")
+
+        # BEM refinement
+        if self._is_bem_refinement(a.selector_text, b.selector_text):
+            return (a, b, "bem_refinement")
+        if self._is_bem_refinement(b.selector_text, a.selector_text):
+            return (b, a, "bem_refinement")
+
+        # Same selector, source order
+        if a.selector_text == b.selector_text:
+            if a.source_order > b.source_order:
+                return (a, b, "source_order")
+            return (b, a, "source_order")
+
+        # Key selector match with different specificity
+        key_a = self._extract_key_selector(a.selector_text)
+        key_b = self._extract_key_selector(b.selector_text)
+        if key_a and key_b and key_a == key_b:
+            if a.specificity > b.specificity:
+                return (a, b, "specificity")
+            elif b.specificity > a.specificity:
+                return (b, a, "specificity")
+
+        return None
+
+    @staticmethod
+    def _is_bem_refinement(candidate: str, base: str) -> bool:
+        """Check if candidate is a BEM refinement of base.
+
+        Only applies to simple class selectors (e.g. .btn → .btn-primary).
+        """
+        candidate = candidate.strip()
+        base = base.strip()
+        if not base or not candidate or len(candidate) <= len(base):
+            return False
+        # Only match simple class selectors (no spaces, combinators, etc.)
+        if " " in base or ">" in base or "+" in base or "~" in base:
+            return False
+        if candidate.startswith(base):
+            next_char = candidate[len(base)]
+            return next_char in ("-", "_", ".")
+        return False
+
+    @staticmethod
+    def _extract_key_selector(selector_text: str) -> Optional[str]:
+        """Extract the rightmost simple selector (key selector)."""
+        parts = re.split(r"\s*[>+~]\s*|\s+", selector_text.strip())
+        return parts[-1] if parts else None
+
+    def _split_css_selectors(
+        self, selectors_node,
+    ) -> list[tuple[str, object]]:
+        """Split comma-separated selectors into (text, AST node) tuples."""
+        result: list[tuple[str, object]] = []
+        current_parts: list = []
+        for child in selectors_node.children:
+            if child.type == ",":
+                if current_parts:
+                    sel_text = self._normalize_selector_text(current_parts)
+                    result.append((sel_text, current_parts[-1]))
+                    current_parts = []
+            else:
+                current_parts.append(child)
+        if current_parts:
+            sel_text = self._normalize_selector_text(current_parts)
+            result.append((sel_text, current_parts[-1]))
+        return result
+
+    @staticmethod
+    def _normalize_selector_text(parts: list) -> str:
+        """Build normalized selector text from AST node parts."""
+        texts = []
+        for part in parts:
+            raw = part.text.decode("utf-8", errors="replace").strip()
+            raw = re.sub(r"\s+", " ", raw)
+            texts.append(raw)
+        return " ".join(texts)
+
+    @staticmethod
+    def _extract_css_import(node) -> Optional[str]:
+        """Extract the import target from a CSS @import statement."""
+        for child in node.children:
+            if child.type == "string_value":
+                raw = child.text.decode("utf-8", errors="replace")
+                return raw.strip("'\"")
+            if child.type == "call_expression":
+                # url('path')
+                for sub in child.children:
+                    if sub.type == "arguments":
+                        for arg in sub.children:
+                            if arg.type == "string_value":
+                                raw = arg.text.decode("utf-8", errors="replace")
+                                return raw.strip("'\"")
+        return None
+
+    @staticmethod
+    def _get_css_media_text(node) -> str:
+        """Extract normalized media query text from a media_statement node."""
+        parts = []
+        for child in node.children:
+            if child.type in ("feature_query", "keyword_query", "binary_query"):
+                raw = child.text.decode("utf-8", errors="replace")
+                parts.append(re.sub(r"\s+", "", raw))
+        return ",".join(parts) if parts else "unknown"
+
+    @staticmethod
+    def _get_css_property_name(decl_node) -> Optional[str]:
+        """Extract property name from a CSS declaration node."""
+        for child in decl_node.children:
+            if child.type == "property_name":
+                return child.text.decode("utf-8", errors="replace")
+            if child.type == "variable_name":
+                return child.text.decode("utf-8", errors="replace")
+        return None
+
+    @staticmethod
+    def _find_var_refs(decl_node) -> list[str]:
+        """Find all var(--name) references in a declaration value."""
+        refs: list[str] = []
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "call_expression":
+                fn_name = None
+                for child in n.children:
+                    if child.type == "function_name":
+                        fn_name = child.text.decode("utf-8", errors="replace")
+                    elif child.type == "arguments" and fn_name == "var":
+                        for arg in child.children:
+                            if arg.type in ("plain_value", "identifier"):
+                                val = arg.text.decode("utf-8", errors="replace")
+                                if val.startswith("--"):
+                                    refs.append(val)
+            for child in n.children:
+                stack.append(child)
+        return refs
+
+    @staticmethod
+    def _has_important(decl_node) -> bool:
+        """Check if a CSS declaration has !important."""
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "important":
+                return True
+            for child in n.children:
+                stack.append(child)
+        return False
+
+    # --- LESS regex-based parser ---
+
+    # Regex patterns for LESS parsing (no tree-sitter grammar available)
+    _LESS_SELECTOR_RE = re.compile(
+        r"^([.#\w][\w\-\s>+~,.:[\]=*^$|\"'()]*?)\s*\{", re.MULTILINE,
+    )
+    _LESS_VARIABLE_RE = re.compile(r"^(@[\w-]+)\s*:\s*(.+?);", re.MULTILINE)
+    _LESS_IMPORT_RE = re.compile(
+        r'@import\s+(?:\([^)]+\)\s+)?["\']([^"\']+)["\']', re.MULTILINE,
+    )
+    _LESS_MIXIN_DEF_RE = re.compile(
+        r"^([.#][\w-]+)\s*\(([^)]*)\)\s*\{", re.MULTILINE,
+    )
+    _LESS_MIXIN_CALL_RE = re.compile(
+        r"^\s*([.#][\w-]+)\s*\(([^)]*)\)\s*;", re.MULTILINE,
+    )
+
+    @staticmethod
+    def _less_specificity(selector_text: str) -> tuple[int, int, int]:
+        """Compute CSS specificity from selector text using regex.
+
+        Returns (a, b, c) where a=IDs, b=classes/attrs/pseudo-classes,
+        c=type selectors/pseudo-elements.
+        """
+        # Strip pseudo-elements first (::before, ::after, etc.)
+        stripped = re.sub(r"::[a-zA-Z-]+", "", selector_text)
+        a = len(re.findall(r"#[\w-]+", stripped))
+        b = len(re.findall(r"\.[\w-]+", stripped))
+        b += len(re.findall(r"\[[\w-]+", stripped))
+        b += len(re.findall(r":[\w-]+", stripped))
+        # Type selectors: standalone word not preceded by . # : [
+        c = len(re.findall(r"(?<![.#:\[])(?:^|[\s>+~])([a-zA-Z][\w]*)", stripped))
+        return (a, b, c)
+
+    def _parse_less(
+        self, path: Path, source: bytes, line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a LESS file using regex-based extraction.
+
+        Creates same NodeInfo/EdgeInfo structures as _parse_css().
+        Supports selectors, @variables, @import, mixins, and mixin calls.
+        Note: nesting is not fully resolved (top-level selectors only).
+        """
+        file_path_str = str(path)
+        text = source.decode("utf-8", errors="replace")
+        nodes: list[NodeInfo] = []
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        # File node
+        nodes.append(NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=text.count("\n") + 1 + line_offset,
+            language="less",
+        ))
+
+        source_order = 0
+
+        # Extract @import statements
+        for m in self._LESS_IMPORT_RE.finditer(text):
+            target = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="IMPORTS_FROM",
+                source=file_path_str,
+                target=target,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract @variable declarations
+        for m in self._LESS_VARIABLE_RE.finditer(text):
+            var_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            qualified = self._qualify(var_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=var_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                extra={"css_kind": "less_variable"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract mixin definitions (before selectors to avoid double-matching)
+        mixin_names: set[str] = set()
+        for m in self._LESS_MIXIN_DEF_RE.finditer(text):
+            mixin_name = m.group(1)
+            params = m.group(2).strip()
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            mixin_names.add(mixin_name)
+            qualified = self._qualify(mixin_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=mixin_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                params=params if params else None,
+                extra={"css_kind": "mixin"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract selectors (skip lines that are mixin definitions)
+        for m in self._LESS_SELECTOR_RE.finditer(text):
+            sel_text = m.group(1).strip()
+            if not sel_text:
+                continue
+            # Skip if this is a mixin definition (has parens)
+            full_line = text[m.start():m.end()]
+            if re.search(r"\(", full_line.split("{")[0]):
+                continue
+            # Skip @-rules
+            if sel_text.startswith("@"):
+                continue
+
+            line_start = text[:m.start()].count("\n") + 1 + line_offset
+            # Split comma-separated selectors
+            for individual in sel_text.split(","):
+                individual = individual.strip()
+                if not individual:
+                    continue
+                specificity = self._less_specificity(individual)
+                qualified = self._qualify(individual, file_path_str, None)
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=individual,
+                    file_path=file_path_str,
+                    line_start=line_start,
+                    line_end=line_start,
+                    language="less",
+                    extra={
+                        "css_kind": "selector",
+                        "specificity": list(specificity),
+                    },
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path_str,
+                    target=qualified,
+                    file_path=file_path_str,
+                    line=line_start,
+                ))
+                # Collect for override detection
+                selector_records.append(self._SelectorRecord(
+                    selector_text=individual,
+                    qualified_name=qualified,
+                    specificity=specificity,
+                    properties={},
+                    has_important={},
+                    line_start=line_start,
+                    line_end=line_start,
+                    source_order=source_order,
+                ))
+                source_order += 1
+
+        # Extract mixin calls
+        for m in self._LESS_MIXIN_CALL_RE.finditer(text):
+            call_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="CALLS",
+                source=file_path_str,
+                target=self._qualify(call_name, file_path_str, None),
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Detect overrides among selectors
+        override_edges = self._detect_css_overrides(
+            selector_records, file_path_str,
+        )
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    # --- JSX / Vue template class extraction ---
+
+    @staticmethod
+    def _camel_to_kebab(name: str) -> str:
+        """Convert camelCase to kebab-case for CSS Modules resolution.
+
+        Examples: btnPrimary → btn-primary, navItem → nav-item
+        """
+        return re.sub(r"(?<=[a-z0-9])([A-Z])", r"-\1", name).lower()
+
+    def _extract_jsx_class_refs(
+        self, attr_node, source: bytes,
+    ) -> tuple[list[str], list[tuple[str, str]]]:
+        """Extract class names from a jsx_attribute node.
+
+        Returns (static_classes, module_refs) where module_refs are
+        (import_name, property_name) tuples for CSS Modules.
+        """
+        static_classes: list[str] = []
+        module_refs: list[tuple[str, str]] = []
+
+        # Check this is a className or class attribute
+        attr_name = None
+        value_node = None
+        for child in attr_node.children:
+            if child.type == "property_identifier":
+                attr_name = child.text.decode("utf-8", errors="replace")
+            elif child.type == "string":
+                value_node = child
+            elif child.type == "jsx_expression":
+                value_node = child
+
+        if attr_name not in ("className", "class"):
+            return static_classes, module_refs
+
+        if value_node is None:
+            return static_classes, module_refs
+
+        if value_node.type == "string":
+            # className="btn btn-primary"
+            text = value_node.text.decode("utf-8", errors="replace")
+            text = text.strip("'\"")
+            static_classes.extend(text.split())
+        elif value_node.type == "jsx_expression":
+            # Look inside the expression
+            for expr_child in value_node.children:
+                if expr_child.type == "string":
+                    # className={"btn btn-primary"}
+                    text = expr_child.text.decode("utf-8", errors="replace")
+                    text = text.strip("'\"")
+                    static_classes.extend(text.split())
+                elif expr_child.type == "template_string":
+                    # className={`btn ${...}`} — extract literal parts
+                    for frag in expr_child.children:
+                        if frag.type == "string_fragment":
+                            for part in frag.text.decode(
+                                "utf-8", errors="replace",
+                            ).split():
+                                if part and not part.startswith("$"):
+                                    static_classes.append(part)
+                elif expr_child.type == "member_expression":
+                    # className={styles.btnPrimary}
+                    obj_name = None
+                    prop_name = None
+                    for me_child in expr_child.children:
+                        if me_child.type == "identifier":
+                            obj_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                        elif me_child.type == "property_identifier":
+                            prop_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                    if obj_name and prop_name:
+                        module_refs.append((obj_name, prop_name))
+
+        return static_classes, module_refs
+
+    def _extract_vue_template_classes(self, node) -> list[str]:
+        """Recursively walk Vue template AST, extract class='...' values.
+
+        Only extracts static class attributes, skips :class dynamic bindings.
+        """
+        classes: list[str] = []
+        stack = [node]
+        while stack:
+            n = stack.pop()
+            if n.type == "attribute":
+                attr_name = None
+                attr_value = None
+                for child in n.children:
+                    if child.type == "attribute_name":
+                        attr_name = child.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                    elif child.type == "quoted_attribute_value":
+                        for v in child.children:
+                            if v.type == "attribute_value":
+                                attr_value = v.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                if attr_name == "class" and attr_value:
+                    classes.extend(attr_value.split())
+            # Skip directive_attribute (:class bindings)
+            elif n.type == "directive_attribute":
+                continue
+            for child in n.children:
+                stack.append(child)
+        return classes
+
     def _resolve_call_targets(
         self,
         nodes: list[NodeInfo],
@@ -2387,6 +3443,24 @@ class CodeParser:
                     enclosing_class, enclosing_func,
                     import_map, defined_names,
                 )
+
+            # --- JSX className extraction ---
+            if (
+                node_type == "jsx_attribute"
+                and language in ("javascript", "typescript", "tsx")
+            ):
+                static_cls, mod_refs = self._extract_jsx_class_refs(
+                    child, source,
+                )
+                if static_cls or mod_refs:
+                    func_key = self._qualify(
+                        enclosing_func or "<module>", file_path, enclosing_class,
+                    )
+                    entry = self._jsx_class_collector.setdefault(
+                        func_key, {"classes": [], "module_refs": []},
+                    )
+                    entry["classes"].extend(static_cls)
+                    entry["module_refs"].extend(mod_refs)
 
             # --- Value references (function-as-value in maps, arrays, args) ---
             self._extract_value_references(
@@ -5447,7 +6521,7 @@ class CodeParser:
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue"]
+                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue", ".css", ".scss"]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
@@ -5467,6 +6541,23 @@ class CodeParser:
                 resolved = self._tsconfig_resolver.resolve_alias(module, file_path)
                 if resolved:
                     return resolved
+
+        elif language in ("css", "scss"):
+            if module.startswith(".") or module.startswith("/"):
+                base = caller_dir / module
+                extensions = [".css", ".scss"]
+                if base.is_file():
+                    return str(base.resolve())
+                for ext in extensions:
+                    target = base.with_suffix(ext)
+                    if target.is_file():
+                        return str(target.resolve())
+                # SCSS partial: _filename.scss
+                base_name = base.name
+                for ext in extensions:
+                    partial = base.parent / f"_{base_name}{ext}"
+                    if partial.is_file():
+                        return str(partial.resolve())
 
         elif language == "dart":
             if module.startswith("."):

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -811,11 +812,12 @@ class CodeParser:
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
         # Per-parse scratch space collecting JSX className/CSS-module refs,
-        # keyed by the qualified name of the enclosing function. Reset at the
-        # start of every parse_bytes() call; not threaded through
-        # _extract_from_tree's recursion (22 call sites) since it is only
-        # ever written by the JSX-attribute branch and read back once parsing
-        # of the current file/script-block finishes.
+        # keyed by the qualified name of the enclosing function. Reset and
+        # consumed only on the generic parse_bytes() path (JS/TS/TSX); the Vue
+        # and Svelte paths return early via _parse_vue/_parse_svelte and never
+        # read it back, so anything the JSX-attribute branch writes during
+        # those parses is inert. Not threaded through _extract_from_tree's
+        # recursion (22 call sites) since a fresh CodeParser is used per file.
         self._jsx_class_collector: dict[str, dict] = {}
         # Config-driven custom languages (.code-review-graph/languages.toml).
         # The built-in tables stay shared module-level constants; only when a
@@ -1068,6 +1070,15 @@ class CodeParser:
             }
             if css_mod_imports:
                 nodes[0].extra["css_module_imports"] = css_mod_imports
+
+        # Record every stylesheet this module imports, resolved to absolute
+        # paths, so STYLES linking can be scoped to the files a component
+        # actually imports rather than matched globally by bare class name.
+        css_import_files = self._collect_css_import_files(
+            tree.root_node, language, path,
+        )
+        if css_import_files:
+            nodes[0].extra["css_import_files"] = css_import_files
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -6374,6 +6385,41 @@ class CodeParser:
                 self._collect_import_names(child, language, source, import_map)
 
         return import_map, defined_names
+
+    def _collect_css_import_files(
+        self, root, language: str, file_path: Path,
+    ) -> list[str]:
+        """Resolved absolute paths of stylesheets this file imports.
+
+        Covers both bound CSS-Module imports (``import s from './x.module.css'``)
+        and plain side-effect imports (``import './x.css'``) — the latter carry
+        no binding and so never appear in the import-name map. Only imports that
+        resolve to an on-disk file are returned. Used to scope STYLES edges.
+        """
+        if language not in ("javascript", "typescript", "tsx"):
+            return []
+        css_exts = (".css", ".scss", ".less", ".sass")
+        import_types = set(self._import_types.get(language, []))
+        # Resolve relative to the caller's path in the SAME convention node
+        # file_paths use (normpath, no symlink canonicalization), so the
+        # results compare equal to selector nodes' file_path in the graph.
+        base_dir = os.path.dirname(str(file_path))
+        resolved: list[str] = []
+        seen: set[str] = set()
+        for child in root.children:
+            if child.type not in import_types:
+                continue
+            for sub in child.children:
+                if sub.type != "string":
+                    continue
+                module = sub.text.decode("utf-8", errors="replace").strip("'\"")
+                if not module.endswith(css_exts) or not module.startswith("."):
+                    continue
+                target = os.path.normpath(os.path.join(base_dir, module))
+                if os.path.isfile(target) and target not in seen:
+                    seen.add(target)
+                    resolved.append(target)
+        return sorted(resolved)
 
     def _collect_js_exported_local_names(
         self, node, defined_names: set[str],

--- a/code_review_graph/tools.py
+++ b/code_review_graph/tools.py
@@ -251,6 +251,11 @@ _QUERY_PATTERNS = {
     "children_of": "Find all nodes contained in a file or class",
     "tests_for": "Find all tests for a given function or class",
     "inheritors_of": "Find all classes that inherit from a given class",
+    "overrides_of": "Find all CSS selectors that a given selector overrides",
+    "overridden_by": "Find all CSS selectors that override a given selector",
+    "styles_of": "Find CSS selectors that style a component or function",
+    "styled_by": "Find components/functions that use a given CSS selector",
+    "conflicts_of": "Find potential cross-file CSS conflicts for a selector",
     "file_summary": "Get a summary of all nodes in a file",
 }
 
@@ -264,7 +269,9 @@ def query_graph(
 
     Args:
         pattern: Query pattern. One of: callers_of, callees_of, imports_of,
-                 importers_of, children_of, tests_for, inheritors_of, file_summary.
+                 importers_of, children_of, tests_for, inheritors_of,
+                 overrides_of, overridden_by, styles_of, styled_by,
+                 conflicts_of, file_summary.
         target: The node name, qualified name, or file path to query about.
         repo_root: Repository root path. Auto-detected if omitted.
 
@@ -386,6 +393,52 @@ def query_graph(
                     child = store.get_node(e.source_qualified)
                     if child:
                         results.append(node_to_dict(child))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overrides_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "OVERRIDES":
+                    overridden = store.get_node(e.target_qualified)
+                    if overridden:
+                        results.append(node_to_dict(overridden))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overridden_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "OVERRIDES":
+                    overrider = store.get_node(e.source_qualified)
+                    if overrider:
+                        results.append(node_to_dict(overrider))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styles_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "STYLES":
+                    styled = store.get_node(e.target_qualified)
+                    if styled:
+                        results.append(node_to_dict(styled))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styled_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "STYLES":
+                    styler = store.get_node(e.source_qualified)
+                    if styler:
+                        results.append(node_to_dict(styler))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "conflicts_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.target_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
+                    edges_out.append(edge_to_dict(e))
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.source_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
                     edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":
@@ -577,6 +630,14 @@ def _generate_review_guidance(impact: dict, changed_files: list[str]) -> str:
         guidance_parts.append(
             f"- {len(inheritance_edges)} inheritance/implementation relationship(s) affected. "
             "Check for Liskov substitution violations."
+        )
+
+    # Check for CSS override changes
+    override_edges = [e for e in impact["edges"] if e.kind == "OVERRIDES"]
+    if override_edges:
+        guidance_parts.append(
+            f"- {len(override_edges)} CSS override relationship(s) affected. "
+            "Check for specificity conflicts and unintended style changes."
         )
 
     # Check for cross-file impact

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -28,6 +28,11 @@ _QUERY_PATTERNS = {
     "children_of": "Find all nodes contained in a file or class",
     "tests_for": "Find all tests for a given function or class",
     "inheritors_of": "Find all classes that inherit from a given class",
+    "overrides_of": "Find all CSS selectors that a given selector overrides",
+    "overridden_by": "Find all CSS selectors that override a given selector",
+    "styles_of": "Find CSS selectors that style a component or function",
+    "styled_by": "Find components/functions that use a given CSS selector",
+    "conflicts_of": "Find potential cross-file CSS conflicts for a selector",
     "file_summary": "Get a summary of all nodes in a file",
 }
 
@@ -152,7 +157,9 @@ def query_graph(
 
     Args:
         pattern: Query pattern. One of: callers_of, callees_of, imports_of,
-                 importers_of, children_of, tests_for, inheritors_of, file_summary.
+                 importers_of, children_of, tests_for, inheritors_of,
+                 overrides_of, overridden_by, styles_of, styled_by,
+                 conflicts_of, file_summary.
         target: The node name, qualified name, or file path to query about.
         repo_root: Repository root path. Auto-detected if omitted.
         detail_level: "standard" (full output) or "minimal" (summary only).
@@ -324,6 +331,52 @@ def query_graph(
                         if child:
                             results.append(node_to_dict(child))
                         edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overrides_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "OVERRIDES":
+                    overridden = store.get_node(e.target_qualified)
+                    if overridden:
+                        results.append(node_to_dict(overridden))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overridden_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "OVERRIDES":
+                    overrider = store.get_node(e.source_qualified)
+                    if overrider:
+                        results.append(node_to_dict(overrider))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styles_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "STYLES":
+                    styled = store.get_node(e.target_qualified)
+                    if styled:
+                        results.append(node_to_dict(styled))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styled_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "STYLES":
+                    styler = store.get_node(e.source_qualified)
+                    if styler:
+                        results.append(node_to_dict(styler))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "conflicts_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.target_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
+                    edges_out.append(edge_to_dict(e))
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.source_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
+                    edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":
             graph_paths = _resolve_graph_file_paths(store, root, [target])

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -267,6 +267,14 @@ def _generate_review_guidance(
             "Check for Liskov substitution violations."
         )
 
+    # Check for CSS override changes
+    override_edges = [e for e in impact["edges"] if e.kind == "OVERRIDES"]
+    if override_edges:
+        guidance_parts.append(
+            f"- {len(override_edges)} CSS override relationship(s) affected. "
+            "Check for specificity conflicts and unintended style changes."
+        )
+
     # Check for cross-file impact
     impacted_file_count = len(impact["impacted_files"])
     if impacted_file_count > 3:

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -195,6 +195,7 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
   .l-imports  { border-top: 2px dashed #f0883e; }
   .l-inherits { border-top: 2.5px dotted #d2a8ff; }
   .l-contains { border-top: 1.5px solid rgba(139,148,158,0.3); }
+  .l-overrides { border-top: 2px dotted #f778ba; }
 
   #stats-bar {
     position: absolute; bottom: 0; left: 0; right: 0;
@@ -267,6 +268,9 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
     <div class="legend-item" data-edge-kind="IMPORTS_FROM"><span class="legend-line l-imports"></span> Imports</div>
     <div class="legend-item" data-edge-kind="INHERITS"><span class="legend-line l-inherits"></span> Inherits</div>
     <div class="legend-item" data-edge-kind="CONTAINS"><span class="legend-line l-contains"></span> Contains</div>
+    <div class="legend-item" data-edge-kind="OVERRIDES"><span class="legend-line l-overrides"></span> Overrides</div>
+    <div class="legend-item" data-edge-kind="STYLES"><span class="legend-line l-styles"></span> Styles</div>
+    <div class="legend-item" data-edge-kind="POTENTIAL_CONFLICT"><span class="legend-line l-conflict"></span> Conflict</div>
   </div>
 </div>
 
@@ -286,7 +290,7 @@ const graphData = __GRAPH_DATA__;
 // -- Config --
 const KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#d2a8ff", Type:"#8b949e" };
 const KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5 };
-const EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)" };
+const EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", OVERRIDES:"#f778ba", STYLES:"#79c0ff", POTENTIAL_CONFLICT:"#f85149" };
 
 // -- Display name: short, clean labels --
 function displayName(d) {
@@ -350,11 +354,14 @@ function showTooltip(ev, d) {
   const bg = KIND_COLOR[d.kind] || "#555";
   const relFile = d.file_path ? d.file_path.split("/").slice(-3).join("/") : "";
   let h = `<span class="tt-name">${escH(d.label)}</span>`;
-  h += `<span class="tt-kind" style="background:${bg};color:#0d1117">${d.kind}</span>`;
+  const ex = d.extra || {};
+  const kindLabel = ex.css_kind ? ("CSS " + escH(ex.css_kind)) : (ex.solidity_kind ? ("Solidity " + escH(ex.solidity_kind)) : escH(d.kind));
+  h += `<span class="tt-kind" style="background:${bg};color:#0d1117">${kindLabel}</span>`;
   if (relFile) h += `<div class="tt-row tt-file">${escH(relFile)}</div>`;
   if (d.line_start != null) h += `<div class="tt-row"><span class="tt-label">Lines: </span>${d.line_start} \u2013 ${d.line_end || d.line_start}</div>`;
   if (d.params) h += `<div class="tt-row"><span class="tt-label">Params: </span>${escH(d.params)}</div>`;
   if (d.return_type) h += `<div class="tt-row"><span class="tt-label">Returns: </span>${escH(d.return_type)}</div>`;
+  if (ex.specificity) { const sp = ex.specificity; h += `<div class="tt-row"><span class="tt-label">Specificity: </span>(${Array.isArray(sp)?sp.join(","):sp})</div>`; }
   tooltip.innerHTML = h;
   tooltip.classList.add("visible");
   moveTooltip(ev);
@@ -388,7 +395,7 @@ const glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
 
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"}].forEach(mk => {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-overrides",color:"#f778ba"},{id:"arrow-styles",color:"#79c0ff"},{id:"arrow-conflict",color:"#f85149"}].forEach(mk => {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")
@@ -421,6 +428,9 @@ const EDGE_CFG = {
   CALLS:        { dash:null,   width:1.5, opacity:0.7,  marker:"url(#arrow-calls)" },
   IMPORTS_FROM: { dash:"6,3",  width:1.5, opacity:0.65, marker:"url(#arrow-imports)" },
   INHERITS:     { dash:"3,4",  width:2,   opacity:0.7,  marker:"url(#arrow-inherits)" },
+  OVERRIDES:    { dash:"2,4",  width:1.5, opacity:0.65, marker:"url(#arrow-overrides)" },
+  STYLES:       { dash:"4,4", width:1.5, opacity:0.6,  marker:"url(#arrow-styles)" },
+  POTENTIAL_CONFLICT: { dash:"2,2", width:2, opacity:0.8, marker:"url(#arrow-conflict)" },
 };
 
 function eStyle(d) { return EDGE_CFG[d.kind] || {dash:null,width:1,opacity:0.3,marker:""}; }
@@ -479,8 +489,9 @@ function updateNodes() {
   enter.append("circle").attr("class","node-circle")
     .attr("r", d => KIND_RADIUS[d.kind] || 6)
     .attr("fill", d => KIND_COLOR[d.kind] || "#8b949e")
-    .attr("stroke", d => d.kind === "File" ? "rgba(88,166,255,0.3)" : "rgba(255,255,255,0.08)")
-    .attr("stroke-width", d => d.kind === "File" ? 2 : 1)
+    .attr("stroke", d => { if ((d.extra||{}).css_kind) return "#f778ba"; return d.kind === "File" ? "rgba(88,166,255,0.3)" : "rgba(255,255,255,0.08)"; })
+    .attr("stroke-width", d => { if ((d.extra||{}).css_kind) return 2; return d.kind === "File" ? 2 : 1; })
+    .attr("stroke-dasharray", d => (d.extra||{}).css_kind ? "3,2" : null)
     .attr("cursor", d => d.kind === "File" ? "pointer" : "grab");
 
   enter

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -678,6 +678,9 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
     <button class="legend-item legend-edge" data-edge-kind="IMPLEMENTS" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #f9e2af"></span> Implements</button>
     <button class="legend-item legend-edge" data-edge-kind="TESTED_BY" aria-pressed="true"><span class="legend-line" style="border-top:2px dotted #f38ba8"></span> Tested By</button>
     <button class="legend-item legend-edge" data-edge-kind="DEPENDS_ON" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #fab387"></span> Depends On</button>
+    <button class="legend-item legend-edge" data-edge-kind="OVERRIDES" aria-pressed="true"><span class="legend-line" style="border-top:2px dotted #f778ba"></span> Overrides</button>
+    <button class="legend-item legend-edge" data-edge-kind="STYLES" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #79c0ff"></span> Styles</button>
+    <button class="legend-item legend-edge" data-edge-kind="POTENTIAL_CONFLICT" aria-pressed="true"><span class="legend-line" style="border-top:2px dotted #f85149"></span> Conflict</button>
   </div>
 </nav>
 <div id="filter-panel">
@@ -746,7 +749,7 @@ var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#
 var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5 };
 var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79 };
 var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross };
-var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387" };
+var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387", OVERRIDES:"#f778ba", STYLES:"#79c0ff", POTENTIAL_CONFLICT:"#f85149" };
 var communityColorScale = d3.scaleOrdinal(d3.schemeTableau10);
 var communityColoringOn = false;
 function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;").replace(/`/g,"&#96;"); }
@@ -831,12 +834,18 @@ var tooltip = document.getElementById("tooltip");
 function showTooltip(ev, d) {
   var bg = communityColoringOn && d.community_id != null ? communityColorScale(d.community_id) : (KIND_COLOR[d.kind] || "#555");
   var relFile = d.file_path ? d.file_path.split("/").slice(-3).join("/") : "";
+  var ex = d.extra || {};
+  var kindLabel = ex.css_kind ? ("CSS " + escH(ex.css_kind)) : escH(d.kind);
   var h = '<span class="tt-name">' + escH(d.label) + '</span>';
-  h += '<span class="tt-kind" style="background:' + bg + ';color:#0d1117">' + escH(d.kind) + '</span>';
+  h += '<span class="tt-kind" style="background:' + bg + ';color:#0d1117">' + kindLabel + '</span>';
   if (relFile) h += '<div class="tt-row tt-file">' + escH(relFile) + '</div>';
   if (d.line_start != null) h += '<div class="tt-row"><span class="tt-label">Lines: </span>' + d.line_start + ' \u2013 ' + (d.line_end || d.line_start) + '</div>';
   if (d.params) h += '<div class="tt-row"><span class="tt-label">Params: </span>' + escH(d.params) + '</div>';
   if (d.return_type) h += '<div class="tt-row"><span class="tt-label">Returns: </span>' + escH(d.return_type) + '</div>';
+  if (ex.specificity) {
+    var sp = ex.specificity;
+    h += '<div class="tt-row"><span class="tt-label">Specificity: </span>(' + (Array.isArray(sp) ? sp.join(",") : sp) + ')</div>';
+  }
   if (d.community_id != null) {
     var comm = communities.find(function(c) { return c.id === d.community_id; });
     if (comm) h += '<div class="tt-row"><span class="tt-label">Community: </span>' + escH(comm.name) + '</div>';
@@ -867,7 +876,7 @@ var defs = svg.append("defs");
 var glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"}].forEach(function(mk) {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"},{id:"arrow-overrides",color:"#f778ba"},{id:"arrow-styles",color:"#79c0ff"},{id:"arrow-conflict",color:"#f85149"}].forEach(function(mk) {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")
@@ -894,6 +903,9 @@ var EDGE_CFG = {
   IMPLEMENTS:   { dash:"4,3", width:1.5, opacity:0.65, marker:"url(#arrow-implements)" },
   TESTED_BY:    { dash:"2,4", width:1.5, opacity:0.6, marker:"url(#arrow-tested_by)" },
   DEPENDS_ON:   { dash:"8,4", width:1, opacity:0.6, marker:"url(#arrow-depends_on)" },
+  OVERRIDES:    { dash:"2,4", width:1.5, opacity:0.65, marker:"url(#arrow-overrides)" },
+  STYLES:       { dash:"4,4", width:1.5, opacity:0.6, marker:"url(#arrow-styles)" },
+  POTENTIAL_CONFLICT: { dash:"2,2", width:2, opacity:0.8, marker:"url(#arrow-conflict)" },
 };
 function eStyle(d) { return EDGE_CFG[d.kind] || {dash:null,width:1,opacity:0.3,marker:""}; }
 function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }
@@ -942,8 +954,9 @@ function updateNodes() {
   enter.append("path").attr("class","node-shape")
     .attr("d", function(d) { return d3.symbol().type(KIND_SHAPE[d.kind] || d3.symbolCircle).size(KIND_AREA[d.kind] || 113)(); })
     .attr("fill", function(d) { return nodeColor(d); })
-    .attr("stroke", function(d) { return d.kind === "File" ? "rgba(88,166,255,0.3)" : "rgba(255,255,255,0.08)"; })
-    .attr("stroke-width", function(d) { return d.kind === "File" ? 2 : 1; })
+    .attr("stroke", function(d) { if ((d.extra||{}).css_kind) return "#f778ba"; return d.kind === "File" ? "rgba(88,166,255,0.3)" : "rgba(255,255,255,0.08)"; })
+    .attr("stroke-width", function(d) { return (d.extra||{}).css_kind ? 2 : (d.kind === "File" ? 2 : 1); })
+    .attr("stroke-dasharray", function(d) { return (d.extra||{}).css_kind ? "3,2" : null; })
     .attr("cursor", "pointer");
   enter
     .on("mouseover", function(ev, d) { highlightConnected(d, true); showTooltip(ev, d); })

--- a/tests/fixtures/button.module.css
+++ b/tests/fixtures/button.module.css
@@ -1,0 +1,9 @@
+.btn-outline {
+  border: 1px solid #333;
+  background: transparent;
+}
+
+.btn-filled {
+  background: #333;
+  color: white;
+}

--- a/tests/fixtures/conflict_a.css
+++ b/tests/fixtures/conflict_a.css
@@ -1,0 +1,8 @@
+.btn {
+  color: red;
+  padding: 10px;
+}
+
+.card {
+  border: 1px solid #ccc;
+}

--- a/tests/fixtures/conflict_b.css
+++ b/tests/fixtures/conflict_b.css
@@ -1,0 +1,8 @@
+.btn {
+  color: blue;
+  padding: 15px;
+}
+
+.sidebar {
+  width: 250px;
+}

--- a/tests/fixtures/sample.css
+++ b/tests/fixtures/sample.css
@@ -1,0 +1,60 @@
+@import "reset.css";
+@import url("components.css");
+
+:root {
+  --primary-color: #3498db;
+  --font-size: 16px;
+  --spacing-md: 1rem;
+}
+
+body {
+  font-size: var(--font-size);
+  color: var(--primary-color);
+}
+
+.btn {
+  padding: 10px 20px;
+  border-radius: 4px;
+  color: blue;
+}
+
+.btn-primary {
+  background: blue;
+  color: white;
+}
+
+#main-header {
+  display: flex;
+  align-items: center;
+}
+
+h1, h2 {
+  font-weight: bold;
+  color: var(--primary-color);
+}
+
+.nav .nav-item {
+  padding: var(--spacing-md);
+}
+
+@media (max-width: 768px) {
+  .btn {
+    padding: 5px 10px;
+  }
+  .sidebar {
+    display: none;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.card {
+  animation: fadeIn 0.3s;
+}
+
+.important-thing {
+  color: red !important;
+}

--- a/tests/fixtures/sample.less
+++ b/tests/fixtures/sample.less
@@ -1,0 +1,29 @@
+@import 'variables';
+
+@primary-color: #3498db;
+@font-size: 16px;
+
+.mixin-flex() {
+  display: flex;
+  align-items: center;
+}
+
+.btn {
+  padding: 10px;
+  font-size: @font-size;
+  color: @primary-color;
+  .mixin-flex();
+
+  &-primary {
+    background: @primary-color;
+    color: white;
+  }
+}
+
+.card {
+  border: 1px solid #ccc;
+
+  .card-title {
+    font-weight: bold;
+  }
+}

--- a/tests/fixtures/sample.scss
+++ b/tests/fixtures/sample.scss
@@ -1,0 +1,46 @@
+@import 'variables';
+@import 'mixins';
+
+$primary-color: #3498db;
+$font-size: 16px;
+$spacing: 1rem;
+
+@mixin flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@mixin responsive($breakpoint) {
+  @media (max-width: $breakpoint) {
+    @content;
+  }
+}
+
+.btn {
+  padding: $spacing;
+  font-size: $font-size;
+  @include flex-center;
+  color: $primary-color;
+
+  &-primary {
+    background: $primary-color;
+    color: white;
+  }
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.card {
+  border: 1px solid #ccc;
+
+  .card-title {
+    font-weight: bold;
+  }
+
+  .card-body {
+    padding: $spacing;
+  }
+}

--- a/tests/fixtures/sample_button.tsx
+++ b/tests/fixtures/sample_button.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from './button.module.css';
+
+function Button({ label }: { label: string }) {
+  return (
+    <button className="btn btn-primary" onClick={() => {}}>
+      {label}
+    </button>
+  );
+}
+
+function StyledButton({ label }: { label: string }) {
+  return (
+    <button className={styles.btnOutline}>
+      {label}
+    </button>
+  );
+}
+
+function DynamicButton({ active }: { active: boolean }) {
+  return (
+    <button className={active ? "active" : "inactive"}>
+      Toggle
+    </button>
+  );
+}
+
+export { Button, StyledButton, DynamicButton };

--- a/tests/fixtures/sample_vue_classes.vue
+++ b/tests/fixtures/sample_vue_classes.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="container main-layout">
+    <h1 class="title">{{ heading }}</h1>
+    <span :class="{active: isActive}">Dynamic</span>
+    <p class="description">Some text</p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const heading = ref('Hello')
+const isActive = ref(true)
+</script>
+
+<style>
+.container { max-width: 1200px; }
+.title { font-size: 2rem; }
+.description { color: #666; }
+</style>

--- a/tests/test_css_linking.py
+++ b/tests/test_css_linking.py
@@ -1,0 +1,177 @@
+"""Tests for cross-file CSS linking and conflict detection."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import (
+    detect_cross_file_conflicts,
+    full_build,
+    link_css_styles,
+)
+from code_review_graph.parser import CodeParser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _build_graph_from_files(tmp_dir: Path, files: dict[str, bytes]) -> GraphStore:
+    """Write files to tmp_dir, build a graph, and return the store."""
+    for rel_path, content in files.items():
+        p = tmp_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(content)
+    db_path = tmp_dir / ".code-review-graph" / "graph.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = GraphStore(str(db_path))
+    full_build(tmp_dir, store)
+    return store
+
+
+class TestCamelToKebab:
+    def test_simple(self):
+        assert CodeParser._camel_to_kebab("btnPrimary") == "btn-primary"
+
+    def test_multiple_words(self):
+        assert CodeParser._camel_to_kebab("navItemActive") == "nav-item-active"
+
+    def test_already_kebab(self):
+        assert CodeParser._camel_to_kebab("btn-primary") == "btn-primary"
+
+    def test_single_word(self):
+        assert CodeParser._camel_to_kebab("btn") == "btn"
+
+
+class TestCSSStylesLinking:
+    def test_static_styles_edge(self):
+        """TSX className should create STYLES edge to matching CSS selector."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="btn">Click</div>;
+}
+''',
+                "styles.css": b'.btn { color: blue; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    "btn" in e.extra.get("class_name", "")
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_vue_same_file_styles_edge(self):
+        """Vue template class + inline <style> should create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.vue": b'''<template>
+  <div class="container">Hello</div>
+</template>
+<style>
+.container { max-width: 1200px; }
+</style>
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    e.extra.get("class_name") == "container"
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_no_styles_edge_for_missing_selector(self):
+        """className with no matching CSS should NOT create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="nonexistent">Hello</div>;
+}
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) == 0
+            finally:
+                store.close()
+
+
+class TestCrossFileConflicts:
+    def test_detects_same_selector_conflict(self):
+        """Same .btn selector in two files should create POTENTIAL_CONFLICT."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                assert any(
+                    ".btn" in e.extra.get("class_name", "")
+                    for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_no_conflict_unique_selectors(self):
+        """Unique selectors (.card, .sidebar) should NOT conflict."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                # .card only in conflict_a, .sidebar only in conflict_b
+                assert not any(
+                    e.extra.get("class_name") == ".card" for e in conflicts
+                )
+                assert not any(
+                    e.extra.get("class_name") == ".sidebar" for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_conflict_has_metadata(self):
+        """Conflict edges should have specificity and confidence metadata."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "a.css": b'.alert { color: red; }',
+                "b.css": b'.alert { color: green; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                c = conflicts[0]
+                assert "confidence" in c.extra
+                assert "source_specificity" in c.extra
+                assert "target_specificity" in c.extra
+            finally:
+                store.close()

--- a/tests/test_css_linking.py
+++ b/tests/test_css_linking.py
@@ -1,0 +1,173 @@
+"""Tests for cross-file CSS linking and conflict detection."""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import (
+    full_build,
+)
+from code_review_graph.parser import CodeParser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _build_graph_from_files(tmp_dir: Path, files: dict[str, bytes]) -> GraphStore:
+    """Write files to tmp_dir, build a graph, and return the store."""
+    for rel_path, content in files.items():
+        p = tmp_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(content)
+    db_path = tmp_dir / ".code-review-graph" / "graph.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = GraphStore(str(db_path))
+    full_build(tmp_dir, store)
+    return store
+
+
+class TestCamelToKebab:
+    def test_simple(self):
+        assert CodeParser._camel_to_kebab("btnPrimary") == "btn-primary"
+
+    def test_multiple_words(self):
+        assert CodeParser._camel_to_kebab("navItemActive") == "nav-item-active"
+
+    def test_already_kebab(self):
+        assert CodeParser._camel_to_kebab("btn-primary") == "btn-primary"
+
+    def test_single_word(self):
+        assert CodeParser._camel_to_kebab("btn") == "btn"
+
+
+class TestCSSStylesLinking:
+    def test_static_styles_edge(self):
+        """TSX className should create STYLES edge to matching CSS selector."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="btn">Click</div>;
+}
+''',
+                "styles.css": b'.btn { color: blue; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    "btn" in e.extra.get("class_name", "")
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_vue_same_file_styles_edge(self):
+        """Vue template class + inline <style> should create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.vue": b'''<template>
+  <div class="container">Hello</div>
+</template>
+<style>
+.container { max-width: 1200px; }
+</style>
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    e.extra.get("class_name") == "container"
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_no_styles_edge_for_missing_selector(self):
+        """className with no matching CSS should NOT create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="nonexistent">Hello</div>;
+}
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) == 0
+            finally:
+                store.close()
+
+
+class TestCrossFileConflicts:
+    def test_detects_same_selector_conflict(self):
+        """Same .btn selector in two files should create POTENTIAL_CONFLICT."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                assert any(
+                    ".btn" in e.extra.get("class_name", "")
+                    for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_no_conflict_unique_selectors(self):
+        """Unique selectors (.card, .sidebar) should NOT conflict."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                # .card only in conflict_a, .sidebar only in conflict_b
+                assert not any(
+                    e.extra.get("class_name") == ".card" for e in conflicts
+                )
+                assert not any(
+                    e.extra.get("class_name") == ".sidebar" for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_conflict_has_metadata(self):
+        """Conflict edges should have specificity and confidence metadata."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "a.css": b'.alert { color: red; }',
+                "b.css": b'.alert { color: green; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                c = conflicts[0]
+                assert "conflict_confidence" in c.extra
+                assert "source_specificity" in c.extra
+                assert "target_specificity" in c.extra
+            finally:
+                store.close()

--- a/tests/test_css_linking.py
+++ b/tests/test_css_linking.py
@@ -41,11 +41,12 @@ class TestCamelToKebab:
 
 class TestCSSStylesLinking:
     def test_static_styles_edge(self):
-        """TSX className should create STYLES edge to matching CSS selector."""
+        """TSX className should create STYLES edge to the imported CSS selector."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
             store = _build_graph_from_files(tmp_dir, {
                 "App.tsx": b'''
+import './styles.css';
 function App() {
   return <div className="btn">Click</div>;
 }

--- a/tests/test_css_selector_bugs.py
+++ b/tests/test_css_selector_bugs.py
@@ -1,0 +1,179 @@
+"""Tests for CSS selector indexing + scoping in link_css_styles.
+
+STYLES edges are scoped: a component links to a selector only when the
+selector lives in the same file or in a stylesheet the component's file
+imports (recorded on the File node as ``css_import_files``). Selector
+indexing extracts every bare class token, so compound/descendant/pseudo
+selectors still match a plain className.
+"""
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import link_css_styles
+from code_review_graph.parser import NodeInfo
+
+
+def _selector(name: str, file_path: str) -> NodeInfo:
+    return NodeInfo(
+        kind="Class",
+        name=name,
+        file_path=file_path,
+        line_start=1,
+        line_end=1,
+        language="css",
+        extra={"css_kind": "selector"},
+    )
+
+
+def _file_importing(file_path: str, css_files: list[str]) -> NodeInfo:
+    return NodeInfo(
+        kind="File",
+        name=file_path,
+        file_path=file_path,
+        line_start=1,
+        line_end=1,
+        language="typescript",
+        extra={"css_import_files": css_files},
+    )
+
+
+class TestStaticScoping:
+    """Static className refs link only to imported/same-file selectors (b0)."""
+
+    def test_static_css_classes_respect_import_scoping(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store.upsert_node(_selector(".btn", "/app/styles.css"))
+            store.upsert_node(_selector(".btn", "/vendored/vendor.css"))
+            # Button imports only /app/styles.css, not the vendored sheet.
+            store.upsert_node(_file_importing(
+                "/app/Button.tsx", ["/app/styles.css"],
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="Button",
+                file_path="/app/Button.tsx",
+                line_start=1,
+                line_end=10,
+                language="typescript",
+                extra={"css_classes": ["btn"]},
+            ))
+            store.commit()
+
+            link_css_styles(store)
+
+            edges = store.get_edges_by_source("/app/Button.tsx::Button")
+            styles = [e for e in edges if e.kind == "STYLES"]
+            assert len(styles) == 1, (
+                f"Expected 1 STYLES edge (only the imported sheet), got "
+                f"{len(styles)}."
+            )
+            assert styles[0].target_qualified == "/app/styles.css::.btn"
+        finally:
+            store.close()
+
+    def test_static_unimported_selector_is_not_linked(self, tmp_path):
+        """A .btn the component never imports must produce no edge."""
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store.upsert_node(_selector(".btn", "/vendored/vendor.css"))
+            store.upsert_node(_file_importing(
+                "/app/Button.tsx", ["/app/styles.css"],
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="Button",
+                file_path="/app/Button.tsx",
+                line_start=1,
+                line_end=10,
+                language="typescript",
+                extra={"css_classes": ["btn"]},
+            ))
+            store.commit()
+
+            link_css_styles(store)
+
+            edges = store.get_edges_by_source("/app/Button.tsx::Button")
+            assert [e for e in edges if e.kind == "STYLES"] == []
+        finally:
+            store.close()
+
+
+class TestVueScoping:
+    """Vue template classes link only within the SFC's own <style> (b1)."""
+
+    def test_vue_template_classes_respect_same_file_scoping(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store.upsert_node(_selector(".card", "/components/Card.vue"))
+            store.upsert_node(_selector(".card", "/other/Other.css"))
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="CardComponent",
+                file_path="/components/Card.vue",
+                line_start=1,
+                line_end=50,
+                language="vue",
+                extra={"vue_template_classes": ["card"]},
+            ))
+            store.commit()
+
+            link_css_styles(store)
+
+            edges = store.get_edges_by_source(
+                "/components/Card.vue::CardComponent",
+            )
+            styles = [e for e in edges if e.kind == "STYLES"]
+            assert len(styles) == 1
+            assert styles[0].target_qualified == "/components/Card.vue::.card"
+        finally:
+            store.close()
+
+
+class TestCompoundSelectorIndexing:
+    """Compound/pseudo selectors are indexed by each bare class (b2/b3)."""
+
+    def _build(self, store, selector_name):
+        store.upsert_node(_selector(selector_name, "/app/styles.css"))
+        store.upsert_node(_file_importing(
+            "/app/Button.tsx", ["/app/styles.css"],
+        ))
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="Button",
+            file_path="/app/Button.tsx",
+            line_start=1,
+            line_end=10,
+            language="typescript",
+            extra={"css_classes": ["btn"]},
+        ))
+        store.commit()
+
+    def test_compound_selector_indexed_by_each_class(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            self._build(store, ".btn.active")  # className 'btn' must match
+            link_css_styles(store)
+            edges = store.get_edges_by_source("/app/Button.tsx::Button")
+            assert len([e for e in edges if e.kind == "STYLES"]) >= 1
+        finally:
+            store.close()
+
+    def test_pseudo_selector_indexed_by_base_class(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            self._build(store, ".btn:hover")  # className 'btn' must match
+            link_css_styles(store)
+            edges = store.get_edges_by_source("/app/Button.tsx::Button")
+            assert len([e for e in edges if e.kind == "STYLES"]) >= 1
+        finally:
+            store.close()
+
+    def test_descendant_selector_indexed_by_each_class(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            self._build(store, ".card .btn")  # trailing 'btn' must match
+            link_css_styles(store)
+            edges = store.get_edges_by_source("/app/Button.tsx::Button")
+            assert len([e for e in edges if e.kind == "STYLES"]) >= 1
+        finally:
+            store.close()

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1,4 +1,4 @@
-"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Solidity, and Vue parsing."""
+"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Solidity, Vue, CSS, and SCSS parsing."""
 
 from pathlib import Path
 
@@ -497,3 +497,313 @@ class TestVueParsing:
     def test_finds_calls(self):
         calls = [e for e in self.edges if e.kind == "CALLS"]
         assert len(calls) >= 1
+
+    def test_vue_style_block_parsing(self):
+        parser = CodeParser()
+        vue_with_style = b"""<template><div>Hello</div></template>
+<script setup>
+const x = 1;
+</script>
+<style scoped>
+.app { color: red; }
+.app .btn { padding: 10px; }
+</style>
+"""
+        nodes, edges = parser.parse_bytes(
+            Path("/tmp/test_style.vue"), vue_with_style,
+        )
+        css_selectors = [
+            n for n in nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        assert len(css_selectors) >= 2
+        for sel in css_selectors:
+            assert sel.language == "vue"
+
+
+class TestCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.css")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.css")) == "css"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".btn-primary" in names
+        assert "#main-header" in names
+        assert "body" in names
+
+    def test_comma_separated_selectors_split(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert "h1" in names
+        assert "h2" in names
+
+    def test_finds_custom_properties(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "custom_property"
+        ]
+        names = {f.name for f in funcs}
+        assert "--primary-color" in names
+        assert "--font-size" in names
+        assert "--spacing-md" in names
+
+    def test_finds_media_queries(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "media_query"
+        ]
+        assert len(classes) >= 1
+
+    def test_finds_keyframes(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "keyframes"
+        ]
+        names = {c.name for c in classes}
+        assert "@keyframes(fadeIn)" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "reset.css" in targets
+        assert "components.css" in targets
+
+    def test_finds_var_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        # body calls --font-size and --primary-color
+        assert len(calls) >= 2
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 5
+
+    def test_specificity_computed(self):
+        classes = {
+            n.name: n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+            and n.parent_name is None  # top-level only
+        }
+        assert classes[".btn"].extra["specificity"] == [0, 1, 0]
+        assert classes["#main-header"].extra["specificity"] == [1, 0, 0]
+        assert classes["body"].extra["specificity"] == [0, 0, 1]
+
+    def test_override_edges_exist(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        assert len(overrides) >= 1
+
+    def test_bem_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        bem = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "bem_refinement"
+        ]
+        assert len(bem) >= 1
+        # .btn-primary overrides .btn
+        targets = {e.target.split("::")[-1] for e in bem}
+        assert ".btn" in targets
+
+    def test_important_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        important = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "important"
+        ]
+        assert len(important) >= 1
+
+    def test_nodes_have_css_language(self):
+        for node in self.nodes:
+            assert node.language == "css"
+
+
+class TestSCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.scss")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.scss")) == "scss"
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert "flex-center" in names
+        assert "responsive" in names
+
+    def test_finds_scss_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "scss_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "$primary-color" in names
+        assert "$font-size" in names
+        assert "$spacing" in names
+
+    def test_finds_include_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("flex-center" in t for t in targets)
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+        assert "mixins" in targets
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_nodes_have_scss_language(self):
+        for node in self.nodes:
+            assert node.language == "scss"
+
+
+class TestJSXClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_button.tsx",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("Component.tsx")) == "tsx"
+
+    def test_extracts_static_classname(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        button = funcs.get("Button")
+        assert button is not None
+        classes = button.extra.get("css_classes", [])
+        assert "btn" in classes
+        assert "btn-primary" in classes
+
+    def test_extracts_css_module_refs(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        styled = funcs.get("StyledButton")
+        assert styled is not None
+        refs = styled.extra.get("css_module_refs", [])
+        assert len(refs) >= 1
+        assert any(
+            r["import"] == "styles" and r["property"] == "btnOutline"
+            for r in refs
+        )
+
+    def test_skips_dynamic_classname(self):
+        """Ternary expressions should not produce css_classes."""
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        dynamic = funcs.get("DynamicButton")
+        assert dynamic is not None
+        # Dynamic ternary should not be in css_classes
+        classes = dynamic.extra.get("css_classes", [])
+        assert "active" not in classes or "inactive" not in classes
+
+    def test_classname_on_correct_function(self):
+        """Classes should attach to the enclosing function, not file."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        assert "css_classes" not in file_node.extra
+
+    def test_css_module_imports_on_file_node(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        mod_imports = file_node.extra.get("css_module_imports", {})
+        assert "styles" in mod_imports
+        assert "button.module.css" in mod_imports["styles"]
+
+
+class TestVueTemplateClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_vue_classes.vue",
+        )
+
+    def test_extracts_static_classes(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "container" in classes
+        assert "main-layout" in classes
+        assert "title" in classes
+        assert "description" in classes
+
+    def test_skips_dynamic_class(self):
+        """Dynamic :class bindings should not appear in static class list."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "active" not in classes
+
+    def test_vue_has_style_selectors(self):
+        """Both template classes and style selectors should be extracted."""
+        selectors = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {s.name for s in selectors}
+        assert ".container" in names
+        assert ".title" in names
+        assert ".description" in names
+
+
+class TestLESSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample.less",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.less")) == "less"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_finds_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function"
+            and n.extra.get("css_kind") == "less_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "@primary-color" in names
+        assert "@font-size" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert ".mixin-flex" in names
+
+    def test_nodes_have_less_language(self):
+        for node in self.nodes:
+            assert node.language == "less"

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1,4 +1,4 @@
-"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Solidity, and Vue parsing."""
+"""Tests for Go, Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Solidity, Vue, CSS, and SCSS parsing."""
 
 from pathlib import Path
 
@@ -825,6 +825,28 @@ class TestVueParsing:
     def test_finds_calls(self):
         calls = [e for e in self.edges if e.kind == "CALLS"]
         assert len(calls) >= 1
+
+    def test_vue_style_block_parsing(self):
+        parser = CodeParser()
+        vue_with_style = b"""<template><div>Hello</div></template>
+<script setup>
+const x = 1;
+</script>
+<style scoped>
+.app { color: red; }
+.app .btn { padding: 10px; }
+</style>
+"""
+        nodes, edges = parser.parse_bytes(
+            Path("/tmp/test_style.vue"), vue_with_style,
+        )
+        css_selectors = [
+            n for n in nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        assert len(css_selectors) >= 2
+        for sel in css_selectors:
+            assert sel.language == "vue"
 
 
 class TestRParsing:
@@ -2548,3 +2570,291 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+
+
+class TestCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.css")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.css")) == "css"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".btn-primary" in names
+        assert "#main-header" in names
+        assert "body" in names
+
+    def test_comma_separated_selectors_split(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert "h1" in names
+        assert "h2" in names
+
+    def test_finds_custom_properties(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "custom_property"
+        ]
+        names = {f.name for f in funcs}
+        assert "--primary-color" in names
+        assert "--font-size" in names
+        assert "--spacing-md" in names
+
+    def test_finds_media_queries(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "media_query"
+        ]
+        assert len(classes) >= 1
+
+    def test_finds_keyframes(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "keyframes"
+        ]
+        names = {c.name for c in classes}
+        assert "@keyframes(fadeIn)" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "reset.css" in targets
+        assert "components.css" in targets
+
+    def test_finds_var_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        # body calls --font-size and --primary-color
+        assert len(calls) >= 2
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 5
+
+    def test_specificity_computed(self):
+        classes = {
+            n.name: n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+            and n.parent_name is None  # top-level only
+        }
+        assert classes[".btn"].extra["specificity"] == [0, 1, 0]
+        assert classes["#main-header"].extra["specificity"] == [1, 0, 0]
+        assert classes["body"].extra["specificity"] == [0, 0, 1]
+
+    def test_override_edges_exist(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        assert len(overrides) >= 1
+
+    def test_bem_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        bem = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "bem_refinement"
+        ]
+        assert len(bem) >= 1
+        # .btn-primary overrides .btn
+        targets = {e.target.split("::")[-1] for e in bem}
+        assert ".btn" in targets
+
+    def test_important_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        important = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "important"
+        ]
+        assert len(important) >= 1
+
+    def test_nodes_have_css_language(self):
+        for node in self.nodes:
+            assert node.language == "css"
+
+
+class TestSCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.scss")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.scss")) == "scss"
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert "flex-center" in names
+        assert "responsive" in names
+
+    def test_finds_scss_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "scss_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "$primary-color" in names
+        assert "$font-size" in names
+        assert "$spacing" in names
+
+    def test_finds_include_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("flex-center" in t for t in targets)
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+        assert "mixins" in targets
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_nodes_have_scss_language(self):
+        for node in self.nodes:
+            assert node.language == "scss"
+
+
+class TestJSXClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_button.tsx",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("Component.tsx")) == "tsx"
+
+    def test_extracts_static_classname(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        button = funcs.get("Button")
+        assert button is not None
+        classes = button.extra.get("css_classes", [])
+        assert "btn" in classes
+        assert "btn-primary" in classes
+
+    def test_extracts_css_module_refs(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        styled = funcs.get("StyledButton")
+        assert styled is not None
+        refs = styled.extra.get("css_module_refs", [])
+        assert len(refs) >= 1
+        assert any(
+            r["import"] == "styles" and r["property"] == "btnOutline"
+            for r in refs
+        )
+
+    def test_skips_dynamic_classname(self):
+        """Ternary expressions should not produce css_classes."""
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        dynamic = funcs.get("DynamicButton")
+        assert dynamic is not None
+        # Dynamic ternary should not be in css_classes
+        classes = dynamic.extra.get("css_classes", [])
+        assert "active" not in classes or "inactive" not in classes
+
+    def test_classname_on_correct_function(self):
+        """Classes should attach to the enclosing function, not file."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        assert "css_classes" not in file_node.extra
+
+    def test_css_module_imports_on_file_node(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        mod_imports = file_node.extra.get("css_module_imports", {})
+        assert "styles" in mod_imports
+        assert "button.module.css" in mod_imports["styles"]
+
+
+class TestVueTemplateClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_vue_classes.vue",
+        )
+
+    def test_extracts_static_classes(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "container" in classes
+        assert "main-layout" in classes
+        assert "title" in classes
+        assert "description" in classes
+
+    def test_skips_dynamic_class(self):
+        """Dynamic :class bindings should not appear in static class list."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "active" not in classes
+
+    def test_vue_has_style_selectors(self):
+        """Both template classes and style selectors should be extracted."""
+        selectors = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {s.name for s in selectors}
+        assert ".container" in names
+        assert ".title" in names
+        assert ".description" in names
+
+
+class TestLESSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample.less",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.less")) == "less"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_finds_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function"
+            and n.extra.get("css_kind") == "less_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "@primary-color" in names
+        assert "@font-size" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert ".mixin-flex" in names
+
+    def test_nodes_have_less_language(self):
+        for node in self.nodes:
+            assert node.language == "less"


### PR DESCRIPTION
## Summary

- **CSS/SCSS parsing** with Tree-sitter: selector extraction, specificity computation `[a,b,c]`, single-file override detection (specificity, `!important`, BEM, source order), custom properties, `@media`/`@keyframes`/`@import`, SCSS `$variables`/`@mixin`/`@include`/`&` nesting, Vue `<style>` block delegation
- **Cross-language STYLES edges**: extract `className` from JSX/TSX and `class` from Vue `<template>`, post-build linking pass connects components to CSS selectors, CSS Modules resolution (`styles.foo` → `.foo` with camelCase-to-kebab)
- **Cross-file conflict detection**: heuristic flagging of same-name selectors across files via `POTENTIAL_CONFLICT` edges with specificity comparison and confidence metadata
- **LESS support**: regex-based parser (no tree-sitter grammar available) for selectors, `@variables`, `.mixins()`, `@import`
- **3 new MCP query patterns**: `styles_of`, `styled_by`, `conflicts_of`
- **Visualization**: STYLES (blue) and POTENTIAL_CONFLICT (red) edge styling with legend entries

## New Edge Types

| Edge | Source | Target | Purpose |
|------|--------|--------|---------|
| `OVERRIDES` | Winning CSS selector | Losing CSS selector | Single-file specificity/cascade override |
| `STYLES` | JSX component / Vue file | CSS selector | Cross-language class reference |
| `POTENTIAL_CONFLICT` | CSS selector | CSS selector | Cross-file same-name selector conflict |

## Architecture

Two-phase approach keeps the parser stateless:
1. **Per-file**: Extract class references during parsing, store in node `extra` metadata
2. **Post-build**: `link_css_styles()` and `detect_cross_file_conflicts()` query the graph and create cross-file edges

Both phases run automatically in `full_build()` and `incremental_update()`.

## Test Plan

- [x] 229 tests passing (47 new)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `TestJSXClassExtraction` — static className, CSS Module refs, dynamic skip, function attachment
- [x] `TestVueTemplateClassExtraction` — static class, dynamic `:class` skip, style+template coexistence
- [x] `TestLESSParsing` — selectors, `@variables`, `@import`, `.mixins`, language tagging
- [x] `TestCSSStylesLinking` — cross-file STYLES edges, Vue same-file linking, missing selector no-op
- [x] `TestCrossFileConflicts` — same-selector conflict, unique selector no-conflict, metadata validation
- [x] `TestCamelToKebab` — camelCase conversion correctness
- [x] Full graph rebuild exercises linking pass end-to-end