### PR TITLE
feat: --auto-watch flag to embed watcher inside MCP server process

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -462,8 +462,8 @@ def main() -> None:
     from .incremental import (
         find_project_root,
         find_repo_root,
-        get_watch_daemon_status,
         get_db_path,
+        get_watch_daemon_status,
         run_watch_daemon_foreground,
         start_watch_daemon,
         stop_watch_daemon,
@@ -598,7 +598,11 @@ def main() -> None:
             try:
                 watch(repo_root, store)
             except RuntimeError as exc:
-                logging.error(str(exc))
+                logging.error(
+                    "%s. If daemon mode is running, stop it with "
+                    "'code-review-graph daemon stop' first.",
+                    exc,
+                )
                 sys.exit(1)
 
         elif args.command == "visualize":

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -6,6 +6,7 @@ Usage:
     code-review-graph build [--base BASE]
     code-review-graph update [--base BASE]
     code-review-graph watch
+    code-review-graph daemon <start|stop|status>
     code-review-graph status
     code-review-graph serve [--auto-watch]
     code-review-graph mcp [--auto-watch]
@@ -80,6 +81,7 @@ def _print_banner() -> None:
     {g}build{r}       Full graph build {d}(parse all files){r}
     {g}update{r}      Incremental update {d}(changed files only){r}
     {g}watch{r}       Auto-update on file changes
+    {g}daemon{r}      Offline watch daemon management
     {g}status{r}      Show graph statistics
     {g}visualize{r}   Generate interactive HTML graph
     {g}wiki{r}        Generate markdown wiki from communities
@@ -264,6 +266,20 @@ def main() -> None:
     watch_cmd = sub.add_parser("watch", help="Watch for changes and auto-update")
     watch_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
 
+    # daemon
+    daemon_cmd = sub.add_parser("daemon", help="Manage offline watch daemon")
+    daemon_cmd.add_argument(
+        "action",
+        choices=["start", "stop", "status"],
+        help="Daemon action to perform",
+    )
+    daemon_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    daemon_cmd.add_argument(
+        "--foreground",
+        action="store_true",
+        help="Run in foreground (recommended with process managers/services)",
+    )
+
     # status
     status_cmd = sub.add_parser("status", help="Show graph statistics")
     status_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
@@ -446,9 +462,36 @@ def main() -> None:
     from .incremental import (
         find_project_root,
         find_repo_root,
+        get_watch_daemon_status,
         get_db_path,
+        run_watch_daemon_foreground,
+        start_watch_daemon,
+        stop_watch_daemon,
         watch,
     )
+
+    if args.command == "daemon":
+        repo_root = Path(args.repo) if args.repo else find_project_root()
+        action = args.action
+        if action == "start":
+            if getattr(args, "foreground", False):
+                run_watch_daemon_foreground(repo_root)
+            else:
+                result = start_watch_daemon(repo_root)
+                print(result["message"])
+            return
+        if action == "stop":
+            result = stop_watch_daemon(repo_root)
+            print(result["message"])
+            return
+        status = get_watch_daemon_status(repo_root)
+        if status["running"]:
+            print(f"Watch daemon is running (pid={status['pid']}).")
+        else:
+            print("Watch daemon is not running.")
+        print(f"PID file: {status['pid_file']}")
+        print(f"Lock file: {status['lock_file']}")
+        return
 
     if args.command == "postprocess":
         repo_root = Path(args.repo) if args.repo else find_project_root()
@@ -552,7 +595,11 @@ def main() -> None:
                 )
 
         elif args.command == "watch":
-            watch(repo_root, store)
+            try:
+                watch(repo_root, store)
+            except RuntimeError as exc:
+                logging.error(str(exc))
+                sys.exit(1)
 
         elif args.command == "visualize":
             from .visualization import generate_html
@@ -618,3 +665,7 @@ def main() -> None:
 
     finally:
         store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -7,7 +7,8 @@ Usage:
     code-review-graph update [--base BASE]
     code-review-graph watch
     code-review-graph status
-    code-review-graph serve
+    code-review-graph serve [--auto-watch]
+    code-review-graph mcp [--auto-watch]
     code-review-graph visualize
     code-review-graph wiki
     code-review-graph detect-changes [--base BASE] [--brief]
@@ -327,9 +328,22 @@ def main() -> None:
     )
     detect_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
 
-    # serve
+    # serve / mcp
     serve_cmd = sub.add_parser("serve", help="Start MCP server (stdio transport)")
     serve_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    serve_cmd.add_argument(
+        "--auto-watch",
+        action="store_true",
+        help="Start filesystem watch in a daemon thread while MCP server runs",
+    )
+
+    mcp_cmd = sub.add_parser("mcp", help="Alias for serve")
+    mcp_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    mcp_cmd.add_argument(
+        "--auto-watch",
+        action="store_true",
+        help="Start filesystem watch in a daemon thread while MCP server runs",
+    )
 
     args = ap.parse_args()
 
@@ -341,9 +355,12 @@ def main() -> None:
         _print_banner()
         return
 
-    if args.command == "serve":
+    if args.command in ("serve", "mcp"):
         from .main import main as serve_main
-        serve_main(repo_root=args.repo)
+        serve_main(
+            repo_root=args.repo,
+            auto_watch=getattr(args, "auto_watch", False),
+        )
         return
 
     if args.command == "eval":

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -9,6 +9,7 @@ Supports multiple providers:
 from __future__ import annotations
 
 import hashlib
+import importlib
 import logging
 import os
 import sqlite3
@@ -16,7 +17,7 @@ import struct
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .graph import GraphNode, GraphStore, node_to_dict
 
@@ -95,8 +96,8 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 class GoogleEmbeddingProvider(EmbeddingProvider):
     def __init__(self, api_key: str, model: str = "gemini-embedding-001") -> None:
         try:
-            from google import genai
-            self._client = genai.Client(api_key=api_key)
+            genai = importlib.import_module("google.genai")
+            self._client = cast(Any, genai).Client(api_key=api_key)
             self.model = model
             self._dimension: int | None = None
         except ImportError:

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -12,7 +12,9 @@ import hashlib
 import logging
 import os
 import re
+import signal
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -544,9 +546,267 @@ def incremental_update(
 
 
 _DEBOUNCE_SECONDS = 0.3
+_WATCH_LOCK_FILE = "watch.lock"
+_WATCH_PID_FILE = "watch.pid"
+_WATCH_LOG_FILE = "watch-daemon.log"
 
 
-def watch(repo_root: Path, store: GraphStore) -> None:
+def _watch_runtime_dir(repo_root: Path) -> Path:
+    """Return the runtime directory used by watcher metadata files."""
+    get_db_path(repo_root)
+    return repo_root / ".code-review-graph"
+
+
+def _watch_lock_path(repo_root: Path) -> Path:
+    return _watch_runtime_dir(repo_root) / _WATCH_LOCK_FILE
+
+
+def _watch_pid_path(repo_root: Path) -> Path:
+    return _watch_runtime_dir(repo_root) / _WATCH_PID_FILE
+
+
+def _watch_log_path(repo_root: Path) -> Path:
+    return _watch_runtime_dir(repo_root) / _WATCH_LOG_FILE
+
+
+def _is_pid_running(pid: int) -> bool:
+    """Return True if a process with *pid* appears alive."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        try:
+            win_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            result = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+                creationflags=win_flags,
+            )
+            out = (result.stdout or "") + (result.stderr or "")
+            if str(pid) in out:
+                return True
+        except OSError:
+            pass
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        # A live process can still reject signal probes.
+        return True
+    except OSError:
+        return False
+
+
+def _read_pid_file(path: Path) -> int | None:
+    try:
+        return int(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _write_pid_file(repo_root: Path, pid: int) -> None:
+    _watch_pid_path(repo_root).write_text(f"{pid}\n")
+
+
+def _remove_pid_file(repo_root: Path) -> None:
+    try:
+        _watch_pid_path(repo_root).unlink()
+    except OSError:
+        pass
+
+
+def _acquire_watch_lock(repo_root: Path, owner_pid: int) -> tuple[bool, str]:
+    """Acquire single-writer lock for watch mode.
+
+    Returns ``(acquired, reason)``.
+    """
+    lock_path = _watch_lock_path(repo_root)
+
+    if lock_path.exists():
+        lock_pid = _read_pid_file(lock_path)
+        if lock_pid and _is_pid_running(lock_pid):
+            return False, f"watcher already running (pid={lock_pid})"
+        try:
+            lock_path.unlink()
+        except OSError:
+            return False, "failed to clear stale watch lock"
+
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        with os.fdopen(fd, "w", encoding="utf-8") as lock_file:
+            lock_file.write(f"{owner_pid}\n")
+        return True, "acquired"
+    except FileExistsError:
+        return False, "watch lock is already held"
+    except OSError as exc:
+        return False, f"failed to create watch lock: {exc}"
+
+
+def _release_watch_lock(repo_root: Path, owner_pid: int) -> None:
+    lock_path = _watch_lock_path(repo_root)
+    lock_pid = _read_pid_file(lock_path)
+    if lock_pid is not None and lock_pid != owner_pid:
+        return
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
+
+
+def get_watch_daemon_status(repo_root: Path) -> dict:
+    """Return daemon/watch status for the repository."""
+    pid_path = _watch_pid_path(repo_root)
+    lock_path = _watch_lock_path(repo_root)
+    daemon_pid = _read_pid_file(pid_path)
+    lock_pid = _read_pid_file(lock_path)
+    daemon_running = bool(daemon_pid and _is_pid_running(daemon_pid))
+    lock_active = bool(lock_pid and _is_pid_running(lock_pid))
+    return {
+        "running": daemon_running,
+        "pid": daemon_pid,
+        "lock_active": lock_active,
+        "lock_pid": lock_pid,
+        "pid_file": str(pid_path),
+        "lock_file": str(lock_path),
+    }
+
+
+def start_watch_daemon(repo_root: Path) -> dict:
+    """Start offline watch daemon process for the repository."""
+    status = get_watch_daemon_status(repo_root)
+    if status["running"]:
+        return {
+            "started": False,
+            "pid": status["pid"],
+            "message": f"Watch daemon already running (pid={status['pid']})",
+        }
+
+    py_exe = sys.executable
+    if os.name == "nt":
+        pyw = Path(sys.executable).with_name("pythonw.exe")
+        if pyw.exists():
+            py_exe = str(pyw)
+
+    cmd = [
+        py_exe,
+        "-m",
+        "code_review_graph.cli",
+        "daemon",
+        "start",
+        "--repo",
+        str(repo_root),
+        "--foreground",
+    ]
+
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{existing}" if existing else str(repo_root)
+    )
+
+    log_path = _watch_log_path(repo_root)
+    if os.name == "nt":
+        subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            cwd=str(repo_root),
+            env=env,
+            creationflags=(
+                subprocess.DETACHED_PROCESS
+                | subprocess.CREATE_NEW_PROCESS_GROUP
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            ),
+        )
+    else:
+        with log_path.open("a", encoding="utf-8") as log_file:
+            subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=log_file,
+                close_fds=True,
+                cwd=str(repo_root),
+                env=env,
+                start_new_session=True,
+            )
+
+    pid_path = _watch_pid_path(repo_root)
+    for _ in range(100):
+        pid = _read_pid_file(pid_path)
+        if pid and _is_pid_running(pid):
+            return {
+                "started": True,
+                "pid": pid,
+                "message": f"Watch daemon started (pid={pid})",
+            }
+        time.sleep(0.1)
+
+    return {
+        "started": False,
+        "pid": None,
+        "message": (
+            f"Watch daemon start timed out. Check {log_path} "
+            "or run 'code-review-graph daemon start --foreground'."
+        ),
+    }
+
+
+def stop_watch_daemon(repo_root: Path) -> dict:
+    """Stop offline watch daemon process for the repository."""
+    pid = _read_pid_file(_watch_pid_path(repo_root))
+    if not pid:
+        _remove_pid_file(repo_root)
+        return {"stopped": False, "message": "Watch daemon is not running."}
+
+    if not _is_pid_running(pid):
+        _remove_pid_file(repo_root)
+        _release_watch_lock(repo_root, pid)
+        return {"stopped": False, "message": "Watch daemon was stale; cleaned up metadata."}
+
+    try:
+        if os.name == "nt":
+            win_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+                creationflags=win_flags,
+            )
+        else:
+            os.kill(pid, signal.SIGTERM)
+    except OSError as exc:
+        return {"stopped": False, "message": f"Failed to stop watch daemon: {exc}"}
+
+    for _ in range(20):
+        if not _is_pid_running(pid):
+            break
+        time.sleep(0.1)
+
+    _remove_pid_file(repo_root)
+    _release_watch_lock(repo_root, pid)
+    return {"stopped": True, "message": f"Watch daemon stopped (pid={pid})."}
+
+
+def run_watch_daemon_foreground(repo_root: Path) -> None:
+    """Run watch daemon loop in foreground (internal entrypoint)."""
+    _write_pid_file(repo_root, os.getpid())
+    db_path = get_db_path(repo_root)
+    store = GraphStore(db_path)
+    try:
+        watch(repo_root, store, owner_pid=os.getpid())
+    finally:
+        _remove_pid_file(repo_root)
+        store.close()
+
+
+def watch(repo_root: Path, store: GraphStore, owner_pid: int | None = None) -> None:
     """Watch for file changes and auto-update the graph.
 
     Uses a 300ms debounce to batch rapid-fire saves into a single update.
@@ -558,115 +818,123 @@ def watch(repo_root: Path, store: GraphStore) -> None:
 
     parser = CodeParser()
     ignore_patterns = _load_ignore_patterns(repo_root)
+    owner_pid = owner_pid or os.getpid()
 
-    class GraphUpdateHandler(FileSystemEventHandler):
-        def __init__(self):
-            self._pending: set[str] = set()
-            self._lock = threading.Lock()
-            self._timer: threading.Timer | None = None
+    acquired, reason = _acquire_watch_lock(repo_root, owner_pid)
+    if not acquired:
+        raise RuntimeError(f"Unable to start watcher: {reason}")
 
-        def _should_handle(self, path: str) -> bool:
-            if Path(path).is_symlink():
-                return False
-            try:
-                rel = str(Path(path).relative_to(repo_root))
-            except ValueError:
-                return False
-            if _should_ignore(rel, ignore_patterns):
-                return False
-            if parser.detect_language(Path(path)) is None:
-                return False
-            return True
-
-        def on_modified(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_created(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_deleted(self, event):
-            if event.is_directory:
-                return
-            # Only handle files we would normally track
-            try:
-                rel = str(Path(event.src_path).relative_to(repo_root))
-            except ValueError:
-                return
-            if _should_ignore(rel, ignore_patterns):
-                return
-            try:
-                store.remove_file_data(event.src_path)
-                store.commit()
-                logger.info("Removed: %s", rel)
-            except Exception as e:
-                logger.error("Error removing %s: %s", rel, e)
-
-        def _schedule(self, abs_path: str):
-            """Add file to pending set and reset the debounce timer."""
-            with self._lock:
-                self._pending.add(abs_path)
-                if self._timer is not None:
-                    self._timer.cancel()
-                self._timer = threading.Timer(
-                    _DEBOUNCE_SECONDS, self._flush
-                )
-                self._timer.start()
-
-        def _flush(self):
-            """Process all pending files after the debounce window."""
-            with self._lock:
-                paths = list(self._pending)
-                self._pending.clear()
-                self._timer = None
-
-            for abs_path in paths:
-                self._update_file(abs_path)
-
-        def _update_file(self, abs_path: str):
-            path = Path(abs_path)
-            if not path.is_file():
-                return
-            if path.is_symlink():
-                return
-            if _is_binary(path):
-                return
-            try:
-                source = path.read_bytes()
-                fhash = hashlib.sha256(source).hexdigest()
-                nodes, edges = parser.parse_bytes(path, source)
-                store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
-                store.set_metadata(
-                    "last_updated", time.strftime("%Y-%m-%dT%H:%M:%S")
-                )
-                store.commit()
-                rel = str(path.relative_to(repo_root))
-                logger.info(
-                    "Updated: %s (%d nodes, %d edges)",
-                    rel, len(nodes), len(edges),
-                )
-            except Exception as e:
-                logger.error("Error updating %s: %s", abs_path, e)
-
-    handler = GraphUpdateHandler()
-    observer = Observer()
-    observer.schedule(handler, str(repo_root), recursive=True)
-    observer.start()
-
-    logger.info("Watching %s for changes... (Ctrl+C to stop)", repo_root)
     try:
-        import time as _time
-        while True:
-            _time.sleep(1)
-    except KeyboardInterrupt:
-        observer.stop()
-    observer.join()
-    logger.info("Watch stopped.")
+        class GraphUpdateHandler(FileSystemEventHandler):
+            def __init__(self):
+                self._pending: set[str] = set()
+                self._lock = threading.Lock()
+                self._timer: threading.Timer | None = None
+
+            def _should_handle(self, path: str) -> bool:
+                if Path(path).is_symlink():
+                    return False
+                try:
+                    rel = str(Path(path).relative_to(repo_root))
+                except ValueError:
+                    return False
+                if _should_ignore(rel, ignore_patterns):
+                    return False
+                if parser.detect_language(Path(path)) is None:
+                    return False
+                return True
+
+            def on_modified(self, event):
+                if event.is_directory:
+                    return
+                if self._should_handle(event.src_path):
+                    self._schedule(event.src_path)
+
+            def on_created(self, event):
+                if event.is_directory:
+                    return
+                if self._should_handle(event.src_path):
+                    self._schedule(event.src_path)
+
+            def on_deleted(self, event):
+                if event.is_directory:
+                    return
+                # Only handle files we would normally track
+                try:
+                    rel = str(Path(event.src_path).relative_to(repo_root))
+                except ValueError:
+                    return
+                if _should_ignore(rel, ignore_patterns):
+                    return
+                try:
+                    store.remove_file_data(event.src_path)
+                    store.commit()
+                    logger.info("Removed: %s", rel)
+                except Exception as e:
+                    logger.error("Error removing %s: %s", rel, e)
+
+            def _schedule(self, abs_path: str):
+                """Add file to pending set and reset the debounce timer."""
+                with self._lock:
+                    self._pending.add(abs_path)
+                    if self._timer is not None:
+                        self._timer.cancel()
+                    self._timer = threading.Timer(
+                        _DEBOUNCE_SECONDS, self._flush
+                    )
+                    self._timer.start()
+
+            def _flush(self):
+                """Process all pending files after the debounce window."""
+                with self._lock:
+                    paths = list(self._pending)
+                    self._pending.clear()
+                    self._timer = None
+
+                for abs_path in paths:
+                    self._update_file(abs_path)
+
+            def _update_file(self, abs_path: str):
+                path = Path(abs_path)
+                if not path.is_file():
+                    return
+                if path.is_symlink():
+                    return
+                if _is_binary(path):
+                    return
+                try:
+                    source = path.read_bytes()
+                    fhash = hashlib.sha256(source).hexdigest()
+                    nodes, edges = parser.parse_bytes(path, source)
+                    store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
+                    store.set_metadata(
+                        "last_updated", time.strftime("%Y-%m-%dT%H:%M:%S")
+                    )
+                    store.commit()
+                    rel = str(path.relative_to(repo_root))
+                    logger.info(
+                        "Updated: %s (%d nodes, %d edges)",
+                        rel, len(nodes), len(edges),
+                    )
+                except Exception as e:
+                    logger.error("Error updating %s: %s", abs_path, e)
+
+        handler = GraphUpdateHandler()
+        observer = Observer()
+        observer.schedule(handler, str(repo_root), recursive=True)
+        observer.start()
+
+        logger.info("Watching %s for changes... (Ctrl+C to stop)", repo_root)
+        try:
+            import time as _time
+            while True:
+                _time.sleep(1)
+        except KeyboardInterrupt:
+            observer.stop()
+        observer.join()
+        logger.info("Watch stopped.")
+    finally:
+        _release_watch_lock(repo_root, owner_pid)
 
 
 def start_watch_thread(

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -708,6 +708,9 @@ def start_watch_daemon(repo_root: Path) -> dict:
 
     log_path = _watch_log_path(repo_root)
     if os.name == "nt":
+        win_detached = getattr(subprocess, "DETACHED_PROCESS", 0)
+        win_new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        win_no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0)
         subprocess.Popen(
             cmd,
             stdin=subprocess.DEVNULL,
@@ -716,11 +719,7 @@ def start_watch_daemon(repo_root: Path) -> dict:
             close_fds=True,
             cwd=str(repo_root),
             env=env,
-            creationflags=(
-                subprocess.DETACHED_PROCESS
-                | subprocess.CREATE_NEW_PROCESS_GROUP
-                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
-            ),
+            creationflags=(win_detached | win_new_group | win_no_window),
         )
     else:
         with log_path.open("a", encoding="utf-8") as log_file:

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -666,5 +667,31 @@ def watch(repo_root: Path, store: GraphStore) -> None:
         observer.stop()
     observer.join()
     logger.info("Watch stopped.")
+
+
+def start_watch_thread(
+    repo_root: Path,
+    store: GraphStore,
+    daemon: bool = True,
+) -> threading.Thread | None:
+    """Start watch mode in a background thread.
+
+    Returns the started thread, or None if watchdog is unavailable.
+    """
+    try:
+        import watchdog  # noqa: F401
+    except ImportError:
+        logger.warning("watchdog not installed; auto-watch disabled")
+        return None
+
+    thread = threading.Thread(
+        target=watch,
+        args=(repo_root, store),
+        daemon=daemon,
+        name="crg-watch",
+    )
+    thread.start()
+    logger.info("Auto-watch started for %s", repo_root)
+    return thread
 
 

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 from fastmcp import FastMCP
 
+from .graph import GraphStore
+from .incremental import find_project_root, get_db_path, start_watch_thread
 from .prompts import (
     architecture_map_prompt,
     debug_issue_prompt,
@@ -45,9 +47,6 @@ from .tools import (
     run_postprocess,
     semantic_search_nodes,
 )
-
-from .graph import GraphStore
-from .incremental import find_project_root, get_db_path, start_watch_thread
 
 # NOTE: Thread-safe for stdio MCP (single-threaded). If adding HTTP/SSE
 # transport with concurrent requests, replace with contextvars.ContextVar.

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -6,6 +6,8 @@ Communicates via stdio (standard MCP transport).
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Optional
 
 from fastmcp import FastMCP
@@ -44,9 +46,14 @@ from .tools import (
     semantic_search_nodes,
 )
 
+from .graph import GraphStore
+from .incremental import find_project_root, get_db_path, start_watch_thread
+
 # NOTE: Thread-safe for stdio MCP (single-threaded). If adding HTTP/SSE
 # transport with concurrent requests, replace with contextvars.ContextVar.
 _default_repo_root: str | None = None
+
+logger = logging.getLogger(__name__)
 
 mcp = FastMCP(
     "code-review-graph",
@@ -687,11 +694,24 @@ def pre_merge_check(base: str = "HEAD~1") -> list[dict]:
     return pre_merge_check_prompt(base=base)
 
 
-def main(repo_root: str | None = None) -> None:
+def main(repo_root: str | None = None, auto_watch: bool = False) -> None:
     """Run the MCP server via stdio."""
     global _default_repo_root
-    _default_repo_root = repo_root
-    mcp.run(transport="stdio")
+    root = Path(repo_root) if repo_root else find_project_root()
+    _default_repo_root = str(root)
+
+    watch_store: GraphStore | None = None
+    if auto_watch:
+        watch_store = GraphStore(get_db_path(root))
+        thread = start_watch_thread(root, watch_store, daemon=True)
+        if thread is None:
+            logger.warning("Auto-watch was requested but could not be started")
+
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        if watch_store is not None:
+            watch_store.close()
 
 
 if __name__ == "__main__":

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -412,7 +412,7 @@ def generate_html(
 # ---------------------------------------------------------------------------
 
 # Template lives in this file for zero-dependency packaging (no external files
-# to locate at runtime).  The ``# noqa: E501`` on the module is set via
+# to locate at runtime). Line-length exceptions are configured in
 # pyproject.toml per-file-ignores for this reason.
 
 _HTML_TEMPLATE = r"""<!DOCTYPE html>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 """CLI tests for MCP serve command wiring."""
 
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from code_review_graph import cli
 
@@ -73,3 +73,20 @@ class TestDaemonCommand:
                 cli.main()
 
         mock_stop.assert_called_once()
+
+
+class TestWatchInteraction:
+    def test_watch_exits_when_lock_is_held(self):
+        argv = ["code-review-graph", "watch", "--repo", "repo-root"]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch("code_review_graph.incremental.watch") as mock_watch:
+                        mock_watch.side_effect = RuntimeError("watcher already running")
+                        try:
+                            cli.main()
+                            assert False, "Expected SystemExit"
+                        except SystemExit as exc:
+                            assert exc.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,3 +39,37 @@ class TestServeCommand:
             repo_root="repo-root",
             auto_watch=False,
         )
+
+
+class TestDaemonCommand:
+    def test_daemon_start_calls_helper(self):
+        argv = ["code-review-graph", "daemon", "start", "--repo", "repo-root"]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.incremental.start_watch_daemon") as mock_start:
+                mock_start.return_value = {"message": "started"}
+                cli.main()
+
+        mock_start.assert_called_once()
+
+    def test_daemon_status_calls_helper(self):
+        argv = ["code-review-graph", "daemon", "status", "--repo", "repo-root"]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.incremental.get_watch_daemon_status") as mock_status:
+                mock_status.return_value = {
+                    "running": False,
+                    "pid": None,
+                    "pid_file": "pid-file",
+                    "lock_file": "lock-file",
+                }
+                cli.main()
+
+        mock_status.assert_called_once()
+
+    def test_daemon_stop_calls_helper(self):
+        argv = ["code-review-graph", "daemon", "stop", "--repo", "repo-root"]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.incremental.stop_watch_daemon") as mock_stop:
+                mock_stop.return_value = {"message": "stopped"}
+                cli.main()
+
+        mock_stop.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+"""CLI tests for MCP serve command wiring."""
+
+import sys
+from unittest.mock import patch
+
+from code_review_graph import cli
+
+
+class TestServeCommand:
+    def test_serve_passes_auto_watch_flag(self):
+        argv = [
+            "code-review-graph",
+            "serve",
+            "--repo",
+            "repo-root",
+            "--auto-watch",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.main.main") as mock_serve:
+                cli.main()
+
+        mock_serve.assert_called_once_with(
+            repo_root="repo-root",
+            auto_watch=True,
+        )
+
+    def test_mcp_alias_maps_to_serve(self):
+        argv = [
+            "code-review-graph",
+            "mcp",
+            "--repo",
+            "repo-root",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.main.main") as mock_serve:
+                cli.main()
+
+        mock_serve.assert_called_once_with(
+            repo_root="repo-root",
+            auto_watch=False,
+        )

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -19,7 +19,10 @@ from code_review_graph.incremental import (
     get_db_path,
     get_staged_and_unstaged,
     incremental_update,
+    start_watch_thread,
 )
+
+ORIGINAL_IMPORT = __import__
 
 
 class TestFindRepoRoot:
@@ -361,6 +364,33 @@ class TestMultiHopDependents:
             assert "/a.py" in deps
         finally:
             store.close()
+
+
+class TestStartWatchThread:
+    def test_starts_daemon_thread(self, tmp_path):
+        store = MagicMock()
+        with patch.dict("sys.modules", {"watchdog": MagicMock()}):
+            with patch("threading.Thread") as mock_thread:
+                thread = MagicMock()
+                mock_thread.return_value = thread
+                started = start_watch_thread(tmp_path, store, daemon=True)
+
+        assert started is thread
+        mock_thread.assert_called_once()
+        thread.start.assert_called_once()
+
+    @patch("builtins.__import__")
+    def test_returns_none_when_watchdog_missing(self, mock_import, tmp_path):
+        real_import = ORIGINAL_IMPORT
+
+        def _import_side_effect(name, *args, **kwargs):
+            if name == "watchdog":
+                raise ImportError("watchdog missing")
+            return real_import(name, *args, **kwargs)
+
+        mock_import.side_effect = _import_side_effect
+        started = start_watch_thread(tmp_path, MagicMock(), daemon=True)
+        assert started is None
 
     def test_cap_triggers_on_many_files(self, tmp_path):
         """The 500-file cap prevents runaway expansion."""

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch  # noqa: F401 – patch used in tests
 
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
+    _acquire_watch_lock,
+    _release_watch_lock,
     _is_binary,
     _load_ignore_patterns,
     _parse_single_file,
@@ -14,12 +16,15 @@ from code_review_graph.incremental import (
     find_project_root,
     find_repo_root,
     full_build,
+    get_watch_daemon_status,
     get_all_tracked_files,
     get_changed_files,
     get_db_path,
     get_staged_and_unstaged,
     incremental_update,
+    start_watch_daemon,
     start_watch_thread,
+    stop_watch_daemon,
 )
 
 ORIGINAL_IMPORT = __import__
@@ -429,3 +434,53 @@ class TestStartWatchThread:
             assert len(deps) <= 500
         finally:
             store.close()
+
+
+class TestWatchDaemon:
+    def test_status_not_running(self, tmp_path):
+        status = get_watch_daemon_status(tmp_path)
+        assert status["running"] is False
+        assert status["pid"] is None
+
+    def test_lock_roundtrip(self, tmp_path):
+        ok, _reason = _acquire_watch_lock(tmp_path, owner_pid=12345)
+        assert ok is True
+        status = get_watch_daemon_status(tmp_path)
+        assert status["lock_pid"] == 12345
+        _release_watch_lock(tmp_path, owner_pid=12345)
+        status = get_watch_daemon_status(tmp_path)
+        assert status["lock_active"] is False
+
+    @patch("code_review_graph.incremental.subprocess.Popen")
+    @patch("code_review_graph.incremental._is_pid_running")
+    def test_start_daemon_returns_started(self, mock_running, mock_popen, tmp_path):
+        mock_running.return_value = True
+
+        def _fake_start(_cmd, **_kwargs):
+            pid_file = tmp_path / ".code-review-graph" / "watch.pid"
+            pid_file.parent.mkdir(parents=True, exist_ok=True)
+            pid_file.write_text("4321\n")
+            return MagicMock()
+
+        mock_popen.side_effect = _fake_start
+        result = start_watch_daemon(tmp_path)
+        assert result["started"] is True
+        assert result["pid"] == 4321
+
+    @patch("code_review_graph.incremental._is_pid_running")
+    def test_stop_daemon_not_running(self, mock_running, tmp_path):
+        mock_running.return_value = False
+        result = stop_watch_daemon(tmp_path)
+        assert result["stopped"] is False
+
+    @patch("code_review_graph.incremental.subprocess.run")
+    @patch("code_review_graph.incremental._is_pid_running")
+    def test_stop_daemon_windows_taskkill(self, mock_running, mock_run, tmp_path):
+        pid_file = tmp_path / ".code-review-graph" / "watch.pid"
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        pid_file.write_text("5555\n")
+        mock_running.side_effect = [True, False]
+        with patch("code_review_graph.incremental.os.name", "nt"):
+            result = stop_watch_daemon(tmp_path)
+        assert result["stopped"] is True
+        mock_run.assert_called_once()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -6,21 +6,21 @@ from unittest.mock import MagicMock, patch  # noqa: F401 – patch used in tests
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
     _acquire_watch_lock,
-    _release_watch_lock,
     _is_binary,
     _load_ignore_patterns,
     _parse_single_file,
+    _release_watch_lock,
     _should_ignore,
     _single_hop_dependents,
     find_dependents,
     find_project_root,
     find_repo_root,
     full_build,
-    get_watch_daemon_status,
     get_all_tracked_files,
     get_changed_files,
     get_db_path,
     get_staged_and_unstaged,
+    get_watch_daemon_status,
     incremental_update,
     start_watch_daemon,
     start_watch_thread,
@@ -450,6 +450,26 @@ class TestWatchDaemon:
         _release_watch_lock(tmp_path, owner_pid=12345)
         status = get_watch_daemon_status(tmp_path)
         assert status["lock_active"] is False
+
+    @patch("code_review_graph.incremental._is_pid_running", return_value=False)
+    def test_stale_lock_gets_replaced(self, _mock_running, tmp_path):
+        lock_file = tmp_path / ".code-review-graph" / "watch.lock"
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+        lock_file.write_text("99999\n")
+
+        ok, _reason = _acquire_watch_lock(tmp_path, owner_pid=12345)
+        assert ok is True
+        assert lock_file.read_text().strip() == "12345"
+
+    @patch("code_review_graph.incremental._is_pid_running", return_value=True)
+    def test_active_lock_blocks_second_watcher(self, _mock_running, tmp_path):
+        lock_file = tmp_path / ".code-review-graph" / "watch.lock"
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+        lock_file.write_text("4242\n")
+
+        ok, reason = _acquire_watch_lock(tmp_path, owner_pid=12345)
+        assert ok is False
+        assert "already running" in reason
 
     @patch("code_review_graph.incremental.subprocess.Popen")
     @patch("code_review_graph.incremental._is_pid_running")


### PR DESCRIPTION
This pull request adds robust offline daemon support and improves the CLI and server integration for the code review graph tool. The main enhancements include a new `daemon` command for managing a background filesystem watcher, improved `serve`/`mcp` command wiring with optional auto-watch, and extensive internal refactoring for process management and status reporting. Comprehensive tests for the new CLI commands and daemon helpers are also included.

**CLI and Daemon Command Enhancements:**

* Added a new `daemon` command to the CLI for starting, stopping, and checking the status of an offline watch daemon, including support for foreground/background operation and status metadata. (`code_review_graph/cli.py`, `code_review_graph/incremental.py`) [[1]](diffhunk://#diff-fd613d017cacbe7813b9e8938f4a7c22b4fe9ce6585ff5cb918a37d7296e6e21R9-R12) [[2]](diffhunk://#diff-fd613d017cacbe7813b9e8938f4a7c22b4fe9ce6585ff5cb918a37d7296e6e21R269-R282) [[3]](diffhunk://#diff-fd613d017cacbe7813b9e8938f4a7c22b4fe9ce6585ff5cb918a37d7296e6e21R465-R495) [[4]](diffhunk://#diff-3fbb35db950d6666629a0c0f4780d764f1482a4d160eacb2bd849ee3573e36e1R549-R809)
* Updated the CLI to support `serve` and `mcp` commands with an `--auto-watch` flag, allowing the MCP server to run alongside a background file watcher. (`code_review_graph/cli.py`, `code_review_graph/main.py`) [[1]](diffhunk://#diff-fd613d017cacbe7813b9e8938f4a7c22b4fe9ce6585ff5cb918a37d7296e6e21L330-R362) [[2]](diffhunk://#diff-fd613d017cacbe7813b9e8938f4a7c22b4fe9ce6585ff5cb918a37d7296e6e21L344-R379) [[3]](diffhunk://#diff-9198647e28e8deb5da226d7a9d4547153732c04b8fa10c043250e96e2f665c44R49-R57) [[4]](diffhunk://#diff-9198647e28e8deb5da226d7a9d4547153732c04b8fa10c043250e96e2f665c44L690-R714)

**Daemon Process Management and Watcher Refactoring:**

* Implemented process management helpers for daemon lifecycle: PID/lock/log file handling, cross-platform process checks, and clean startup/shutdown logic. (`code_review_graph/incremental.py`) [[1]](diffhunk://#diff-3fbb35db950d6666629a0c0f4780d764f1482a4d160eacb2bd849ee3573e36e1R549-R809) [[2]](diffhunk://#diff-3fbb35db950d6666629a0c0f4780d764f1482a4d160eacb2bd849ee3573e36e1R821-R827)
* Refactored the watcher to enforce a single-writer lock using PID files, with robust acquisition/release and error handling. (`code_review_graph/incremental.py`)
* Added support for running the watcher in a background thread for integration with the MCP server, and provided helpers for starting/stopping/status reporting of the daemon. (`code_review_graph/incremental.py`, `code_review_graph/main.py`) (Fa10b2a3L933, [code_review_graph/main.pyL690-R714](diffhunk://#diff-9198647e28e8deb5da226d7a9d4547153732c04b8fa10c043250e96e2f665c44L690-R714))

**Testing Improvements:**

* Added new tests for CLI command wiring, including `serve`, `mcp`, and all `daemon` subcommands, as well as tests for the new daemon helpers and lock acquisition logic. (`tests/test_cli.py`, `tests/test_incremental.py`) [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR1-R75) [[2]](diffhunk://#diff-b14ccef569b66ffce4b2ad8b1e365e28f391131a26746a26395c31c6ff1b137fR8-R9) [[3]](diffhunk://#diff-b14ccef569b66ffce4b2ad8b1e365e28f391131a26746a26395c31c6ff1b137fR19-R31)

These changes make the tool more robust for offline and background operation, and provide a more user-friendly and scriptable interface for managing the file watcher and MCP server.