### PR TITLE
fix: generate valid Claude Code hook schema (closes #138)

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 # --- Multi-platform MCP install ---
 
+
 def _zed_settings_path() -> Path:
     """Return the Zed settings.json path for the current OS."""
     if platform.system() == "Darwin":
@@ -121,9 +122,7 @@ def install_platform_configs(
         List of platform names that were configured.
     """
     if target == "all":
-        platforms_to_install = {
-            k: v for k, v in PLATFORMS.items() if v["detect"]()
-        }
+        platforms_to_install = {k: v for k, v in PLATFORMS.items() if v["detect"]()}
     else:
         if target not in PLATFORMS:
             logger.error("Unknown platform: %s", target)
@@ -151,10 +150,7 @@ def install_platform_configs(
             if not isinstance(arr, list):
                 arr = []
             # Check if already present
-            if any(
-                isinstance(s, dict) and s.get("name") == "code-review-graph"
-                for s in arr
-            ):
+            if any(isinstance(s, dict) and s.get("name") == "code-review-graph" for s in arr):
                 print(f"  {plat['name']}: already configured in {config_path}")
                 configured.append(plat["name"])
                 continue
@@ -183,6 +179,7 @@ def install_platform_configs(
 
     return configured
 
+
 # --- Skill file contents ---
 
 _SKILLS: dict[str, dict[str, str]] = {
@@ -206,10 +203,10 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Use `children_of` on a file to see all its functions and classes.\n"
             "- Use `find_large_functions` to identify complex code.\n\n"
             "## Token Efficiency Rules\n"
-            "- ALWAYS start with `get_minimal_context(task=\"<your task>\")` "
+            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
             "before any other graph tool.\n"
-            "- Use `detail_level=\"minimal\"` on all calls. Only escalate to "
-            "\"standard\" when minimal is insufficient.\n"
+            '- Use `detail_level="minimal"` on all calls. Only escalate to '
+            '"standard" when minimal is insufficient.\n'
             "- Target: complete any review/debug/refactor task in ≤5 tool calls "
             "and ≤800 total output tokens."
         ),
@@ -224,7 +221,7 @@ _SKILLS: dict[str, dict[str, str]] = {
             "1. Run `detect_changes` to get risk-scored change analysis.\n"
             "2. Run `get_affected_flows` to find impacted execution paths.\n"
             "3. For each high-risk function, run `query_graph` with "
-            "pattern=\"tests_for\" to check test coverage.\n"
+            'pattern="tests_for" to check test coverage.\n'
             "4. Run `get_impact_radius` to understand the blast radius.\n"
             "5. For any untested changes, suggest specific test cases.\n\n"
             "### Output Format\n\n"
@@ -234,10 +231,10 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Suggested improvements\n"
             "- Overall merge recommendation\n\n"
             "## Token Efficiency Rules\n"
-            "- ALWAYS start with `get_minimal_context(task=\"<your task>\")` "
+            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
             "before any other graph tool.\n"
-            "- Use `detail_level=\"minimal\"` on all calls. Only escalate to "
-            "\"standard\" when minimal is insufficient.\n"
+            '- Use `detail_level="minimal"` on all calls. Only escalate to '
+            '"standard" when minimal is insufficient.\n'
             "- Target: complete any review/debug/refactor task in ≤5 tool calls "
             "and ≤800 total output tokens."
         ),
@@ -260,10 +257,10 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Look at affected flows to find the entry point that triggers the bug.\n"
             "- Recent changes are the most common source of new issues.\n\n"
             "## Token Efficiency Rules\n"
-            "- ALWAYS start with `get_minimal_context(task=\"<your task>\")` "
+            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
             "before any other graph tool.\n"
-            "- Use `detail_level=\"minimal\"` on all calls. Only escalate to "
-            "\"standard\" when minimal is insufficient.\n"
+            '- Use `detail_level="minimal"` on all calls. Only escalate to '
+            '"standard" when minimal is insufficient.\n'
             "- Target: complete any review/debug/refactor task in ≤5 tool calls "
             "and ≤800 total output tokens."
         ),
@@ -275,10 +272,10 @@ _SKILLS: dict[str, dict[str, str]] = {
             "## Refactor Safely\n\n"
             "Use the knowledge graph to plan and execute refactoring with confidence.\n\n"
             "### Steps\n\n"
-            "1. Use `refactor_tool` with mode=\"suggest\" for community-driven "
+            '1. Use `refactor_tool` with mode="suggest" for community-driven '
             "refactoring suggestions.\n"
-            "2. Use `refactor_tool` with mode=\"dead_code\" to find unreferenced code.\n"
-            "3. For renames, use `refactor_tool` with mode=\"rename\" to preview all "
+            '2. Use `refactor_tool` with mode="dead_code" to find unreferenced code.\n'
+            '3. For renames, use `refactor_tool` with mode="rename" to preview all '
             "affected locations.\n"
             "4. Use `apply_refactor_tool` with the refactor_id to apply renames.\n"
             "5. After changes, run `detect_changes` to verify the refactoring impact.\n\n"
@@ -288,10 +285,10 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Use `get_affected_flows` to ensure no critical paths are broken.\n"
             "- Run `find_large_functions` to identify decomposition targets.\n\n"
             "## Token Efficiency Rules\n"
-            "- ALWAYS start with `get_minimal_context(task=\"<your task>\")` "
+            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
             "before any other graph tool.\n"
-            "- Use `detail_level=\"minimal\"` on all calls. Only escalate to "
-            "\"standard\" when minimal is insufficient.\n"
+            '- Use `detail_level="minimal"` on all calls. Only escalate to '
+            '"standard" when minimal is insufficient.\n'
             "- Target: complete any review/debug/refactor task in ≤5 tool calls "
             "and ≤800 total output tokens."
         ),
@@ -334,8 +331,12 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
 def generate_hooks_config() -> dict[str, Any]:
     """Generate Claude Code hooks configuration.
 
-    Returns a hooks config dict with PostToolUse, SessionStart, and
-    PreCommit hooks for automatic graph updates.
+    Returns a hooks config dict with PostToolUse and SessionStart hooks
+    matching the Claude Code hook schema:
+    https://docs.claude.com/en/docs/claude-code/hooks
+
+    Each event entry has a top-level ``matcher`` (optional) and an inner
+    ``hooks`` array of command handlers. Timeouts are expressed in seconds.
 
     Returns:
         Dict with hooks configuration suitable for .claude/settings.json.
@@ -345,20 +346,24 @@ def generate_hooks_config() -> dict[str, Any]:
             "PostToolUse": [
                 {
                     "matcher": "Edit|Write|Bash",
-                    "command": "code-review-graph update --skip-flows",
-                    "timeout": 5000,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph update --quiet --skip-flows",
+                            "timeout": 5,
+                        },
+                    ],
                 },
             ],
             "SessionStart": [
                 {
-                    "command": "code-review-graph status",
-                    "timeout": 3000,
-                },
-            ],
-            "PreCommit": [
-                {
-                    "command": "code-review-graph detect-changes --brief",
-                    "timeout": 10000,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph status --json",
+                            "timeout": 3,
+                        },
+                    ],
                 },
             ],
         }
@@ -461,14 +466,16 @@ def _inject_instructions(file_path: Path, marker: str, section: str) -> bool:
 def inject_claude_md(repo_root: Path) -> None:
     """Append MCP tools section to CLAUDE.md."""
     _inject_instructions(
-        repo_root / "CLAUDE.md", _CLAUDE_MD_SECTION_MARKER, _CLAUDE_MD_SECTION,
+        repo_root / "CLAUDE.md",
+        _CLAUDE_MD_SECTION_MARKER,
+        _CLAUDE_MD_SECTION,
     )
 
 
 # Cross-platform instruction files so every AI coding tool uses the graph.
 _PLATFORM_INSTRUCTION_FILES = {
-    "AGENTS.md": "AGENTS.md",       # Cursor, OpenCode, Antigravity
-    "GEMINI.md": "GEMINI.md",       # Antigravity / Gemini CLI
+    "AGENTS.md": "AGENTS.md",  # Cursor, OpenCode, Antigravity
+    "GEMINI.md": "GEMINI.md",  # Antigravity / Gemini CLI
     ".cursorrules": ".cursorrules",  # Cursor (legacy, widely used)
     ".windsurfrules": ".windsurfrules",  # Windsurf
 }

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -64,9 +64,7 @@ class TestGenerateSkills:
         skills_dir = generate_skills(tmp_path)
         for path in skills_dir.iterdir():
             content = path.read_text()
-            assert "detail_level" in content, (
-                f"{path.name} missing detail_level reference"
-            )
+            assert "detail_level" in content, f"{path.name} missing detail_level reference"
 
     def test_idempotent(self, tmp_path):
         """Running twice should not fail and files should still be valid."""
@@ -84,32 +82,43 @@ class TestGenerateHooksConfig:
     def test_has_post_tool_use(self):
         config = generate_hooks_config()
         assert "PostToolUse" in config["hooks"]
-        hooks = config["hooks"]["PostToolUse"]
-        assert len(hooks) >= 1
-        assert hooks[0]["matcher"] == "Edit|Write|Bash"
-        assert "update" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 5000
+        entries = config["hooks"]["PostToolUse"]
+        assert len(entries) >= 1
+        entry = entries[0]
+        assert entry["matcher"] == "Edit|Write|Bash"
+        inner = entry["hooks"]
+        assert len(inner) >= 1
+        assert inner[0]["type"] == "command"
+        assert "update" in inner[0]["command"]
+        # Timeouts must be in seconds (not milliseconds)
+        assert inner[0]["timeout"] == 5
 
     def test_has_session_start(self):
         config = generate_hooks_config()
         assert "SessionStart" in config["hooks"]
-        hooks = config["hooks"]["SessionStart"]
-        assert len(hooks) >= 1
-        assert "status" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 3000
+        entries = config["hooks"]["SessionStart"]
+        assert len(entries) >= 1
+        inner = entries[0]["hooks"]
+        assert len(inner) >= 1
+        assert inner[0]["type"] == "command"
+        assert "status" in inner[0]["command"]
+        assert inner[0]["timeout"] == 3
 
-    def test_has_pre_commit(self):
+    def test_does_not_emit_precommit(self):
+        """PreCommit is not a valid Claude Code hook event and must not be emitted."""
         config = generate_hooks_config()
-        assert "PreCommit" in config["hooks"]
-        hooks = config["hooks"]["PreCommit"]
-        assert len(hooks) >= 1
-        assert "detect-changes" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 10000
+        assert "PreCommit" not in config["hooks"]
 
-    def test_has_all_three_hook_types(self):
+    def test_all_commands_wrapped_in_inner_hooks_array(self):
+        """Every event entry must have an inner `hooks` array with type=command."""
         config = generate_hooks_config()
-        hook_types = set(config["hooks"].keys())
-        assert hook_types == {"PostToolUse", "SessionStart", "PreCommit"}
+        for event, entries in config["hooks"].items():
+            for entry in entries:
+                assert "hooks" in entry, f"{event} entry missing inner 'hooks' array"
+                assert isinstance(entry["hooks"], list)
+                for handler in entry["hooks"]:
+                    assert handler.get("type") == "command"
+                    assert "command" in handler
 
 
 class TestInstallHooks:
@@ -132,7 +141,6 @@ class TestInstallHooks:
         assert data["customSetting"] is True
         assert "PostToolUse" in data["hooks"]
         assert "SessionStart" in data["hooks"]
-        assert "PreCommit" in data["hooks"]
 
     def test_creates_claude_directory(self, tmp_path):
         install_hooks(tmp_path)
@@ -184,9 +192,12 @@ class TestInjectClaudeMd:
 
 class TestInstallPlatformConfigs:
     def test_install_cursor_config(self, tmp_path):
-        with patch.dict(PLATFORMS, {
-            "cursor": {**PLATFORMS["cursor"], "detect": lambda: True},
-        }):
+        with patch.dict(
+            PLATFORMS,
+            {
+                "cursor": {**PLATFORMS["cursor"], "detect": lambda: True},
+            },
+        ):
             configured = install_platform_configs(tmp_path, target="cursor")
         assert "Cursor" in configured
         config_path = tmp_path / ".cursor" / "mcp.json"
@@ -199,32 +210,39 @@ class TestInstallPlatformConfigs:
         windsurf_dir = tmp_path / ".codeium" / "windsurf"
         windsurf_dir.mkdir(parents=True)
         config_path = windsurf_dir / "mcp_config.json"
-        with patch.dict(PLATFORMS, {
-            "windsurf": {
-                **PLATFORMS["windsurf"],
-                "config_path": lambda root: config_path,
-                "detect": lambda: True,
+        with patch.dict(
+            PLATFORMS,
+            {
+                "windsurf": {
+                    **PLATFORMS["windsurf"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
             },
-        }):
+        ):
             configured = install_platform_configs(tmp_path, target="windsurf")
         assert "Windsurf" in configured
         data = json.loads(config_path.read_text())
         entry = data["mcpServers"]["code-review-graph"]
         assert "type" not in entry
         import shutil
+
         expected_cmd = "uvx" if shutil.which("uvx") else "code-review-graph"
         assert entry["command"] == expected_cmd
 
     def test_install_zed_config(self, tmp_path):
         zed_settings = tmp_path / "zed" / "settings.json"
         zed_settings.parent.mkdir(parents=True)
-        with patch.dict(PLATFORMS, {
-            "zed": {
-                **PLATFORMS["zed"],
-                "config_path": lambda root: zed_settings,
-                "detect": lambda: True,
+        with patch.dict(
+            PLATFORMS,
+            {
+                "zed": {
+                    **PLATFORMS["zed"],
+                    "config_path": lambda root: zed_settings,
+                    "detect": lambda: True,
+                },
             },
-        }):
+        ):
             configured = install_platform_configs(tmp_path, target="zed")
         assert "Zed" in configured
         data = json.loads(zed_settings.read_text())
@@ -235,13 +253,16 @@ class TestInstallPlatformConfigs:
         continue_dir = tmp_path / ".continue"
         continue_dir.mkdir()
         config_path = continue_dir / "config.json"
-        with patch.dict(PLATFORMS, {
-            "continue": {
-                **PLATFORMS["continue"],
-                "config_path": lambda root: config_path,
-                "detect": lambda: True,
+        with patch.dict(
+            PLATFORMS,
+            {
+                "continue": {
+                    **PLATFORMS["continue"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
             },
-        }):
+        ):
             configured = install_platform_configs(tmp_path, target="continue")
         assert "Continue" in configured
         data = json.loads(config_path.read_text())
@@ -277,9 +298,7 @@ class TestInstallPlatformConfigs:
         assert "code-review-graph" in data["mcpServers"]
 
     def test_dry_run_no_write(self, tmp_path):
-        configured = install_platform_configs(
-            tmp_path, target="claude", dry_run=True
-        )
+        configured = install_platform_configs(tmp_path, target="claude", dry_run=True)
         assert "Claude Code" in configured
         assert not (tmp_path / ".mcp.json").exists()
 
@@ -292,18 +311,19 @@ class TestInstallPlatformConfigs:
         config_path = tmp_path / ".continue" / "config.json"
         config_path.parent.mkdir(parents=True)
         existing = {
-            "mcpServers": [
-                {"name": "code-review-graph", "command": "uvx", "args": ["serve"]}
-            ]
+            "mcpServers": [{"name": "code-review-graph", "command": "uvx", "args": ["serve"]}]
         }
         config_path.write_text(json.dumps(existing))
-        with patch.dict(PLATFORMS, {
-            "continue": {
-                **PLATFORMS["continue"],
-                "config_path": lambda root: config_path,
-                "detect": lambda: True,
+        with patch.dict(
+            PLATFORMS,
+            {
+                "continue": {
+                    **PLATFORMS["continue"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
             },
-        }):
+        ):
             install_platform_configs(tmp_path, target="continue")
         data = json.loads(config_path.read_text())
         assert len(data["mcpServers"]) == 1


### PR DESCRIPTION
Closes #138

## Problem

`generate_hooks_config()` emits a hooks config that Claude Code rejects with schema errors, so `code-review-graph install` corrupts `~/.claude/settings.json`. Three bugs in the same function:

1. **`PreCommit` is not a valid Claude Code hook event** → `Invalid key in record`.
2. **Missing inner `hooks` array wrapper.** Each entry must have `hooks: [{type: "command", command, timeout}]`, but the old output put `command`/`timeout` directly on the entry → `hooks: Expected array, but received undefined` (the exact error in the issue for `SessionStart`).
3. **Timeouts in milliseconds instead of seconds.** `5000`, `3000`, `10000` — the `PostToolUse` hook effectively had an 83-minute timeout.

Verified against the official schema: https://docs.claude.com/en/docs/claude-code/hooks

## Fix

Rewrite `generate_hooks_config()` to match the documented schema:

```json
"PostToolUse": [
  {
    "matcher": "Edit|Write|Bash",
    "hooks": [
      {"type": "command", "command": "code-review-graph update --quiet --skip-flows", "timeout": 5}
    ]
  }
]
```

- Remove the `PreCommit` entry (no equivalent Claude Code event; pre-commit behavior belongs in a git hook).
- Wrap `PostToolUse` and `SessionStart` handlers in `hooks: [{type: "command", ...}]`.
- Convert timeouts from ms to seconds (`5000` → `5`, `3000` → `3`).

## Testing

- [x] `test_has_post_tool_use` / `test_has_session_start` updated for the nested structure
- [x] New `test_does_not_emit_precommit` — regression guard for this issue
- [x] New `test_all_commands_wrapped_in_inner_hooks_array` — structural invariant
- [x] Full suite: 611 passed, 5 skipped, 0 failed
- [x] `ruff check` clean