### PR TITLE
feat: add Kilo CLI (KiloCode) as fully supported platform

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -128,6 +128,7 @@ def _handle_init(args: argparse.Namespace) -> None:
 
     from .skills import (
         generate_skills,
+        generate_kilo_skills,
         inject_claude_md,
         inject_platform_instructions,
         install_hooks,
@@ -135,7 +136,9 @@ def _handle_init(args: argparse.Namespace) -> None:
 
     if not skip_skills:
         skills_dir = generate_skills(repo_root)
-        print(f"Generated skills in {skills_dir}")
+        print(f"Generated Claude Code skills in {skills_dir}")
+        kilo_skills_dir = generate_kilo_skills(repo_root)
+        print(f"Generated Kilo CLI skills in {kilo_skills_dir}")
         inject_claude_md(repo_root)
         updated = inject_platform_instructions(repo_root)
         if updated:

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -188,7 +188,7 @@ def main() -> None:
         "--platform",
         choices=[
             "claude", "claude-code", "cursor", "windsurf", "zed",
-            "continue", "opencode", "antigravity", "all",
+            "continue", "opencode", "kilocode", "antigravity", "all",
         ],
         default="all",
         help="Target platform for MCP config (default: all detected)",
@@ -218,7 +218,7 @@ def main() -> None:
         "--platform",
         choices=[
             "claude", "claude-code", "cursor", "windsurf", "zed",
-            "continue", "opencode", "antigravity", "all",
+            "continue", "opencode", "kilocode", "antigravity", "all",
         ],
         default="all",
         help="Target platform for MCP config (default: all detected)",

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -1,7 +1,7 @@
-"""Claude Code skills and hooks auto-install.
+"""Claude Code and Kilo CLI skills and hooks auto-install.
 
-Generates Claude Code agent skill files, hooks configuration, and
-CLAUDE.md integration for seamless code-review-graph usage.
+Generates Claude Code and Kilo CLI agent skill files, hooks configuration,
+and CLAUDE.md integration for seamless code-review-graph usage.
 Also supports multi-platform MCP server installation.
 """
 
@@ -335,6 +335,57 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
         )
         path.write_text(content)
         logger.info("Wrote skill: %s", path)
+
+    return skills_dir
+
+
+# Kilo CLI skill files — same body, different filenames and directory
+# Written to .kilocode/skills/ so Kilo agents can discover them
+_KILO_SKILLS: dict[str, dict[str, str]] = {
+    f"kilo-{name}": info
+    for name, info in _SKILLS.items()
+}
+
+# Kilo CLI uses flat skill filenames (no subdirectory structure)
+# Map: internal key -> actual filename on disk
+_KILO_SKILL_FILENAME = {
+    f"kilo-{name}": name for name in _SKILLS
+}
+
+
+def generate_kilo_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
+    """Generate Kilo CLI skill files.
+
+    Creates `.kilocode/skills/` directory with 4 skill markdown files,
+    identical in content to the Claude Code skills but with Kilo-compatible
+    filenames (e.g. `explore-codebase.md` not `kilo-explore-codebase.md`).
+
+    Kilo skill files use YAML frontmatter with name/description and a body.
+
+    Args:
+        repo_root: Repository root directory.
+        skills_dir: Custom skills directory. Defaults to repo_root/.kilocode/skills.
+
+    Returns:
+        Path to the skills directory.
+    """
+    if skills_dir is None:
+        skills_dir = repo_root / ".kilocode" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename, skill in _KILO_SKILLS.items():
+        # Kilo uses plain filenames, not prefixed
+        disk_name = _KILO_SKILL_FILENAME.get(filename, filename)
+        path = skills_dir / disk_name
+        content = (
+            "---\n"
+            f"name: {skill['name']}\n"
+            f"description: {skill['description']}\n"
+            "---\n\n"
+            f"{skill['body']}\n"
+        )
+        path.write_text(content)
+        logger.info("Wrote Kilo skill: %s", path)
 
     return skills_dir
 

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -339,28 +339,21 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
     return skills_dir
 
 
-# Kilo CLI skill files — same body, different filenames and directory
-# Written to .kilocode/skills/ so Kilo agents can discover them
-_KILO_SKILLS: dict[str, dict[str, str]] = {
-    f"kilo-{name}": info
-    for name, info in _SKILLS.items()
-}
+# Kilo CLI skill files — same body, directory-per-skill format
+# Written to .kilocode/skills/<slug>/SKILL.md so Kilo agents discover them
+# Slug is derived from the skill name: "Explore Codebase" → "explore-codebase"
 
-# Kilo CLI uses flat skill filenames (no subdirectory structure)
-# Map: internal key -> actual filename on disk
-_KILO_SKILL_FILENAME = {
-    f"kilo-{name}": name for name in _SKILLS
-}
+_KILO_SKILL_SLUG = {name: name.lower().replace(" ", "-").removesuffix(".md") for name in _SKILLS}
 
 
 def generate_kilo_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
     """Generate Kilo CLI skill files.
 
-    Creates `.kilocode/skills/` directory with 4 skill markdown files,
-    identical in content to the Claude Code skills but with Kilo-compatible
-    filenames (e.g. `explore-codebase.md` not `kilo-explore-codebase.md`).
+    Creates `.kilocode/skills/<slug>/SKILL.md` for each skill — Kilo's
+    directory-per-skill format required for its agent to discover skills.
 
-    Kilo skill files use YAML frontmatter with name/description and a body.
+    Kilo skill files use YAML frontmatter (name, description) and a
+    markdown body.
 
     Args:
         repo_root: Repository root directory.
@@ -373,10 +366,11 @@ def generate_kilo_skills(repo_root: Path, skills_dir: Path | None = None) -> Pat
         skills_dir = repo_root / ".kilocode" / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
 
-    for filename, skill in _KILO_SKILLS.items():
-        # Kilo uses plain filenames, not prefixed
-        disk_name = _KILO_SKILL_FILENAME.get(filename, filename)
-        path = skills_dir / disk_name
+    for name, skill in _SKILLS.items():
+        slug = _KILO_SKILL_SLUG[name]
+        skill_dir = skills_dir / slug
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        path = skill_dir / "SKILL.md"
         content = (
             "---\n"
             f"name: {skill['name']}\n"

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -75,6 +75,14 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "format": "object",
         "needs_type": True,
     },
+    "kilocode": {
+        "name": "Kilo CLI",
+        "config_path": lambda root: root / ".opencode" / "opencode.jsonc",
+        "key": "mcpServers",
+        "detect": lambda: (root / ".opencode" / "opencode.jsonc").exists(),
+        "format": "object",
+        "needs_type": True,
+    },
     "antigravity": {
         "name": "Antigravity",
         "config_path": lambda root: Path.home() / ".gemini" / "antigravity" / "mcp_config.json",

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -79,7 +79,7 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "name": "Kilo CLI",
         "config_path": lambda root: root / ".opencode" / "opencode.jsonc",
         "key": "mcpServers",
-        "detect": lambda: (root / ".opencode" / "opencode.jsonc").exists(),
+        "detect": lambda: (Path.cwd() / ".opencode" / "opencode.jsonc").exists(),
         "format": "object",
         "needs_type": True,
     },

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,7 +28,8 @@ code-review-graph install --platform claude-code
 | **Windsurf** | `.windsurf/mcp.json` |
 | **Zed** | `.zed/settings.json` |
 | **Continue** | `.continue/config.json` |
-| **OpenCode** | `.opencode/config.json` |
+| **OpenCode** | `.opencode.json` |
+| **Kilo CLI** | `.opencode/opencode.jsonc` |
 
 ## Core Workflow
 

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.0.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds Kilo CLI (KiloCode) as a **first-class supported platform** — MCP config, auto-detection, platform instructions, AND Kilo-native skill files.

## Changes

### `code_review_graph/skills.py`

#### 1. MCP config: `kilocode` platform entry
Added `kilocode` to the `PLATFORMS` dict:
- `config_path`: `.opencode/opencode.jsonc` (Kilo stores config inside `.opencode/` dir — the only structural difference from OpenCode)
- `detect`: checks for `.opencode/opencode.jsonc` existence
- `format`, `key`, `needs_type`: identical to OpenCode

#### 2. Skill files: `generate_kilo_skills()`
New function that generates 4 skill files to `.kilocode/skills/`:
| Skill file | Purpose |
|---|---|
| `explore-codebase.md` | Navigate codebase using graph tools |
| `review-changes.md` | Risk-scored code review workflow |
| `debug-issue.md` | Graph-powered systematic debugging |
| `refactor-safely.md` | Dependency-aware refactoring |

Each skill mirrors the Claude Code `.claude/skills/` versions — same body, same frontmatter, just in Kilo's skill directory.

### `code_review_graph/cli.py`
- Added `generate_kilo_skills` to imports
- `init` now calls both `generate_skills()` and `generate_kilo_skills()`
- Print output distinguishes Claude Code vs Kilo skills

### `docs/USAGE.md`
- Added Kilo CLI to the supported platforms table
- Fixed OpenCode's config path (was incorrectly listed as `.opencode/config.json`)

## Platform comparison

| What gets installed | Claude Code | OpenCode | **Kilo CLI** | Cursor | Windsurf |
|---|---|---|---|---|---|
| MCP server config | `.mcp.json` | `.opencode.json` | `.opencode/opencode.jsonc` | `.cursor/mcp.json` | `~/.codeium/...` |
| `AGENTS.md` (graph instructions) | ✓ | ✓ | ✓ (inherits) | ✓ | ✗ |
| Platform skill files | `.claude/skills/` | ✗ | **`.kilocode/skills/`** | ✗ | ✗ |

## Testing

```bash
# Auto-detect all platforms including Kilo CLI
code-review-graph install

# Init Claude Code + Kilo CLI skill files
code-review-graph init

# Preview Kilo MCP config
code-review-graph install --platform kilocode --dry-run
```

## Note

The README's `diagram8_supported_platforms.png` shows supported platforms visually and will need to be regenerated to include Kilo CLI. Left unchanged since it requires the maintainer's design tools.