### PR TITLE
added configurable data directory support using CRG_DATA_DIR environment variable #155

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -429,6 +429,7 @@ def main() -> None:
     from .incremental import (
         find_project_root,
         find_repo_root,
+        get_data_dir,
         get_db_path,
         watch,
     )
@@ -539,7 +540,7 @@ def main() -> None:
 
         elif args.command == "visualize":
             from .visualization import generate_html
-            html_path = repo_root / ".code-review-graph" / "graph.html"
+            html_path = get_data_dir(repo_root) / "graph.html"
             vis_mode = getattr(args, "mode", "auto") or "auto"
             generate_html(store, html_path, mode=vis_mode)
             print(f"Visualization ({vis_mode}): {html_path}")
@@ -565,7 +566,7 @@ def main() -> None:
 
         elif args.command == "wiki":
             from .wiki import generate_wiki
-            wiki_dir = repo_root / ".code-review-graph" / "wiki"
+            wiki_dir = get_data_dir(repo_root) / "wiki"
             result = generate_wiki(store, wiki_dir, force=args.force)
             total = result["pages_generated"] + result["pages_updated"] + result["pages_unchanged"]
             print(

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -72,15 +72,39 @@ def find_project_root(start: Path | None = None) -> Path:
     return start or Path.cwd()
 
 
+def get_data_dir(repo_root: Path) -> Path:
+    """Get the data directory, respecting CRG_DATA_DIR environment variable.
+
+    By default, returns `.code-review-graph/` at the repository root.
+    Can be overridden via the `CRG_DATA_DIR` environment variable.
+    If CRG_DATA_DIR is relative, it's resolved relative to repo_root.
+
+    Args:
+        repo_root: Repository root path.
+
+    Returns:
+        Absolute path to the data directory.
+    """
+    env_path = os.environ.get("CRG_DATA_DIR")
+    if env_path:
+        path = Path(env_path)
+        if not path.is_absolute():
+            path = repo_root / path  # Make relative to repo root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    return repo_root / ".code-review-graph"
+
+
 def get_db_path(repo_root: Path) -> Path:
     """Determine the database path for a repository.
 
-    Creates the ``.code-review-graph/`` directory and an inner ``.gitignore``
-    (with ``*``) so generated files are never committed.  If a legacy
-    ``.code-review-graph.db`` exists at the repo root the database is migrated
-    into the new directory (WAL/SHM side-files are discarded).
+    Creates the data directory (default: ``.code-review-graph/``) and an inner
+    ``.gitignore`` (with ``*``) so generated files are never committed.
+    Can be overridden via the CRG_DATA_DIR environment variable.
+    If a legacy ``.code-review-graph.db`` exists at the repo root the database
+    is migrated into the new directory (WAL/SHM side-files are discarded).
     """
-    crg_dir = repo_root / ".code-review-graph"
+    crg_dir = get_data_dir(repo_root)
     new_db = crg_dir / "graph.db"
 
     # Ensure directory exists

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -325,7 +325,7 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
             "---\n\n"
             f"{skill['body']}\n"
         )
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         logger.info("Wrote skill: %s", path)
 
     return skills_dir

--- a/code_review_graph/tools/docs.py
+++ b/code_review_graph/tools/docs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from ..embeddings import EmbeddingStore, embed_all_nodes
-from ..incremental import get_db_path
+from ..incremental import get_data_dir, get_db_path
 from ._common import _get_store
 
 # ---------------------------------------------------------------------------
@@ -158,8 +158,8 @@ def generate_wiki_func(
 
     [DOCS] Creates a wiki page for each detected community and an index
     page. Pages are written to ``.code-review-graph/wiki/`` inside the
-    repository. Only regenerates pages whose content has changed unless
-    force=True.
+    repository (or custom location via CRG_DATA_DIR environment variable).
+    Only regenerates pages whose content has changed unless force=True.
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
@@ -172,7 +172,7 @@ def generate_wiki_func(
 
     store, root = _get_store(repo_root)
     try:
-        wiki_dir = root / ".code-review-graph" / "wiki"
+        wiki_dir = get_data_dir(root) / "wiki"
         result = generate_wiki(store, wiki_dir, force=force)
         total = (
             result["pages_generated"]
@@ -220,7 +220,7 @@ def get_wiki_page_func(
     from ..wiki import get_wiki_page
 
     _, root = _get_store(repo_root)
-    wiki_dir = root / ".code-review-graph" / "wiki"
+    wiki_dir = get_data_dir(root) / "wiki"
     content = get_wiki_page(wiki_dir, community_name)
     if content is None:
         return {

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -16,6 +16,7 @@ from code_review_graph.incremental import (
     full_build,
     get_all_tracked_files,
     get_changed_files,
+    get_data_dir,
     get_db_path,
     get_staged_and_unstaged,
     incremental_update,
@@ -78,6 +79,42 @@ class TestGetDbPath:
         get_db_path(tmp_path)
         for suffix in ("-wal", "-shm", "-journal"):
             assert not (tmp_path / f".code-review-graph.db{suffix}").exists()
+
+
+class TestGetDataDir:
+    def test_default_returns_code_review_graph_dir(self, tmp_path):
+        """Test default behavior without CRG_DATA_DIR env var."""
+        result = get_data_dir(tmp_path)
+        assert result == tmp_path / ".code-review-graph"
+
+    def test_absolute_path_from_env(self, tmp_path):
+        """Test CRG_DATA_DIR with absolute path."""
+        custom_dir = tmp_path / "custom" / "data"
+        custom_dir.mkdir(parents=True, exist_ok=True)
+        with patch.dict("os.environ", {"CRG_DATA_DIR": str(custom_dir)}):
+            result = get_data_dir(tmp_path)
+            assert result == custom_dir
+
+    def test_relative_path_from_env(self, tmp_path):
+        """Test CRG_DATA_DIR with relative path (relative to repo_root)."""
+        with patch.dict("os.environ", {"CRG_DATA_DIR": ".cache/graph"}):
+            result = get_data_dir(tmp_path)
+            assert result == tmp_path / ".cache" / "graph"
+            # Should create the directory
+            assert result.is_dir()
+
+    def test_creates_directory_for_relative_path(self, tmp_path):
+        """Test that directory is created for relative paths."""
+        with patch.dict("os.environ", {"CRG_DATA_DIR": ".build/analysis"}):
+            result = get_data_dir(tmp_path)
+            assert result.is_dir()
+            assert (tmp_path / ".build" / "analysis").is_dir()
+
+    def test_clears_env_var(self, tmp_path):
+        """Test that clearing env var reverts to default."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_data_dir(tmp_path)
+            assert result == tmp_path / ".code-review-graph"
 
 
 class TestIgnorePatterns:

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.0.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
The .code-review-graph directory is currently hardcoded at the repository root, with no way to customize its location. This causes issues with project structure, CI/CD workflows, and monorepo setups.

Introduced support for a configurable data directory using the CRG_DATA_DIR environment variable
Centralized path resolution via a helper function (get_data_dir)
Updated all relevant usages:
Database (graph.db)
Wiki directory
HTML graph output
Registry path addressing the issue #155 