### PR TITLE
fix(go): resolve method names from field_identifier in method_declaration

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2188,6 +2188,13 @@ class CodeParser:
                     result = self._get_name(child, language, kind)
                     if result:
                         return result
+        # Go methods: tree-sitter-go uses field_identifier for the name
+        # (e.g. func (s *T) MethodName(...) { }). Must run before the generic
+        # loop, which would match the result type's type_identifier (e.g. int64).
+        if language == "go" and node.type == "method_declaration":
+            for child in node.children:
+                if child.type == "field_identifier":
+                    return child.text.decode("utf-8", errors="replace")
         # Most languages use a 'name' child
         for child in node.children:
             if child.type in (


### PR DESCRIPTION
## Summary

Go methods were often missing from the knowledge graph or stored under the wrong name (for example `int64`, `string`, `error`) because `_get_name()` did not match how **tree-sitter-go** models method names.

## Root cause

For `method_declaration`, the method name is a **`field_identifier`** child, not an `identifier`. The generic loop only matches `identifier`, `type_identifier`, and similar. That leads to:

- Methods **without** a result type: no matching name → the method is skipped entirely.
- Methods **with** a named result type (e.g. `int64`): the first `type_identifier` after the parameter lists is the **return type**, which was incorrectly used as the function name.

## Change

In `_get_name()`, add a Go-specific branch for `method_declaration` that returns the **`field_identifier`** text, placed **before** the generic child loop (same ordering idea as the existing C/C++ handling so return types are not mistaken for names).

## Verification

- Parse a small file with `func (s *T) Foo() {}` and `func (s *T) Bar() int64 { return 0 }`; both should emit `Function` nodes named `Foo` and `Bar`, not `int64`.
- Parse a large `service.go` with many receiver methods; `Function` count should match expectations and bogus `int64` / `string` / `error` “functions” from return types should disappear.
