### PR TITLE
feat: add Luau language support (#153)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -101,6 +101,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".t": "perl",
     ".xs": "c",  # Perl XS: parsed as C to capture functions/structs/includes
     ".lua": "lua",
+    ".luau": "luau",
     ".ipynb": "notebook",
 }
 
@@ -136,6 +137,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
     ],
     "dart": ["class_definition", "mixin_declaration", "enum_declaration"],
     "lua": [],  # Lua has no class keyword; table-based OOP handled via constructs handler
+    "luau": ["type_definition"],  # Luau type aliases; table-based OOP via constructs handler
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -170,6 +172,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     # function_signature inside it).
     "dart": ["function_signature"],
     "lua": ["function_declaration"],
+    "luau": ["function_declaration"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -193,8 +196,9 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "solidity": ["import_directive"],
     # Dart: import_or_export wraps library_import > import_specification > configurable_uri
     "dart": ["import_or_export"],
-    # Lua: require() is a function_call, handled via _extract_lua_constructs
+    # Lua/Luau: require() is a function_call, handled via _extract_lua_constructs
     "lua": [],
+    "luau": [],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -220,6 +224,7 @@ _CALL_TYPES: dict[str, list[str]] = {
     "scala": ["call_expression", "instance_expression", "generic_function"],
     "solidity": ["call_expression"],
     "lua": ["function_call"],
+    "luau": ["function_call"],
 }
 
 # Patterns that indicate a test function
@@ -908,8 +913,8 @@ class CodeParser:
             ):
                 continue
 
-            # --- Lua-specific constructs ---
-            if language == "lua" and self._extract_lua_constructs(
+            # --- Lua/Luau-specific constructs ---
+            if language in ("lua", "luau") and self._extract_lua_constructs(
                 child, node_type, source, language, file_path,
                 nodes, edges, enclosing_class, enclosing_func,
                 import_map, defined_names, _depth,
@@ -2161,11 +2166,11 @@ class CodeParser:
                 for child in node.children:
                     if child.type in ("receive", "fallback"):
                         return child.text.decode("utf-8", errors="replace")
-        # Lua: function_declaration names may be dot_index_expression or
+        # Lua/Luau: function_declaration names may be dot_index_expression or
         # method_index_expression (e.g. function Animal.new() / Animal:speak()).
         # Return only the method name; the table name is used as parent_name
         # in _extract_lua_constructs.
-        if language == "lua" and node.type == "function_declaration":
+        if language in ("lua", "luau") and node.type == "function_declaration":
             for child in node.children:
                 if child.type in ("dot_index_expression", "method_index_expression"):
                     # Last identifier child is the method name
@@ -2470,9 +2475,9 @@ class CodeParser:
         if first.type == "function":
             return first.text.decode("utf-8", errors="replace")
 
-        # Lua: dot_index_expression (obj.method) and method_index_expression
+        # Lua/Luau: dot_index_expression (obj.method) and method_index_expression
         # (obj:method) — extract the rightmost identifier as the call name.
-        if language == "lua" and first.type in (
+        if language in ("lua", "luau") and first.type in (
             "dot_index_expression", "method_index_expression",
         ):
             for child in reversed(first.children):

--- a/tests/fixtures/sample.luau
+++ b/tests/fixtures/sample.luau
@@ -1,0 +1,119 @@
+-- sample.luau - Luau test fixture for tree-sitter parsing
+-- Exercises Luau-specific features: type annotations, type aliases, and Lua constructs
+
+-- Module-level require() imports
+local HttpService = require(game.ReplicatedStorage.HttpService)
+local utils = require("lib.utils")
+local log = require("logging").getLogger("sample")
+
+-- Type alias (Luau-specific)
+type Vector3 = {
+    x: number,
+    y: number,
+    z: number,
+}
+
+type Callback = (input: string) -> string
+
+-- Top-level function with type annotations
+function greet(name: string): string
+    print("Hello, " .. name)
+    return name
+end
+
+-- Local function with type annotations
+local function add(a: number, b: number): number
+    return a + b
+end
+
+-- Variable assignment creating a function
+local transform = function(data: any): string
+    return HttpService:JSONEncode(data)
+end
+
+-- Table constructor as a "class" using metatable + __index pattern
+local Animal = {}
+Animal.__index = Animal
+
+-- Constructor with type annotations
+function Animal.new(name: string, sound: string): Animal
+    local self = setmetatable({}, Animal)
+    self.name = name
+    self.sound = sound
+    return self
+end
+
+-- Method defined with colon syntax
+function Animal:speak(): string
+    log:info(self.name .. " says " .. self.sound)
+    return self.sound
+end
+
+-- Another colon-syntax method
+function Animal:rename(new_name: string): string
+    local old = self.name
+    self.name = new_name
+    return old
+end
+
+-- Inheritance pattern
+local Dog = setmetatable({}, { __index = Animal })
+Dog.__index = Dog
+
+function Dog.new(name: string): Dog
+    local self = Animal.new(name, "Woof")
+    return setmetatable(self, Dog)
+end
+
+function Dog:fetch(item: string): string
+    self:speak()
+    print(self.name .. " fetches " .. item)
+    return item
+end
+
+-- Nested function calls and method calls
+local function process_animals(): string
+    local a = Animal.new("Cat", "Meow")
+    local d = Dog.new("Rex")
+
+    a:speak()
+    d:speak()
+    d:fetch("ball")
+
+    local encoded = HttpService:JSONEncode({ animals = { a.name, d.name } })
+    print(string.format("Processed %d animals", 2))
+    utils.log(encoded)
+
+    return encoded
+end
+
+-- Test functions
+local function test_greet()
+    local result = greet("World")
+    assert(result == "World", "greet should return name")
+end
+
+local function test_animal_speak()
+    local a = Animal.new("TestCat", "Mew")
+    local sound = a:speak()
+    assert(sound == "Mew", "speak should return sound")
+end
+
+local function test_dog_fetch()
+    local d = Dog.new("TestDog")
+    local item = d:fetch("stick")
+    assert(item == "stick", "fetch should return item")
+end
+
+-- Return statement (module pattern)
+return {
+    greet = greet,
+    add = add,
+    transform = transform,
+    Animal = Animal,
+    Dog = Dog,
+    process_animals = process_animals,
+    test_greet = test_greet,
+    test_animal_speak = test_animal_speak,
+    test_dog_fetch = test_dog_fetch,
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -815,3 +815,116 @@ class TestLuaParsing:
         sources = {e.source.split("::")[-1] for e in calls}
         assert "Dog.fetch" in sources  # Dog:fetch calls self:speak and print
         assert "Animal.speak" in sources  # Animal:speak calls log:info
+
+
+class TestLuauParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.luau")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("init.luau")) == "luau"
+        assert self.parser.detect_language(Path("module.luau")) == "luau"
+
+    def test_finds_type_aliases(self):
+        types = [n for n in self.nodes if n.kind == "Class"]
+        names = {t.name for t in types}
+        assert "Vector3" in names
+        assert "Callback" in names
+
+    def test_finds_top_level_functions(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name is None
+        ]
+        names = {f.name for f in funcs}
+        assert "greet" in names
+        assert "add" in names
+        assert "process_animals" in names
+
+    def test_finds_variable_assigned_functions(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name is None
+        ]
+        names = {f.name for f in funcs}
+        assert "transform" in names
+
+    def test_finds_dot_syntax_methods(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Animal"
+        ]
+        names = {f.name for f in funcs}
+        assert "new" in names
+
+    def test_finds_colon_syntax_methods(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Animal"
+        ]
+        names = {f.name for f in funcs}
+        assert "speak" in names
+        assert "rename" in names
+
+    def test_finds_inherited_table_methods(self):
+        dog_funcs = [
+            n for n in self.nodes
+            if n.kind in ("Function", "Test") and n.parent_name == "Dog"
+        ]
+        names = {f.name for f in dog_funcs}
+        assert "new" in names
+        assert "fetch" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "lib.utils" in targets
+        assert "logging" in targets
+        assert len(imports) >= 2
+
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert "print" in targets
+        assert "setmetatable" in targets
+        assert "assert" in targets
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target.split("::")[-1] for e in contains}
+        assert "greet" in targets
+        assert "add" in targets
+        assert "Animal.new" in targets
+        assert "Animal.speak" in targets
+        assert "Dog.fetch" in targets
+
+    def test_method_parent_names(self):
+        funcs = {
+            (n.name, n.parent_name) for n in self.nodes
+            if n.kind == "Function" and n.parent_name is not None
+        }
+        assert ("new", "Animal") in funcs
+        assert ("speak", "Animal") in funcs
+        assert ("rename", "Animal") in funcs
+        assert ("new", "Dog") in funcs
+        assert ("fetch", "Dog") in funcs
+
+    def test_detects_test_functions(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        names = {t.name for t in tests}
+        assert "test_greet" in names
+        assert "test_animal_speak" in names
+        assert "test_dog_fetch" in names
+        assert len(tests) == 3
+
+    def test_nodes_have_luau_language(self):
+        for node in self.nodes:
+            assert node.language == "luau"
+
+    def test_calls_inside_methods(self):
+        """Verify that calls inside methods have correct source qualified names."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        sources = {e.source.split("::")[-1] for e in calls}
+        assert "Dog.fetch" in sources
+        assert "Animal.speak" in sources


### PR DESCRIPTION
## Summary
- Adds Luau (Roblox Lua) as a supported language, closing #153.
- Luau shares most AST node types with Lua, so the existing Lua constructs handler is reused.
- Luau-specific `type_definition` nodes are mapped as `Class` nodes to capture type aliases (`type Vector3 = { ... }`).

## Changes
- `code_review_graph/parser.py`:
  - Added `.luau` extension mapping in `EXTENSION_TO_LANGUAGE`
  - Added `"luau"` entries to `_CLASS_TYPES` (with `type_definition`), `_FUNCTION_TYPES`, `_IMPORT_TYPES`, `_CALL_TYPES`
  - Extended 3 `language == "lua"` checks to `language in ("lua", "luau")`
- `tests/fixtures/sample.luau`: Comprehensive fixture exercising type aliases, typed functions, table-based OOP (dot + colon syntax), require imports, and test functions
- `tests/test_multilang.py`: 14 new tests in `TestLuauParsing`

## What Luau parsing supports
- Type aliases as Class nodes
- Functions with type annotations
- Table-based OOP (dot + colon syntax)
- `require()` import detection
- Function call and test function detection

## Test Plan
- [x] 14 new Luau tests pass
- [x] All 14 existing Lua tests pass (no regression)
- [x] Full multilang suite: 129/129 pass
- [x] `ruff check` clean on changed Python files