### PR TITLE
fix: avoid UTF-8 decode errors in detect_changes

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -50,6 +50,8 @@ def parse_git_diff_ranges(
             ["git", "diff", "--unified=0", base, "--"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=repo_root,
             timeout=_GIT_TIMEOUT,
         )


### PR DESCRIPTION
## Summary
- prevent git diff parsing from crashing on non-UTF-8 bytes
- decode diff output with replacement to keep range parsing stable

## Changes
- set encoding/errors on diff subprocess to avoid UnicodeDecodeError

Fixes #169
