### PR TITLE
docs: clarify gitignore behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ vendor/**
 node_modules/**
 ```
 
+Note: in git repos, only tracked files are indexed (`git ls-files`), so gitignored files are skipped automatically. Use `.code-review-graphignore` to exclude tracked files or when git isn't available.
+
 Optional dependency groups:
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -135,3 +135,5 @@ generated/**
 vendor/**
 *.generated.ts
 ```
+
+In git repos, indexing is based on tracked files (`git ls-files`), so gitignored files are skipped automatically. Use `.code-review-graphignore` to exclude tracked files or when git isn't available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@
 ## Data Flow
 
 ### Full Build
-1. `collect_all_files()` gathers all parseable files (respecting `.gitignore` and `.code-review-graphignore`)
+1. `collect_all_files()` gathers tracked files (`git ls-files`) and applies `.code-review-graphignore` (gitignored files are skipped automatically when git is available)
 2. For each file, `CodeParser.parse_file()` uses Tree-sitter to extract AST
 3. AST walker identifies structural nodes (classes, functions, imports) and edges (calls, inheritance)
 4. `GraphStore.store_file_nodes_edges()` persists to SQLite with file hash for change detection


### PR DESCRIPTION
## Summary
- clarify that indexing uses tracked files (git ls-files) when git is available
- explain that gitignored files are skipped automatically
- note when to use .code-review-graphignore

## Testing
- docs only