### PR TITLE
feat: add Codex MCP install support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Codex platform install support**: `code-review-graph install --platform codex` now appends a `mcp_servers.code-review-graph` section to `~/.codex/config.toml` without overwriting existing Codex settings
+
 ## [2.2.2] - 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ code-review-graph build            # parse your codebase
 One command sets up everything. `install` detects which AI coding tools you have, writes the correct MCP configuration for each one, and injects graph-aware instructions into your platform rules. It auto-detects whether you installed via `uvx` or `pip`/`pipx` and generates the right config. Restart your editor/tool after installing.
 
 <p align="center">
-  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, and Antigravity" width="85%" />
+  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Codex, Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, and Antigravity" width="85%" />
 </p>
 
 To target a specific platform:
 
 ```bash
+code-review-graph install --platform codex       # configure only Codex
 code-review-graph install --platform cursor      # configure only Cursor
 code-review-graph install --platform claude-code  # configure only Claude Code
 ```
@@ -328,5 +329,5 @@ MIT. See [LICENSE](LICENSE).
 <br>
 <a href="https://code-review-graph.com">code-review-graph.com</a><br><br>
 <code>pip install code-review-graph && code-review-graph install</code><br>
-<sub>Works with Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, and Antigravity</sub>
+<sub>Works with Codex, Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, and Antigravity</sub>
 </p>

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -187,7 +187,7 @@ def main() -> None:
     install_cmd.add_argument(
         "--platform",
         choices=[
-            "claude", "claude-code", "cursor", "windsurf", "zed",
+            "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
             "continue", "opencode", "antigravity", "all",
         ],
         default="all",
@@ -217,7 +217,7 @@ def main() -> None:
     init_cmd.add_argument(
         "--platform",
         choices=[
-            "claude", "claude-code", "cursor", "windsurf", "zed",
+            "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
             "continue", "opencode", "antigravity", "all",
         ],
         default="all",

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -27,6 +27,14 @@ def _zed_settings_path() -> Path:
 
 
 PLATFORMS: dict[str, dict[str, Any]] = {
+    "codex": {
+        "name": "Codex",
+        "config_path": lambda root: Path.home() / ".codex" / "config.toml",
+        "key": "mcp_servers",
+        "detect": lambda: (Path.home() / ".codex").exists(),
+        "format": "toml",
+        "needs_type": True,
+    },
     "claude": {
         "name": "Claude Code",
         "config_path": lambda root: root / ".mcp.json",
@@ -105,6 +113,50 @@ def _build_server_entry(plat: dict[str, Any], key: str = "") -> dict[str, Any]:
     return entry
 
 
+def _format_toml_value(value: Any) -> str:
+    """Format a primitive Python value as TOML."""
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "[" + ", ".join(_format_toml_value(item) for item in value) + "]"
+    raise TypeError(f"Unsupported TOML value: {type(value)!r}")
+
+
+def _merge_toml_mcp_server(
+    config_path: Path,
+    server_name: str,
+    server_entry: dict[str, Any],
+    dry_run: bool = False,
+) -> bool:
+    """Append a Codex MCP server section without clobbering the rest of the file."""
+    section_header = f"[mcp_servers.{server_name}]"
+    existing = ""
+    if config_path.exists():
+        existing = config_path.read_text(encoding="utf-8")
+        if section_header in existing:
+            return False
+
+    section_lines = [section_header]
+    for key, value in server_entry.items():
+        section_lines.append(f"{key} = {_format_toml_value(value)}")
+    section = "\n".join(section_lines) + "\n"
+
+    if dry_run:
+        return True
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = ""
+    if existing:
+        prefix = existing if existing.endswith("\n") else existing + "\n"
+        if not prefix.endswith("\n\n"):
+            prefix += "\n"
+    config_path.write_text(prefix + section, encoding="utf-8")
+    return True
+
+
 def install_platform_configs(
     repo_root: Path,
     target: str = "all",
@@ -136,6 +188,24 @@ def install_platform_configs(
         config_path: Path = plat["config_path"](repo_root)
         server_key = plat["key"]
         server_entry = _build_server_entry(plat, key=key)
+
+        if plat["format"] == "toml":
+            changed = _merge_toml_mcp_server(
+                config_path,
+                "code-review-graph",
+                server_entry,
+                dry_run=dry_run,
+            )
+            if not changed:
+                print(f"  {plat['name']}: already configured in {config_path}")
+                configured.append(plat["name"])
+                continue
+            if dry_run:
+                print(f"  [dry-run] {plat['name']}: would write {config_path}")
+            else:
+                print(f"  {plat['name']}: configured {config_path}")
+            configured.append(plat["name"])
+            continue
 
         # Read existing config
         existing: dict[str, Any] = {}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15,6 +15,7 @@ code-review-graph build      # parse your codebase
 To target a specific platform instead of auto-detecting all:
 
 ```bash
+code-review-graph install --platform codex
 code-review-graph install --platform cursor
 code-review-graph install --platform claude-code
 ```
@@ -23,6 +24,7 @@ code-review-graph install --platform claude-code
 
 | Platform | Config file |
 |----------|-------------|
+| **Codex** | `~/.codex/config.toml` |
 | **Claude Code** | `.mcp.json` |
 | **Cursor** | `.cursor/mcp.json` |
 | **Windsurf** | `.windsurf/mcp.json` |

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,7 @@
 """Tests for skills and hooks auto-install."""
 
 import json
+import tomllib
 from unittest.mock import patch
 
 from code_review_graph.skills import (
@@ -183,6 +184,72 @@ class TestInjectClaudeMd:
 
 
 class TestInstallPlatformConfigs:
+    def test_install_codex_config(self, tmp_path):
+        codex_config = tmp_path / ".codex" / "config.toml"
+        with patch.dict(PLATFORMS, {
+            "codex": {
+                **PLATFORMS["codex"],
+                "config_path": lambda root: codex_config,
+                "detect": lambda: True,
+            },
+        }):
+            configured = install_platform_configs(tmp_path, target="codex")
+        assert "Codex" in configured
+        data = tomllib.loads(codex_config.read_text())
+        entry = data["mcp_servers"]["code-review-graph"]
+        assert entry["type"] == "stdio"
+        assert entry["args"] == ["code-review-graph", "serve"] or entry["args"] == [
+            "serve"
+        ]
+
+    def test_install_codex_preserves_existing_toml(self, tmp_path):
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            'model = "gpt-5.4"\n\n[mcp_servers.other]\ncommand = "other"\n',
+            encoding="utf-8",
+        )
+        with patch.dict(PLATFORMS, {
+            "codex": {
+                **PLATFORMS["codex"],
+                "config_path": lambda root: codex_config,
+                "detect": lambda: True,
+            },
+        }):
+            install_platform_configs(tmp_path, target="codex")
+        data = tomllib.loads(codex_config.read_text())
+        assert data["model"] == "gpt-5.4"
+        assert data["mcp_servers"]["other"]["command"] == "other"
+        assert data["mcp_servers"]["code-review-graph"]["command"] in {
+            "uvx",
+            "code-review-graph",
+        }
+
+    def test_install_codex_no_duplicate(self, tmp_path):
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            '\n'.join(
+                [
+                    '[mcp_servers.code-review-graph]',
+                    'command = "uvx"',
+                    'args = ["code-review-graph", "serve"]',
+                    'type = "stdio"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        with patch.dict(PLATFORMS, {
+            "codex": {
+                **PLATFORMS["codex"],
+                "config_path": lambda root: codex_config,
+                "detect": lambda: True,
+            },
+        }):
+            install_platform_configs(tmp_path, target="codex")
+        assert codex_config.read_text().count("[mcp_servers.code-review-graph]") == 1
+
     def test_install_cursor_config(self, tmp_path):
         with patch.dict(PLATFORMS, {
             "cursor": {**PLATFORMS["cursor"], "detect": lambda: True},
@@ -259,10 +326,27 @@ class TestInstallPlatformConfigs:
         assert entry["env"] == []
 
     def test_install_all_detected(self, tmp_path):
-        """Installing 'all' configures claude and opencode (always detected)."""
-        configured = install_platform_configs(tmp_path, target="all")
+        """Installing 'all' configures auto-detected platforms."""
+        codex_config = tmp_path / ".codex" / "config.toml"
+        with patch.dict(PLATFORMS, {
+            "codex": {
+                **PLATFORMS["codex"],
+                "config_path": lambda root: codex_config,
+                "detect": lambda: True,
+            },
+            "claude": {**PLATFORMS["claude"], "detect": lambda: True},
+            "opencode": {**PLATFORMS["opencode"], "detect": lambda: True},
+            "cursor": {**PLATFORMS["cursor"], "detect": lambda: False},
+            "windsurf": {**PLATFORMS["windsurf"], "detect": lambda: False},
+            "zed": {**PLATFORMS["zed"], "detect": lambda: False},
+            "continue": {**PLATFORMS["continue"], "detect": lambda: False},
+            "antigravity": {**PLATFORMS["antigravity"], "detect": lambda: False},
+        }):
+            configured = install_platform_configs(tmp_path, target="all")
+        assert "Codex" in configured
         assert "Claude Code" in configured
         assert "OpenCode" in configured
+        assert codex_config.exists()
         assert (tmp_path / ".mcp.json").exists()
         assert (tmp_path / ".opencode.json").exists()
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,8 +1,9 @@
 """Tests for skills and hooks auto-install."""
 
 import json
-import tomllib
 from unittest.mock import patch
+
+import tomllib
 
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,


### PR DESCRIPTION
## Summary

- add `codex` as a supported `install`/`init` platform target
- append a `[mcp_servers.code-review-graph]` section to `~/.codex/config.toml` without overwriting existing Codex settings
- document Codex support in the README, usage guide, and changelog
- cover the new install path with Codex-specific tests, including preserving existing TOML and avoiding duplicate entries

## Test plan

- [x] `uv run pytest tests/test_skills.py --tb=short -q`
- [x] `uvx ruff check code_review_graph/ tests/test_skills.py`
