### PR TITLE
fix: emit valid Claude Code hook schema in settings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Invalid Claude Code hook schema in `.claude/settings.json`**: `generate_hooks_config()` now emits the schema Claude Code actually expects — each event entry wraps its command in an inner `hooks: [{type: "command", command, timeout}]` array instead of a flat `command:` field. Without this, Claude Code rejected the entire file with `Expected array, but received undefined` and neither `PostToolUse` nor `SessionStart` hooks fired. Also removed the bogus `PreCommit` event (not a Claude Code hook event — valid events are `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, `SessionStart`, `SessionEnd`) and narrowed the `PostToolUse` matcher from `Edit|Write|Bash` to `Edit|Write` since Bash invocations do not modify source files directly. Added a regression test that asserts the generated config conforms to the hook schema (fixes #97, #163, #172).
+
 ## [2.2.2] - 2026-04-08
 
 ### Added

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -334,8 +334,10 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
 def generate_hooks_config() -> dict[str, Any]:
     """Generate Claude Code hooks configuration.
 
-    Returns a hooks config dict with PostToolUse, SessionStart, and
-    PreCommit hooks for automatic graph updates.
+    Returns a hooks config dict with PostToolUse and SessionStart hooks
+    for automatic graph updates. Each event entry wraps its command in the
+    Claude Code hook schema:
+    ``hooks: [{"type": "command", "command": ..., "timeout": ...}]``.
 
     Returns:
         Dict with hooks configuration suitable for .claude/settings.json.
@@ -344,21 +346,25 @@ def generate_hooks_config() -> dict[str, Any]:
         "hooks": {
             "PostToolUse": [
                 {
-                    "matcher": "Edit|Write|Bash",
-                    "command": "code-review-graph update --skip-flows",
-                    "timeout": 5000,
+                    "matcher": "Edit|Write",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph update --skip-flows",
+                            "timeout": 5000,
+                        },
+                    ],
                 },
             ],
             "SessionStart": [
                 {
-                    "command": "code-review-graph status",
-                    "timeout": 3000,
-                },
-            ],
-            "PreCommit": [
-                {
-                    "command": "code-review-graph detect-changes --brief",
-                    "timeout": 10000,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph status",
+                            "timeout": 3000,
+                        },
+                    ],
                 },
             ],
         }

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -84,32 +84,63 @@ class TestGenerateHooksConfig:
     def test_has_post_tool_use(self):
         config = generate_hooks_config()
         assert "PostToolUse" in config["hooks"]
-        hooks = config["hooks"]["PostToolUse"]
-        assert len(hooks) >= 1
-        assert hooks[0]["matcher"] == "Edit|Write|Bash"
-        assert "update" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 5000
+        entries = config["hooks"]["PostToolUse"]
+        assert len(entries) >= 1
+        assert entries[0]["matcher"] == "Edit|Write"
+        inner = entries[0]["hooks"]
+        assert len(inner) >= 1
+        assert inner[0]["type"] == "command"
+        assert "update" in inner[0]["command"]
+        assert inner[0]["timeout"] == 5000
 
     def test_has_session_start(self):
         config = generate_hooks_config()
         assert "SessionStart" in config["hooks"]
-        hooks = config["hooks"]["SessionStart"]
-        assert len(hooks) >= 1
-        assert "status" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 3000
+        entries = config["hooks"]["SessionStart"]
+        assert len(entries) >= 1
+        inner = entries[0]["hooks"]
+        assert len(inner) >= 1
+        assert inner[0]["type"] == "command"
+        assert "status" in inner[0]["command"]
+        assert inner[0]["timeout"] == 3000
 
-    def test_has_pre_commit(self):
-        config = generate_hooks_config()
-        assert "PreCommit" in config["hooks"]
-        hooks = config["hooks"]["PreCommit"]
-        assert len(hooks) >= 1
-        assert "detect-changes" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 10000
+    def test_only_supported_hook_events(self):
+        """Only events valid under Claude Code's hook schema should be emitted.
 
-    def test_has_all_three_hook_types(self):
+        ``PreCommit`` is a git concept and not a Claude Code hook event; it
+        must not appear in the generated config.
+        """
         config = generate_hooks_config()
         hook_types = set(config["hooks"].keys())
-        assert hook_types == {"PostToolUse", "SessionStart", "PreCommit"}
+        assert hook_types == {"PostToolUse", "SessionStart"}
+        assert "PreCommit" not in hook_types
+
+    def test_entries_use_claude_code_hook_schema(self):
+        """Regression guard for the Claude Code hook schema.
+
+        Claude Code rejects entries that put ``command`` directly on the
+        event entry. Each entry must wrap its command(s) in a
+        ``hooks: [{"type": "command", "command": ..., "timeout": ...}]``
+        array — missing that wrapper causes the entire settings.json to
+        fail to parse ("Expected array, but received undefined").
+        """
+        config = generate_hooks_config()
+        for event_name, entries in config["hooks"].items():
+            for entry in entries:
+                assert "command" not in entry, (
+                    f"{event_name} entry has a flat `command` field; "
+                    "it must be wrapped in an inner `hooks` array"
+                )
+                assert "hooks" in entry, (
+                    f"{event_name} entry is missing the inner `hooks` array"
+                )
+                assert isinstance(entry["hooks"], list)
+                for hook in entry["hooks"]:
+                    assert hook.get("type") == "command", (
+                        f"{event_name} inner hook missing type=\"command\""
+                    )
+                    assert "command" in hook
+                    assert "timeout" in hook
 
 
 class TestInstallHooks:
@@ -132,7 +163,6 @@ class TestInstallHooks:
         assert data["customSetting"] is True
         assert "PostToolUse" in data["hooks"]
         assert "SessionStart" in data["hooks"]
-        assert "PreCommit" in data["hooks"]
 
     def test_creates_claude_directory(self, tmp_path):
         install_hooks(tmp_path)


### PR DESCRIPTION
Claude Code rejects the file generated by `code-review-graph install` with "Expected array, but received undefined" because each entry under PostToolUse/SessionStart needs an inner `hooks: [{type, command}]` array, not a flat `command:` field. On top of that, the generator emits a `PreCommit` block — which isn't a Claude Code event at all.

Consequence: the entire settings.json is discarded, so neither the PostToolUse auto-update hook nor the SessionStart status hook ever fires.

This rewrites generate_hooks_config() to produce the correct schema, drops the bogus PreCommit block, and narrows the PostToolUse matcher from `Edit|Write|Bash` to `Edit|Write`. Bash calls in Claude Code don't modify source files directly, so running an incremental graph update after every shell command was just noise.

Tests in TestGenerateHooksConfig were updated to assert the new schema, plus a new regression test (test_entries_use_claude_code_hook_schema) guards against the flat-command shape recurring.

Fixes #97, #163, #172.