### PR TITLE
fix: rebuild crashes with "cannot start a transaction within a transaction"

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -236,6 +236,11 @@ class GraphStore:
         self, file_path: str, nodes: list[NodeInfo], edges: list[EdgeInfo], fhash: str = ""
     ) -> None:
         """Atomically replace all data for a file."""
+        # Flush any pending implicit transaction opened by earlier DML on this
+        # connection so the explicit BEGIN IMMEDIATE below doesn't trip SQLite's
+        # "cannot start a transaction within a transaction" error.
+        if self._conn.in_transaction:
+            self._conn.commit()
         self._conn.execute("BEGIN IMMEDIATE")
         try:
             self.remove_file_data(file_path)

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -352,8 +352,13 @@ def full_build(repo_root: Path, store: GraphStore) -> dict:
     # Purge stale data from files no longer on disk
     existing_files = set(store.get_all_files())
     current_abs = {str(repo_root / f) for f in files}
-    for stale in existing_files - current_abs:
-        store.remove_file_data(stale)
+    stale_files = existing_files - current_abs
+    if stale_files:
+        for stale in stale_files:
+            store.remove_file_data(stale)
+        # Commit the implicit transaction opened by the DELETEs so the
+        # subsequent BEGIN IMMEDIATE in store_file_nodes_edges succeeds.
+        store.commit()
 
     total_nodes = 0
     total_edges = 0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -107,6 +107,25 @@ class TestGraphStore:
         result = self.store.get_nodes_by_file("/test/file.py")
         assert len(result) == 2
 
+    def test_store_file_nodes_edges_after_dangling_dml(self):
+        """Regression: store_file_nodes_edges must recover when the connection
+        is already inside an implicit transaction opened by a prior DML (e.g.
+        the stale-file purge loop in full_build). Previously this raised
+        'cannot start a transaction within a transaction'.
+        """
+        # Simulate the purge loop: run DELETEs without committing so the
+        # connection is left in an implicit transaction.
+        self.store.upsert_node(self._make_file_node("/stale.py"))
+        self.store.commit()
+        self.store.remove_file_data("/stale.py")
+        assert self.store._conn.in_transaction
+
+        nodes = [self._make_file_node(), self._make_func_node()]
+        # Should not raise sqlite3.OperationalError.
+        self.store.store_file_nodes_edges("/test/file.py", nodes, [])
+
+        assert len(self.store.get_nodes_by_file("/test/file.py")) == 2
+
     def test_search_nodes(self):
         self.store.upsert_node(self._make_func_node("authenticate"))
         self.store.upsert_node(self._make_func_node("authorize"))


### PR DESCRIPTION
## The problem

Running `code-review-graph build` on a large repo (~9k files) after an earlier interrupted build crashes almost immediately with:

```
sqlite3.OperationalError: cannot start a transaction within a transaction
```

I hit this on a big source tree on my Macbook M1 Pro. The first build ran through the parse phase to completion, then I Ctrl-C'd it while community detection was stuck (separate perf issue — the file-based fallback is quadratic on large graphs). On the retry, the rebuild blew up on the very first file:

```
INFO: Progress: ... files parsed ... (never gets here)
Traceback (most recent call last):
  ...
  File ".../incremental.py", line 397, in full_build
      store.store_file_nodes_edges(...)
  File ".../graph.py", line 239, in store_file_nodes_edges
      self._conn.execute("BEGIN IMMEDIATE")
sqlite3.OperationalError: cannot start a transaction within a transaction
```

## Why it happens

`full_build` starts by purging any files that used to exist in the DB but no longer exist on disk:

```python
for stale in existing_files - current_abs:
    store.remove_file_data(stale)
```

`remove_file_data` issues two `DELETE` statements and returns without committing. Under Python's default (legacy) `sqlite3` isolation mode, those `DELETE`s silently open an implicit transaction. The very next `store_file_nodes_edges()` call then runs an explicit `BEGIN IMMEDIATE` — and SQLite rejects it because one is already open.

The reason this went undetected is that the purge loop is usually a no-op: if every file still exists on disk, `existing_files - current_abs` is empty and the buggy path never runs. My interrupted build had left the DB with thousands of file rows whose absolute paths no longer matched the set the rebuild was computing, so every single one was treated as stale and the connection was left dirty before parsing even started.

## The fix

Two parts:

1. **`incremental.py`** — `full_build` now calls `store.commit()` once after draining the purge loop, so the parse phase starts with a clean connection.
2. **`graph.py`** — `store_file_nodes_edges` checks `conn.in_transaction` and flushes any dangling implicit transaction before its `BEGIN IMMEDIATE`. Defensive: if any future code path leaves DML uncommitted, the atomic per-file replace still works instead of crashing the build.

## Test plan

- [x] New regression test `test_store_file_nodes_edges_after_dangling_dml` primes an implicit transaction via `remove_file_data` and asserts `store_file_nodes_edges` still succeeds. Fails on `main`, passes with the fix.
- [x] `uv run pytest tests/test_graph.py tests/test_incremental.py` — 45 passed
- [x] `uv run pytest tests/test_tools.py tests/test_integration_v2.py` — 66 passed
- [x] Manually reproduced the crash on a real repo and confirmed the fix allows the rebuild to proceed past the purge loop.