### PR TITLE
fix: correct Claude Code hook schema and add git pre-commit hook

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -130,6 +130,7 @@ def _handle_init(args: argparse.Namespace) -> None:
         generate_skills,
         inject_claude_md,
         inject_platform_instructions,
+        install_git_hook,
         install_hooks,
     )
 
@@ -144,6 +145,9 @@ def _handle_init(args: argparse.Namespace) -> None:
     if not skip_hooks:
         install_hooks(repo_root)
         print(f"Installed hooks in {repo_root / '.claude' / 'settings.json'}")
+        git_hook = install_git_hook(repo_root)
+        if git_hook:
+            print(f"Installed git pre-commit hook in {git_hook}")
 
     print()
     print("Next steps:")

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -332,37 +332,78 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
 
 
 def generate_hooks_config() -> dict[str, Any]:
-    """Generate Claude Code hooks configuration.
+    """Return Claude Code hook definitions for .claude/settings.json.
 
-    Returns a hooks config dict with PostToolUse, SessionStart, and
-    PreCommit hooks for automatic graph updates.
-
-    Returns:
-        Dict with hooks configuration suitable for .claude/settings.json.
+    Hooks use the v1.x+ schema: each entry needs a ``matcher`` and a nested
+    ``hooks`` array. Timeouts are in seconds. ``PreCommit`` is not a valid
+    Claude Code event — pre-commit checks are handled by ``install_git_hook``.
     """
     return {
         "hooks": {
             "PostToolUse": [
                 {
                     "matcher": "Edit|Write|Bash",
-                    "command": "code-review-graph update --skip-flows",
-                    "timeout": 5000,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph update --skip-flows",
+                            "timeout": 30,
+                        },
+                    ],
                 },
             ],
             "SessionStart": [
                 {
-                    "command": "code-review-graph status",
-                    "timeout": 3000,
-                },
-            ],
-            "PreCommit": [
-                {
-                    "command": "code-review-graph detect-changes --brief",
-                    "timeout": 10000,
+                    "matcher": "",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "code-review-graph status",
+                            "timeout": 10,
+                        },
+                    ],
                 },
             ],
         }
     }
+
+
+def install_git_hook(repo_root: Path) -> Path | None:
+    """Install a git pre-commit hook that prints a risk summary before each commit.
+
+    Called automatically by ``code-review-graph install``
+    Creates ``.git/hooks/pre-commit`` if it doesn't exist, or appends to an
+    existing one — preserving any hooks already there. Returns None when no
+    ``.git`` directory is found.
+    """
+    _SCRIPT = """\
+#!/bin/sh
+# Installed by code-review-graph. Remove this file to disable pre-commit graph checks.
+if command -v code-review-graph >/dev/null 2>&1; then
+    code-review-graph detect-changes --brief || true
+fi
+"""
+    _MARKER = "code-review-graph detect-changes"
+
+    git_dir = repo_root / ".git"
+    if not git_dir.is_dir():
+        logger.warning("No .git directory found at %s — skipping git hook install.", repo_root)
+        return None
+
+    hook_path = git_dir / "hooks" / "pre-commit"
+    hook_path.parent.mkdir(exist_ok=True)
+
+    if hook_path.exists():
+        existing = hook_path.read_text(encoding="utf-8")
+        if _MARKER in existing:
+            return hook_path
+        hook_path.write_text(existing.rstrip("\n") + "\n" + _SCRIPT, encoding="utf-8")
+    else:
+        hook_path.write_text(_SCRIPT, encoding="utf-8")
+
+    hook_path.chmod(0o755)
+    logger.info("Wrote git pre-commit hook: %s", hook_path)
+    return hook_path
 
 
 def install_hooks(repo_root: Path) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,8 @@
 """Tests for skills and hooks auto-install."""
 
 import json
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 from code_review_graph.skills import (
@@ -9,6 +11,7 @@ from code_review_graph.skills import (
     generate_hooks_config,
     generate_skills,
     inject_claude_md,
+    install_git_hook,
     install_hooks,
     install_platform_configs,
 )
@@ -84,32 +87,67 @@ class TestGenerateHooksConfig:
     def test_has_post_tool_use(self):
         config = generate_hooks_config()
         assert "PostToolUse" in config["hooks"]
-        hooks = config["hooks"]["PostToolUse"]
-        assert len(hooks) >= 1
-        assert hooks[0]["matcher"] == "Edit|Write|Bash"
-        assert "update" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 5000
+        entry = config["hooks"]["PostToolUse"][0]
+        assert entry["matcher"] == "Edit|Write|Bash"
+        inner = entry["hooks"][0]
+        assert inner["type"] == "command"
+        assert "update" in inner["command"]
+        assert 0 < inner["timeout"] <= 600
 
     def test_has_session_start(self):
         config = generate_hooks_config()
         assert "SessionStart" in config["hooks"]
-        hooks = config["hooks"]["SessionStart"]
-        assert len(hooks) >= 1
-        assert "status" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 3000
+        entry = config["hooks"]["SessionStart"][0]
+        assert "matcher" in entry
+        inner = entry["hooks"][0]
+        assert inner["type"] == "command"
+        assert "status" in inner["command"]
+        assert 0 < inner["timeout"] <= 600
 
-    def test_has_pre_commit(self):
+    def test_no_pre_commit(self):
         config = generate_hooks_config()
-        assert "PreCommit" in config["hooks"]
-        hooks = config["hooks"]["PreCommit"]
-        assert len(hooks) >= 1
-        assert "detect-changes" in hooks[0]["command"]
-        assert hooks[0]["timeout"] == 10000
+        assert "PreCommit" not in config["hooks"]
 
-    def test_has_all_three_hook_types(self):
+    def test_hook_entries_use_nested_hooks_array(self):
         config = generate_hooks_config()
-        hook_types = set(config["hooks"].keys())
-        assert hook_types == {"PostToolUse", "SessionStart", "PreCommit"}
+        for hook_type, entries in config["hooks"].items():
+            for entry in entries:
+                assert "hooks" in entry, f"{hook_type} entry missing 'hooks' array"
+                assert "command" not in entry, f"{hook_type} has bare 'command' outside hooks[]"
+
+
+class TestInstallGitHook:
+    def _make_git_repo(self, tmp_path: Path) -> Path:
+        (tmp_path / ".git" / "hooks").mkdir(parents=True)
+        return tmp_path
+
+    def test_creates_executable_pre_commit_hook(self, tmp_path):
+        hook_path = install_git_hook(self._make_git_repo(tmp_path))
+        assert hook_path is not None and hook_path.name == "pre-commit"
+        assert os.access(hook_path, os.X_OK)
+        content = hook_path.read_text()
+        assert content.startswith("#!/")
+        assert "code-review-graph detect-changes" in content
+
+    def test_appends_to_existing_hook(self, tmp_path):
+        repo = self._make_git_repo(tmp_path)
+        hook_path = repo / ".git" / "hooks" / "pre-commit"
+        hook_path.write_text("#!/bin/sh\nexisting-command\n", encoding="utf-8")
+        hook_path.chmod(0o755)
+        install_git_hook(repo)
+        content = hook_path.read_text()
+        assert "existing-command" in content
+        assert "code-review-graph detect-changes" in content
+
+    def test_idempotent(self, tmp_path):
+        repo = self._make_git_repo(tmp_path)
+        install_git_hook(repo)
+        install_git_hook(repo)
+        content = (repo / ".git" / "hooks" / "pre-commit").read_text()
+        assert content.count("code-review-graph detect-changes") == 1
+
+    def test_no_git_dir_returns_none(self, tmp_path):
+        assert install_git_hook(tmp_path) is None
 
 
 class TestInstallHooks:
@@ -132,7 +170,7 @@ class TestInstallHooks:
         assert data["customSetting"] is True
         assert "PostToolUse" in data["hooks"]
         assert "SessionStart" in data["hooks"]
-        assert "PreCommit" in data["hooks"]
+        assert "PreCommit" not in data["hooks"]
 
     def test_creates_claude_directory(self, tmp_path):
         install_hooks(tmp_path)


### PR DESCRIPTION
## Problem

Running `code-review-graph install --platform claude-code` writes a
`.claude/settings.json` with an invalid hook schema. Claude Code throws
a Settings Error on startup and skips the entire file, so none of the
automation (PostToolUse, SessionStart) ever runs.

Fixes #201 #188 

## Root cause

Three bugs in `generate_hooks_config()` in `skills.py`:

1. Hook entries had a bare `"command"` key — Claude Code v1.x+ requires
   a nested `"hooks": [{"type": "command", ...}]` array
2. `"PreCommit"` is not a valid Claude Code hook event type. Its presence
   caused the `"Invalid key in record"` error that made Claude Code skip
   the entire file
3. Timeout values of `5000`/`3000` were interpreted as seconds (per docs),
   meaning 83 and 50 minutes

## Fix

- Correct the hook schema to match the Claude Code v1.x+ spec
- Remove `PreCommit` (never valid in any Claude Code release)
- Fix timeouts to sensible values (30s, 10s)
- Replace the lost pre-commit intent with a real git pre-commit hook
  via `install_git_hook()`, which appends to existing hooks safely

## Testing

- unit tests updated and passing
- Manually verified: `install --platform claude-code` now produces a
  valid settings file and a working `.git/hooks/pre-commit`