### PR TITLE
Replace bare exception fallbacks with specific logging

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -36,12 +36,15 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 def _get_version() -> str:
     """Get the installed package version."""
     try:
         return pkg_version("code-review-graph")
-    except PackageNotFoundError:
+    except PackageNotFoundError as exc:
+        logger.debug("Package metadata unavailable, falling back to 'dev': %s", exc)
         return "dev"
 
 

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -771,7 +771,7 @@ class GraphStore:
             }
         except sqlite3.OperationalError as exc:
             # community_id column may not exist yet on pre-v6 schemas
-            logger.debug("get_all_community_ids: schema not yet migrated (%s)", exc)
+            logger.debug("Community IDs unavailable (schema not yet migrated): %s", exc)
             return {}
 
     def get_node_ids_by_files(
@@ -848,7 +848,7 @@ class GraphStore:
             ).fetchall()
         except sqlite3.OperationalError as exc:
             # communities table doesn't exist yet on pre-v4 schemas
-            logger.debug("get_communities_raw: table missing (%s)", exc)
+            logger.debug("Communities list unavailable (table missing): %s", exc)
             return []
 
     def get_community_member_qns(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+"""Tests for CLI helpers."""
+
+import logging
+from importlib.metadata import PackageNotFoundError
+
+from code_review_graph import cli
+
+
+def test_get_version_logs_and_falls_back_to_dev(monkeypatch, caplog):
+    def _raise_package_not_found(_dist_name: str) -> str:
+        raise PackageNotFoundError("code-review-graph")
+
+    monkeypatch.setattr(cli, "pkg_version", _raise_package_not_found)
+
+    with caplog.at_level(logging.DEBUG, logger="code_review_graph.cli"):
+        version = cli._get_version()
+
+    assert version == "dev"
+    assert "Package metadata unavailable" in caplog.text

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,5 +1,7 @@
 """Tests for the graph storage and query engine."""
 
+import logging
+import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -223,6 +225,35 @@ class TestGraphStore:
         self.store.set_metadata("test_key", "test_value")
         assert self.store.get_metadata("test_key") == "test_value"
         assert self.store.get_metadata("nonexistent") is None
+
+    def test_get_all_community_ids_logs_when_column_missing(self, caplog):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE nodes (qualified_name TEXT PRIMARY KEY)"
+        )
+        store = GraphStore.__new__(GraphStore)
+        store._conn = conn
+
+        with caplog.at_level(logging.DEBUG, logger="code_review_graph.graph"):
+            result = store.get_all_community_ids()
+
+        assert result == {}
+        assert "Community IDs unavailable" in caplog.text
+        conn.close()
+
+    def test_get_communities_list_logs_when_table_missing(self, caplog):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        store = GraphStore.__new__(GraphStore)
+        store._conn = conn
+
+        with caplog.at_level(logging.DEBUG, logger="code_review_graph.graph"):
+            result = store.get_communities_list()
+
+        assert result == []
+        assert "Communities list unavailable" in caplog.text
+        conn.close()
 
 
 class TestImpactRadiusSql:


### PR DESCRIPTION
Fixes #194.

## Summary
This PR replaces bare `except Exception` fallbacks in optional-path code with narrower exception handling and debug logging, while preserving the existing graceful fallback behavior.

## What Changed
- narrowed SQLite fallbacks in:
  - `code_review_graph/graph.py`
  - `code_review_graph/wiki.py`
  - `code_review_graph/visualization.py`
  - `code_review_graph/migrations.py`
  - `code_review_graph/tools/context.py`
- narrowed parser/metadata/runtime fallbacks in:
  - `code_review_graph/parser.py`
  - `code_review_graph/tsconfig_resolver.py`
  - `code_review_graph/registry.py`
  - `code_review_graph/cli.py`
  - `code_review_graph/eval/benchmarks/search_quality.py`
- added debug logging so optional failures are visible during debugging
- kept the existing fallback return values such as `{}`, `[]`, `None`, and `"dev"`

## Tests
- added `tests/test_cli.py` for `_get_version()` fallback logging
- added logging/fallback coverage in `tests/test_graph.py`

## Verification
- `./.venv/bin/python -m pytest tests --tb=short -q`
- result: `618 passed, 5 skipped, 2 xpassed`

## Notes
This change is intentionally scoped to the issue-reported bare fallback handlers and does not alter existing `except Exception as e` paths that already log or return structured errors.
