### PR TITLE
chore: release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,29 @@
 
 ## [Unreleased]
 
+## [2.2.3] - 2026-04-11
+
+### Fixed
+- **Claude Code hook schema** (PR #208, fixes #97, #138, #163, #168, #172, #182, #188, #191, #201): `generate_hooks_config()` now emits the valid v1.x+ Claude Code schema — every hook entry has `matcher` + a nested `hooks: [{type, command, timeout}]` array, and timeouts are in seconds. The invalid `PreCommit` event has been removed; pre-commit checks are now installed as a real git hook via `install_git_hook()`. Users upgrading from 2.2.2 must re-run `code-review-graph install` to rewrite `.claude/settings.json`.
+- **SQLite transaction nesting** (PR #205, fixes #110, #135, #181): `GraphStore.__init__` now connects with `isolation_level=None`, disabling Python's implicit transactions that were the root cause of `sqlite3.OperationalError: cannot start a transaction within a transaction` on `update`. `store_file_nodes_edges` adds a defensive `in_transaction` flush before `BEGIN IMMEDIATE`.
+- **Go method receivers** (PR #166): `_extract_name_from_node` now resolves Go method names from `field_identifier` inside `method_declaration`, fixing method names that were previously picked up as the result type (e.g. `int64`) instead of the method name.
+- **UTF-8 decode errors in `detect_changes`** (PR #170, fixes #169): Diff parsing now uses `errors="replace"` so diffs containing binary files no longer crash the tool.
+- **`--platform` target scope** (PR #142, fixes #133): `code-review-graph install --platform <target>` now correctly filters skills, hooks, and instruction files so you only get configuration for the requested platform.
+- **Large-repo community detection hangs** (PR #213, PR #183): Removed recursive sub-community splitting, capped Leiden at `n_iterations=2`, and batched `store_communities` writes. 100k+ node graphs no longer hang in `_compute_summaries`.
+- **CI**: ruff lint + `tomllib` on Python 3.10 (PR #220) — `tests/test_skills.py` now uses a conditional `tomli` backport on 3.10, `N806`/`E501`/`W291` fixes in `skills.py`/`communities.py`/`parser.py`, and the embedded `noqa` reference in `visualization.py` was rephrased so ruff stops parsing it as a directive.
+- **Missing dev dependencies** (PR #159): `pytest-cov` added to dev extras, 50 ruff errors swept, one failing test fixed.
+- **JSX component CALLS edges** (PR #154): JSX component usage now produces CALLS edges so component-to-component relationships appear in the graph.
+
 ### Added
-- **Codex platform install support**: `code-review-graph install --platform codex` now appends a `mcp_servers.code-review-graph` section to `~/.codex/config.toml` without overwriting existing Codex settings
+- **Codex platform install support** (PR #177): `code-review-graph install --platform codex` appends a `mcp_servers.code-review-graph` section to `~/.codex/config.toml` without overwriting existing Codex settings.
+- **Luau language support** (PR #165, closes #153): Roblox Luau (`.luau`) parsing — functions, classes, local functions, requires, tests.
+- **REFERENCES edge type** (PR #217): New edge kind for symbol references that aren't direct calls (map/dispatch lookups, string-keyed handlers), including Python and TypeScript patterns.
+- **`recurse_submodules` build option** (PR #215): Build/update can now optionally recurse into git submodules.
+- **`.gitignore` default for `.code-review-graph/`** (PR #185): Fresh installs automatically add the SQLite DB directory to `.gitignore` so the database isn't accidentally committed.
+- **Clearer gitignore docs** (PR #171, closes #157): Documentation now spells out that `code-review-graph` already respects `.gitignore` via `git ls-files`.
+
+### Changed
+- Community detection is now bounded — large repos complete in reasonable time instead of hanging indefinitely.
 
 ## [2.2.2] - 2026-04-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.2.2"
+version = "2.2.3"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.2.2"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Cuts **v2.2.3** to actually ship the 16 commits of fixes sitting on `main` since v2.2.2 was tagged on 2026-04-08. Users on `uvx code-review-graph` / pip-installed v2.2.2 are still hitting bugs that were already fixed in `main` — this release closes that gap.

## Why now

Current `main` is **17 commits ahead of v2.2.2**, with 7 real `fix:` commits including the entire hooks-schema complaint cluster (~8 duplicate issues) and the SQLite transaction nesting bug (~3 issues). Verified by inspecting v2.2.2 vs current `main`:

- **v2.2.2 `skills.py::generate_hooks_config`** emits flat `{matcher, command, timeout}` entries (no nested `hooks` array), uses `timeout: 5000` / `10000` in ms where the schema says seconds, and includes `PreCommit` which is not a valid Claude Code event.
- **v2.2.2 `graph.py::GraphStore.__init__`** has no `isolation_level=None`, so `sqlite3` runs implicit transactions — the direct cause of `sqlite3.OperationalError: cannot start a transaction within a transaction` on update.

Both fixes are present on `main` but not in any release.

## What's in this PR

Just the version bump and a proper CHANGELOG entry:

- `pyproject.toml` — `version = "2.2.2"` → `"2.2.3"`
- `CHANGELOG.md` — new `## [2.2.3] - 2026-04-11` section covering all 17 unreleased commits
- `uv.lock` — regenerated (just the project version metadata)

No code changes beyond that; the actual fixes already landed in their individual PRs (#208, #205, #166, #170, #142, #213, #183, #220, #159, #154, #177, #165, #217, #215, #185, #171).

## Test plan

Verified locally on Python 3.11:

- [x] `uv run ruff check code_review_graph/` → `All checks passed!`
- [x] `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` → `Success: no issues found in 44 source files`
- [x] `uv run bandit -r code_review_graph/ -c pyproject.toml` → 0 High/Medium/Low
- [x] `uv run pytest --cov-fail-under=65` → **691 passed, 1 skipped, 2 xpassed, coverage 73.72%**
- [ ] CI on this PR (3.10 / 3.11 / 3.12 / 3.13)

## After merge

1. Tag `v2.2.3` on the merge commit and push the tag.
2. Publish to PyPI.
3. Comment "Fixed in v2.2.3, please `uvx --reinstall code-review-graph`" on the 8 hooks-cluster issues + 2 SQLite issues and close them.

## Closes (after PyPI publish)

Hooks-schema cluster: #97, #138, #163, #168, #172, #182, #188, #191
SQLite transaction cluster: #110, #135
Already-fixed-but-never-closed: #153 (Luau), #175 (gitignore), #157 (gitignore docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)