### PR TITLE
fix: serve --repo flag + wiki slug collisions (smoke-test followups)

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -48,6 +48,23 @@ from .tools import (
 # transport with concurrent requests, replace with contextvars.ContextVar.
 _default_repo_root: str | None = None
 
+
+def _resolve_repo_root(repo_root: Optional[str]) -> Optional[str]:
+    """Resolve repo_root for a tool call.
+
+    Order of precedence:
+    1. Explicit ``repo_root`` passed by the MCP client (highest).
+    2. ``--repo`` CLI flag passed to ``code-review-graph serve``
+       (captured in ``_default_repo_root``).
+    3. None — the underlying impl will fall back to the server's cwd.
+
+    Previously, only ``get_docs_section_tool`` consulted ``_default_repo_root``,
+    so ``serve --repo <X>`` had no effect for the other 21 tools. See: #222
+    follow-up.
+    """
+    return repo_root if repo_root else _default_repo_root
+
+
 mcp = FastMCP(
     "code-review-graph",
     instructions=(
@@ -82,7 +99,7 @@ def build_or_update_graph_tool(
             When None (default), falls back to CRG_RECURSE_SUBMODULES env var.
     """
     return build_or_update_graph(
-        full_rebuild=full_rebuild, repo_root=repo_root, base=base,
+        full_rebuild=full_rebuild, repo_root=_resolve_repo_root(repo_root), base=base,
         postprocess=postprocess, recurse_submodules=recurse_submodules,
     )
 
@@ -106,7 +123,7 @@ def run_postprocess_tool(
         repo_root: Repository root path. Auto-detected if omitted.
     """
     return run_postprocess(
-        flows=flows, communities=communities, fts=fts, repo_root=repo_root,
+        flows=flows, communities=communities, fts=fts, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -131,7 +148,7 @@ def get_minimal_context_tool(
     """
     return get_minimal_context(
         task=task, changed_files=changed_files,
-        repo_root=repo_root, base=base,
+        repo_root=_resolve_repo_root(repo_root), base=base,
     )
 
 
@@ -157,7 +174,7 @@ def get_impact_radius_tool(
     """
     return get_impact_radius(
         changed_files=changed_files, max_depth=max_depth,
-        repo_root=repo_root, base=base, detail_level=detail_level,
+        repo_root=_resolve_repo_root(repo_root), base=base, detail_level=detail_level,
     )
 
 
@@ -187,7 +204,7 @@ def query_graph_tool(
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
     return query_graph(
-        pattern=pattern, target=target, repo_root=repo_root,
+        pattern=pattern, target=target, repo_root=_resolve_repo_root(repo_root),
         detail_level=detail_level,
     )
 
@@ -220,7 +237,7 @@ def get_review_context_tool(
     return get_review_context(
         changed_files=changed_files, max_depth=max_depth,
         include_source=include_source, max_lines_per_file=max_lines_per_file,
-        repo_root=repo_root, base=base, detail_level=detail_level,
+        repo_root=_resolve_repo_root(repo_root), base=base, detail_level=detail_level,
     )
 
 
@@ -249,7 +266,7 @@ def semantic_search_nodes_tool(
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
     return semantic_search_nodes(
-        query=query, kind=kind, limit=limit, repo_root=repo_root, model=model,
+        query=query, kind=kind, limit=limit, repo_root=_resolve_repo_root(repo_root), model=model,
         detail_level=detail_level,
     )
 
@@ -274,7 +291,7 @@ def embed_graph_tool(
         model: Embedding model name (HuggingFace ID or local path).
                Falls back to CRG_EMBEDDING_MODEL env var, then all-MiniLM-L6-v2.
     """
-    return embed_graph(repo_root=repo_root, model=model)
+    return embed_graph(repo_root=_resolve_repo_root(repo_root), model=model)
 
 
 @mcp.tool()
@@ -289,7 +306,7 @@ def list_graph_stats_tool(
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return list_graph_stats(repo_root=repo_root)
+    return list_graph_stats(repo_root=_resolve_repo_root(repo_root))
 
 
 @mcp.tool()
@@ -332,7 +349,7 @@ def find_large_functions_tool(
     """
     return find_large_functions(
         min_lines=min_lines, kind=kind, file_path_pattern=file_path_pattern,
-        limit=limit, repo_root=repo_root,
+        limit=limit, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -359,7 +376,7 @@ def list_flows_tool(
         repo_root: Repository root path. Auto-detected if omitted.
     """
     return list_flows(
-        repo_root=repo_root, sort_by=sort_by, limit=limit, kind=kind,
+        repo_root=_resolve_repo_root(repo_root), sort_by=sort_by, limit=limit, kind=kind,
         detail_level=detail_level,
     )
 
@@ -386,7 +403,7 @@ def get_flow_tool(
     """
     return get_flow(
         flow_id=flow_id, flow_name=flow_name,
-        include_source=include_source, repo_root=repo_root,
+        include_source=include_source, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -408,7 +425,7 @@ def get_affected_flows_tool(
         repo_root: Repository root path. Auto-detected if omitted.
     """
     return get_affected_flows_func(
-        changed_files=changed_files, base=base, repo_root=repo_root,
+        changed_files=changed_files, base=base, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -434,7 +451,7 @@ def list_communities_tool(
         repo_root: Repository root path. Auto-detected if omitted.
     """
     return list_communities_func(
-        repo_root=repo_root, sort_by=sort_by, min_size=min_size,
+        repo_root=_resolve_repo_root(repo_root), sort_by=sort_by, min_size=min_size,
         detail_level=detail_level,
     )
 
@@ -462,7 +479,7 @@ def get_community_tool(
     """
     return get_community_func(
         community_name=community_name, community_id=community_id,
-        include_members=include_members, repo_root=repo_root,
+        include_members=include_members, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -479,7 +496,7 @@ def get_architecture_overview_tool(
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_architecture_overview_func(repo_root=repo_root)
+    return get_architecture_overview_func(repo_root=_resolve_repo_root(repo_root))
 
 
 @mcp.tool()
@@ -509,7 +526,7 @@ def detect_changes_tool(
     return detect_changes_func(
         base=base, changed_files=changed_files,
         include_source=include_source, max_depth=max_depth,
-        repo_root=repo_root, detail_level=detail_level,
+        repo_root=_resolve_repo_root(repo_root), detail_level=detail_level,
     )
 
 
@@ -545,7 +562,7 @@ def refactor_tool(
     """
     return refactor_func(
         mode=mode, old_name=old_name, new_name=new_name,
-        kind=kind, file_pattern=file_pattern, repo_root=repo_root,
+        kind=kind, file_pattern=file_pattern, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -568,7 +585,7 @@ def apply_refactor_tool(
         repo_root: Repository root path. Auto-detected if omitted.
     """
     return apply_refactor_func(
-        refactor_id=refactor_id, repo_root=repo_root,
+        refactor_id=refactor_id, repo_root=_resolve_repo_root(repo_root),
     )
 
 
@@ -587,7 +604,7 @@ def generate_wiki_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         force: If True, regenerate all pages even if content unchanged. Default: False.
     """
-    return generate_wiki_func(repo_root=repo_root, force=force)
+    return generate_wiki_func(repo_root=_resolve_repo_root(repo_root), force=force)
 
 
 @mcp.tool()
@@ -604,7 +621,9 @@ def get_wiki_page_tool(
         community_name: Community name to look up.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_wiki_page_func(community_name=community_name, repo_root=repo_root)
+    return get_wiki_page_func(
+        community_name=community_name, repo_root=_resolve_repo_root(repo_root),
+    )
 
 
 @mcp.tool()

--- a/code_review_graph/wiki.py
+++ b/code_review_graph/wiki.py
@@ -194,9 +194,24 @@ def generate_wiki(
 
     page_entries: list[tuple[str, str, int]] = []  # (slug, name, size)
 
+    # Track slugs we've already used in THIS run so two communities that
+    # slugify to the same filename don't overwrite each other (#222 follow-up).
+    # Previously "Data Processing" and "data processing" both became
+    # "data-processing.md", causing silent data loss and inflated "updated"
+    # counters (each collision was counted as an update while only one file
+    # made it to disk).
+    used_slugs: set[str] = set()
+
     for comm in communities:
         name = comm["name"]
-        slug = _slugify(name)
+        base_slug = _slugify(name)
+        slug = base_slug
+        suffix = 2
+        while slug in used_slugs:
+            slug = f"{base_slug}-{suffix}"
+            suffix += 1
+        used_slugs.add(slug)
+
         filename = f"{slug}.md"
         filepath = wiki_path / filename
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,45 @@
+"""Tests for the MCP server entry point.
+
+Focused on the ``_resolve_repo_root`` helper that threads the
+``serve --repo <X>`` CLI flag into every tool wrapper. Previously only
+``get_docs_section_tool`` respected the flag and the other 21 tools
+silently fell back to cwd.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_review_graph import main as crg_main
+
+
+class TestResolveRepoRoot:
+    """Precedence rules for _resolve_repo_root (see #222 follow-up)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_default(self):
+        """Save and restore the module-level default before/after each test."""
+        original = crg_main._default_repo_root
+        yield
+        crg_main._default_repo_root = original
+
+    def test_none_when_neither_is_set(self):
+        crg_main._default_repo_root = None
+        assert crg_main._resolve_repo_root(None) is None
+
+    def test_empty_string_treated_as_unset(self):
+        """Empty string from an MCP client should not shadow the --repo flag."""
+        crg_main._default_repo_root = "/tmp/flag-repo"
+        assert crg_main._resolve_repo_root("") == "/tmp/flag-repo"
+
+    def test_flag_used_when_client_omits_repo_root(self):
+        crg_main._default_repo_root = "/tmp/flag-repo"
+        assert crg_main._resolve_repo_root(None) == "/tmp/flag-repo"
+
+    def test_client_arg_wins_over_flag(self):
+        crg_main._default_repo_root = "/tmp/flag-repo"
+        assert crg_main._resolve_repo_root("/explicit") == "/explicit"
+
+    def test_client_arg_used_when_no_flag(self):
+        crg_main._default_repo_root = None
+        assert crg_main._resolve_repo_root("/explicit") == "/explicit"

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -187,3 +187,68 @@ class TestWiki:
         index_content = (Path(self.wiki_dir) / "index.md").read_text()
         assert "Total communities" in index_content
         assert "0" in index_content  # 0 communities
+
+    def test_generate_wiki_handles_slug_collisions(self, monkeypatch):
+        """Communities whose names slugify to the same string must each get
+        their own page — earlier behaviour silently overwrote the first
+        community's file with the second's content and counted the second
+        as an 'updated' page (see #222 follow-up).
+        """
+        # Fake three communities whose _slugify outputs collide:
+        #   "Data Processing"  -> data-processing
+        #   "data processing"  -> data-processing
+        #   "Data  Processing" -> data-processing
+        colliding_communities = [
+            {
+                "name": "Data Processing", "size": 5, "cohesion": 0.9,
+                "dominant_language": "python", "description": "first",
+                "members": [], "member_qns": set(),
+            },
+            {
+                "name": "data processing", "size": 4, "cohesion": 0.8,
+                "dominant_language": "python", "description": "second",
+                "members": [], "member_qns": set(),
+            },
+            {
+                "name": "Data  Processing", "size": 3, "cohesion": 0.7,
+                "dominant_language": "python", "description": "third",
+                "members": [], "member_qns": set(),
+            },
+        ]
+
+        import code_review_graph.wiki as wiki_mod
+        monkeypatch.setattr(
+            wiki_mod, "get_communities", lambda store: colliding_communities,
+        )
+
+        result = generate_wiki(self.store, self.wiki_dir)
+
+        # 3 unique .md pages + 1 index.md should land on disk.
+        wiki_files = sorted(p.name for p in Path(self.wiki_dir).glob("*.md"))
+        expected = {
+            "data-processing.md",
+            "data-processing-2.md",
+            "data-processing-3.md",
+            "index.md",
+        }
+        assert set(wiki_files) == expected, wiki_files
+
+        # Counter must match what actually hit the disk.
+        page_total = (
+            result["pages_generated"]
+            + result["pages_updated"]
+            + result["pages_unchanged"]
+        )
+        assert page_total == len(wiki_files), (
+            f"counter {result} but {len(wiki_files)} files on disk"
+        )
+
+        # Every community's description must survive (no data loss).
+        content_first = (Path(self.wiki_dir) / "data-processing.md").read_text()
+        content_second = (Path(self.wiki_dir) / "data-processing-2.md").read_text()
+        content_third = (Path(self.wiki_dir) / "data-processing-3.md").read_text()
+        # Descriptions are rendered in the page body; make sure all three
+        # communities produced distinct content.
+        assert content_first != content_second
+        assert content_first != content_third
+        assert content_second != content_third


### PR DESCRIPTION
## Summary

Two orthogonal bugs surfaced by the 6-repo smoke test on #222. Both are pre-existing on \`main\` (i.e. they're not caused by #222 or v2.2.3) and both are independent of the fastmcp bump, so I've put them on their own branch off \`main\`. Either PR can land first.

## Bug 1 — \`serve --repo <X>\` ignored by 21 of 24 MCP tools

**Symptom** (from the smoke test): on the first pass I launched \`code-review-graph serve\` with \`cwd=/tmp\` and all 6 eval repos returned identical stats for a phantom \"code-review-graph\" graph. Every tool call fell back to \`find_repo_root()\` from cwd, which resolved to this repo.

**Root cause**: \`main.py:694\` captures the \`--repo\` CLI flag into the module-level \`_default_repo_root\`, but only \`get_docs_section_tool\` (line 311) reads it. The other 21 \`@mcp.tool()\` wrappers all declare \`repo_root: Optional[str] = None\` and pass that straight through to the impl.

**Blast radius**: near-zero in practice. The \`install\` command writes \`.mcp.json\` with \`args = [\"code-review-graph\", \"serve\"]\` (no \`--repo\`) and Claude Code launches the server with \`cwd=<repo>\`, so first-time users never hit this. But anyone scripting \`serve\` manually, running a multi-repo orchestrator, or using a non-standard MCP client would silently get the wrong graph.

**Fix**: single \`_resolve_repo_root(repo_root)\` helper with explicit precedence:
1. Explicit \`repo_root\` passed by the MCP client (highest)
2. \`_default_repo_root\` captured from \`serve --repo <X>\`
3. \`None\` — caller falls back to cwd (same as before)

Every tool wrapper now calls \`repo_root=_resolve_repo_root(repo_root)\` at the call site. 21 sites updated; \`get_docs_section_tool\` already read \`_default_repo_root\` directly so no change there.

Tests: \`tests/test_main.py::TestResolveRepoRoot\` — 5 cases covering all precedence combinations, including the subtle \"empty string should not shadow the flag\" case.

## Bug 2 — wiki slug collisions silently overwrite pages

**Symptom** (from the smoke test): on every repo, \`generate_wiki\` reported more \"updated\" pages than actually landed on disk. express reported \"32 new, 75 updated, 0 unchanged (107 total pages)\" but only 32 physical \`.md\` files existed.

**Root cause**: \`_slugify()\` folds non-alphanumerics to dashes and truncates to 80 chars, which collapses similar community names to the same filename:

\`\`\`
\"Data Processing\"  -> data-processing
\"data processing\"  -> data-processing
\"Data  Processing\" -> data-processing
\`\`\`

The previous \`generate_wiki\` loop wrote every community to \`<slug>.md\` regardless of collisions. Each time a later community hit an already-existing file, its content was compared (didn't match), the file was **overwritten**, and \`pages_updated\` was incremented. The first community's wiki page was silently lost.

That means the \"counter double-count\" I initially described was actually masking a **correctness bug**: 75 communities' wiki content on express never made it to disk at all. Anyone relying on the wiki for architecture documentation would have been missing ~70% of their community pages on a sizable repo.

**Fix**: track used slugs per-run in a set and append \`-2\`, \`-3\`, ... until the slug is unique. Every community now gets its own file; the counter matches the actual number of files on disk; no data loss.

\`get_wiki_page()\` lookup still works for the first community because its slug is unchanged, and the existing partial-match fallback at \`wiki.py:284\` picks up the numbered variants for later collisions.

Tests: \`tests/test_wiki.py::TestWiki::test_generate_wiki_handles_slug_collisions\` — monkeypatches \`get_communities\` to return 3 colliding names, asserts 3 unique \`.md\` files + \`index.md\` land on disk, asserts counter matches physical file count, asserts each file has distinct content.

## Test plan

Verified locally on Python 3.11 (both bugs, both on a branch off fresh \`main\`):

- [x] \`uv run ruff check code_review_graph/\` → \`All checks passed!\`
- [x] \`uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional\` → \`Success: no issues found in 44 source files\`
- [x] \`uv run bandit -r code_review_graph/ -c pyproject.toml\` → 0 H/M/L
- [x] \`uv run pytest --cov-fail-under=65\` → **697 passed, 1 skipped, 2 xpassed, coverage 74.81%**
- [x] \`_resolve_repo_root\` unit tests cover None / \"\" / flag-only / explicit-only / both-set
- [x] Wiki collision test creates 3 physical files from 3 colliding names, verifies no content loss
- [ ] CI matrix on this PR (3.10 / 3.11 / 3.12 / 3.13)

## Branch base

Based on \`main\` at \`d3e56d9\` (post-v2.2.3), **not** on #222. These two fixes are independent of the fastmcp bump, so they can merge before, after, or in parallel with #222. If you merge #222 first there may be a trivial test-file-level merge conflict — resolution is just keeping both test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)