### PR TITLE
chore: release v2.2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [2.2.3.1] - 2026-04-11
+
+Hotfix on top of 2.2.3 for two bugs surfaced by a full first-time-user smoke test against six real OSS repos (express, fastapi, flask, gin, httpx, next.js).
+
+### Fixed
+- **`serve --repo <X>` was ignored by 21 of 24 MCP tools** (PR #223): `main.py` captured the `--repo` CLI flag into `_default_repo_root`, but only `get_docs_section_tool` read it. The other 21 `@mcp.tool()` wrappers all took `repo_root: Optional[str] = None` and passed that straight through to the impl, which fell back to `find_repo_root()` from cwd. The real-world blast radius is small — the `install` command writes `.mcp.json` without a `--repo` flag and Claude Code launches the server with `cwd=<repo>` — but anyone scripting `serve` manually or running a multi-repo orchestrator would silently get the wrong graph. Added a single `_resolve_repo_root()` helper with explicit precedence (client arg > `--repo` flag > `None → cwd`) and threaded it through all 24 wrappers. New unit tests cover the precedence rules.
+- **Wiki slug collisions silently overwrote pages** (PR #223): `_slugify()` folds non-alphanumerics to dashes and truncates to 80 chars, so similar community names collided (`"Data Processing"`, `"data processing"`, `"Data  Processing"` all → `data-processing.md`). `generate_wiki()` wrote each community to `<slug>.md` regardless, so later iterations overwrote earlier files while the counter reported them as "updated". On the express smoke test this was **~70% silent data loss** (32 real files vs 107 claimed pages). Fixed by tracking used slugs per-run and appending `-2`, `-3`, … until unique. Every community now gets its own page; the counter matches the physical file count; `get_wiki_page()` still resolves by name via the existing partial-match fallback. New regression test monkey-patches three colliding names and asserts no content loss.
+
 ## [2.2.3] - 2026-04-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.2.3"
+version = "2.2.3.1"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.2.3"
+version = "2.2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Hotfix on top of 2.2.3 shipping the two bugs surfaced by the 6-repo smoke test (#223, just merged). This release deliberately does **not** include the contents of #222 (fastmcp 2.x bump, Windows event-loop fix, Dart/Go parser, etc.) — those are still waiting on Windows reporter confirmation before v2.2.4.

## What's in this release

- **#223** — `serve --repo <X>` now honored by all 24 MCP tools (was only read by `get_docs_section_tool`).
- **#223** — wiki slug collisions no longer silently overwrite pages (~70% data loss on real repos like express).

That's it. No other fixes, no dependency bumps, no schema changes.

## What's NOT in this release

Everything in #222, which is still open:

- fastmcp 1.0 → 2.14.6 (CVEs #139, fakeredis #195) — blocked on Windows confirmation
- Windows `ProactorEventLoop` → `WindowsSelectorEventLoopPolicy` (#46, #136) — blocked on Windows confirmation
- Go receiver methods (#190), Dart parser bugs (#87), nested `node_modules` ignores (#91), `except Exception` cleanup (#194), viz auto-collapse (#132), eval yaml guard (#212), VS Code `better-sqlite3` 12.x (#218)

Once @pvnsai73 or @dev-limucc reports back on the Windows branch, we merge #222 and cut v2.2.4 with all of the above.

## Test plan

Verified locally on Python 3.11:

- [x] `uv run ruff check code_review_graph/` → `All checks passed!`
- [x] `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` → `Success: no issues found in 44 source files`
- [x] `uv run bandit -r code_review_graph/ -c pyproject.toml` → 0 H/M/L
- [x] `uv run pytest --cov-fail-under=65` → **697 passed, 1 skipped, 2 xpassed, coverage 74.81%**
- [ ] CI matrix on this PR (3.10 / 3.11 / 3.12 / 3.13)

## After merge

1. Tag `v2.2.3.1` on the merge commit.
2. `gh release create v2.2.3.1` — triggers the existing `publish.yml` workflow, which builds + uploads to PyPI.
3. Update the Windows-test request comments on #46 and #136 with "you can also test on v2.2.3.1 to get the wiki + --repo fixes, though the actual Windows hang fix still requires building from #222's branch".

🤖 Generated with [Claude Code](https://claude.com/claude-code)