### PR TITLE
feat: add dry_run preview to apply_refactor_tool (#176)

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -571,6 +571,7 @@ def refactor_tool(
 def apply_refactor_tool(
     refactor_id: str,
     repo_root: Optional[str] = None,
+    dry_run: bool = False,
 ) -> dict:
     """Apply a previously previewed refactoring to source files.
 
@@ -578,15 +579,24 @@ def apply_refactor_tool(
     applies the exact string replacements to the target files. Previews
     expire after 10 minutes.
 
+    When ``dry_run=True``, returns a unified diff for each edited file
+    **without writing to disk**. The pending refactor is preserved so
+    the caller can review the diffs and then call this tool again with
+    ``dry_run=False`` using the same ``refactor_id`` to actually apply
+    the changes (two-step commit pattern).
+
     Security: All edit paths are validated to be within the repo root.
     Only exact string replacements are performed (no regex, no eval).
 
     Args:
         refactor_id: The refactor ID from refactor_tool's response.
         repo_root: Repository root path. Auto-detected if omitted.
+        dry_run: If True, preview diffs without writing files. Default False.
     """
     return apply_refactor_func(
-        refactor_id=refactor_id, repo_root=_resolve_repo_root(repo_root),
+        refactor_id=refactor_id,
+        repo_root=_resolve_repo_root(repo_root),
+        dry_run=dry_run,
     )
 
 

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -8,6 +8,7 @@ traversal prevention.
 
 from __future__ import annotations
 
+import difflib
 import logging
 import threading
 import time
@@ -338,6 +339,7 @@ def suggest_refactorings(store: GraphStore) -> list[dict[str, Any]]:
 def apply_refactor(
     refactor_id: str,
     repo_root: Path,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Apply a previously previewed refactoring to source files.
 
@@ -345,12 +347,21 @@ def apply_refactor(
     within the repo root, then performs exact string replacements on the
     target files.
 
+    When ``dry_run=True``, computes a unified diff for each edited file
+    and returns it in the response **without writing to disk**. The pending
+    refactor is left in place so the caller can review the diff and then
+    invoke ``apply_refactor`` again with ``dry_run=False`` using the same
+    ``refactor_id`` to actually apply the changes.
+
     Args:
         refactor_id: ID from a prior ``rename_preview`` call.
         repo_root: Validated repository root path.
+        dry_run: If True, return unified diffs without writing files.
 
     Returns:
-        Status dict with applied count and modified files.
+        Status dict with applied count and modified files. When
+        ``dry_run=True``, also includes ``dry_run: True`` and a
+        ``diffs`` list with one entry per edited file.
     """
     repo_root = repo_root.resolve()
 
@@ -372,9 +383,18 @@ def apply_refactor(
 
     edits = preview.get("edits", [])
     if not edits:
-        return {"status": "ok", "applied": 0, "files_modified": [], "edits_applied": 0}
+        result: dict[str, Any] = {
+            "status": "ok",
+            "applied": 0,
+            "files_modified": [],
+            "edits_applied": 0,
+        }
+        if dry_run:
+            result["dry_run"] = True
+            result["diffs"] = []
+        return result
 
-    # --- Path traversal validation ---
+    # --- Path traversal validation (runs in both dry-run and real apply) ---
     for edit in edits:
         edit_path = Path(edit["file"]).resolve()
         try:
@@ -392,6 +412,7 @@ def apply_refactor(
     # --- Apply edits ---
     files_modified: set[str] = set()
     edits_applied = 0
+    diffs: list[dict[str, str]] = []
 
     for edit in edits:
         file_path = Path(edit["file"])
@@ -427,6 +448,21 @@ def apply_refactor(
                 new_content = content.replace(old_text, new_text, 1)
         else:
             new_content = content.replace(old_text, new_text, 1)
+
+        if dry_run:
+            # Compute a unified diff instead of writing.
+            diff_text = "".join(
+                difflib.unified_diff(
+                    content.splitlines(keepends=True),
+                    new_content.splitlines(keepends=True),
+                    fromfile=f"a/{file_path}",
+                    tofile=f"b/{file_path}",
+                    n=3,
+                ),
+            )
+            diffs.append({"file": str(file_path), "diff": diff_text})
+            continue
+
         try:
             file_path.write_text(new_content, encoding="utf-8")
             edits_applied += 1
@@ -434,6 +470,22 @@ def apply_refactor(
             logger.info("apply_refactor: applied edit to %s", file_path)
         except OSError as exc:
             logger.error("apply_refactor: could not write %s: %s", file_path, exc)
+
+    if dry_run:
+        # Leave the preview in _pending_refactors so the caller can apply
+        # it after reviewing the diff.  Do NOT consume the refactor_id.
+        logger.info(
+            "apply_refactor: dry-run completed %s — %d diffs generated",
+            refactor_id, len(diffs),
+        )
+        return {
+            "status": "ok",
+            "applied": 0,
+            "files_modified": [],
+            "edits_applied": 0,
+            "dry_run": True,
+            "diffs": diffs,
+        }
 
     # Remove from pending after successful application.
     with _refactor_lock:

--- a/code_review_graph/tools/refactor_tools.py
+++ b/code_review_graph/tools/refactor_tools.py
@@ -133,19 +133,27 @@ def refactor_func(
 def apply_refactor_func(
     refactor_id: str,
     repo_root: str | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Apply a previously previewed refactoring to source files.
 
     [REFACTOR] Validates the refactor_id, checks expiry, ensures all edit
     paths are within the repo root, then performs exact string replacements.
 
+    When ``dry_run=True``, returns unified diffs for each edited file
+    **without writing to disk**. The pending refactor is left in place so
+    the caller can review the diffs and then call this function again with
+    ``dry_run=False`` using the same ``refactor_id`` to actually apply.
+
     Args:
         refactor_id: ID returned by a prior ``refactor_tool(mode="rename")``
             call.
         repo_root: Repository root path. Auto-detected if omitted.
+        dry_run: If True, return unified diffs without writing files.
 
     Returns:
-        Status with count of applied edits and modified files.
+        Status with count of applied edits and modified files. When
+        ``dry_run=True``, also includes a ``diffs`` list.
     """
     try:
         root = (
@@ -156,5 +164,5 @@ def apply_refactor_func(
     except (RuntimeError, ValueError) as exc:
         return {"status": "error", "error": str(exc)}
 
-    result = apply_refactor(refactor_id, root)
+    result = apply_refactor(refactor_id, root, dry_run=dry_run)
     return result

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -351,6 +351,170 @@ class TestApplyRefactor:
             (tmp_dir / ".git").rmdir()
             tmp_dir.rmdir()
 
+    def test_apply_refactor_dry_run_returns_diff(self):
+        """Regression test for #176: dry_run returns a unified diff and
+        does not write to disk or consume the preview."""
+        tmp_dir = Path(tempfile.mkdtemp())
+        (tmp_dir / ".git").mkdir()
+        target_file = tmp_dir / "example.py"
+        original_content = "def old_func():\n    return old_func\n"
+        target_file.write_text(original_content, encoding="utf-8")
+        try:
+            rid = "dryrun1"
+            with _refactor_lock:
+                _pending_refactors[rid] = {
+                    "refactor_id": rid,
+                    "type": "rename",
+                    "old_name": "old_func",
+                    "new_name": "new_func",
+                    "edits": [{
+                        "file": str(target_file),
+                        "line": 1,
+                        "old": "old_func",
+                        "new": "new_func",
+                        "confidence": "high",
+                    }],
+                    "stats": {"high": 1, "medium": 0, "low": 0},
+                    "created_at": time.time(),
+                }
+            result = apply_refactor(rid, tmp_dir, dry_run=True)
+
+            # Response shape.
+            assert result["status"] == "ok"
+            assert result["dry_run"] is True
+            assert result["edits_applied"] == 0
+            assert result["files_modified"] == []
+            assert "diffs" in result
+            assert len(result["diffs"]) == 1
+
+            # Diff content.
+            diff = result["diffs"][0]
+            assert diff["file"] == str(target_file)
+            assert "--- a/" in diff["diff"]
+            assert "+++ b/" in diff["diff"]
+            assert "-def old_func():" in diff["diff"]
+            assert "+def new_func():" in diff["diff"]
+
+            # File on disk must be untouched.
+            assert target_file.read_text(encoding="utf-8") == original_content
+
+            # Preview must still be in the cache (not consumed).
+            with _refactor_lock:
+                assert rid in _pending_refactors
+        finally:
+            with _refactor_lock:
+                _pending_refactors.pop(rid, None)
+            target_file.unlink(missing_ok=True)
+            (tmp_dir / ".git").rmdir()
+            tmp_dir.rmdir()
+
+    def test_apply_refactor_dry_run_then_apply(self):
+        """Regression test for #176: a dry-run followed by a real apply
+        with the same refactor_id succeeds and writes the file."""
+        tmp_dir = Path(tempfile.mkdtemp())
+        (tmp_dir / ".git").mkdir()
+        target_file = tmp_dir / "example.py"
+        target_file.write_text("def old_func():\n    pass\n", encoding="utf-8")
+        try:
+            rid = "dryrun_then_apply"
+            with _refactor_lock:
+                _pending_refactors[rid] = {
+                    "refactor_id": rid,
+                    "type": "rename",
+                    "old_name": "old_func",
+                    "new_name": "new_func",
+                    "edits": [{
+                        "file": str(target_file),
+                        "line": 1,
+                        "old": "old_func",
+                        "new": "new_func",
+                        "confidence": "high",
+                    }],
+                    "stats": {"high": 1, "medium": 0, "low": 0},
+                    "created_at": time.time(),
+                }
+
+            # Dry run first — no write, preview retained.
+            dry_result = apply_refactor(rid, tmp_dir, dry_run=True)
+            assert dry_result["status"] == "ok"
+            assert dry_result["dry_run"] is True
+            assert "old_func" in target_file.read_text(encoding="utf-8")
+
+            # Real apply with the same refactor_id — writes the file.
+            real_result = apply_refactor(rid, tmp_dir, dry_run=False)
+            assert real_result["status"] == "ok"
+            assert real_result["edits_applied"] == 1
+            assert "dry_run" not in real_result  # shape unchanged on real apply
+            content = target_file.read_text(encoding="utf-8")
+            assert "new_func" in content
+            assert "old_func" not in content
+
+            # Preview now consumed.
+            with _refactor_lock:
+                assert rid not in _pending_refactors
+        finally:
+            target_file.unlink(missing_ok=True)
+            (tmp_dir / ".git").rmdir()
+            tmp_dir.rmdir()
+
+    def test_apply_refactor_dry_run_blocks_path_traversal(self):
+        """Regression test for #176: path-traversal check still fires in
+        dry-run mode — dry-run must not be an escape hatch for safety."""
+        tmp_dir = Path(tempfile.mkdtemp())
+        (tmp_dir / ".git").mkdir()
+        try:
+            rid = "dryrun_traversal"
+            with _refactor_lock:
+                _pending_refactors[rid] = {
+                    "refactor_id": rid,
+                    "type": "rename",
+                    "old_name": "old",
+                    "new_name": "new",
+                    "edits": [{
+                        "file": "/etc/passwd",
+                        "line": 1,
+                        "old": "old",
+                        "new": "new",
+                        "confidence": "high",
+                    }],
+                    "stats": {"high": 1, "medium": 0, "low": 0},
+                    "created_at": time.time(),
+                }
+            result = apply_refactor(rid, tmp_dir, dry_run=True)
+            assert result["status"] == "error"
+            assert "outside repo root" in result["error"].lower()
+        finally:
+            with _refactor_lock:
+                _pending_refactors.pop(rid, None)
+            (tmp_dir / ".git").rmdir()
+            tmp_dir.rmdir()
+
+    def test_apply_refactor_dry_run_rejects_expired(self):
+        """Regression test for #176: expired previews are still rejected
+        in dry-run mode."""
+        tmp_dir = Path(tempfile.mkdtemp())
+        (tmp_dir / ".git").mkdir()
+        try:
+            rid = "dryrun_expired"
+            with _refactor_lock:
+                _pending_refactors[rid] = {
+                    "refactor_id": rid,
+                    "type": "rename",
+                    "old_name": "old",
+                    "new_name": "new",
+                    "edits": [],
+                    "stats": {"high": 0, "medium": 0, "low": 0},
+                    "created_at": time.time() - REFACTOR_EXPIRY_SECONDS - 10,
+                }
+            result = apply_refactor(rid, tmp_dir, dry_run=True)
+            assert result["status"] == "error"
+            assert "expired" in result["error"].lower()
+        finally:
+            with _refactor_lock:
+                _pending_refactors.pop(rid, None)
+            (tmp_dir / ".git").rmdir()
+            tmp_dir.rmdir()
+
 
 class TestPendingRefactorsThreadSafe:
     """Tests for thread-safety of the pending refactors storage."""


### PR DESCRIPTION
## Summary
Adds a `dry_run: bool = False` parameter to `apply_refactor_tool` so callers can preview a unified diff of every edited file **without writing to disk**. When `dry_run=True` the pending refactor is kept in the cache so the caller can review the diffs and call the tool again with the same `refactor_id` to actually apply — the two-step commit pattern the maintainer explicitly validated in the issue thread.

Closes #176.

## Root cause
`apply_refactor_tool` wrote changes to disk immediately with no confirmation step. In agentic workflows where multiple MCP tools are chained, this tool could be called as a side effect of a broader task the developer didn't intend to modify files for — and there was no undo path beyond `git checkout`.

Maintainer validation from the issue thread:
> Valid security/UX concern. apply_refactor_tool currently writes changes to disk immediately with no confirmation step. The suggested two-step approach (dry_run first, then confirmed=true to apply) is the right pattern for agentic workflows...

## Fix
1. **`code_review_graph/refactor.py`** — `apply_refactor()` gains `dry_run: bool = False`. When `True`, compute a unified diff via stdlib `difflib.unified_diff` between the original file content and the post-edit content, collect per-file entries in a `diffs` list, and return without writing. The preview is **not** popped from `_pending_refactors` in dry-run mode so a follow-up real apply works.
2. **`code_review_graph/tools/refactor_tools.py`** — `apply_refactor_func()` threads `dry_run` through.
3. **`code_review_graph/main.py`** — `apply_refactor_tool` MCP decorator exposes `dry_run` to clients with an updated docstring.
4. Path-traversal validation and expiry checks still run in dry-run mode — dry-run is **not** an escape hatch for security.

## Return shape
The non-dry-run path is **unchanged** (no new keys) so no existing caller breaks. Dry-run adds two keys:
```python
{
    "status": "ok",
    "applied": 0,
    "files_modified": [],
    "edits_applied": 0,
    "dry_run": True,
    "diffs": [{"file": "...", "diff": "--- a/...\n+++ b/...\n@@ ..."}]
}
```

## Tests added (`tests/test_refactor.py::TestApplyRefactor`)
- `test_apply_refactor_dry_run_returns_diff` — valid unified diff, file on disk untouched, preview still cached
- `test_apply_refactor_dry_run_then_apply` — dry-run followed by real apply with the same `refactor_id` writes the file and consumes the preview
- `test_apply_refactor_dry_run_blocks_path_traversal` — path-traversal check still fires
- `test_apply_refactor_dry_run_rejects_expired` — expired previews still rejected

## Test results

| Stage | Result |
|---|---|
| Stage 1 — new targeted tests | **4/4 passed** |
| Stage 2 — `tests/test_refactor.py` full | 26 passed, 16 pre-existing Windows file-lock teardown errors (verified identical on unchanged `main`) |
| Stage 3 — adjacent `tests/test_tools.py` | 62 passed, 15 pre-existing Windows teardown errors |
| Stage 4 — full suite | **699 passed**, 6 pre-existing Windows failures in `test_incremental`/`test_notebook` (verified identical on `main`) |
| Stage 5 — `ruff check` on all 4 touched files | **clean** |
| Stage 6 — MCP tool-wrapper smoke test | dry_run=True returns valid diff without writing; dry_run=False after dry-run writes and consumes |

**Zero regressions.** All pre-existing test issues are Windows-specific file-lock teardown failures that reproduce on unchanged `main`.

## Why this fix is safe
- No new dependency — `difflib` is stdlib.
- Non-dry-run return shape is unchanged; existing callers and tests work unmodified.
- Dry-run preserves the `refactor_id` so a real apply can follow without re-running `rename_preview`.
- Security invariants (path traversal, expiry) are enforced in both modes.