### PR TITLE
feat: qwen-code platform + Objective-C + Bash parser support

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -203,7 +203,7 @@ def main() -> None:
         "--platform",
         choices=[
             "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
-            "continue", "opencode", "antigravity", "all",
+            "continue", "opencode", "antigravity", "qwen", "all",
         ],
         default="all",
         help="Target platform for MCP config (default: all detected)",
@@ -233,7 +233,7 @@ def main() -> None:
         "--platform",
         choices=[
             "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
-            "continue", "opencode", "antigravity", "all",
+            "continue", "opencode", "antigravity", "qwen", "all",
         ],
         default="all",
         help="Target platform for MCP config (default: all detected)",

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -104,6 +104,10 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".xs": "c",  # Perl XS: parsed as C to capture functions/structs/includes
     ".lua": "lua",
     ".luau": "luau",
+    ".m": "objc",  # Objective-C (.h still maps to C; .mm defers to C++ for simplicity)
+    ".sh": "bash",
+    ".bash": "bash",
+    ".zsh": "bash",
     ".ipynb": "notebook",
 }
 
@@ -140,6 +144,11 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "dart": ["class_definition", "mixin_declaration", "enum_declaration"],
     "lua": [],  # Lua has no class keyword; table-based OOP handled via constructs handler
     "luau": ["type_definition"],  # Luau type aliases; table-based OOP via constructs handler
+    "objc": [
+        "class_interface", "class_implementation",
+        "category_interface", "protocol_declaration",
+    ],
+    "bash": [],  # Shell has no classes
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -175,6 +184,12 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "dart": ["function_signature"],
     "lua": ["function_declaration"],
     "luau": ["function_declaration"],
+    # Objective-C: method_definition lives inside implementation_definition
+    # inside class_implementation. C-style function_definition is also present
+    # for main() and helper functions.
+    "objc": ["method_definition", "function_definition"],
+    # Bash: only function_definition; everything else is a command.
+    "bash": ["function_definition"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -201,6 +216,11 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     # Lua/Luau: require() is a function_call, handled via _extract_lua_constructs
     "lua": [],
     "luau": [],
+    # Objective-C: #import "..." and #include "..." both arrive as preproc_include
+    # (tree-sitter-objc doesn't distinguish via a separate preproc_import node).
+    "objc": ["preproc_include"],
+    # Bash: source / . <file> is a command — handled in _extract_bash_source below.
+    "bash": [],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -227,6 +247,11 @@ _CALL_TYPES: dict[str, list[str]] = {
     "solidity": ["call_expression"],
     "lua": ["function_call"],
     "luau": ["function_call"],
+    # Objective-C: [receiver message:args] produces message_expression;
+    # C-style foo(x) produces call_expression.
+    "objc": ["message_expression", "call_expression"],
+    # Bash: every command invocation is a "command" node.
+    "bash": ["command"],
 }
 
 # Patterns that indicate a test function
@@ -928,6 +953,16 @@ class CodeParser:
             ):
                 continue
 
+            # --- Bash-specific constructs ---
+            # ``source ./foo.sh`` and ``. ./foo.sh`` are commands in
+            # tree-sitter-bash; re-interpret them as IMPORTS_FROM edges so
+            # cross-script wiring works the same as in other languages.
+            if language == "bash" and node_type == "command":
+                if self._extract_bash_source_command(
+                    child, file_path, edges,
+                ):
+                    continue
+
             # --- Dart call detection (see #87) ---
             # tree-sitter-dart does not wrap calls in a single
             # ``call_expression`` node; instead the pattern is
@@ -1029,6 +1064,42 @@ class CodeParser:
                 import_map=import_map, defined_names=defined_names,
                 _depth=_depth + 1,
             )
+
+    def _extract_bash_source_command(
+        self,
+        node,
+        file_path: str,
+        edges: list[EdgeInfo],
+    ) -> bool:
+        """Detect ``source foo.sh`` / ``. foo.sh`` and emit an IMPORTS_FROM
+        edge. Returns True if handled (so the main loop skips recursing
+        into this command). See: #197
+        """
+        command_name: Optional[str] = None
+        args: list[str] = []
+        for sub in node.children:
+            if sub.type == "command_name":
+                command_name = sub.text.decode("utf-8", errors="replace").strip()
+            elif sub.type in ("word", "string", "raw_string") and command_name:
+                txt = sub.text.decode("utf-8", errors="replace").strip()
+                # Strip surrounding quotes if present
+                if len(txt) >= 2 and txt[0] in ("'", '"') and txt[-1] == txt[0]:
+                    txt = txt[1:-1]
+                if txt:
+                    args.append(txt)
+        if command_name in ("source", ".") and args:
+            target = args[0]
+            # Try to resolve relative paths to real files
+            resolved = self._resolve_module_to_file(target, file_path, "bash")
+            edges.append(EdgeInfo(
+                kind="IMPORTS_FROM",
+                source=file_path,
+                target=resolved if resolved else target,
+                file_path=file_path,
+                line=node.start_point[0] + 1,
+            ))
+            return True
+        return False
 
     def _extract_dart_calls_from_children(
         self,
@@ -2522,6 +2593,17 @@ class CodeParser:
         """Language-aware module-to-file resolution."""
         caller_dir = Path(file_path).parent
 
+        if language == "bash":
+            # ``source ./lib.sh`` or ``source lib.sh`` — resolve relative
+            # to the caller's directory. See: #197
+            try:
+                target = (caller_dir / module).resolve()
+                if target.is_file():
+                    return str(target)
+            except (OSError, ValueError):
+                pass
+            return None
+
         if language == "python":
             rel_path = module.replace(".", "/")
             candidates = [rel_path + ".py", rel_path + "/__init__.py"]
@@ -2808,14 +2890,32 @@ class CodeParser:
                     return child.text.decode("utf-8", errors="replace")
                 if child.type == "package" and child.text != b"package":
                     return child.text.decode("utf-8", errors="replace")
-        # For C/C++: function names are inside function_declarator/pointer_declarator
-        # Check these first to avoid matching the return type_identifier
-        if language in ("c", "cpp") and kind == "function":
+        # For C/C++/Objective-C: function names are inside
+        # function_declarator / pointer_declarator. Check these first to
+        # avoid matching the return type_identifier as the function name.
+        if language in ("c", "cpp", "objc") and kind == "function":
             for child in node.children:
                 if child.type in ("function_declarator", "pointer_declarator"):
                     result = self._get_name(child, language, kind)
                     if result:
                         return result
+
+        # Objective-C method_definition: the method name is the first
+        # ``identifier`` child (first part of the selector). Multi-part
+        # selectors like ``- (void)add:(int)a to:(int)b`` keep ``add`` as
+        # the canonical method name; later parts are keyword arguments.
+        if language == "objc" and node.type == "method_definition":
+            for child in node.children:
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
+
+        # Bash function_definition: ``foo() { ... }`` — tree-sitter-bash
+        # stores the function name as a ``word`` child, which the generic
+        # loop below doesn't recognize.
+        if language == "bash" and node.type == "function_definition":
+            for child in node.children:
+                if child.type == "word":
+                    return child.text.decode("utf-8", errors="replace")
         # Go methods: tree-sitter-go uses field_identifier for the name
         # (e.g. func (s *T) MethodName(...) { }). Must run before the generic
         # loop, which would match the result type's type_identifier (e.g. int64).
@@ -3113,6 +3213,33 @@ class CodeParser:
             for child in node.children:
                 if child.type in ("type_identifier", "identifier"):
                     return child.text.decode("utf-8", errors="replace")
+            return None
+
+        # Objective-C: [receiver method:arg] — the method name is the
+        # SECOND identifier-like child (the first is the receiver). For
+        # multi-part selectors like `[obj add:a to:b]` we keep the first
+        # part (`add`) as the call name; later parts are keyword arguments.
+        if language == "objc" and node.type == "message_expression":
+            receiver_skipped = False
+            for child in node.children:
+                if child.type in ("[", "]"):
+                    continue
+                if not receiver_skipped:
+                    # First non-bracket child is the receiver (identifier,
+                    # message_expression for chained calls, etc.)
+                    receiver_skipped = True
+                    continue
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
+            return None
+
+        # Bash: `command` node's first child is the command name.
+        if language == "bash" and node.type == "command":
+            for child in node.children:
+                if child.type == "command_name":
+                    # command_name wraps a word — get its text
+                    txt = child.text.decode("utf-8", errors="replace").strip()
+                    return txt or None
             return None
 
         # Solidity wraps call targets in an 'expression' node – unwrap it

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -92,6 +92,14 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "format": "object",
         "needs_type": False,
     },
+    "qwen": {
+        "name": "Qwen Code",
+        "config_path": lambda root: Path.home() / ".qwen" / "settings.json",
+        "key": "mcpServers",
+        "detect": lambda: (Path.home() / ".qwen").exists(),
+        "format": "object",
+        "needs_type": True,
+    },
 }
 
 

--- a/tests/fixtures/sample.m
+++ b/tests/fixtures/sample.m
@@ -1,0 +1,47 @@
+#import <Foundation/Foundation.h>
+#import "Logger.h"
+
+@interface Calculator : NSObject
+@property(nonatomic) NSInteger result;
+- (NSInteger)add:(NSInteger)a to:(NSInteger)b;
+- (void)reset;
++ (Calculator *)sharedCalculator;
+@end
+
+@implementation Calculator
+
+- (NSInteger)add:(NSInteger)a to:(NSInteger)b {
+    NSInteger sum = a + b;
+    self.result = sum;
+    [self logResult:sum];
+    return sum;
+}
+
+- (void)reset {
+    self.result = 0;
+    NSLog(@"Calculator reset");
+}
+
+- (void)logResult:(NSInteger)value {
+    NSLog(@"Result: %ld", (long)value);
+}
+
++ (Calculator *)sharedCalculator {
+    static Calculator *instance = nil;
+    if (instance == nil) {
+        instance = [[Calculator alloc] init];
+    }
+    return instance;
+}
+
+@end
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        Calculator *calc = [Calculator sharedCalculator];
+        NSInteger r = [calc add:3 to:4];
+        [calc reset];
+        NSLog(@"Final: %ld", (long)r);
+    }
+    return 0;
+}

--- a/tests/fixtures/sample.sh
+++ b/tests/fixtures/sample.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Sample shell script exercising the bash parser.
+
+set -euo pipefail
+
+source ./sample_lib.sh
+. ./sample_config.sh
+
+readonly DATA_DIR="/tmp/crg-example"
+
+log_info() {
+    local msg="$1"
+    echo "[INFO] $msg"
+}
+
+log_error() {
+    local msg="$1"
+    echo "[ERROR] $msg" >&2
+}
+
+ensure_dir() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+        log_info "created $dir"
+    fi
+}
+
+cleanup() {
+    rm -rf "$DATA_DIR"
+    log_info "cleaned up $DATA_DIR"
+}
+
+main() {
+    log_info "starting"
+    ensure_dir "$DATA_DIR"
+    # Simulate some work
+    echo "processing" > "$DATA_DIR/status"
+    cleanup
+    log_info "done"
+}
+
+main "$@"

--- a/tests/fixtures/sample_lib.sh
+++ b/tests/fixtures/sample_lib.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Helper library sourced by sample.sh — used to verify `source` is
+# resolved to a real file by _resolve_module_to_file.
+
+lib_helper() {
+    echo "helper called"
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -966,3 +966,128 @@ class TestLuauParsing:
         sources = {e.source.split("::")[-1] for e in calls}
         assert "Dog.fetch" in sources
         assert "Animal.speak" in sources
+
+
+class TestObjectiveCParsing:
+    """Objective-C parser — closes #88."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.m")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("foo.m")) == "objc"
+
+    def test_nodes_have_objc_language(self):
+        for n in self.nodes:
+            assert n.language == "objc"
+
+    def test_finds_class(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        # Both @interface and @implementation produce Class nodes; that's
+        # fine because they upsert to the same qualified name in the store.
+        names = {c.name for c in classes}
+        assert "Calculator" in names
+
+    def test_finds_instance_and_class_methods(self):
+        funcs = {
+            (n.name, n.parent_name) for n in self.nodes if n.kind == "Function"
+        }
+        assert ("add", "Calculator") in funcs
+        assert ("reset", "Calculator") in funcs
+        assert ("logResult", "Calculator") in funcs
+        assert ("sharedCalculator", "Calculator") in funcs
+
+    def test_finds_c_main(self):
+        """Top-level C-style main() must be extracted via the
+        function_declarator pattern that C/C++ already use (#88)."""
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        main_fn = next((f for f in funcs if f.name == "main"), None)
+        assert main_fn is not None
+        assert main_fn.parent_name is None  # top-level, not attached to a class
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        # Angle-bracket system headers and quoted user headers both arrive
+        # as preproc_include in tree-sitter-objc.
+        assert any("Foundation" in t for t in targets)
+        assert any("Logger" in t for t in targets)
+
+    def test_extracts_message_expression_calls(self):
+        """Objective-C uses [receiver method:args] for method calls; these
+        must produce CALLS edges (#88)."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = [e.target for e in calls]
+        # Internal [self logResult:sum] should resolve to Calculator.logResult
+        assert any(t.endswith("::Calculator.logResult") for t in targets)
+        # [Calculator sharedCalculator] from main should also resolve
+        assert any(t.endswith("::Calculator.sharedCalculator") for t in targets)
+        # External NSLog(...) call_expression should be captured too
+        assert "NSLog" in targets
+
+
+class TestBashParsing:
+    """Bash/Shell parser — closes #197."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.sh")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("build.sh")) == "bash"
+        assert self.parser.detect_language(Path("build.bash")) == "bash"
+        assert self.parser.detect_language(Path("run.zsh")) == "bash"
+
+    def test_nodes_have_bash_language(self):
+        for n in self.nodes:
+            assert n.language == "bash"
+
+    def test_finds_functions(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "log_info" in funcs
+        assert "log_error" in funcs
+        assert "ensure_dir" in funcs
+        assert "cleanup" in funcs
+        assert "main" in funcs
+
+    def test_functions_have_no_parent(self):
+        """Bash has no classes so every function should be top-level."""
+        for n in self.nodes:
+            if n.kind == "Function":
+                assert n.parent_name is None
+
+    def test_source_creates_import_edge(self):
+        """`source ./lib.sh` / `. ./config.sh` should produce IMPORTS_FROM
+        edges (#197)."""
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) >= 2
+        targets = [e.target for e in imports]
+        # sample_lib.sh exists on disk so should be resolved to an absolute path
+        assert any(t.endswith("sample_lib.sh") for t in targets)
+        # sample_config.sh doesn't exist; unresolved path is kept as-is
+        assert any("sample_config.sh" in t for t in targets)
+
+    def test_command_invocations_create_call_edges(self):
+        """Each `command` node inside a function body should become a
+        CALLS edge keyed on its command_name (#197)."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        # Built-ins and external commands kept as bare names
+        assert "echo" in targets
+        assert "mkdir" in targets
+        # Internal function calls should resolve to qualified names
+        assert any(t.endswith("::log_info") for t in targets)
+        assert any(t.endswith("::ensure_dir") for t in targets)
+        assert any(t.endswith("::cleanup") for t in targets)
+
+    def test_main_calls_resolve_to_internal_functions(self):
+        """main() should have CALLS edges to log_info, ensure_dir, and cleanup."""
+        calls = [
+            e for e in self.edges
+            if e.kind == "CALLS" and e.source.endswith("::main")
+        ]
+        call_targets = {e.target for e in calls}
+        assert any(t.endswith("::log_info") for t in call_targets)
+        assert any(t.endswith("::ensure_dir") for t in call_targets)
+        assert any(t.endswith("::cleanup") for t in call_targets)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -423,6 +423,49 @@ class TestInstallPlatformConfigs:
         assert entry["type"] == "stdio"
         assert entry["env"] == []
 
+    def test_install_qwen_config(self, tmp_path):
+        """Qwen Code uses ~/.qwen/settings.json with mcpServers (see #83)."""
+        qwen_config = tmp_path / ".qwen" / "settings.json"
+        with patch.dict(
+            PLATFORMS,
+            {
+                "qwen": {
+                    **PLATFORMS["qwen"],
+                    "config_path": lambda root: qwen_config,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            configured = install_platform_configs(tmp_path, target="qwen")
+        assert "Qwen Code" in configured
+        data = json.loads(qwen_config.read_text())
+        entry = data["mcpServers"]["code-review-graph"]
+        assert entry["type"] == "stdio"
+        assert entry["args"][-1] == "serve"
+
+    def test_install_qwen_preserves_existing_servers(self, tmp_path):
+        """Adding qwen should merge with, not clobber, existing mcpServers."""
+        qwen_config = tmp_path / ".qwen" / "settings.json"
+        qwen_config.parent.mkdir(parents=True)
+        qwen_config.write_text(
+            json.dumps({"mcpServers": {"other-server": {"command": "other"}}}),
+            encoding="utf-8",
+        )
+        with patch.dict(
+            PLATFORMS,
+            {
+                "qwen": {
+                    **PLATFORMS["qwen"],
+                    "config_path": lambda root: qwen_config,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            install_platform_configs(tmp_path, target="qwen")
+        data = json.loads(qwen_config.read_text())
+        assert "other-server" in data["mcpServers"]
+        assert "code-review-graph" in data["mcpServers"]
+
     def test_install_all_detected(self, tmp_path):
         """Installing 'all' configures auto-detected platforms."""
         codex_config = tmp_path / ".codex" / "config.toml"


### PR DESCRIPTION
## Summary

Three feature-request closeouts from the post-v2.2.4 audit:

- **#83** — Qwen Code as an install platform (`--platform qwen` writes `~/.qwen/settings.json` using the same `mcpServers` schema as Cursor/Windsurf).
- **#88** — Objective-C parser (`.m` files) — classes, instance + class methods, `[message expression]` calls, C-style `main()`, and `#import`/`#include`.
- **#197** — Bash/Shell parser (`.sh`, `.bash`, `.zsh`) — functions, `command` invocations as CALLS, and `source`/`.` as IMPORTS_FROM with path resolution.

Both languages already have grammars in `tree-sitter-language-pack`, so no new runtime dependencies.

## Commits

1. **`fd56a3c` feat: add qwen-code as a supported MCP install platform (#83)**
   - New `PLATFORMS["qwen"]` entry in `code_review_graph/skills.py` with `config_path = ~/.qwen/settings.json`, `key = "mcpServers"`, `format = "object"`, `needs_type = True`.
   - Added `qwen` to the `--platform` choices in `cli.py` for both `install` and `init`.
   - Uses the existing object-format merge path — no new install logic.
   - Tests: `test_install_qwen_config`, `test_install_qwen_preserves_existing_servers`.

2. **`b1fbcd5` feat: add Objective-C and Bash/Shell parser support (#88, #197)**
   - **Objective-C** (`.m` → `objc`):
     - Class types: `class_interface`, `class_implementation`, `category_interface`, `protocol_declaration`
     - Function types: `method_definition` + C-style `function_definition`
     - Imports: `preproc_include` (`#import` and `#include` both)
     - Calls: `message_expression` + `call_expression`
     - `_get_name` now recognizes `method_definition` (first `identifier` = method name, e.g. `add:to:` keeps `add`) and threads `objc` into the existing C/C++ `function_declarator` path so top-level `main()` is picked up.
     - `_get_call_name` handles `message_expression` by skipping the `[`, skipping the receiver, and returning the next `identifier` — works for simple calls, multi-part selectors, and chained `[[... alloc] init]`.
     - Note: `.h` stays mapped to `c` (Obj-C `.h` disambiguation is a separate can of worms), `.mm` stays mapped to `cpp` for now.
   - **Bash** (`.sh` / `.bash` / `.zsh` → `bash`):
     - Function type: `function_definition` (name is a `word` child — added to `_get_name`)
     - Calls: every `command` node; `_get_call_name` returns the `command_name` text
     - Imports: new `_extract_bash_source_command()` hook in `_extract_from_tree` detects `source path` / `. path`, strips quotes, and emits `IMPORTS_FROM` edges; `_do_resolve_module` has a new `bash` branch that resolves relative paths against the caller's directory when the target file exists on disk
     - No classes (shell has none)

## Verified end-to-end on fixtures

**`tests/fixtures/sample.m`** (Calculator with `@interface` + `@implementation` + C `main`):
- 8 nodes, 18 edges
- 5 functions: `add`, `reset`, `logResult`, `sharedCalculator` (all with `parent_name="Calculator"`), and `main` (top-level)
- 2 IMPORTS_FROM: `Foundation/Foundation.h`, `Logger.h`
- 9 CALLS including `[self logResult:sum]` → `::Calculator.logResult` (resolved), `[Calculator sharedCalculator]` → `::Calculator.sharedCalculator`, plus `NSLog`, `alloc`, `init`

**`tests/fixtures/sample.sh`** (sample script with `source`, 5 functions, and nested calls):
- 6 nodes, 18 edges
- 5 functions: `log_info`, `log_error`, `ensure_dir`, `cleanup`, `main`
- 2 IMPORTS_FROM: `sample_lib.sh` resolved to absolute path (file exists), `sample_config.sh` kept as raw string
- 11 CALLS — internal calls like `main` → `log_info` / `ensure_dir` / `cleanup` resolved to qualified names; external commands (`echo`, `mkdir`, `rm`) kept as bare names

## Test plan

- [x] `uv run ruff check code_review_graph/` → clean
- [x] `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` → clean
- [x] `uv run bandit -r code_review_graph/ -c pyproject.toml` → 0 H/M/L
- [x] `uv run pytest --cov-fail-under=65` → **717 passed, 1 skipped, 2 xpassed, coverage 74.84%**
  - 16 new tests total: 2 qwen platform install tests, 7 Objective-C, 7 Bash
- [ ] CI matrix (3.10 / 3.11 / 3.12 / 3.13)

## Closes

- #83 (qwen-code)
- #88 (Objective-C)
- #197 (Bash/Shell)

## Out of scope for this PR — from the same audit

- **#112 Elixir** — volunteer @hk151109 said they'd raise a PR this weekend. If no PR lands in 1-2 weeks, I'll implement.
- **#176 apply_refactor dry-run** — volunteer @VaibhavDangaich committed to implement. Same policy.
- **#173 install CLAUDE.md preview** — PR #204 is already open.
- **#174 cloud embeddings warning** — PR #179 is already open (overlaps with #207).
- **#155 configurable DB location** — PR #207 is open but has review comments.
- **#199 Terraform/HCL + Helm** — HCL is M-sized and needs a design call (call-graph model doesn't map onto infra DAGs); Helm is L. Deferring.
- **#210 TOON serialization** — you already declined this on-issue; deferring.
- **#211 `.code-review-ignore`** — closed as already-implemented (`.code-review-graphignore` has been working since before v2.2.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)