### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-04-11
+
+Additive feature release — new language parsers, new platform install target, MCP tool UX improvements, and out-of-tree graph storage. No breaking changes from v2.2.4.
+
+### Added
+
+- **Elixir parser** (PR #228, closes #112): `.ex` and `.exs` files now produce modules as Class nodes, `def`/`defp`/`defmacro`/`defmacrop` as Function/Test nodes attached to their enclosing module, `alias`/`import`/`require`/`use` as `IMPORTS_FROM` edges, and everything else as `CALLS` edges. Internal call resolution walks into `do_block` bodies so `MathHelpers.double` correctly resolves its call to `Calculator.compute`.
+- **Objective-C parser** (PR #227, closes #88): `.m` files parse classes (`@interface`, `@implementation`, `@protocol`), instance and class methods, `[receiver message:args]` message expressions, C-style `main()`, and `#import`/`#include`. Multi-part selectors like `add:to:` keep `add` as the canonical method name.
+- **Bash/Shell parser** (PR #227, closes #197): `.sh`, `.bash`, and `.zsh` files parse functions, `command` invocations as `CALLS`, and `source path` / `. path` as `IMPORTS_FROM` edges with path resolution when the target file exists.
+- **Qwen Code as a supported MCP install platform** (PR #227, closes #83): `code-review-graph install --platform qwen` writes a merged `~/.qwen/settings.json` using the same `mcpServers` schema as Cursor/Windsurf — it does not clobber existing Qwen config.
+- **`apply_refactor_tool` dry-run mode** (PR #228, closes #176): new `dry_run: bool = False` parameter on the MCP tool and underlying `apply_refactor()` function. When true, returns a unified diff per file without touching disk and leaves the `refactor_id` valid for a follow-up real apply. Multi-edit files now apply sequentially against updated content in both modes (fixes a subtle bug where separate edits on the same file could stomp each other).
+- **`CRG_DATA_DIR` environment variable** (PR #228, closes #155): when set, replaces the default `<repo>/.code-review-graph` directory verbatim. Useful for ephemeral workspaces, Docker volumes, shared CI caches, and multi-repo orchestrators. Supported by the CLI, MCP tools, and the registry.
+- **`CRG_REPO_ROOT` environment variable** (PR #228, closes #155): `find_project_root()` now checks `CRG_REPO_ROOT` before the usual git-root walk — useful for anyone scripting the CLI from a cwd outside the target repo.
+- **`install --no-instructions` and `-y`/`--yes` flags** (PR #228, closes #173): new flags on `code-review-graph install` to opt out of the `CLAUDE.md`/`AGENTS.md`/`.cursorrules`/`.windsurfrules` injection entirely (`--no-instructions`) or auto-confirm it without an interactive prompt (`-y`/`--yes`). The CLI also now prints the list of files it will touch before writing, so even without `--dry-run` users see what's coming.
+- **Cloud embeddings stderr warning** (PR #228, closes #174): `get_provider()` now prints an explicit warning to stderr before returning a Google Gemini or MiniMax provider, explaining that source code will be sent to an external API. `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` suppresses the warning for scripted workflows. The warning is on stderr only — it never writes to stdout or reads from stdin, so the MCP stdio transport remains uncorrupted.
+- **TROUBLESHOOTING quick-reference** (PR #228): new top section in `docs/TROUBLESHOOTING.md` covering the four most common support questions — hook schema errors, `command not found` after pip install, project-vs-user scoping, and "built the graph but Claude Code doesn't see it".
+
+### Fixed
+
+- **Multi-edit refactor correctness** (PR #228): when a single `apply_refactor` call had multiple edits targeting the same file, the previous implementation re-read the file once per edit and could silently stomp earlier changes. The plan-computation step now groups edits by file and applies them sequentially against the updated content; this fix applies to both the real-write and the new dry-run path.
+
+### Changed
+
+- `install` and `init` commands now preview instruction-file targets before writing (no-op if nothing would change). This is always-on and does not require `--dry-run`.
+- Default embedding path remains fully local (`sentence-transformers`); no behavior change unless you explicitly opt in to a cloud provider.
+
+### Deprecated
+
+Nothing.
+
+### Security
+
+- The cloud-embedding stderr warning (#174) is a privacy improvement; it does not change the behavior of offline local embeddings, which remain the default.
+
+### Upgrade notes
+
+- Nothing to do beyond `uvx --reinstall code-review-graph` or `pip install -U code-review-graph`. If you're coming from v2.2.2 or earlier, re-run `code-review-graph install` once to pick up the v2.2.3 hook schema rewrite.
+- `CRG_DATA_DIR` is optional — if you don't set it, graphs continue to live at `<repo>/.code-review-graph` as before.
+- VS Code extension v0.2.2 (from v2.2.4) still needs to be **repackaged and republished** separately; the PyPI `publish.yml` workflow does not cover it.
+
+### Superseded PRs
+
+- PR #204 (install preview, @lngyeen) — reimplemented cleanly in #228 with `isatty()`-guarded confirmation.
+- PR #207 (`CRG_DATA_DIR`/`CRG_REPO_ROOT`, @yashmewada9618) — reimplemented cleanly in #228 without `input()`-on-stdio and `mcp._local_only` fragility.
+- PR #179 (cloud embeddings warning, @Bakul2006) — reimplemented cleanly in #228 with stderr-only messaging and no stdio reads.
+
+Credit to @lngyeen, @yashmewada9618, and @Bakul2006 for the original designs.
+
 ## [2.2.4] - 2026-04-11
 
 Ships the 11 bugs from PR #222 plus the `v2.2.3.1` smoke-test hotfixes, for users upgrading directly from `v2.2.3` or earlier.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.2.4"
+version = "2.3.0"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.2.4"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Minor-version bump to ship the post-v2.2.4 feature bundle from #228 (merged). All additive — new languages, new platform, new env vars, new MCP parameters, new docs.

## What's in this release

**New languages + platforms:**
- #112 Elixir parser (`.ex`/`.exs`)
- #88 Objective-C parser (`.m`) — from v2.3.0 but first landed via #227
- #197 Bash/Shell parser (`.sh`/`.bash`/`.zsh`) — from v2.3.0 but first landed via #227
- #83 Qwen Code as install platform (`--platform qwen`)

**MCP tool UX:**
- #176 `apply_refactor_tool(dry_run=True)` returns unified diffs without writing
- #173 `install --no-instructions` + `-y`/`--yes` flags, plus pre-write preview
- #174 Cloud embeddings stderr warning + `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` opt-out

**Graph storage:**
- #155 `CRG_DATA_DIR` and `CRG_REPO_ROOT` env vars — keep graphs outside the working tree, or script the CLI from anywhere

**Bug fix:**
- Multi-edit refactor correctness (separate edits on the same file could silently stomp each other in `apply_refactor`)

**Docs:**
- `TROUBLESHOOTING.md` quick-reference section for the 4 most common support questions

## Test plan

- [x] `uv run ruff check code_review_graph/` → clean
- [x] `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` → clean
- [x] `uv run bandit -r code_review_graph/ -c pyproject.toml` → 0 H/M/L
- [x] `uv run pytest --cov-fail-under=65` → **735 passed, 1 skipped, 2 xpassed, 74.63% coverage**
- [ ] CI matrix (3.10 / 3.11 / 3.12 / 3.13)

## After merge

Tag `v2.3.0`, create GitHub release, watch `publish.yml` push to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)