### PR TITLE
chore: release v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-04-11
+
+Hotfix for the Windows long-running-MCP-tool hang that v2.2.4 only partially fixed.
+
+### Fixed
+- **Windows MCP hang on long-running tools** (PR #231, fixes #46, #136): follow-up to v2.2.4. [@dev-limucc reported on #136](https://github.com/tirth8205/code-review-graph/issues/136) that the `WindowsSelectorEventLoopPolicy` fix from v2.2.4 was necessary but not sufficient — read-only tools worked, but `build_or_update_graph_tool(full_rebuild=True)` and `embed_graph_tool` still hung indefinitely on Windows 11 / Python 3.14. Root cause: FastMCP 2.x dispatches sync handlers inline on the only event-loop thread, so handlers that run for more than a few seconds (especially those that spawn subprocesses or do CPU-bound inference) stop the loop from pumping stdin/stdout. **Fix**: converted the five heavy tools (`build_or_update_graph_tool`, `run_postprocess_tool`, `embed_graph_tool`, `detect_changes_tool`, `generate_wiki_tool`) to `async def` and offloaded the blocking work via `asyncio.to_thread`. The other 19 tools are fast SQLite-read paths and stay sync. Zero config, works on every platform. New regression tests assert the five tools are registered as coroutines AND that each one's source literally contains `asyncio.to_thread` as a defense-in-depth lock-in.
+
 ## [2.3.0] - 2026-04-11
 
 Additive feature release — new language parsers, new platform install target, MCP tool UX improvements, and out-of-tree graph storage. No breaking changes from v2.2.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.3.0"
+version = "2.3.1"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Patch-level release for the Windows long-running-MCP-tool hang. v2.2.4 shipped the event-loop policy fix but [Limucc's test on #136](https://github.com/tirth8205/code-review-graph/issues/136#issuecomment-4230128602) showed that was necessary but not sufficient — read-only tools worked, but `build_or_update_graph_tool` and `embed_graph_tool` still hung indefinitely. #231 fixed the remaining problem by converting 5 heavy tools to `async def` + `asyncio.to_thread`.

## What's in this release

- **#231** — five heavy MCP tools now async (`build_or_update_graph_tool`, `run_postprocess_tool`, `embed_graph_tool`, `detect_changes_tool`, `generate_wiki_tool`). The other 19 fast-path tools stay sync.

That's it. No other changes from v2.3.0.

## Test plan

- [x] `uv run pytest --cov-fail-under=65` → **737 passed, 1 skipped, 2 xpassed, 74.63% coverage**
- [x] 2 new lock-in tests verify the 5 tools register as coroutines + literally call `asyncio.to_thread`
- [ ] CI matrix
- [ ] Windows verification — post-release, will ping @dev-limucc on #136

## After merge

Tag, publish to PyPI, comment on #46 and #136 asking Limucc to re-test with `uvx code-review-graph@2.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)