### PR TITLE
feat: add Elixir (.ex/.exs) parsing support (#112)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -104,6 +104,8 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".xs": "c",  # Perl XS: parsed as C to capture functions/structs/includes
     ".lua": "lua",
     ".luau": "luau",
+    ".ex": "elixir",
+    ".exs": "elixir",
     ".ipynb": "notebook",
 }
 
@@ -140,6 +142,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "dart": ["class_definition", "mixin_declaration", "enum_declaration"],
     "lua": [],  # Lua has no class keyword; table-based OOP handled via constructs handler
     "luau": ["type_definition"],  # Luau type aliases; table-based OOP via constructs handler
+    "elixir": [],  # Elixir modules are `call` nodes, handled via constructs handler
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -175,6 +178,8 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "dart": ["function_signature"],
     "lua": ["function_declaration"],
     "luau": ["function_declaration"],
+    # Elixir: def/defp are `call` nodes, handled via constructs handler
+    "elixir": [],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -201,6 +206,8 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     # Lua/Luau: require() is a function_call, handled via _extract_lua_constructs
     "lua": [],
     "luau": [],
+    # Elixir: alias/import/require/use are `call` nodes, handled via constructs handler
+    "elixir": [],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -227,6 +234,7 @@ _CALL_TYPES: dict[str, list[str]] = {
     "solidity": ["call_expression"],
     "lua": ["function_call"],
     "luau": ["function_call"],
+    "elixir": ["call"],
 }
 
 # Patterns that indicate a test function
@@ -928,6 +936,14 @@ class CodeParser:
             ):
                 continue
 
+            # --- Elixir-specific constructs (defmodule/def/alias/etc.) ---
+            if language == "elixir" and self._extract_elixir_constructs(
+                child, node_type, source, language, file_path,
+                nodes, edges, enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            ):
+                continue
+
             # --- Dart call detection (see #87) ---
             # tree-sitter-dart does not wrap calls in a single
             # ``call_expression`` node; instead the pattern is
@@ -1426,6 +1442,347 @@ class CodeParser:
                         # Fallback: strip quotes from full text
                         raw = arg.text.decode("utf-8", errors="replace")
                         return raw.strip("'\"")
+        return None
+
+    # ------------------------------------------------------------------
+    # Elixir-specific helpers
+    # ------------------------------------------------------------------
+
+    # Keywords that form structural constructs; all are represented as
+    # `call` nodes whose first child is an `identifier` with one of these
+    # texts.  Regular function calls fall through to generic handling.
+    _ELIXIR_DEF_KEYWORDS = frozenset({"def", "defp", "defmacro", "defmacrop"})
+    _ELIXIR_IMPORT_KEYWORDS = frozenset({"alias", "import", "require", "use"})
+
+    def _extract_elixir_constructs(
+        self,
+        child,
+        node_type: str,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle Elixir-specific AST constructs.
+
+        Every Elixir statement is represented as a ``call`` node whose
+        first child is an ``identifier`` naming the macro/keyword
+        (``defmodule``, ``def``, ``alias``, ``import``, ``require``,
+        ``use``, ``test``).  This handler intercepts those and emits
+        graph nodes/edges.  Regular function calls fall through and are
+        handled by the generic CALLS machinery.
+
+        Returns True if the child was fully handled and should be skipped
+        by the main loop.
+        """
+        if node_type != "call" or not child.children:
+            return False
+
+        first = child.children[0]
+        if first.type != "identifier":
+            # e.g. `dot` for Module.func(...) — let generic CALLS handle it.
+            return False
+
+        kw = first.text.decode("utf-8", errors="replace")
+
+        if kw == "defmodule":
+            return self._handle_elixir_defmodule(
+                child, source, language, file_path, nodes, edges,
+                enclosing_class, import_map, defined_names, _depth,
+            )
+        if kw in self._ELIXIR_DEF_KEYWORDS:
+            return self._handle_elixir_def(
+                child, source, language, file_path, nodes, edges,
+                enclosing_class, import_map, defined_names, _depth,
+                visibility="private" if kw in ("defp", "defmacrop") else "public",
+            )
+        if kw in self._ELIXIR_IMPORT_KEYWORDS:
+            return self._handle_elixir_import(
+                child, language, file_path, edges, kw,
+            )
+        if kw == "test" and enclosing_class is not None:
+            return self._handle_elixir_test(
+                child, source, language, file_path, nodes, edges,
+                enclosing_class, import_map, defined_names, _depth,
+            )
+        return False
+
+    def _handle_elixir_defmodule(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle ``defmodule Name do ... end``.
+
+        Emits a Class node and recurses into the ``do_block`` with
+        ``enclosing_class=<full qualified module name>``.  Nested
+        ``defmodule`` calls produce dot-joined names (``Outer.Inner``).
+        """
+        module_name = self._elixir_first_alias_arg(child)
+        if not module_name:
+            return False
+
+        # Support nested defmodule: qualify with the enclosing class.
+        full_name = (
+            f"{enclosing_class}.{module_name}" if enclosing_class else module_name
+        )
+        qualified = self._qualify(full_name, file_path, None)
+
+        nodes.append(NodeInfo(
+            kind="Class",
+            name=full_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=None,
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=file_path,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into the do_block with the new enclosing class.
+        for sub in child.children:
+            if sub.type == "do_block":
+                self._extract_from_tree(
+                    sub, source, language, file_path, nodes, edges,
+                    enclosing_class=full_name,
+                    enclosing_func=None,
+                    import_map=import_map,
+                    defined_names=defined_names,
+                    _depth=_depth + 1,
+                )
+        return True
+
+    def _handle_elixir_def(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+        visibility: str,
+    ) -> bool:
+        """Handle ``def foo(args) do ... end`` and ``defp foo(args) ...``.
+
+        The function name lives inside ``arguments > call > identifier``
+        (the function signature is itself a nested call node).  Short form
+        ``def foo, do: body`` is also supported.
+        """
+        func_name: Optional[str] = None
+        signature_call = None
+
+        for sub in child.children:
+            if sub.type != "arguments":
+                continue
+            for arg in sub.children:
+                if arg.type == "call" and arg.children:
+                    # Standard form: def name(params) ...
+                    for sub2 in arg.children:
+                        if sub2.type == "identifier":
+                            func_name = sub2.text.decode("utf-8", errors="replace")
+                            signature_call = arg
+                            break
+                    if func_name:
+                        break
+                if arg.type == "identifier":
+                    # Zero-arg shortcut: def foo, do: body
+                    func_name = arg.text.decode("utf-8", errors="replace")
+                    break
+            break
+
+        if not func_name:
+            return False
+
+        is_test = _is_test_function(func_name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(func_name, file_path, enclosing_class)
+        params = (
+            self._get_params(signature_call, language, source)
+            if signature_call is not None else None
+        )
+
+        nodes.append(NodeInfo(
+            kind=kind,
+            name=func_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            params=params,
+            modifiers=visibility,
+            is_test=is_test,
+        ))
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class else file_path
+        )
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into the do_block with enclosing_func set.  Short-form
+        # bodies live inside arguments > keywords > pair.
+        for sub in child.children:
+            if sub.type == "do_block":
+                self._extract_from_tree(
+                    sub, source, language, file_path, nodes, edges,
+                    enclosing_class=enclosing_class,
+                    enclosing_func=func_name,
+                    import_map=import_map,
+                    defined_names=defined_names,
+                    _depth=_depth + 1,
+                )
+            elif sub.type == "arguments":
+                for arg in sub.children:
+                    if arg.type == "keywords":
+                        self._extract_from_tree(
+                            arg, source, language, file_path, nodes, edges,
+                            enclosing_class=enclosing_class,
+                            enclosing_func=func_name,
+                            import_map=import_map,
+                            defined_names=defined_names,
+                            _depth=_depth + 1,
+                        )
+        return True
+
+    def _handle_elixir_import(
+        self,
+        child,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        keyword: str,
+    ) -> bool:
+        """Handle ``alias``/``import``/``require``/``use`` top-level calls.
+
+        Emits an IMPORTS_FROM edge targeting the aliased module name.
+        """
+        target = self._elixir_first_alias_arg(child)
+        if not target:
+            return False
+        resolved = self._resolve_module_to_file(target, file_path, language)
+        edges.append(EdgeInfo(
+            kind="IMPORTS_FROM",
+            source=file_path,
+            target=resolved if resolved else target,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+            extra={"elixir_keyword": keyword},
+        ))
+        return True
+
+    def _handle_elixir_test(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: str,
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle the ExUnit ``test "name" do ... end`` macro.
+
+        Emits a Test node named by the string literal, attached to the
+        enclosing module.  Only fires when inside a module (otherwise
+        a top-level ``test`` call is treated as a regular CALLS edge).
+        """
+        test_name: Optional[str] = None
+        for sub in child.children:
+            if sub.type != "arguments":
+                continue
+            for arg in sub.children:
+                if arg.type == "string":
+                    for sub2 in arg.children:
+                        if sub2.type == "quoted_content":
+                            test_name = sub2.text.decode("utf-8", errors="replace")
+                            break
+                    if not test_name:
+                        raw = arg.text.decode("utf-8", errors="replace")
+                        test_name = raw.strip("'\"")
+                    break
+            break
+        if not test_name:
+            return False
+
+        qualified = self._qualify(test_name, file_path, enclosing_class)
+        nodes.append(NodeInfo(
+            kind="Test",
+            name=test_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            is_test=True,
+        ))
+        container = self._qualify(enclosing_class, file_path, None)
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into do_block with enclosing_func = test name.
+        for sub in child.children:
+            if sub.type == "do_block":
+                self._extract_from_tree(
+                    sub, source, language, file_path, nodes, edges,
+                    enclosing_class=enclosing_class,
+                    enclosing_func=test_name,
+                    import_map=import_map,
+                    defined_names=defined_names,
+                    _depth=_depth + 1,
+                )
+        return True
+
+    @staticmethod
+    def _elixir_first_alias_arg(call_node) -> Optional[str]:
+        """Return the text of the first ``alias`` argument of a call.
+
+        Used to extract module names from ``defmodule Name``, ``alias X``,
+        ``import X``, ``require X``, and ``use X``.
+        """
+        for sub in call_node.children:
+            if sub.type != "arguments":
+                continue
+            for arg in sub.children:
+                if arg.type == "alias":
+                    return arg.text.decode("utf-8", errors="replace")
         return None
 
     # ------------------------------------------------------------------
@@ -3140,6 +3497,15 @@ class CodeParser:
         if language in ("lua", "luau") and first.type in (
             "dot_index_expression", "method_index_expression",
         ):
+            for child in reversed(first.children):
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
+            return None
+
+        # Elixir: Module.func(args) is a `call` whose first child is `dot`
+        # with shape  alias + . + identifier.  Return only the method name;
+        # the module alias is captured as IMPORTS_FROM elsewhere.
+        if language == "elixir" and first.type == "dot":
             for child in reversed(first.children):
                 if child.type == "identifier":
                     return child.text.decode("utf-8", errors="replace")

--- a/tests/fixtures/sample.ex
+++ b/tests/fixtures/sample.ex
@@ -1,0 +1,63 @@
+# sample.ex - Elixir test fixture for tree-sitter parsing
+# Exercises modules (including nested), def/defp, imports, ExUnit tests,
+# pipe operator, and Module.function calls.
+
+defmodule Calculator do
+  @moduledoc "A simple calculator module for fixture testing."
+
+  alias Calculator.Helpers
+  import Enum, only: [sum: 1]
+  require Logger
+  use GenServer
+
+  @doc "Adds two integers."
+  def add(a, b) do
+    Logger.info("adding")
+    Helpers.log("add called")
+    a + b
+  end
+
+  # Short-form function definition
+  def multiply(a, b), do: a * b
+
+  # Public function using the pipe operator
+  def sum_list(list) do
+    list
+    |> Enum.filter(fn x -> x > 0 end)
+    |> Enum.sum()
+  end
+
+  # Private function
+  defp private_helper(x) do
+    x * 2
+  end
+
+  # Nested module
+  defmodule Helpers do
+    def log(msg) do
+      IO.puts(msg)
+    end
+
+    def format_number(n), do: Integer.to_string(n)
+  end
+end
+
+defmodule CalculatorTest do
+  use ExUnit.Case
+
+  alias Calculator
+
+  test "adds two numbers" do
+    assert Calculator.add(1, 2) == 3
+  end
+
+  test "multiplies numbers" do
+    result = Calculator.multiply(2, 3)
+    assert result == 6
+  end
+
+  test "sums positive numbers" do
+    result = Calculator.sum_list([-1, 2, 3, -4, 5])
+    assert result == 10
+  end
+end

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -966,3 +966,125 @@ class TestLuauParsing:
         sources = {e.source.split("::")[-1] for e in calls}
         assert "Dog.fetch" in sources
         assert "Animal.speak" in sources
+
+
+class TestElixirParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.ex")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("lib/foo.ex")) == "elixir"
+        assert self.parser.detect_language(Path("test/foo_test.exs")) == "elixir"
+
+    def test_finds_top_level_modules(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "Calculator" in names
+        assert "CalculatorTest" in names
+
+    def test_finds_nested_module_with_qualified_name(self):
+        """Nested defmodule produces a dot-joined class name."""
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "Calculator.Helpers" in names
+
+    def test_finds_public_functions(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Calculator"
+        ]
+        names = {f.name for f in funcs}
+        assert "add" in names
+        assert "multiply" in names  # short-form def foo, do: ...
+        assert "sum_list" in names  # uses pipe operator
+
+    def test_finds_private_function_with_visibility_modifier(self):
+        privates = [
+            n for n in self.nodes
+            if n.kind == "Function"
+            and n.parent_name == "Calculator"
+            and n.modifiers == "private"
+        ]
+        names = {f.name for f in privates}
+        assert "private_helper" in names
+
+    def test_public_functions_marked_public(self):
+        adds = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.name == "add"
+        ]
+        assert len(adds) == 1
+        assert adds[0].modifiers == "public"
+
+    def test_finds_nested_module_functions(self):
+        """Functions inside nested Helpers module have the dot-qualified parent."""
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Calculator.Helpers"
+        ]
+        names = {f.name for f in funcs}
+        assert "log" in names
+        assert "format_number" in names
+
+    def test_finds_aliases_and_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "Calculator.Helpers" in targets  # alias
+        assert "Enum" in targets                # import
+        assert "Logger" in targets              # require
+        assert "GenServer" in targets           # use
+        assert "ExUnit.Case" in targets         # use inside test module
+
+    def test_finds_module_dot_function_calls(self):
+        """Module.function(args) produces a CALLS edge with the method name.
+
+        External modules (Logger, IO) resolve to the bare method name.
+        Locally-aliased modules (Helpers -> Calculator.Helpers) resolve to
+        the fully-qualified node name via the parser's alias resolution.
+        """
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        # From `Logger.info("adding")` inside add/2 — external, bare name
+        assert "info" in targets
+        # From `IO.puts(msg)` inside Helpers.log — external, bare name
+        assert "puts" in targets
+        # From `Helpers.log("add called")` — local alias, resolved to qualified
+        assert any(t.endswith("::Calculator.Helpers.log") for t in targets)
+
+    def test_finds_local_qualified_calls_in_tests(self):
+        """Calls to the local Calculator module resolve via CALLS edges."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("add" in t for t in targets)
+        assert any("multiply" in t for t in targets)
+
+    def test_detects_exunit_test_blocks(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        names = {t.name for t in tests}
+        assert "adds two numbers" in names
+        assert "multiplies numbers" in names
+        assert "sums positive numbers" in names
+        assert len(tests) == 3
+
+    def test_tests_belong_to_calculator_test_module(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        for t in tests:
+            assert t.parent_name == "CalculatorTest"
+            assert t.is_test is True
+
+    def test_nodes_have_elixir_language(self):
+        for node in self.nodes:
+            assert node.language == "elixir"
+
+    def test_finds_contains_edges(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target.split("::")[-1] for e in contains}
+        # File contains top-level modules
+        assert "Calculator" in targets
+        assert "CalculatorTest" in targets
+        assert "Calculator.Helpers" in targets
+        # Modules contain their functions (qualified form)
+        assert "Calculator.add" in targets
+        assert "Calculator.multiply" in targets
+        assert "Calculator.Helpers.log" in targets


### PR DESCRIPTION
## Summary
Register `.ex` and `.exs` with tree-sitter-elixir. Extract modules as `Class` nodes (with dot-qualified names for nested modules), `def`/`defp`/`defmacro`/`defmacrop` as `Function` nodes with a visibility modifier, `alias`/`import`/`require`/`use` as `IMPORTS_FROM` edges, and ExUnit `test "name" do ... end` blocks as `Test` nodes attached to their enclosing module.

Closes #112.

## Root cause
Elixir was not listed in `EXTENSION_TO_LANGUAGE` and had no entries in any of the type mapping dicts, so `.ex` / `.exs` files were completely skipped by `build_or_update_graph`. Elixir's AST is unusual — **every structural construct is a `call` node** (`defmodule`, `def`, `alias`, `test`), so it cannot be handled by the normal `_FUNCTION_TYPES` / `_CLASS_TYPES` / `_IMPORT_TYPES` dict-mapping pattern and needs a dedicated constructs handler.

## Implementation approach
1. `EXTENSION_TO_LANGUAGE`: `.ex` and `.exs` → `"elixir"`
2. `_CLASS_TYPES["elixir"] = []`, `_FUNCTION_TYPES["elixir"] = []`, `_IMPORT_TYPES["elixir"] = []` — handled via constructs handler
3. `_CALL_TYPES["elixir"] = ["call"]` — regular calls still flow through the generic path
4. New `_extract_elixir_constructs()` dispatched next to `_extract_lua_constructs`. It intercepts `call` nodes whose first child is an `identifier` with text matching one of the Elixir structural keywords:
   - `defmodule` → `_handle_elixir_defmodule` (Class node + recurse into `do_block`)
   - `def` / `defp` / `defmacro` / `defmacrop` → `_handle_elixir_def` (Function node with visibility stored in `.modifiers`; recurses into `do_block` or short-form `keywords > pair`; handles `def foo, do: body` shortcut)
   - `alias` / `import` / `require` / `use` → `_handle_elixir_import` (IMPORTS_FROM edge with the original keyword recorded in `extra`)
   - `test` (only inside an enclosing module) → `_handle_elixir_test` (Test node named by the string literal)
5. For any other `call` node, the handler returns `False` and the generic CALLS machinery fires — so `Logger.info(x)`, `Helpers.log(y)`, and `assert x == y` all produce regular CALLS edges.
6. `_get_call_name` — new elixir branch for `first.type == "dot"` which returns the rightmost identifier (the method name in `Module.func()`).
7. **Nested defmodule**: qualified name is built by joining `enclosing_class` with the inner module name, so `defmodule Helpers` inside `Calculator` produces the class name `"Calculator.Helpers"`.

## What's captured
- Top-level and nested modules (`defmodule Calculator do ... defmodule Helpers do ... end end`)
- Public and private functions with `.modifiers` = `"public"` / `"private"`
- Short-form `def foo, do: body`
- Pipe-operator chains (`list |> Enum.filter(...) |> Enum.sum()`)
- All 4 import keywords: `alias` / `import` / `require` / `use`
- ExUnit `test "name" do ... end` → Test node; calls inside resolve correctly
- Local alias resolution: `Helpers.log(x)` inside a module that does `alias Calculator.Helpers` resolves to the qualified local `Calculator.Helpers.log` node
- External `Module.function(x)` calls → CALLS edge with the method name

## Tests added (`tests/test_multilang.py::TestElixirParsing` — 14 tests)
- `test_detects_language` (.ex and .exs)
- `test_finds_top_level_modules`
- `test_finds_nested_module_with_qualified_name`
- `test_finds_public_functions` (including pipe-operator and short-form def)
- `test_finds_private_function_with_visibility_modifier`
- `test_public_functions_marked_public`
- `test_finds_nested_module_functions` (parent = `"Calculator.Helpers"`)
- `test_finds_aliases_and_imports` (all 4 import keywords)
- `test_finds_module_dot_function_calls` (external bare name + local alias resolution)
- `test_finds_local_qualified_calls_in_tests`
- `test_detects_exunit_test_blocks`
- `test_tests_belong_to_calculator_test_module`
- `test_nodes_have_elixir_language`
- `test_finds_contains_edges` (file → module → function hierarchy)

**New fixture:** `tests/fixtures/sample.ex` exercises `@moduledoc`, all 4 import keywords (with options), `def`, short-form `def`, `defp`, pipe operator, nested `defmodule`, and a full ExUnit test module with three `test` blocks.

## Test results

| Stage | Result |
|---|---|
| Stage 1 — new targeted tests | **14/14 passed** |
| Stage 2 — `tests/test_multilang.py` full | **144/144 passed** — zero regressions across any language |
| Stage 3 — adjacent `tests/test_parser.py` | **67/67 passed** |
| Stage 4 — full suite | **709 passed**, 6 pre-existing Windows failures in `test_incremental`/`test_notebook` (verified identical on unchanged `main`) |
| Stage 5 — `ruff check` on changed files | **clean** |
| Stage 6 — fixture smoke parse | 13 nodes, 30 edges — all modules, nested module, public/private functions, and all 3 ExUnit tests detected |

**Zero regressions.** All new code is gated on the `elixir` language check so existing languages are untouched.