### PR TITLE
feat(bash): add .ksh extension to bash parser (#235)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -108,6 +108,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".sh": "bash",
     ".bash": "bash",
     ".zsh": "bash",
+    ".ksh": "bash",  # Korn shell — close enough to bash for tree-sitter-bash (#235)
     ".ex": "elixir",
     ".exs": "elixir",
     ".ipynb": "notebook",

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1087,6 +1087,39 @@ class TestBashParsing:
         assert self.parser.detect_language(Path("build.sh")) == "bash"
         assert self.parser.detect_language(Path("build.bash")) == "bash"
         assert self.parser.detect_language(Path("run.zsh")) == "bash"
+        # Regression for #235 — Korn shell (.ksh) should parse as bash.
+        assert self.parser.detect_language(Path("legacy.ksh")) == "bash"
+
+    def test_ksh_extension_parses_as_bash(self, tmp_path):
+        """Regression for #235: a real .ksh file is parsed through the bash
+        grammar end-to-end and produces the same structural nodes/edges
+        as an equivalent .sh file."""
+        fixture_source = (FIXTURES / "sample.sh").read_text(encoding="utf-8")
+        ksh_copy = tmp_path / "legacy.ksh"
+        ksh_copy.write_text(fixture_source, encoding="utf-8")
+
+        ksh_nodes, ksh_edges = self.parser.parse_file(ksh_copy)
+
+        # Language tagging: every node must be "bash".
+        assert ksh_nodes, "parser produced zero nodes for .ksh file"
+        for n in ksh_nodes:
+            assert n.language == "bash"
+
+        # Same function set as the .sh fixture.
+        ksh_funcs = {n.name for n in ksh_nodes if n.kind == "Function"}
+        sh_funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert ksh_funcs == sh_funcs, (
+            f".ksh and .sh produced different function sets: "
+            f"sh-only={sh_funcs - ksh_funcs}, ksh-only={ksh_funcs - sh_funcs}"
+        )
+
+        # Same structural-edge totals by kind.
+        def by_kind(edges):
+            counts: dict[str, int] = {}
+            for e in edges:
+                counts[e.kind] = counts.get(e.kind, 0) + 1
+            return counts
+        assert by_kind(ksh_edges) == by_kind(self.edges)
 
     def test_nodes_have_bash_language(self):
         for n in self.nodes:


### PR DESCRIPTION
## Summary
Register `.ksh` (Korn shell) with `tree-sitter-bash` alongside the existing `.sh` / `.bash` / `.zsh` entries shipped in #227. Korn shell is close enough to Bash syntactically that `tree-sitter-bash` handles the structural features the graph captures (function definitions, commands, `source`/`.` includes) correctly.

Closes #235.

## Why this PR
In the close comment on #230 you explicitly flagged this as worth a follow-up:

> If there's anything your implementation does that mine doesn't (e.g. .ksh extension, additional test coverage), please open a follow-up issue pointing at the specific feature and I'll merge it in. **The .ksh extension in particular looks worth adding — I didn't include it in #227.**

This PR is exactly that: the tracking issue (#235) plus the minimal change to address it.

## Why it matters
Korn shell is still used in legacy AIX/Solaris operations, IBM internal tooling, and enterprise CI scripts. Repositories that ship `.ksh` scripts currently index to `0 nodes` because the extension is unrecognized — the same failure mode that motivated #197.

## Implementation
A single line added to `EXTENSION_TO_LANGUAGE` in `code_review_graph/parser.py`:

```python
".ksh": "bash",  # Korn shell — close enough to bash for tree-sitter-bash (#235)
```

All of the bash parsing machinery shipped in #227 (`_FUNCTION_TYPES`, `_CALL_TYPES`, `_extract_bash_source_command`, name/call resolution) already handles any file routed through the `"bash"` language path — so no further wiring is needed.

## Tests added (`tests/test_multilang.py::TestBashParsing`)
1. **`test_detects_language`** — extended with a `.ksh` assertion to lock the mapping in as a regression guard.
2. **`test_ksh_extension_parses_as_bash`** — end-to-end regression test that copies `tests/fixtures/sample.sh` to a temp `legacy.ksh`, parses it through `CodeParser.parse_file()`, and asserts:
   - Every node's `language` field is `"bash"`
   - The set of extracted `Function` names is identical to the `.sh` run
   - The `CONTAINS` / `CALLS` / `IMPORTS_FROM` edge counts per kind match

The second assertion specifically proves `.ksh` is fully wired through the same structural extraction path as `.sh`, not a degenerate zero-result read.

## Test results

| Stage | Result |
|---|---|
| Stage 1 — new targeted tests | **2/2 passed** |
| Stage 2 — `tests/test_multilang.py` full | **152/152 passed** — zero regressions |
| Stage 3 — adjacent `tests/test_parser.py` | **67/67 passed** |
| Stage 4 — full suite | **733 passed**, 8 pre-existing Windows failures (`test_incremental` x3 + `test_main` async detection x1 + `test_notebook` Databricks x4) — verified identical on unchanged `main` |
| Stage 5 — `ruff check` | **clean** on `parser.py` and `test_multilang.py` |
| Stage 6 — end-to-end smoke | `detect_language("legacy.ksh")` → `"bash"`; parsing a real `.ksh` file produces 6 `Function` nodes, 18 edges, all tagged `language=bash` |

**Zero regressions.** Single-line extension mapping change plus a targeted regression guard.