### PR TITLE
fix(incremental): add stop_at to find_repo_root / find_project_root (#241)

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -71,19 +71,44 @@ DEFAULT_IGNORE_PATTERNS = [
 ]
 
 
-def find_repo_root(start: Path | None = None) -> Optional[Path]:
-    """Walk up from start to find the nearest .git directory."""
+def find_repo_root(
+    start: Path | None = None,
+    stop_at: Path | None = None,
+) -> Optional[Path]:
+    """Walk up from ``start`` to find the nearest ``.git`` directory.
+
+    Args:
+        start: Starting directory.  Defaults to ``Path.cwd()``.
+        stop_at: Optional boundary — if provided, the walk examines
+            ``stop_at`` for a ``.git`` directory and then stops without
+            crossing above it.  Useful for tests that create a synthetic
+            repo under ``tmp_path`` (so the walk does not accidentally
+            climb into a developer's home-directory dotfiles repo) and
+            for any production caller that wants to bound the ancestor
+            walk — e.g. multi-repo orchestrators, CI containers with
+            bind-mounted volumes, embedded sandboxes.  See #241.
+
+    Returns:
+        The first ancestor containing ``.git``, or ``None`` if no
+        ancestor up to and including ``stop_at`` (when set) or the
+        filesystem root (when ``stop_at is None``) contains one.
+    """
     current = start or Path.cwd()
     while current != current.parent:
         if (current / ".git").exists():
             return current
+        if stop_at is not None and current == stop_at:
+            return None
         current = current.parent
     if (current / ".git").exists():
         return current
     return None
 
 
-def find_project_root(start: Path | None = None) -> Path:
+def find_project_root(
+    start: Path | None = None,
+    stop_at: Path | None = None,
+) -> Path:
     """Find the project root.
 
     Resolution order (highest precedence first):
@@ -91,15 +116,20 @@ def find_project_root(start: Path | None = None) -> Path:
     1. ``CRG_REPO_ROOT`` environment variable — explicit override for
        anyone scripting the CLI from outside the repo (CI jobs, daemons,
        multi-repo orchestrators). See: #155
-    2. Git repository root via :func:`find_repo_root` from ``start``.
+    2. Git repository root via :func:`find_repo_root` from ``start``,
+       honoring ``stop_at`` if provided.
     3. ``start`` itself (or cwd if no start given).
+
+    ``stop_at`` is forwarded to :func:`find_repo_root` so callers that
+    want to bound the ancestor walk (typically tests; see #241) can do so
+    without having to call ``find_repo_root`` directly.
     """
     env_override = os.environ.get("CRG_REPO_ROOT", "").strip()
     if env_override:
         p = Path(env_override).expanduser().resolve()
         if p.exists():
             return p
-    root = find_repo_root(start)
+    root = find_repo_root(start, stop_at=stop_at)
     if root:
         return root
     return start or Path.cwd()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -35,9 +35,48 @@ class TestFindRepoRoot:
         assert find_repo_root(sub) == tmp_path
 
     def test_returns_none_without_git(self, tmp_path):
+        """No .git between ``sub`` and ``tmp_path`` -> None.
+
+        Bounded with ``stop_at=tmp_path`` so the walk does not climb into
+        ancestors outside the test sandbox.  On Windows in particular,
+        ``tmp_path`` lives under ``C:/Users/<user>/AppData/Local/Temp/...``
+        and if the user has ``git init`` anywhere under their home (dotfiles,
+        chezmoi, etc.) the unbounded walk would find that ancestor .git and
+        the test would fail for reasons unrelated to the product.  See #241.
+        """
         sub = tmp_path / "no_git"
         sub.mkdir()
-        assert find_repo_root(sub) is None
+        assert find_repo_root(sub, stop_at=tmp_path) is None
+
+    def test_stop_at_prevents_escape_to_outer_git(self, tmp_path):
+        """Positive regression test for #241: ``stop_at`` must halt the
+        walk even when an ancestor *does* contain ``.git``.
+
+        Without ``stop_at`` the walk correctly finds the outer .git; with
+        ``stop_at=inner`` the walk is bounded and returns None.
+        """
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        (outer / ".git").mkdir()
+        inner = outer / "inner"
+        inner.mkdir()
+
+        # Unbounded walk finds the ancestor .git (existing behavior).
+        assert find_repo_root(inner) == outer
+
+        # Bounded walk stops at ``inner`` and never climbs to ``outer``.
+        assert find_repo_root(inner, stop_at=inner) is None
+
+    def test_stop_at_finds_git_at_boundary(self, tmp_path):
+        """stop_at does not suppress a .git that lives *at* the boundary."""
+        boundary = tmp_path / "boundary"
+        boundary.mkdir()
+        (boundary / ".git").mkdir()
+        inner = boundary / "inner"
+        inner.mkdir()
+
+        # The walk examines ``boundary`` and finds the .git before stopping.
+        assert find_repo_root(inner, stop_at=boundary) == boundary
 
 
 class TestFindProjectRoot:
@@ -45,10 +84,34 @@ class TestFindProjectRoot:
         (tmp_path / ".git").mkdir()
         assert find_project_root(tmp_path) == tmp_path
 
-    def test_falls_back_to_start(self, tmp_path):
+    def test_falls_back_to_start(self, tmp_path, monkeypatch):
+        """With no .git and no env override, find_project_root returns ``sub``.
+
+        Bounded with ``stop_at=tmp_path`` to prevent the ancestor walk from
+        escaping the test sandbox (see #241), and ``CRG_REPO_ROOT`` is
+        cleared so a developer env var cannot shadow the test expectation.
+        """
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
         sub = tmp_path / "no_git"
         sub.mkdir()
-        assert find_project_root(sub) == sub
+        assert find_project_root(sub, stop_at=tmp_path) == sub
+
+    def test_stop_at_forwarded_to_find_repo_root(self, tmp_path, monkeypatch):
+        """Positive regression test for #241: find_project_root must forward
+        stop_at to find_repo_root, not silently drop it."""
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        (outer / ".git").mkdir()
+        inner = outer / "inner"
+        inner.mkdir()
+
+        # Without stop_at, find_project_root climbs to outer (existing behavior).
+        assert find_project_root(inner) == outer
+
+        # With stop_at=inner, the walk is bounded and find_project_root falls
+        # back to its third resolution rule (the start path itself).
+        assert find_project_root(inner, stop_at=inner) == inner
 
 
 class TestGetDbPath:


### PR DESCRIPTION
## Summary
Two tests in `tests/test_incremental.py` have been failing on any developer machine whose `tmp_path` has a git-initialized ancestor:

- `TestFindRepoRoot::test_returns_none_without_git`
- `TestFindProjectRoot::test_falls_back_to_start`

This PR adds an optional `stop_at: Path | None = None` parameter to both `find_repo_root()` and `find_project_root()`, uses it in the two flaky tests to bound the walk to `tmp_path`, and adds 3 new positive regression tests to lock in the new parameter's semantics.

Closes #241.

## Root cause
pytest's `tmp_path` lives under `$TMPDIR`, which on Windows 11 resolves to `C:/Users/<user>/AppData/Local/Temp/pytest-of-<user>/...`. If the user has ever run `git init` anywhere under their home directory (dotfiles repo, chezmoi, yadm, a bare `git init ~` — all very common on developer machines), then `find_repo_root()` walking up from `tmp_path/no_git` finds the ancestor `.git` and returns `C:/Users/<user>` instead of `None`. The same failure mode affects Linux and macOS users with a git-initialized home directory.

`find_repo_root` previously had no way to bound its ancestor walk — it always climbed to the filesystem root. This is correct production behavior (a nested script inside a git repo *should* find its repo) but makes the function un-testable in environments where the tmp path sits inside a git-initialized ancestor.

## Fix
Add an optional `stop_at: Path | None = None` parameter to both `find_repo_root()` and `find_project_root()`:

```python
def find_repo_root(
    start: Path | None = None,
    stop_at: Path | None = None,
) -> Optional[Path]:
    current = start or Path.cwd()
    while current != current.parent:
        if (current / ".git").exists():
            return current
        if stop_at is not None and current == stop_at:
            return None
        current = current.parent
    ...
```

**Semantics:**
- `stop_at=None` (default): existing behavior, walk all the way to the filesystem root
- `stop_at=<path>`: the walk examines `stop_at` for `.git` **and then stops** — it never crosses above the boundary
- A `.git` at exactly the boundary is still found (it's examined before the stop check)

`find_project_root` forwards `stop_at` to `find_repo_root`, so both public APIs gain the same testability handle.

**Fully backward-compatible.** All 7 production callers pass no argument:
- `cli.py` (4 call sites)
- `tools/refactor_tools.py` (1 call site)
- `tools/_common.py` (1 call site)
- internal call in `find_project_root` itself

`stop_at` is also a **legitimate production API** — callers that want to bound the ancestor walk (multi-repo orchestrators, CI containers with bind-mounted volumes, embedded sandboxes, Docker build contexts) can now do so without resorting to monkeypatching.

## Tests updated / added
1. **`TestFindRepoRoot::test_returns_none_without_git`** — now passes `stop_at=tmp_path` (the actual fix for the flakiness). Docstring explains *why* the bound is needed.
2. **`TestFindRepoRoot::test_stop_at_prevents_escape_to_outer_git`** [NEW] — positive regression test: when an outer directory has `.git`, an unbounded walk finds it but a bounded walk with `stop_at=inner` returns `None`. Locks in the new parameter's semantics.
3. **`TestFindRepoRoot::test_stop_at_finds_git_at_boundary`** [NEW] — regression test: `stop_at` must **not** suppress a `.git` that lives at the boundary itself. The walk examines `stop_at` for `.git` before stopping, so a repo rooted exactly at the boundary is still found.
4. **`TestFindProjectRoot::test_falls_back_to_start`** — now passes `stop_at=tmp_path` **and** monkeypatches `CRG_REPO_ROOT` via `monkeypatch.delenv(...)` so a developer env var can no longer shadow the test expectation.
5. **`TestFindProjectRoot::test_stop_at_forwarded_to_find_repo_root`** [NEW] — regression test: `find_project_root` must forward `stop_at` to `find_repo_root`, not silently drop it. Also verifies the fall-through path (return `start` when the bounded walk finds nothing) still works.

## Test results

| Stage | Result |
|---|---|
| Stage 1 — `TestFindRepoRoot` + `TestFindProjectRoot` | **8/8 passed** (up from 6/8 on unchanged `main`) |
| Stage 2 — `tests/test_incremental.py` full | 48 passed, 1 pre-existing failure (`test_default_uses_repo_subdir` — UTF-8 gitignore bug, fixed on the parallel branch in PR #240) |
| Stage 3 — adjacent `tests/test_tools.py` (`find_project_root` is used there) | 62 passed, 15 pre-existing Windows teardown errors |
| Stage 4 — full suite | **737 passed**, 6 pre-existing Windows failures — all 6 are covered by the parallel #239/#240 fix PR; **none are regressions from this change**. Once both PRs merge, all 8 pre-existing Windows failures will be resolved. |
| Stage 5 — `ruff check` on `incremental.py` + `test_incremental.py` | **clean** |

**Net baseline effect:** this PR independently removes 2 failures (8 → 6). Combined with PR #240, the full Windows baseline goes from 8 failures to 0.

## Relationship to #240
PR #240 and this PR are **independent** and touch disjoint code paths:
- **#240** fixes product bugs in `get_data_dir()` UTF-8, `parse_bytes` CRLF handling, and the stale FastMCP API in `test_main.py`.
- **This PR** adds a new `stop_at` parameter to `find_repo_root` / `find_project_root` and fixes the 2 test environment flakiness.

They can be merged in either order — no conflicts, no shared files.

## Why this fix is safe
- `stop_at` default is `None`, preserving existing behavior exactly.
- All 7 production callers pass no argument for `stop_at`.
- A new regression test (`test_stop_at_finds_git_at_boundary`) locks in the "inclusive of boundary" semantics so a future refactor can't accidentally change the behavior.
- No product API removed or renamed.