### PR TITLE
feat: automatically build graph for new worktree in Claude Code

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,6 +12,15 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "code-review-graph build >/dev/null 2>&1 &"
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit|Bash",
         "hooks": [
           {


### PR DESCRIPTION
## Problem

When entering a git worktree mid-session via `EnterWorktree`, the knowledge graph was never initialized. The existing `SessionStart` hook only fires when a Claude Code session starts fresh — it does not fire when `EnterWorktree` is called within an already-running session. New worktrees were silently left without a graph, requiring manual intervention.

## Change

**`hooks/hooks.json`** — adds a `PostToolUse[EnterWorktree]` hook:
```json
"command": "code-review-graph build >/dev/null 2>&1 &"
```

## Key decisions

**`PostToolUse[EnterWorktree]` not a top-level event**
`EnterWorktree` is a tool, not a lifecycle event. Claude Code's hook system dispatches it as a `PostToolUse` event with `EnterWorktree` as the matcher — not as a dedicated top-level key like `SessionStart`. Verified that the matcher fires correctly in testing.

**`SessionStart` and `PostToolUse[EnterWorktree]` handle different scenarios**
These two hooks are not redundant — they cover mutually exclusive cases:
- `SessionStart` fires when Claude Code opens fresh in a worktree directory (no `EnterWorktree` tool call involved)
- `PostToolUse[EnterWorktree]` fires when a worktree is entered during an existing session

**Background build (`&`)**
The build is backgrounded to avoid blocking mid-session. Running it synchronously would introduce a noticeable delay mid-conversation on larger repos.

**No existence check**
The hook always runs `code-review-graph build` without checking for an existing `graph.db`. New worktrees are always empty, so the check would be dead code.

**Inlined command, no separate script**
The command is one line, so it's inlined directly in `hooks.json` rather than adding a shell script.

**`>/dev/null 2>&1` not `2>/dev/null`**
All output is suppressed since the build runs in the background — there is no session context to receive stderr anyway.

## Testing

Verified end-to-end: called `EnterWorktree` in a fresh repo with the hooks configured, confirmed `PostToolUse` fired, `code-review-graph build` ran, and `.code-review-graph/graph.db` appeared in the new worktree.
