### PR TITLE
fix: correct hooks schema and prevent clobbering existing hooks on install

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -502,7 +502,7 @@ def install_hooks(repo_root: Path) -> None:
             logger.warning("Could not read existing %s: %s", settings_path, exc)
 
     hooks_config = generate_hooks_config()
-    existing.update(hooks_config)
+    existing.setdefault("hooks", {}).update(hooks_config["hooks"])
 
     settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
     logger.info("Wrote hooks config: %s", settings_path)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -117,7 +117,7 @@ The graph uses SQLite with WAL mode. If you see lock errors:
 ## Graph seems stale
 - Hooks auto-update on edit/commit
 - If stale, run `/code-review-graph:build-graph` manually
-- Check that hooks are configured in `hooks/hooks.json` (see [hooks documentation](../hooks/hooks.json))
+- Check that hooks are configured in `.claude/settings.json` (re-run `code-review-graph install` to regenerate)
 
 ## Embeddings not working
 - Install with: `pip install code-review-graph[embeddings]`

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,10 +2,12 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "code-review-graph status",
+            "timeout": 10
           }
         ]
       }
@@ -16,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "code-review-graph update 2>/dev/null || true"
+            "command": "code-review-graph update --skip-flows",
+            "timeout": 30
           }
         ]
       }

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -176,6 +176,7 @@ class TestInstallHooks:
         assert "PostToolUse" in data["hooks"]
         assert "SessionStart" in data["hooks"]
         assert "PreCommit" not in data["hooks"]
+        assert "OtherHook" in data["hooks"]  # pre-existing hooks must not be clobbered
 
     def test_creates_claude_directory(self, tmp_path):
         install_hooks(tmp_path)


### PR DESCRIPTION
  ## What this fixes

  ### 1. hooks/hooks.json — malformed and stale static template
  - SessionStart entry was missing the required "matcher" field
  - ${CLAUDE_PLUGIN_ROOT} is not a real Claude Code env var — silently expands to empty string at runtime, making the command fail
  - Commands and timeouts were diverged from what generate_hooks_config() actually writes (--skip-flows and timeout values were missing)

  ### 2. skills.py — shallow merge clobbers existing hooks
  existing.update(hooks_config) replaced the entire hooks key on reinstall,
  wiping any hooks from other tools already in .claude/settings.json.
  Fixed with a deep merge: existing.setdefault("hooks", {}).update(hooks_config["hooks"])

  ### 3. tests/test_skills.py — merge test had a gap
  test_merges_with_existing never asserted that OtherHook survived the merge,
  so the clobber went undetected. Assertion added.

  ### 4. docs/TROUBLESHOOTING.md — stale reference
  Pointed users at hooks/hooks.json as authoritative, but the installed config
  comes from generate_hooks_config() in skills.py. Updated to point at
  .claude/settings.json with the correct fix command.