### PR TITLE
fix: index Go method receiver functions in _get_name

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3186,7 +3186,7 @@ class CodeParser:
         for child in node.children:
             if child.type in (
                 "identifier", "name", "type_identifier", "property_identifier",
-                "simple_identifier", "constant",
+                "simple_identifier", "constant", "field_identifier",
             ):
                 return child.text.decode("utf-8", errors="replace")
         # For Go type declarations, look for type_spec


### PR DESCRIPTION
## Problem

Go method receiver functions (`func (r *Receiver) Method(...)`) are silently skipped during parsing, making them invisible in the graph. This affects ~90% of functions in a typical Go codebase.

### Root cause

In tree-sitter-go, `method_declaration` nodes use `field_identifier` for the method name, while `function_declaration` uses `identifier`. The `_get_name` helper only checks for `identifier` (and a few other types), so it returns `None` for all method receivers, and `_extract_functions` silently skips them at line 1551.

```
function_declaration  → name child type: identifier        ✅ matched
method_declaration    → name child type: field_identifier   ❌ not matched (this bug)
```

### Fix

Add `"field_identifier"` to the name-matching tuple in `_get_name`.

## Tested

Production Go codebase (800+ files, Go 1.24):

| Metric | Before | After | Delta |
|---|---|---|---|
| Nodes | 3,675 | 4,473 | **+798** |
| Edges | 80,693 | 93,497 | **+12,804** |

| Query | Before | After |
|---|---|---|
| `children_of MyStruct` (struct with 56 methods) | 0 methods | **56 methods** |
| `callers_of SomeMethod` | 0 results | **17 results** |
| `semantic_search "SomeMethod"` | 0 results | **1 result** |
| `callers_of helperFunc` (standalone) | 0 results | **1 result** |

Qualified names are correctly structured with receiver type as parent:
```
file.go::MyStruct.GetItem
file.go::myHelper.ProcessData
```

### Safety

`field_identifier` is Go-specific — it does not appear as a direct child of function/method nodes in any other supported language. Verified against tree-sitter grammars for Java, TypeScript, C#, PHP, Ruby, Python, Rust, C/C++, Kotlin, and Swift.

Notably, `field_identifier` is already used in the same file at line 2495 (call-site extraction) — it was just missing from name extraction.