### PR TITLE
feat(bash): add .ksh extension to bash parser (closes #235)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -108,6 +108,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".sh": "bash",
     ".bash": "bash",
     ".zsh": "bash",
+    ".ksh": "bash",
     ".ex": "elixir",
     ".exs": "elixir",
     ".ipynb": "notebook",

--- a/tests/fixtures/sample.ksh
+++ b/tests/fixtures/sample.ksh
@@ -1,0 +1,16 @@
+#!/bin/ksh
+# Sample Korn shell script exercising the bash parser via the .ksh extension.
+
+source ./sample_lib.sh
+
+backup_logs() {
+    echo "archiving"
+    tar czf backup.tgz /var/log
+}
+
+rotate() {
+    backup_logs
+    echo "done"
+}
+
+rotate

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1038,6 +1038,7 @@ class TestBashParsing:
         assert self.parser.detect_language(Path("build.sh")) == "bash"
         assert self.parser.detect_language(Path("build.bash")) == "bash"
         assert self.parser.detect_language(Path("run.zsh")) == "bash"
+        assert self.parser.detect_language(Path("deploy.ksh")) == "bash"
 
     def test_nodes_have_bash_language(self):
         for n in self.nodes:
@@ -1091,6 +1092,20 @@ class TestBashParsing:
         assert any(t.endswith("::log_info") for t in call_targets)
         assert any(t.endswith("::ensure_dir") for t in call_targets)
         assert any(t.endswith("::cleanup") for t in call_targets)
+
+    def test_ksh_extension_parses_as_bash(self):
+        """.ksh files should parse through the bash grammar and produce the
+        same node/edge shapes as .sh (follow-up to #197)."""
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(FIXTURES / "sample.ksh")
+        assert nodes, "expected at least one node from sample.ksh"
+        for n in nodes:
+            assert n.language == "bash"
+        funcs = {n.name for n in nodes if n.kind == "Function"}
+        assert "backup_logs" in funcs
+        assert "rotate" in funcs
+        calls = {e.target for e in edges if e.kind == "CALLS"}
+        assert any(t.endswith("::backup_logs") for t in calls)
 
 
 class TestElixirParsing:


### PR DESCRIPTION
## Summary

Registers `.ksh` in `EXTENSION_TO_LANGUAGE` so Korn shell scripts are parsed through the existing tree-sitter-bash grammar shipped in v2.3.1 (#197 / PR #230).

You explicitly invited this in your close comment on PR #230:
> "The .ksh extension in particular looks worth adding — I didn't include it in my version."

Closes #235.

## Diff shape

32 insertions, 0 deletions, 3 files:

- **`code_review_graph/parser.py`** — one line added after `.zsh` in the extension map.
- **`tests/test_multilang.py`** — one assert in `TestBashParsing.test_detects_language` for `deploy.ksh`, plus a new `test_ksh_extension_parses_as_bash` that parses the fixture and asserts: at least one node, all nodes carry `language == "bash"`, functions `backup_logs` + `rotate` are detected, and the CALLS edge graph contains `::backup_logs`.
- **`tests/fixtures/sample.ksh`** — new minimal Korn shell fixture exercising functions, `source`, and an internal call.

No changes to the grammar, parser logic, tests for `.sh`/`.bash`/`.zsh`, or any other language.

## Test plan

```
$ uv run pytest tests/test_multilang.py::TestBashParsing -q
........                                                                 [100%]
8 passed, 1 warning in 1.71s

$ uv run pytest tests/test_multilang.py -q
152 passed, 1 warning in 10.58s

$ uv run ruff check code_review_graph/parser.py tests/test_multilang.py
All checks passed!
```

## Scope notes

- Single-dialect only: no `.ksh93` / `.mksh` / `.pdksh` — keep that for a follow-up issue if anyone asks.
- No duplicate `TestKshParsing` class — the grammar is identical, so the two extra tests above cover the routing claim without duplicating grammar coverage.
- The new fixture deliberately reuses `sample_lib.sh` (already in the fixtures dir) so we don't add a second library file.