### PR TITLE
feat(parser): shebang-based language detection for extension-less scripts (closes #237)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -113,6 +113,29 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".ipynb": "notebook",
 }
 
+# Shebang interpreter basename -> registered language. Used as a fallback for
+# extension-less scripts (see _detect_language_from_shebang, closes #237).
+_SHEBANG_INTERPRETER_TO_LANGUAGE: dict[str, str] = {
+    "bash": "bash",
+    "sh": "bash",
+    "zsh": "bash",
+    "ksh": "bash",
+    "dash": "bash",
+    "ash": "bash",
+    "python": "python",
+    "python2": "python",
+    "python3": "python",
+    "pypy": "python",
+    "pypy3": "python",
+    "node": "javascript",
+    "nodejs": "javascript",
+    "ruby": "ruby",
+    "perl": "perl",
+    "lua": "lua",
+    "Rscript": "r",
+    "php": "php",
+}
+
 # Tree-sitter node type mappings per language
 # Maps (language) -> dict of semantic role -> list of TS node types
 _CLASS_TYPES: dict[str, list[str]] = {
@@ -359,7 +382,44 @@ class CodeParser:
         return self._parsers[language]
 
     def detect_language(self, path: Path) -> Optional[str]:
-        return EXTENSION_TO_LANGUAGE.get(path.suffix.lower())
+        lang = EXTENSION_TO_LANGUAGE.get(path.suffix.lower())
+        if lang is not None:
+            return lang
+        if path.suffix == "":
+            return self._detect_language_from_shebang(path)
+        return None
+
+    def _detect_language_from_shebang(self, path: Path) -> Optional[str]:
+        """Map the shebang interpreter of an extension-less script to a
+        registered language. Reads at most 256 bytes. Returns None for
+        missing, unreadable, binary, or unknown shebangs (closes #237).
+        """
+        try:
+            with path.open("rb") as f:
+                head = f.read(256)
+        except (OSError, PermissionError):
+            return None
+        if not head.startswith(b"#!"):
+            return None
+        newline = head.find(b"\n")
+        raw = head[2:newline] if newline != -1 else head[2:]
+        try:
+            line = raw.decode("utf-8").strip()
+        except UnicodeDecodeError:
+            return None
+        parts = line.split()
+        if not parts:
+            return None
+        first = parts[0]
+        first_name = first.rsplit("/", 1)[-1]
+        if first_name == "env":
+            # "#!/usr/bin/env python3" — interpreter is the next token.
+            interpreter = parts[1] if len(parts) >= 2 else None
+        else:
+            interpreter = first_name
+        if not interpreter:
+            return None
+        return _SHEBANG_INTERPRETER_TO_LANGUAGE.get(interpreter)
 
     def parse_file(self, path: Path) -> tuple[list[NodeInfo], list[EdgeInfo]]:
         """Parse a single file and return extracted nodes and edges."""

--- a/tests/fixtures/shebang_bash_script
+++ b/tests/fixtures/shebang_bash_script
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Extension-less script — routed to bash via shebang detection (#237).
+
+log_info() {
+    echo "[info] $1"
+}
+
+deploy() {
+    log_info "starting"
+    log_info "done"
+}
+
+deploy

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -902,3 +902,102 @@ class TestValueReferences:
         # At least some targets should be fully qualified
         qualified_refs = [e for e in refs if "::" in e.target]
         assert len(qualified_refs) > 0
+
+
+class TestShebangLanguageDetection:
+    """Shebang-based detection for extension-less scripts (closes #237)."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def _write(self, tmp_dir: str, name: str, content: bytes) -> Path:
+        path = Path(tmp_dir) / name
+        path.write_bytes(content)
+        return path
+
+    def test_direct_shebang_bash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "deploy", b"#!/bin/bash\necho hi\n")
+            assert self.parser.detect_language(p) == "bash"
+
+    def test_env_form_shebang_python(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "bin_myapp", b"#!/usr/bin/env python3\nprint('x')\n")
+            assert self.parser.detect_language(p) == "python"
+
+    def test_env_form_shebang_node(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "bootstrap", b"#!/usr/bin/env node\nconsole.log(1);\n")
+            assert self.parser.detect_language(p) == "javascript"
+
+    def test_shebang_with_trailing_flags(self):
+        """`#!/bin/bash -euo pipefail` should still resolve to bash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "installer", b"#!/bin/bash -euo pipefail\necho ok\n")
+            assert self.parser.detect_language(p) == "bash"
+
+    def test_mapped_interpreters_route_correctly(self):
+        cases = [
+            (b"#!/bin/sh\n", "bash"),
+            (b"#!/bin/zsh\n", "bash"),
+            (b"#!/bin/ksh\n", "bash"),
+            (b"#!/bin/dash\n", "bash"),
+            (b"#!/usr/bin/env ash\n", "bash"),
+            (b"#!/usr/bin/env python\n", "python"),
+            (b"#!/usr/bin/env python2\n", "python"),
+            (b"#!/usr/bin/env pypy3\n", "python"),
+            (b"#!/usr/bin/env nodejs\n", "javascript"),
+            (b"#!/usr/bin/env ruby\n", "ruby"),
+            (b"#!/usr/bin/perl\n", "perl"),
+            (b"#!/usr/bin/env lua\n", "lua"),
+            (b"#!/usr/bin/env Rscript\n", "r"),
+            (b"#!/usr/bin/env php\n", "php"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            for i, (content, expected) in enumerate(cases):
+                p = self._write(tmp, f"script_{i}", content)
+                assert self.parser.detect_language(p) == expected, (
+                    f"{content!r} -> expected {expected}"
+                )
+
+    def test_missing_shebang_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "plain", b"just some text\nno shebang here\n")
+            assert self.parser.detect_language(p) is None
+
+    def test_unknown_interpreter_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "mystery", b"#!/usr/bin/env fortran\n")
+            assert self.parser.detect_language(p) is None
+
+    def test_binary_content_returns_none(self):
+        """Binary files that happen to start with 0x23 0x21 must not crash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "bin", b"#!\xff\xfe\x00\x01\x02binary-payload")
+            assert self.parser.detect_language(p) is None
+
+    def test_empty_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "empty", b"")
+            assert self.parser.detect_language(p) is None
+
+    def test_missing_file_returns_none(self):
+        """Non-existent paths must not raise."""
+        assert self.parser.detect_language(Path("/does/not/exist/script")) is None
+
+    def test_extension_wins_over_shebang(self):
+        """.py with a bash shebang stays Python — shebang is a fallback only."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "weird.py", b"#!/bin/bash\nprint('x')\n")
+            assert self.parser.detect_language(p) == "python"
+
+    def test_parse_file_on_shebang_only_script(self):
+        """End-to-end: an extension-less bash script should produce function nodes
+        via the existing bash parser (#237)."""
+        nodes, _edges = self.parser.parse_file(FIXTURES / "shebang_bash_script")
+        assert nodes, "expected at least one node from shebang_bash_script"
+        for n in nodes:
+            assert n.language == "bash"
+        func_names = {n.name for n in nodes if n.kind == "Function"}
+        assert "log_info" in func_names
+        assert "deploy" in func_names


### PR DESCRIPTION
## Summary

Implements #237 exactly as scoped in the issue. Extension-less scripts with a shebang (`bin/myapp`, `.git/hooks/pre-commit`, `scripts/deploy`, etc.) are now routed to the appropriate parser instead of being silently skipped.

Closes #237.

## How it works

`detect_language()` becomes a two-step lookup:

1. Extension match via `EXTENSION_TO_LANGUAGE` (unchanged — wins every time).
2. If no extension (`path.suffix == ""`), call `_detect_language_from_shebang()` which:
   - Reads the first 256 bytes.
   - Accepts direct (`#!/bin/bash`) and env (`#!/usr/bin/env python3`) forms.
   - Tolerates trailing flags (`#!/bin/bash -e`).
   - Returns `None` for missing file, unreadable bytes, non-UTF-8 content, unknown interpreter, or any parse failure.

Mapping (straight from the issue):

| Interpreter | Maps to |
|---|---|
| `bash`, `sh`, `zsh`, `ksh`, `dash`, `ash` | `bash` |
| `python`, `python2`, `python3`, `pypy`, `pypy3` | `python` |
| `node`, `nodejs` | `javascript` |
| `ruby` | `ruby` |
| `perl` | `perl` |
| `lua` | `lua` |
| `Rscript` | `r` |
| `php` | `php` |

## Non-goals (respected)

- Does **not** override extension-based detection — `.py` with `#!/bin/bash` stays Python. Covered by `test_extension_wins_over_shebang`.
- Does **not** read bytes for files with a known extension. No perf regression.
- Does **not** add new languages. Only routes extension-less files to languages already registered.

## Diff shape

173 insertions, 1 deletion, 3 files:

- `code_review_graph/parser.py` (+62, -1): module-level `_SHEBANG_INTERPRETER_TO_LANGUAGE` constant, new `_detect_language_from_shebang()` method, updated `detect_language()` body.
- `tests/test_parser.py` (+99): new `TestShebangLanguageDetection` class with 12 tests.
- `tests/fixtures/shebang_bash_script` (new): extension-less Korn/bash fixture for the end-to-end parse test.

## Test plan

```
$ uv run pytest tests/test_parser.py::TestShebangLanguageDetection -q
............                                                             [100%]
12 passed, 1 warning in 0.05s

$ uv run pytest tests/test_parser.py tests/test_multilang.py::TestBashParsing -q
86 passed, 1 warning in 2.51s
```

Tests cover: direct shebang, env-form shebang, all mapped interpreters, trailing flags, missing shebang, unknown interpreter, binary content (0xff 0xfe ...), empty file, non-existent path, extension-wins-over-shebang, and end-to-end `parse_file()` producing function nodes from a shebang-only script.

## Notes

- Pairs naturally with PR #270 (`.ksh` extension) since `#!/bin/ksh` now also routes to bash via this fallback.
- One pre-existing unused-variable ruff warning in `TestValueReferences` (line 901) is **not** modified here — it's on `main` already and outside the scope of this PR.