### PR TITLE
fix(java): extract method name from identifier, not return type

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3357,6 +3357,16 @@ class CodeParser:
             for child in node.children:
                 if child.type == "field_identifier":
                     return child.text.decode("utf-8", errors="replace")
+        # Java methods: tree-sitter-java puts type_identifier or generic_type
+        # (return type) before identifier (method name).  Must run before
+        # the generic loop, which would match the return type's
+        # type_identifier (e.g. "String", "ConfigBean").
+        # Constructors are fine — they have no return type node.
+        # Kotlin is unaffected: its syntax places the name before the type.
+        if language == "java" and node.type == "method_declaration":
+            for child in node.children:
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
         # Swift extensions: name is inside user_type > type_identifier
         # (e.g. `extension MyClass: Protocol { ... }`)
         if language == "swift" and node.type == "class_declaration":

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -137,6 +137,22 @@ class TestJavaParsing:
         assert "save" in names
         assert "getUser" in names
 
+    def test_method_names_not_return_types(self):
+        """Method names must be the actual name, not the return type.
+
+        tree-sitter-java puts type_identifier (return type) before
+        identifier (method name).  Without the Java-specific branch in
+        _get_name the generic loop picks up the return type instead.
+        """
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        # getName()/getEmail() return String — must not be indexed as "String"
+        assert "getName" in names
+        assert "getEmail" in names
+        assert "getId" in names
+        # createUser() returns User — must not be indexed as "User" (the class)
+        assert "createUser" in names
+
     def test_finds_imports(self):
         imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) >= 2


### PR DESCRIPTION
tree-sitter-java places type_identifier (return type) before identifier (method name) in method_declaration nodes.
The generic _get_name() loop matched type_identifier first, causing methods to be indexed under their return type instead of their actual name.

For example:

* `public String getName()` was indexed as "String" instead of "getName", and
* `public ConfigBean getUtilityIngestionBean()`was indexed as "ConfigBean".

This broke callers_of,callees_of, and
children_of queries for any Java method with a non-void, non-generic return type.

Adds a Java-specific branch in _get_name() that returns the first identifier child for method_declaration nodes, following the same pattern as the Go fix (field_identifier) from PR #166.

Kotlin & Scala  is unaffected — its syntax places the name before the return type.