### PR TITLE
fix(java): extract bare type names from superclass/super_interfaces nodes

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3450,7 +3450,23 @@ class CodeParser:
                     for arg in child.children:
                         if arg.type in ("identifier", "attribute"):
                             bases.append(arg.text.decode("utf-8", errors="replace"))
-        elif language in ("java", "csharp", "kotlin"):
+        elif language == "java":
+            # Java: superclass and super_interfaces wrap the keyword
+            # (extends/implements) around type_identifier children.
+            # Taking .text would include the keyword (e.g. "implements Foo").
+            # Drill into the children to extract bare type names.
+            for child in node.children:
+                if child.type == "superclass":
+                    for sub in child.children:
+                        if sub.type in ("type_identifier", "generic_type"):
+                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                elif child.type == "super_interfaces":
+                    for sub in child.children:
+                        if sub.type == "type_list":
+                            for ident in sub.children:
+                                if ident.type in ("type_identifier", "generic_type"):
+                                    bases.append(ident.text.decode("utf-8", errors="replace"))
+        elif language in ("csharp", "kotlin"):
             # Look for superclass/interfaces in extends/implements clauses
             for child in node.children:
                 if child.type in (

--- a/tests/fixtures/SampleJava.java
+++ b/tests/fixtures/SampleJava.java
@@ -57,3 +57,10 @@ class UserService {
         return repo.findById(id);
     }
 }
+
+class CachedRepo extends InMemoryRepo {
+    @Override
+    public void save(User user) {
+        super.save(user);
+    }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -143,8 +143,32 @@ class TestJavaParsing:
 
     def test_finds_inheritance(self):
         inherits = [e for e in self.edges if e.kind == "INHERITS"]
-        # InMemoryRepo implements UserRepository
-        assert len(inherits) >= 1
+        # InMemoryRepo implements UserRepository + CachedRepo extends InMemoryRepo
+        assert len(inherits) >= 2
+        targets = {e.target for e in inherits}
+        assert "UserRepository" in targets
+        assert "InMemoryRepo" in targets
+
+    def test_inheritance_target_is_bare_name(self):
+        """INHERITS edge target must be the type name, not 'implements Foo'.
+
+        tree-sitter-java wraps extends/implements in superclass and
+        super_interfaces nodes whose .text includes the keyword.
+        Without the Java-specific branch in _get_bases the full text
+        (e.g. 'implements UserRepository') is stored as the edge target.
+        """
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        # Must have both extends and implements edges to test both paths
+        assert len(inherits) >= 2, (
+            "Expected at least 2 INHERITS edges (extends + implements)"
+        )
+        for e in inherits:
+            assert not e.target.startswith("implements "), (
+                f"INHERITS target should be bare type name, got: {e.target!r}"
+            )
+            assert not e.target.startswith("extends "), (
+                f"INHERITS target should be bare type name, got: {e.target!r}"
+            )
 
     def test_finds_calls(self):
         calls = [e for e in self.edges if e.kind == "CALLS"]


### PR DESCRIPTION
tree-sitter-java wraps extends/implements clauses in superclass and super_interfaces nodes whose .text includes the keyword. The _get_bases() function was storing the full text (e.g. "implements UserRepository") as the INHERITS edge target instead of just the type name.

This caused inheritors_of queries to fail — the query looks up edges by the qualified class name or bare name, neither of which matches "implements UserRepository".

Adds a Java-specific branch in _get_bases() that drills into the AST children to extract type_identifier nodes (including generic_type for parameterized interfaces like IBar<String>). C#/Kotlin are unaffected and retain the existing behavior.