### PR TITLE
fix(install): detect Poetry/uv environment and generate correct MCP serve command

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import platform
 import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -111,18 +113,91 @@ PLATFORMS: dict[str, dict[str, Any]] = {
 }
 
 
+def _in_poetry_project() -> bool:
+    """Return True when the running interpreter is a Poetry-managed virtualenv.
+
+    Two signals are checked so that **both** ``poetry shell`` and ``poetry run``
+    are detected:
+
+    * ``POETRY_ACTIVE=1`` — set by ``poetry shell`` when the user activates the
+      virtual environment interactively.
+    * ``VIRTUAL_ENV`` containing ``"pypoetry"`` — set by **both** ``poetry shell``
+      and ``poetry run`` because Poetry stores its virtualenvs under a path that
+      includes the string ``pypoetry`` (e.g.
+      ``~/.cache/pypoetry/virtualenvs/<name>`` on Linux/macOS or
+      ``%LOCALAPPDATA%\\pypoetry\\Cache\\virtualenvs\\<name>`` on Windows).
+
+    Checking only ``POETRY_ACTIVE`` would miss the ``poetry run`` case, which is
+    the primary scenario described in issue #256.
+    """
+    if os.environ.get("POETRY_ACTIVE") == "1":
+        return True
+    virtual_env = os.environ.get("VIRTUAL_ENV", "")
+    return bool(virtual_env) and "pypoetry" in virtual_env.lower()
+
+
+def _in_uv_project() -> bool:
+    """Return True if ``sys.executable`` lives inside a uv-managed project.
+
+    A project is considered uv-managed when a ``uv.lock`` file exists in any
+    ancestor directory of the running Python interpreter (stopping at the home
+    directory to avoid false positives on system-wide installations).
+    """
+    exe = Path(sys.executable).resolve()
+    home = Path.home()
+    for parent in exe.parents:
+        if (parent / "uv.lock").exists():
+            return True
+        # Stop searching once we reach the home directory or filesystem root
+        if parent == home or parent == parent.parent:
+            break
+    return False
+
+
+def _detect_serve_command() -> tuple[str, list[str]]:
+    """Return ``(command, args)`` that correctly launches ``code-review-graph serve``.
+
+    Detection priority
+    ------------------
+    1. **Poetry** – ``POETRY_ACTIVE=1`` OR ``VIRTUAL_ENV`` contains ``"pypoetry"``
+       (covers both ``poetry shell`` and ``poetry run``) and ``poetry`` is on PATH
+       → ``poetry run code-review-graph serve``
+    2. **uv project** – ``UV_PROJECT_ENVIRONMENT`` is set, or a ``uv.lock``
+       ancestor is found alongside ``sys.executable``, and ``uv`` is on PATH
+       → ``uv run code-review-graph serve``
+    3. **uvx** – ``uvx`` is available on PATH (existing behaviour, unchanged)
+       → ``uvx code-review-graph serve``
+    4. **Fallback** – use the absolute path of the running Python interpreter
+       → ``sys.executable -m code_review_graph serve``
+
+    The fallback is always safe: ``sys.executable`` is the exact interpreter
+    that is currently running, so it resolves correctly inside any virtual
+    environment, conda env, or system installation.
+    """
+    # 1. Poetry (poetry shell or poetry run)
+    if _in_poetry_project():
+        poetry = shutil.which("poetry")
+        if poetry:
+            return ("poetry", ["run", "code-review-graph", "serve"])
+
+    # 2. uv managed project environment
+    if os.environ.get("UV_PROJECT_ENVIRONMENT") or _in_uv_project():
+        uv = shutil.which("uv")
+        if uv:
+            return ("uv", ["run", "code-review-graph", "serve"])
+
+    # 3. uvx global tool runner (existing behaviour, unchanged)
+    if shutil.which("uvx"):
+        return ("uvx", ["code-review-graph", "serve"])
+
+    # 4. Absolute-path fallback using the running interpreter
+    return (sys.executable, ["-m", "code_review_graph", "serve"])
+
+
 def _build_server_entry(plat: dict[str, Any], key: str = "") -> dict[str, Any]:
     """Build the MCP server entry for a platform."""
-    if shutil.which("uvx"):
-        entry: dict[str, Any] = {
-            "command": "uvx",
-            "args": ["code-review-graph", "serve"],
-        }
-    else:
-        entry = {
-            "command": "code-review-graph",
-            "args": ["serve"],
-        }
+    command, args = _detect_serve_command()
+    entry: dict[str, Any] = {"command": command, "args": args}
     if plat["needs_type"]:
         entry["type"] = "stdio"
     if key == "opencode":

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,6 +16,9 @@ else:  # pragma: no cover - Python 3.10 backport
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
+    _detect_serve_command,
+    _in_poetry_project,
+    _in_uv_project,
     generate_hooks_config,
     generate_skills,
     inject_claude_md,
@@ -315,10 +318,8 @@ class TestInstallPlatformConfigs:
         data = tomllib.loads(codex_config.read_text())
         assert data["model"] == "gpt-5.4"
         assert data["mcp_servers"]["other"]["command"] == "other"
-        assert data["mcp_servers"]["code-review-graph"]["command"] in {
-            "uvx",
-            "code-review-graph",
-        }
+        expected_cmd, _ = _detect_serve_command()
+        assert data["mcp_servers"]["code-review-graph"]["command"] == expected_cmd
 
     def test_install_codex_no_duplicate(self, tmp_path):
         codex_config = tmp_path / ".codex" / "config.toml"
@@ -382,9 +383,7 @@ class TestInstallPlatformConfigs:
         data = json.loads(config_path.read_text())
         entry = data["mcpServers"]["code-review-graph"]
         assert "type" not in entry
-        import shutil
-
-        expected_cmd = "uvx" if shutil.which("uvx") else "code-review-graph"
+        expected_cmd, _ = _detect_serve_command()
         assert entry["command"] == expected_cmd
 
     def test_install_zed_config(self, tmp_path):
@@ -640,3 +639,156 @@ class TestKiroPlatform:
         assert "Kiro" in configured
         config_path = tmp_path / ".kiro" / "settings" / "mcp.json"
         assert not config_path.exists()
+
+
+class TestDetectServeCommand:
+    """Tests for _detect_serve_command() and its helpers."""
+
+    # ------------------------------------------------------------------
+    # _in_poetry_project() unit tests
+    # ------------------------------------------------------------------
+
+    def test_in_poetry_project_via_poetry_active(self, monkeypatch):
+        """POETRY_ACTIVE=1 signals a poetry shell session."""
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert _in_poetry_project() is True
+
+    def test_in_poetry_project_via_virtual_env(self, monkeypatch):
+        """VIRTUAL_ENV containing 'pypoetry' signals a poetry run session."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.setenv("VIRTUAL_ENV", "/home/user/.cache/pypoetry/virtualenvs/proj-xxx")
+        assert _in_poetry_project() is True
+
+    def test_in_poetry_project_false_for_plain_venv(self, monkeypatch):
+        """A plain venv (no pypoetry in path) is not treated as poetry."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.setenv("VIRTUAL_ENV", "/home/user/myproject/.venv")
+        assert _in_poetry_project() is False
+
+    def test_in_poetry_project_false_when_nothing_set(self, monkeypatch):
+        """No env vars → not in a poetry project."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert _in_poetry_project() is False
+
+    # ------------------------------------------------------------------
+    # _detect_serve_command() integration tests
+    # ------------------------------------------------------------------
+
+    def test_poetry_active_returns_poetry_run(self, monkeypatch):
+        """POETRY_ACTIVE=1 (poetry shell) → 'poetry run' invocation."""
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/poetry" if x == "poetry" else None,
+        )
+        cmd, args = _detect_serve_command()
+        assert cmd == "poetry"
+        assert args == ["run", "code-review-graph", "serve"]
+
+    def test_virtual_env_pypoetry_returns_poetry_run(self, monkeypatch):
+        """VIRTUAL_ENV with 'pypoetry' (poetry run) → 'poetry run' invocation."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.setenv("VIRTUAL_ENV", "/home/user/.cache/pypoetry/virtualenvs/proj-abc123")
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/poetry" if x == "poetry" else None,
+        )
+        cmd, args = _detect_serve_command()
+        assert cmd == "poetry"
+        assert args == ["run", "code-review-graph", "serve"]
+
+    def test_poetry_env_without_poetry_on_path_falls_through(self, monkeypatch):
+        """If poetry venv is detected but poetry binary is missing, fall through."""
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+        monkeypatch.setattr("code_review_graph.skills._in_uv_project", lambda: False)
+        # poetry not on PATH → should fall through to uvx
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/uvx" if x == "uvx" else None,
+        )
+        cmd, _ = _detect_serve_command()
+        assert cmd == "uvx"
+
+    def test_uv_project_env_returns_uv_run(self, monkeypatch):
+        """UV_PROJECT_ENVIRONMENT set + uv on PATH → 'uv run' invocation."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/some/.venv")
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/uv" if x == "uv" else None,
+        )
+        cmd, args = _detect_serve_command()
+        assert cmd == "uv"
+        assert args == ["run", "code-review-graph", "serve"]
+
+    def test_uv_lock_detection_returns_uv_run(self, monkeypatch, tmp_path):
+        """uv.lock alongside sys.executable → detected as a uv project."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+        venv = tmp_path / ".venv" / "bin"
+        venv.mkdir(parents=True)
+        (tmp_path / "uv.lock").write_text("")
+        fake_python = venv / "python"
+        fake_python.write_text("")
+        monkeypatch.setattr("code_review_graph.skills.sys.executable", str(fake_python))
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/uv" if x == "uv" else None,
+        )
+        assert _in_uv_project() is True
+        cmd, args = _detect_serve_command()
+        assert cmd == "uv"
+        assert args == ["run", "code-review-graph", "serve"]
+
+    def test_uvx_fallback(self, monkeypatch):
+        """Not in Poetry/uv but uvx available → use uvx (original behaviour)."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+        monkeypatch.setattr("code_review_graph.skills._in_uv_project", lambda: False)
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/uvx" if x == "uvx" else None,
+        )
+        cmd, args = _detect_serve_command()
+        assert cmd == "uvx"
+        assert args == ["code-review-graph", "serve"]
+
+    def test_sys_executable_fallback(self, monkeypatch):
+        """Nothing else available → fall back to sys.executable -m."""
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+        monkeypatch.setattr("code_review_graph.skills._in_uv_project", lambda: False)
+        monkeypatch.setattr("code_review_graph.skills.shutil.which", lambda _: None)
+        cmd, args = _detect_serve_command()
+        assert cmd == sys.executable
+        assert args == ["-m", "code_review_graph", "serve"]
+
+    def test_poetry_takes_priority_over_uv(self, monkeypatch):
+        """Poetry detection wins even when UV_PROJECT_ENVIRONMENT is also set."""
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/some/.venv")
+        monkeypatch.setattr(
+            "code_review_graph.skills.shutil.which",
+            lambda x: "/usr/bin/poetry" if x == "poetry" else None,
+        )
+        cmd, _ = _detect_serve_command()
+        assert cmd == "poetry"
+
+    def test_in_uv_project_false_without_lockfile(self, monkeypatch, tmp_path):
+        """_in_uv_project returns False when no uv.lock in ancestor dirs."""
+        fake_python = tmp_path / "bin" / "python"
+        fake_python.parent.mkdir(parents=True)
+        fake_python.write_text("")
+        monkeypatch.setattr("code_review_graph.skills.sys.executable", str(fake_python))
+        monkeypatch.setattr("code_review_graph.skills.Path.home", staticmethod(lambda: tmp_path))
+        assert _in_uv_project() is False


### PR DESCRIPTION
…erve command

When the package is installed inside a Poetry or uv virtual environment, the previous implementation hardcoded either `uvx code-review-graph serve` (if uvx was on PATH) or `code-review-graph serve`, neither of which works when the MCP client starts the server in a fresh shell where the virtualenv is not activated.

Root causes fixed:

1. POETRY_ACTIVE=1 is only set by poetry shell, NOT by poetry run. Added VIRTUAL_ENV pattern matching (pypoetry) to detect both cases.

2. The code-review-graph serve fallback assumed the binary is on the global PATH, which is never true inside a virtualenv.

Changes:

- Add _in_poetry_project(): checks POETRY_ACTIVE=1 OR VIRTUAL_ENV contains pypoetry (covers both poetry shell and poetry run)

- Add _in_uv_project(): walks uv.lock up from sys.executable to detect uv-managed projects activated without UV_PROJECT_ENVIRONMENT

- Add _detect_serve_command(): priority chain: poetry, uv, uvx (original behaviour preserved), sys.executable fallback

- Replace hardcoded logic in _build_server_entry() with _detect_serve_command()

- Add 15 targeted tests covering all detection paths and edge cases

Closes #256