### PR TITLE
fix: disable FastMCP banner for stdio transport

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -904,7 +904,9 @@ def main(repo_root: str | None = None) -> None:
     if sys.platform == "win32":
         import asyncio
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    mcp.run(transport="stdio")
+    # Stdio MCP must keep stdout strictly JSON-RPC. FastMCP's banner/update
+    # notices corrupt the handshake stream on clients like Codex CLI.
+    mcp.run(transport="stdio", show_banner=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- 这是一个兼容性修复，不改变业务工具逻辑
- 只影响 `stdio` 启动行为
- 对 Cursor / Codex / Claude Code 这类走 MCP `stdio` 的客户端有直接收益