### PR TITLE
fix: skip user-level hooks gracefully when not in a git repository

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -432,7 +432,7 @@ def generate_hooks_config() -> dict[str, Any]:
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph update --skip-flows",
+                            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph update --skip-flows || true",
                             "timeout": 30,
                         },
                     ],

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -432,7 +432,7 @@ def generate_hooks_config() -> dict[str, Any]:
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "code-review-graph update --skip-flows",
+                            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph update --skip-flows",
                             "timeout": 30,
                         },
                     ],
@@ -444,7 +444,7 @@ def generate_hooks_config() -> dict[str, Any]:
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "code-review-graph status",
+                            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph status || echo 'Not a git repo, skipping'",
                             "timeout": 10,
                         },
                     ],


### PR DESCRIPTION
## Description

- `generate_hooks_config()` now guards both `PostToolUse` and `SessionStart` hook commands with `git rev-parse --git-dir` check
- Prevents noisy errors when Claude Code runs outside a git repository (e.g. home directory)

**Before (error when running outside a git repo):**
```
PostToolUse:Edit hook error
PostToolUse:Bash hook error
```

**After:** hooks are silently skipped in non-git directories.

## Tested

- [x] `TestGenerateHooksConfig` tests pass (5/5)