### PR TITLE
Fix PHP CALL extraction: add support for method, static, and unqualified function calls #297

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -275,7 +275,12 @@ _CALL_TYPES: dict[str, list[str]] = {
     ],
     "kotlin": ["call_expression"],
     "swift": ["call_expression"],
-    "php": ["function_call_expression", "member_call_expression"],
+    "php": [
+        "function_call_expression",
+        "member_call_expression",
+        "scoped_call_expression",
+        "nullsafe_member_call_expression",
+    ],
     "scala": ["call_expression", "instance_expression", "generic_function"],
     "solidity": ["call_expression"],
     "lua": ["function_call"],
@@ -3662,6 +3667,39 @@ class CodeParser:
             return None
 
         first = node.children[0]
+
+        if language == "php":
+            def _normalize_php_name(text: str) -> str:
+                # PHP global/function names can be prefixed with '\\'.
+                return text.lstrip("\\")
+
+            if node.type == "function_call_expression":
+                for child in node.children:
+                    if child.type in ("name", "qualified_name"):
+                        raw = child.text.decode("utf-8", errors="replace")
+                        return _normalize_php_name(raw)
+                return None
+
+            if node.type in (
+                "member_call_expression",
+                "nullsafe_member_call_expression",
+            ):
+                for child in reversed(node.children):
+                    if child.type == "name":
+                        return child.text.decode("utf-8", errors="replace")
+                return None
+
+            if node.type == "scoped_call_expression":
+                parts = []
+                for child in node.children:
+                    if child.type in ("name", "qualified_name"):
+                        raw = child.text.decode("utf-8", errors="replace")
+                        parts.append(_normalize_php_name(raw))
+                if len(parts) >= 2:
+                    return f"{parts[0]}::{parts[-1]}"
+                if parts:
+                    return parts[0]
+                return None
 
         # Scala: instance_expression (new Foo(...)) – extract the type name
         if node.type == "instance_expression":

--- a/tests/fixtures/sample.php
+++ b/tests/fixtures/sample.php
@@ -41,3 +41,60 @@ function createUser(Repository $repo, string $name): User {
     $repo->save($user);
     return $user;
 }
+
+function sqlQuery(string $query): array {
+    return [];
+}
+
+function xl(string $value): string {
+    return $value;
+}
+
+function text(string $value): string {
+    return $value;
+}
+
+class SearchService {
+    public function search(string $term): array {
+        return [];
+    }
+}
+
+class QueryUtils {
+    public static function fetchRecords(): array {
+        return [];
+    }
+}
+
+class EncounterService {
+    public static function create(array $payload): bool {
+        return true;
+    }
+}
+
+class ExtendedRepo extends InMemoryRepo {
+    public function __construct() {
+        parent::__construct();
+    }
+
+    public static function factory(): self {
+        return new self();
+    }
+
+    private function execute(): void {
+        // no-op helper used for call extraction coverage
+    }
+
+    public function runQueries(?SearchService $service): void {
+        sqlQuery("SELECT 1");
+        xl("hello");
+        text("world");
+        $this->execute();
+        $service?->search("blood pressure");
+        QueryUtils::fetchRecords();
+        EncounterService::create([]);
+        parent::__construct();
+        self::factory();
+        \dirname("/tmp");
+    }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -268,6 +268,33 @@ class TestPHPParsing:
         names = {f.name for f in funcs}
         assert len(names) > 0
 
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        target_names = {t.split("::")[-1].split(".")[-1] for t in targets}
+
+        run_queries_targets = {
+            e.target for e in calls if e.source.endswith("::ExtendedRepo.runQueries")
+        }
+
+        # Plain function calls
+        assert "sqlQuery" in target_names
+        assert "xl" in target_names
+        assert "text" in target_names
+
+        # Member and nullsafe method calls
+        assert "execute" in target_names
+        assert "search" in target_names
+
+        # Scoped/static calls
+        assert "QueryUtils::fetchRecords" in targets
+        assert "EncounterService::create" in targets
+        assert any(t.endswith("__construct") for t in run_queries_targets)
+        assert any(t.endswith("factory") for t in run_queries_targets)
+
+        # Global namespaced calls should normalize to a stable name
+        assert "dirname" in target_names
+
 
 class TestKotlinParsing:
     def setup_method(self):


### PR DESCRIPTION
Root cause: PHP node child-type mismatch in _get_call_name.
Fix: PHP-specific handling + scoped/nullsafe node coverage + regression tests. 
Addressing the issue #297  and #273 

Changes
Expanded PHP call node coverage in parser call node configuration.
Added PHP-specific call-name extraction logic 