### PR TITLE
fix: formatting in skills.py table

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -543,7 +543,7 @@ Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
 ### Key Tools
 
 | Tool | Use when |
-|------|----------|
+| ------ | ---------- |
 | `detect_changes` | Reviewing code changes — gives risk-scored analysis |
 | `get_review_context` | Need source snippets for review — token-efficient |
 | `get_impact_radius` | Understanding blast radius of a change |


### PR DESCRIPTION
My OCD did not like seeing a single Markdown error in an otherwise pristine file.

Resolve Markdown Lint error MD060.

MD060/table-column-style: Table column style [Table pipe is missing space to the left for style "compact"]
