### PR TITLE
docs: add guide for venv usage

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -70,7 +70,34 @@ source ~/.zshrc
 
 **TL;DR**: install the tool **once**, then run `code-review-graph install && code-review-graph build` inside **each** project you want graph-aware reviews in.
 
-### 4. "I built the graph but Claude Code doesn't see it in a new session"
+### 4. Using a venv? You must update `settings.json` manually
+
+Claude Code hooks and MCP tool paths in `.claude/settings.json` are **hardcoded at install time**. If you switch to (or create) a virtual environment after running `code-review-graph install`, the paths will still point to the old interpreter and the server will silently fail or use the wrong Python.
+
+**Fix — update the `command`/`args` in `.mcp.json` and any hook commands in `.claude/settings.json` to match your venv:**
+
+```json
+// .mcp.json — point to your venv's Python or uvx inside the venv
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "/path/to/your/venv/bin/uvx",
+      "args": ["code-review-graph", "serve"]
+    }
+  }
+}
+```
+
+Or simply re-run `code-review-graph install` **from within the activated venv** so the paths are regenerated correctly:
+
+```bash
+source .venv/bin/activate          # activate your venv first
+code-review-graph install          # rewrites .mcp.json and hook paths
+```
+
+Then fully quit and reopen Claude Code so it picks up the new config.
+
+### 5. "I built the graph but Claude Code doesn't see it in a new session"
 
 Most likely causes, ranked:
 


### PR DESCRIPTION
## Update Troubleshooting Guide for Virtual Environment Usage

### Summary

This PR enhances the troubleshooting documentation by adding guidance for users working with Python virtual environments and MCP configuration.

### Changes

* Added a new section explaining issues when switching to or using a virtual environment after running `code-review-graph install`
* Documented that `.claude/settings.json` and `.mcp.json` contain **hardcoded paths** determined at install time
* Provided two resolution approaches:

  * Manually updating paths in configuration files
  * Re-running `code-review-graph install` within the active virtual environment
* Included an example configuration snippet for clarity
* Renumbered the subsequent troubleshooting section accordingly

### Rationale

Users working with virtual environments may encounter silent failures due to outdated interpreter paths in MCP and hook configurations. This addition clarifies the root cause and provides actionable fixes, reducing setup friction.

### Impact

* Documentation-only change
* Improves developer experience for users leveraging virtual environments
* No impact on runtime behavior or existing functionality

### Testing

No tests required as this is a documentation update.

---
