### PR TITLE
Add update command to pre-commit script

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -466,6 +466,7 @@ def install_git_hook(repo_root: Path) -> Path | None:
 #!/bin/sh
 # Installed by code-review-graph. Remove this file to disable pre-commit graph checks.
 if command -v code-review-graph >/dev/null 2>&1; then
+    code-review-graph update || true
     code-review-graph detect-changes --brief || true
 fi
 """


### PR DESCRIPTION
Run `code-review-graph update` before `detect-changes` so the hook uses the latest graph state.

Without this, `detect-changes` may run against a stale graph after recent code changes.