### PR TITLE
feat: add GDScript (Godot) as a supported language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **GDScript support** (Godot): `.gd` files are parsed via the `gdscript` tree-sitter grammar shipped with `tree-sitter-language-pack`. Extracts inner classes (`class Name:`), the file-level `class_name` identity, functions (including `static func`), `extends` parent class as an IMPORTS_FROM edge, direct calls (`call`) and method calls (`attribute_call`). Adds 10 tests and `tests/fixtures/sample.gd`.
+
 ## [2.3.2] - 2026-04-14
 
 Major feature release — 15 new capabilities, 6 community PRs merged, 6 new MCP tools, 4 new languages, multi-format export, and graph analysis suite.

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -117,6 +117,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".psd1": "powershell",
     ".svelte": "svelte",
     ".jl": "julia",
+    ".gd": "gdscript",
 }
 
 # Tree-sitter node type mappings per language
@@ -164,6 +165,9 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "zig": ["container_declaration"],
     "powershell": ["class_statement"],
     "julia": ["struct_definition", "abstract_definition"],
+    # GDScript: inner classes use ``class Name:`` (class_definition); the
+    # file-level ``class_name Name`` gives the script itself an identity.
+    "gdscript": ["class_definition", "class_name_statement"],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -214,6 +218,8 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
         "function_definition",
         "short_function_definition",
     ],
+    # GDScript: ``func name(args) -> ReturnType:`` — includes ``static func``.
+    "gdscript": ["function_definition"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -254,6 +260,11 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "powershell": [],
     # Julia: import/using are import_statement nodes.
     "julia": ["import_statement", "using_statement"],
+    # GDScript has no ``import`` keyword. The closest analogue is
+    # ``extends OtherClass`` / ``extends "res://path.gd"``, which establishes
+    # a hard dependency on the parent script. preload()/load() calls remain
+    # as ordinary CALLS edges.
+    "gdscript": ["extends_statement"],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -292,6 +303,9 @@ _CALL_TYPES: dict[str, list[str]] = {
     "zig": ["call_expression", "builtin_call_expr"],
     "powershell": ["command_expression"],
     "julia": ["call_expression"],
+    # GDScript: bare calls produce ``call``; ``obj.method()`` is an
+    # ``attribute`` node whose right-hand side is an ``attribute_call``.
+    "gdscript": ["call", "attribute_call"],
 }
 
 # Patterns that indicate a test function
@@ -3650,6 +3664,25 @@ class CodeParser:
             val = _find_string_literal(node)
             if val:
                 imports.append(val)
+        elif language == "gdscript":
+            # ``extends Node`` → type > identifier("Node")
+            # ``extends "res://path.gd"`` → string literal
+            # ``extends SomeClass.Nested`` → type node (keep full text)
+            for child in node.children:
+                if child.type == "type":
+                    txt = child.text.decode("utf-8", errors="replace").strip()
+                    if txt:
+                        imports.append(txt)
+                elif child.type == "string":
+                    val = child.text.decode("utf-8", errors="replace").strip("'\"")
+                    if val:
+                        imports.append(val)
+                elif child.type == "identifier":
+                    # Fallback: some grammar variants expose the parent type as
+                    # a bare identifier next to the ``extends`` keyword.
+                    txt = child.text.decode("utf-8", errors="replace")
+                    if txt and txt != "extends":
+                        imports.append(txt)
         else:
             # Fallback: just record the text
             imports.append(text)

--- a/tests/fixtures/sample.gd
+++ b/tests/fixtures/sample.gd
@@ -1,0 +1,41 @@
+extends Node
+class_name SampleManager
+
+const MAX_SIZE = 10
+const OtherScript = preload("res://scripts/other.gd")
+
+signal item_added(item: Item)
+
+@export var speed: float = 2.5
+@onready var timer: Timer = $Timer
+
+var items: Array[Item] = []
+
+
+class Item:
+	var name: String
+	var level: int
+
+	func promote() -> void:
+		level += 1
+
+
+func _ready() -> void:
+	timer.start()
+	_load_items()
+	OtherScript.register(self)
+
+
+func _load_items() -> void:
+	for i in range(MAX_SIZE):
+		var item := Item.new()
+		items.append(item)
+		item_added.emit(item)
+
+
+func get_item(idx: int) -> Item:
+	return items[idx]
+
+
+static func helper() -> int:
+	return 42

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1202,3 +1202,82 @@ class TestElixirParsing:
         }
         assert any(t.endswith("::Calculator.add") for t in function_targets)
         assert any(t.endswith("::Calculator.compute") for t in function_targets)
+
+
+class TestGDScriptParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.gd")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("player.gd")) == "gdscript"
+        assert self.parser.detect_language(Path("globals/manager.gd")) == "gdscript"
+
+    def test_finds_class_name_statement(self):
+        """File-level ``class_name X`` declaration becomes a Class node."""
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "SampleManager" in classes
+
+    def test_finds_inner_class(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "Item" in classes
+
+    def test_finds_top_level_functions(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name is None
+        ]
+        names = {f.name for f in funcs}
+        for expected in ("_ready", "_load_items", "get_item", "helper"):
+            assert expected in names, f"missing top-level function {expected}"
+
+    def test_finds_inner_class_methods(self):
+        """Methods defined inside ``class Inner:`` should attach to the inner class."""
+        inner_funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Item"
+        ]
+        names = {f.name for f in inner_funcs}
+        assert "promote" in names
+
+    def test_finds_extends_as_import(self):
+        """``extends Node`` is the GDScript analogue of an import — parent class."""
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "Node" in targets, f"expected Node in imports, got {targets}"
+
+    def test_finds_direct_calls(self):
+        """Bare calls (``range(...)``, ``_load_items()``) produce CALLS edges."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert "range" in targets
+
+    def test_finds_attribute_calls(self):
+        """``obj.method(...)`` calls live inside ``attribute`` nodes as ``attribute_call``."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        # timer.start(), items.append(item), item_added.emit(item)
+        assert "start" in targets
+        assert "append" in targets
+        assert "emit" in targets
+
+    def test_internal_calls_resolve_to_qualified_names(self):
+        """A bare ``_load_items()`` call inside _ready should resolve to the
+        same-file function's qualified name."""
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any(t.endswith("::_load_items") for t in targets), (
+            f"expected ::_load_items in call targets, got {targets}"
+        )
+
+    def test_contains_edges_wire_classes_and_functions(self):
+        contains = [(e.source, e.target) for e in self.edges if e.kind == "CONTAINS"]
+        # File CONTAINS the top-level Class and Function nodes.
+        file_contains = {t for s, t in contains if not s.endswith(".gd::Item")
+                         and not s.endswith(".gd::SampleManager")}
+        assert any(t.endswith("::SampleManager") for t in file_contains)
+        assert any(t.endswith("::Item") for t in file_contains)
+        assert any(t.endswith("::_ready") for t in file_contains)
+        # Inner class CONTAINS its method.
+        item_contains = {t for s, t in contains if s.endswith("::Item")}
+        assert any(t.endswith("::Item.promote") for t in item_contains)


### PR DESCRIPTION
## Summary

Adds [GDScript](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html) — the scripting language for the [Godot Engine](https://godotengine.org) — as a fully supported language in code-review-graph. GDScript uses the [tree-sitter-gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript) grammar, already shipped in `tree-sitter-language-pack` as `gdscript.abi3.so`, so no new dependencies are required. `.gd` files are now parsed end-to-end: classes, functions, `extends` parent-class imports, and method calls all land in the graph.

## What changed

**`code_review_graph/parser.py`**

*   Added `".gd": "gdscript"` to `EXTENSION_TO_LANGUAGE`
*   Added `"gdscript": ["class_definition", "class_name_statement"]` to `_CLASS_TYPES` — covers inner classes (`class Name:`) and the file-level `class_name Name` identity declaration
*   Added `"gdscript": ["function_definition"]` to `_FUNCTION_TYPES` — covers `func`, `static func`, and annotated `@onready func`
*   Added `"gdscript": ["extends_statement"]` to `_IMPORT_TYPES` — treats the parent class / script path as a hard import dependency
*   Added `"gdscript": ["call", "attribute_call"]` to `_CALL_TYPES` — bare calls produce `call`; `obj.method()` is an `attribute` node whose right-hand side is an `attribute_call`
*   Added a `gdscript` branch to `_extract_import()` that resolves `extends Node` (type → identifier), `extends "res://path.gd"` (string literal), and `extends SomeClass.Nested` (type node)

**`tests/test_multilang.py`**

*   Added `TestGDScriptParsing` class with 10 unit tests covering: language detection, `class_name` extraction, inner-class extraction, top-level & inner-class function extraction, `extends` → IMPORTS_FROM edge, direct and attribute method calls, qualified-name resolution for same-file calls, and CONTAINS edge wiring for both the file and the inner class

**`tests/fixtures/sample.gd`**

*   New fixture exercising `extends Node`, `class_name`, `const preload(...)`, `signal`, `@export` / `@onready` annotations, inner class with its own method, bare calls, attribute calls, and `static func`

**`CHANGELOG.md`**

*   Added GDScript entry under `[Unreleased]`

## Node-type mapping

| Semantic role        | GDScript tree-sitter node types                  | Notes                                                                 |
| -------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
| `_CLASS_TYPES`       | `class_definition`, `class_name_statement`       | Inner `class X:` + file-level `class_name X`                          |
| `_FUNCTION_TYPES`    | `function_definition`                            | Includes `static func` and annotated funcs                            |
| `_IMPORT_TYPES`      | `extends_statement`                              | Parent class / script path as IMPORTS_FROM edge                       |
| `_CALL_TYPES`        | `call`, `attribute_call`                         | `attribute_call` lives inside an `attribute` node for `obj.method()`  |

The generic `_get_name()` handler already covers GDScript — `class_definition`, `class_name_statement`, and `function_definition` all expose a child of type `name` — so no changes were needed to name extraction.

## How to test

```
# Run the GDScript-specific tests
pytest tests/test_multilang.py::TestGDScriptParsing -v

# Run the full multilang + parser suite
pytest tests/test_multilang.py tests/test_parser.py -q

# Lint
ruff check code_review_graph/
```

Local run: **10 new tests pass**, **234 parser/multilang tests pass in total**, `ruff` clean.

## Usage

```
# Any Godot project
code-review-graph build --full
code-review-graph status        # .gd files now appear in language breakdown
```

Example queries that now work on a Godot codebase:

*   `get_impact_radius_tool({target: "ItemsManager.add_main_grid_item"})` — blast radius before editing a manager method
*   `query_graph_tool({pattern: "callers_of", name: "_ready"})` — find every scene that overrides `_ready`
*   `semantic_search_nodes_tool({query: "merge two items"})` — locate the merge logic by concept

## Known gaps / future work

*   `preload("res://x.gd")` and `load("res://x.gd")` currently show up as `CALLS` edges with target `preload` / `load`. Promoting them to `IMPORTS_FROM` would require a bespoke `_extract_gdscript_constructs` hook (mirroring `_extract_lua_constructs`). Left out to keep this PR minimal.
*   `.tscn` (scene) and `.tres` (resource) files carry real cross-file dependencies via `[ext_resource path="..."]`, but they have no tree-sitter grammar. A follow-up PR can add a regex-based handler — same pattern as `_parse_notebook` / `_parse_databricks_py_notebook`.
*   `signal` declarations are not modeled (no semantic role fits). They could be added as `Type` nodes later if signal-aware review becomes useful.
