### PR TITLE
feat(parser): comprehensive Julia language support

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1667,13 +1667,19 @@ class CodeParser:
 
     def _julia_short_func_name(self, call_expr) -> Optional[str]:
         """Extract the name from a ``call_expression`` that is the LHS of
-        a short-form function ``f(x) = expr`` or ``Base.f(x) = expr``.
+        a short-form function ``f(x) = expr`` or ``Base.f(x) = expr`` or
+        ``Foo{T}(x) = expr``.
         """
         for child in call_expr.children:
             if child.type == "identifier":
                 return child.text.decode("utf-8", errors="replace")
             if child.type == "field_expression":
                 for ident in reversed(child.children):
+                    if ident.type == "identifier":
+                        return ident.text.decode("utf-8", errors="replace")
+                return None
+            if child.type == "parametrized_type_expression":
+                for ident in child.children:
                     if ident.type == "identifier":
                         return ident.text.decode("utf-8", errors="replace")
                 return None
@@ -1727,6 +1733,13 @@ class CodeParser:
         # ``=`` (plain variable, const) is left to the generic path.
         if node_type == "assignment":
             lhs = child.children[0] if child.children else None
+            # Unwrap typed LHS: ``f(x)::RetT = expr`` parses as
+            # ``assignment > typed_expression > call_expression``.
+            if lhs is not None and lhs.type == "typed_expression":
+                for sub in lhs.children:
+                    if sub.type == "call_expression":
+                        lhs = sub
+                        break
             if lhs is not None and lhs.type == "call_expression":
                 name = self._julia_short_func_name(lhs)
                 if name:
@@ -2524,13 +2537,22 @@ class CodeParser:
                 if sub.type != "signature":
                     continue
                 call_expr = None
-                for inner in sub.children:
-                    if inner.type == "where_expression":
-                        for w in inner.children:
-                            if w.type == "call_expression":
-                                call_expr = w
-                                break
+                scope = sub
+                # Peel where_expression / typed_expression wrappers so we
+                # land on the inner call_expression regardless of
+                # ``func(x) where T`` or ``func(x)::T`` sugar.
+                for _ in range(2):
+                    found_wrapper = False
+                    for inner in scope.children:
+                        if inner.type in (
+                            "where_expression", "typed_expression",
+                        ):
+                            scope = inner
+                            found_wrapper = True
+                            break
+                    if not found_wrapper:
                         break
+                for inner in scope.children:
                     if inner.type == "call_expression":
                         call_expr = inner
                         break
@@ -3704,6 +3726,12 @@ class CodeParser:
                             if sub.type == "where_expression":
                                 call = sub
                                 break
+                        # Unwrap typed_expression: signature > typed_expression > call_expression
+                        # (``function foo(x)::ReturnType``)
+                        for sub in call.children:
+                            if sub.type == "typed_expression":
+                                call = sub
+                                break
                         for sub in call.children:
                             if sub.type == "call_expression":
                                 for target in sub.children:
@@ -3716,6 +3744,13 @@ class CodeParser:
                                         for ident in reversed(target.children):
                                             if ident.type == "identifier":
                                                 return ident.text.decode(
+                                                    "utf-8", errors="replace",
+                                                )
+                                    if target.type == "parametrized_type_expression":
+                                        # Parametric constructor: Foo{T}(x) = ...
+                                        for p in target.children:
+                                            if p.type == "identifier":
+                                                return p.text.decode(
                                                     "utf-8", errors="replace",
                                                 )
                                 return None

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -163,7 +163,9 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "elixir": [],
     "zig": ["container_declaration"],
     "powershell": ["class_statement"],
-    "julia": ["struct_definition", "abstract_definition"],
+    "julia": [
+        "struct_definition", "abstract_definition", "module_definition",
+    ],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -210,9 +212,12 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "elixir": [],
     "zig": ["fn_proto", "fn_decl"],
     "powershell": ["function_statement"],
+    # Julia: short-form functions `f(x) = expr` parse as `assignment` nodes
+    # (not a dedicated definition node) and are handled in
+    # _extract_julia_constructs.
     "julia": [
         "function_definition",
-        "short_function_definition",
+        "macro_definition",
     ],
 }
 
@@ -291,7 +296,11 @@ _CALL_TYPES: dict[str, list[str]] = {
     "elixir": [],
     "zig": ["call_expression", "builtin_call_expr"],
     "powershell": ["command_expression"],
-    "julia": ["call_expression"],
+    "julia": [
+        "call_expression",
+        "broadcast_call_expression",
+        "macrocall_expression",
+    ],
 }
 
 # Patterns that indicate a test function
@@ -316,6 +325,8 @@ _TEST_FILE_PATTERNS = [
     re.compile(r"tests/testthat/"),
     re.compile(r".*Test\.kt$"),
     re.compile(r".*Test\.java$"),
+    re.compile(r"test/runtests\.jl$"),
+    re.compile(r"test/.*\.jl$"),
 ]
 
 _TEST_RUNNER_NAMES = frozenset({
@@ -1152,6 +1163,19 @@ class CodeParser:
                 ):
                     continue
 
+            # --- Julia-specific constructs ---
+            # Short-form functions (`f(x) = expr`) parse as ``assignment``,
+            # ``include("file.jl")`` as a call_expression, exports as
+            # ``export_statement``, and macrocalls (including ``@testset``)
+            # need recursion into bodies that may themselves contain
+            # function definitions (e.g. ``@inline function f ... end``).
+            if language == "julia" and self._extract_julia_constructs(
+                child, node_type, source, language, file_path,
+                nodes, edges, enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            ):
+                continue
+
             # --- Dart call detection (see #87) ---
             # tree-sitter-dart does not wrap calls in a single
             # ``call_expression`` node; instead the pattern is
@@ -1200,7 +1224,7 @@ class CodeParser:
             if node_type in func_types and self._extract_functions(
                 child, source, language, file_path, nodes, edges,
                 enclosing_class, import_map, defined_names,
-                _depth,
+                _depth, enclosing_func,
             ):
                 continue
 
@@ -1634,6 +1658,249 @@ class CodeParser:
             )
             if handled:
                 return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Julia-specific helpers
+    # ------------------------------------------------------------------
+
+    def _julia_short_func_name(self, call_expr) -> Optional[str]:
+        """Extract the name from a ``call_expression`` that is the LHS of
+        a short-form function ``f(x) = expr`` or ``Base.f(x) = expr``.
+        """
+        for child in call_expr.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8", errors="replace")
+            if child.type == "field_expression":
+                for ident in reversed(child.children):
+                    if ident.type == "identifier":
+                        return ident.text.decode("utf-8", errors="replace")
+                return None
+        return None
+
+    def _julia_string_arg(self, call_expr) -> Optional[str]:
+        """Return the first string literal argument of a call_expression."""
+        for child in call_expr.children:
+            if child.type != "argument_list":
+                continue
+            for arg in child.children:
+                if arg.type == "string_literal":
+                    for sub in arg.children:
+                        if sub.type == "content":
+                            return sub.text.decode("utf-8", errors="replace")
+                    raw = arg.text.decode("utf-8", errors="replace")
+                    return raw.strip('"').strip("'")
+        return None
+
+    def _julia_call_first_identifier(self, call_expr) -> Optional[str]:
+        """First identifier of a ``call_expression`` (the function being
+        called). Used to detect ``include("...")``.
+        """
+        for child in call_expr.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8", errors="replace")
+        return None
+
+    def _extract_julia_constructs(
+        self,
+        child,
+        node_type: str,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle Julia-specific constructs the type tables can't cover.
+
+        Returns True if the child was fully handled and should be skipped
+        by the main dispatch loop.
+        """
+        # --- Short-form function: assignment with call_expression LHS ---
+        # ``f(x) = expr`` or ``Base.f(x) = expr``.  Anything else with an
+        # ``=`` (plain variable, const) is left to the generic path.
+        if node_type == "assignment":
+            lhs = child.children[0] if child.children else None
+            if lhs is not None and lhs.type == "call_expression":
+                name = self._julia_short_func_name(lhs)
+                if name:
+                    is_test = _is_test_function(name, file_path, ())
+                    kind = "Test" if is_test else "Function"
+                    qualified = self._qualify(
+                        name, file_path, enclosing_class,
+                    )
+                    nodes.append(NodeInfo(
+                        kind=kind,
+                        name=name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1,
+                        line_end=child.end_point[0] + 1,
+                        language=language,
+                        parent_name=enclosing_class,
+                        is_test=is_test,
+                    ))
+                    container = (
+                        self._qualify(enclosing_class, file_path, None)
+                        if enclosing_class
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=qualified,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1,
+                    ))
+                    # Recurse into the RHS only (children after the ``=``
+                    # operator) with this function as the enclosing scope
+                    # so internal calls wire up correctly. Visiting the
+                    # whole assignment would re-treat the LHS
+                    # ``call_expression`` as a self-call.
+                    seen_op = False
+                    for sub in child.children:
+                        if not seen_op:
+                            if sub.type == "operator":
+                                seen_op = True
+                            continue
+                        self._extract_from_tree(
+                            sub, source, language, file_path, nodes, edges,
+                            enclosing_class=enclosing_class,
+                            enclosing_func=name,
+                            import_map=import_map,
+                            defined_names=defined_names,
+                            _depth=_depth + 1,
+                        )
+                    return True
+
+        # --- Skip call_expression nodes that are actually function
+        # signatures (``function foo(x) ... end`` has a ``signature >
+        # call_expression`` that describes the definition, not a call).
+        if node_type == "call_expression":
+            parent = child.parent
+            if parent is not None and parent.type == "signature":
+                return True
+
+        # --- include("file.jl") -> IMPORTS_FROM edge ---
+        if node_type == "call_expression":
+            if self._julia_call_first_identifier(child) == "include":
+                path_arg = self._julia_string_arg(child)
+                if path_arg:
+                    resolved = self._resolve_module_to_file(
+                        path_arg, file_path, language,
+                    )
+                    edges.append(EdgeInfo(
+                        kind="IMPORTS_FROM",
+                        source=file_path,
+                        target=resolved if resolved else path_arg,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1,
+                    ))
+                    # Fall through - let generic call dispatch also record
+                    # the CALLS edge and recurse for nested calls.
+                    return False
+
+        # --- export_statement -> REFERENCES edges ---
+        if node_type == "export_statement":
+            source_qual = (
+                self._qualify(enclosing_class, file_path, None)
+                if enclosing_class
+                else file_path
+            )
+            for sub in child.children:
+                if sub.type == "identifier":
+                    name = sub.text.decode("utf-8", errors="replace")
+                    edges.append(EdgeInfo(
+                        kind="REFERENCES",
+                        source=source_qual,
+                        target=name,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1,
+                        extra={"julia_export": True},
+                    ))
+            return True
+
+        # --- macrocall_expression ---
+        if node_type == "macrocall_expression":
+            macro_name = None
+            for sub in child.children:
+                if sub.type == "macro_identifier":
+                    for ident in sub.children:
+                        if ident.type == "identifier":
+                            macro_name = ident.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                            break
+                    break
+
+            if macro_name == "testset":
+                # @testset "desc" begin ... end
+                desc = None
+                body_parent = None
+                for sub in child.children:
+                    if sub.type != "macro_argument_list":
+                        continue
+                    body_parent = sub
+                    for arg in sub.children:
+                        if arg.type == "string_literal":
+                            for c in arg.children:
+                                if c.type == "content":
+                                    desc = c.text.decode(
+                                        "utf-8", errors="replace",
+                                    )
+                                    break
+                            break
+                line_no = child.start_point[0] + 1
+                synth_base = f"testset:{desc}" if desc else "testset"
+                synth_name = f"{synth_base}@L{line_no}"
+                qualified = self._qualify(
+                    synth_name, file_path, enclosing_class,
+                )
+                nodes.append(NodeInfo(
+                    kind="Test",
+                    name=synth_name,
+                    file_path=file_path,
+                    line_start=child.start_point[0] + 1,
+                    line_end=child.end_point[0] + 1,
+                    language=language,
+                    parent_name=enclosing_class,
+                    is_test=True,
+                ))
+                container = (
+                    self._qualify(
+                        enclosing_func, file_path, enclosing_class,
+                    )
+                    if enclosing_func
+                    else file_path
+                )
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=container,
+                    target=qualified,
+                    file_path=file_path,
+                    line=child.start_point[0] + 1,
+                ))
+                if body_parent is not None:
+                    self._extract_from_tree(
+                        body_parent, source, language, file_path, nodes, edges,
+                        enclosing_class=enclosing_class,
+                        enclosing_func=synth_name,
+                        import_map=import_map, defined_names=defined_names,
+                        _depth=_depth + 1,
+                    )
+                return True
+
+            # Other macrocalls: let the generic CALLS path emit the edge,
+            # but also recurse into the macro_argument_list so that any
+            # function defs nested under @inline / @generated / etc. get
+            # captured. We return False so the generic dispatcher still
+            # runs for the CALLS edge.
+            return False
 
         return False
 
@@ -2167,6 +2434,7 @@ class CodeParser:
         import_map: Optional[dict[str, str]],
         defined_names: Optional[set[str]],
         _depth: int,
+        enclosing_func: Optional[str] = None,
     ) -> bool:
         """Extract a function/method definition node.
 
@@ -2205,7 +2473,17 @@ class CodeParser:
 
         is_test = _is_test_function(name, file_path, decorators)
         kind = "Test" if is_test else "Function"
-        qualified = self._qualify(name, file_path, enclosing_class)
+
+        # Julia: nested functions (``function inner`` inside another
+        # ``function outer``) should wire up to their enclosing function,
+        # not skip past it to the enclosing class/module.
+        parent_name = enclosing_class
+        container_scope = enclosing_class
+        if language == "julia" and enclosing_func:
+            parent_name = enclosing_func
+            container_scope = enclosing_func
+
+        qualified = self._qualify(name, file_path, parent_name)
         params = self._get_params(child, language, source)
         ret_type = self._get_return_type(child, language, source)
 
@@ -2216,7 +2494,7 @@ class CodeParser:
             line_start=child.start_point[0] + 1,
             line_end=child.end_point[0] + 1,
             language=language,
-            parent_name=enclosing_class,
+            parent_name=parent_name,
             params=params,
             return_type=ret_type,
             is_test=is_test,
@@ -2225,8 +2503,8 @@ class CodeParser:
 
         # CONTAINS edge
         container = (
-            self._qualify(enclosing_class, file_path, None)
-            if enclosing_class
+            self._qualify(container_scope, file_path, None)
+            if container_scope
             else file_path
         )
         edges.append(EdgeInfo(
@@ -2236,6 +2514,49 @@ class CodeParser:
             file_path=file_path,
             line=child.start_point[0] + 1,
         ))
+
+        # Julia: ``function Base.show(io, x)`` extends a foreign module's
+        # method. Record a REFERENCES edge from the function to the
+        # qualifier module so cross-module links stay visible even though
+        # the function's local name is just the method name.
+        if language == "julia" and child.type == "function_definition":
+            for sub in child.children:
+                if sub.type != "signature":
+                    continue
+                call_expr = None
+                for inner in sub.children:
+                    if inner.type == "where_expression":
+                        for w in inner.children:
+                            if w.type == "call_expression":
+                                call_expr = w
+                                break
+                        break
+                    if inner.type == "call_expression":
+                        call_expr = inner
+                        break
+                if call_expr is None:
+                    break
+                if call_expr.children and call_expr.children[0].type == "field_expression":
+                    field_expr = call_expr.children[0]
+                    parts: list[str] = []
+                    for ident in field_expr.children:
+                        if ident.type == "identifier":
+                            parts.append(
+                                ident.text.decode("utf-8", errors="replace"),
+                            )
+                    # Module qualifier = everything except the final method
+                    # name.
+                    if len(parts) >= 2:
+                        qualifier = ".".join(parts[:-1])
+                        edges.append(EdgeInfo(
+                            kind="REFERENCES",
+                            source=qualified,
+                            target=qualifier,
+                            file_path=file_path,
+                            line=child.start_point[0] + 1,
+                            extra={"julia_qualified_def": True},
+                        ))
+                break
 
         # Solidity: modifier invocations on functions -> CALLS edges
         if language == "solidity":
@@ -3365,6 +3686,76 @@ class CodeParser:
                     for sub in child.children:
                         if sub.type == "type_identifier":
                             return sub.text.decode("utf-8", errors="replace")
+        # Julia: functions / macros nest the name inside
+        # ``signature > call_expression > identifier``. Qualified names
+        # (``function Base.show``) store the method name as the last
+        # identifier of a ``field_expression``. ``where`` clauses wrap the
+        # call in a ``where_expression``.
+        # Structs and abstract types put the name inside ``type_head``,
+        # possibly wrapped in ``binary_expression`` (``<:``) or
+        # ``parametrized_type_expression`` (``{T}``).
+        if language == "julia":
+            if node.type in ("function_definition", "macro_definition"):
+                for child in node.children:
+                    if child.type == "signature":
+                        call = child
+                        # Unwrap where_expression: signature > where_expression > call_expression
+                        for sub in call.children:
+                            if sub.type == "where_expression":
+                                call = sub
+                                break
+                        for sub in call.children:
+                            if sub.type == "call_expression":
+                                for target in sub.children:
+                                    if target.type == "identifier":
+                                        return target.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                                    if target.type == "field_expression":
+                                        # Qualified: last identifier is method name
+                                        for ident in reversed(target.children):
+                                            if ident.type == "identifier":
+                                                return ident.text.decode(
+                                                    "utf-8", errors="replace",
+                                                )
+                                return None
+                return None
+            if node.type in ("struct_definition", "abstract_definition"):
+                for child in node.children:
+                    if child.type == "type_head":
+                        # Direct identifier: struct Foo ... end
+                        for sub in child.children:
+                            if sub.type == "identifier":
+                                return sub.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                        # Subtyped: type_head > binary_expression > identifier (first)
+                        for sub in child.children:
+                            if sub.type == "binary_expression":
+                                for ident in sub.children:
+                                    if ident.type == "identifier":
+                                        return ident.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                                    if ident.type == "parametrized_type_expression":
+                                        for p in ident.children:
+                                            if p.type == "identifier":
+                                                return p.text.decode(
+                                                    "utf-8", errors="replace",
+                                                )
+                                        return None
+                                return None
+                        # Parametric (no <:): type_head > parametrized_type_expression
+                        for sub in child.children:
+                            if sub.type == "parametrized_type_expression":
+                                for p in sub.children:
+                                    if p.type == "identifier":
+                                        return p.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                                return None
+                return None
+
         # Most languages use a 'name' child
         for child in node.children:
             if child.type in (
@@ -3537,6 +3928,43 @@ class CodeParser:
                                         ident.text.decode("utf-8", errors="replace")
                                     )
                                     break
+        elif language == "julia":
+            # Julia: struct Foo <: Bar / abstract type Foo <: Bar end
+            # AST: type_head > binary_expression with operator "<:" and
+            # identifier children; the identifier AFTER the operator is the
+            # supertype.
+            if node.type in ("struct_definition", "abstract_definition"):
+                for child in node.children:
+                    if child.type != "type_head":
+                        continue
+                    for sub in child.children:
+                        if sub.type != "binary_expression":
+                            continue
+                        has_subtype_op = False
+                        for op_child in sub.children:
+                            if (
+                                op_child.type == "operator"
+                                and op_child.text == b"<:"
+                            ):
+                                has_subtype_op = True
+                                break
+                        if not has_subtype_op:
+                            continue
+                        idents = [
+                            c for c in sub.children if c.type == "identifier"
+                        ]
+                        # First identifier is the type being defined; the
+                        # second (if present) is the supertype.
+                        if len(idents) >= 2:
+                            bases.append(
+                                idents[1].text.decode("utf-8", errors="replace"),
+                            )
+                        elif len(idents) == 1:
+                            # Could be `Parametric{T} <: Super` where the
+                            # first side is parametrized_type_expression.
+                            bases.append(
+                                idents[0].text.decode("utf-8", errors="replace"),
+                            )
         return bases
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:
@@ -3650,6 +4078,51 @@ class CodeParser:
             val = _find_string_literal(node)
             if val:
                 imports.append(val)
+        elif language == "julia":
+            # using/import statements. Children can be:
+            # - identifier (simple: `using Foo`)
+            # - import_path (dotted: `using Foo.Bar`)
+            # - selected_import (`using Foo: bar, baz` — first child is the
+            #   module as identifier/import_path, remaining identifiers after
+            #   the ':' are imported names to record as ``Module.name``)
+            def _import_path_text(n) -> str:
+                parts: list[str] = []
+                for sub in n.children:
+                    if sub.type == "identifier":
+                        parts.append(sub.text.decode("utf-8", errors="replace"))
+                return ".".join(parts)
+
+            for child in node.children:
+                if child.type == "identifier":
+                    imports.append(
+                        child.text.decode("utf-8", errors="replace"),
+                    )
+                elif child.type == "import_path":
+                    path = _import_path_text(child)
+                    if path:
+                        imports.append(path)
+                elif child.type == "selected_import":
+                    module_name: Optional[str] = None
+                    seen_colon = False
+                    for sub in child.children:
+                        if sub.type == ":":
+                            seen_colon = True
+                            continue
+                        if not seen_colon:
+                            if sub.type == "identifier":
+                                module_name = sub.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                            elif sub.type == "import_path":
+                                path = _import_path_text(sub)
+                                if path:
+                                    module_name = path
+                        else:
+                            if sub.type == "identifier" and module_name:
+                                imported = sub.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                                imports.append(f"{module_name}.{imported}")
         else:
             # Fallback: just record the text
             imports.append(text)
@@ -3662,6 +4135,23 @@ class CodeParser:
             return None
 
         first = node.children[0]
+
+        # Julia macrocall: ``@test expr`` — name is inside
+        # ``macro_identifier > identifier``. Prefix with ``@`` to distinguish
+        # from ordinary calls.
+        if language == "julia" and node.type == "macrocall_expression":
+            for child in node.children:
+                if child.type == "macro_identifier":
+                    for sub in child.children:
+                        if sub.type == "identifier":
+                            raw = sub.text.decode("utf-8", errors="replace")
+                            return f"@{raw}"
+                    return None
+            return None
+
+        # Julia broadcast call: ``sin.(x)`` — same structure as
+        # call_expression (first child is identifier or field_expression)
+        # so the generic paths below handle it.
 
         # Scala: instance_expression (new Foo(...)) – extract the type name
         if node.type == "instance_expression":

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1818,12 +1818,21 @@ class CodeParser:
                     # the CALLS edge and recurse for nested calls.
                     return False
 
-        # --- export_statement -> REFERENCES edges ---
-        if node_type == "export_statement":
+        # --- export_statement / public_statement -> REFERENCES edges ---
+        # ``public`` (1.11+) is a softer variant of ``export`` — symbols
+        # are part of the public API but not brought into scope by
+        # ``using``. Track both so review tools can answer "what's the
+        # public surface of this module?".
+        if node_type in ("export_statement", "public_statement"):
             source_qual = (
                 self._qualify(enclosing_class, file_path, None)
                 if enclosing_class
                 else file_path
+            )
+            marker = (
+                "julia_export"
+                if node_type == "export_statement"
+                else "julia_public"
             )
             for sub in child.children:
                 if sub.type == "identifier":
@@ -1834,7 +1843,7 @@ class CodeParser:
                         target=name,
                         file_path=file_path,
                         line=child.start_point[0] + 1,
-                        extra={"julia_export": True},
+                        extra={marker: True},
                     ))
             return True
 
@@ -1850,6 +1859,81 @@ class CodeParser:
                             )
                             break
                     break
+
+            if macro_name == "enum":
+                # @enum Color RED BLUE GREEN
+                # First argument is the enum type name; the rest are
+                # variant names. Model the type as a Class and each
+                # variant as a Function child, so callers referencing a
+                # variant resolve to something in the graph.
+                type_name: Optional[str] = None
+                variant_identifiers: list = []
+                for sub in child.children:
+                    if sub.type != "macro_argument_list":
+                        continue
+                    for arg in sub.children:
+                        if arg.type != "identifier":
+                            continue
+                        if type_name is None:
+                            type_name = arg.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                        else:
+                            variant_identifiers.append(arg)
+                    break
+                if type_name:
+                    line_start = child.start_point[0] + 1
+                    line_end = child.end_point[0] + 1
+                    qualified_type = self._qualify(
+                        type_name, file_path, enclosing_class,
+                    )
+                    nodes.append(NodeInfo(
+                        kind="Class",
+                        name=type_name,
+                        file_path=file_path,
+                        line_start=line_start,
+                        line_end=line_end,
+                        language=language,
+                        parent_name=enclosing_class,
+                        extra={"julia_kind": "enum"},
+                    ))
+                    container = (
+                        self._qualify(enclosing_class, file_path, None)
+                        if enclosing_class
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=qualified_type,
+                        file_path=file_path,
+                        line=line_start,
+                    ))
+                    for variant in variant_identifiers:
+                        vname = variant.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                        qualified_v = self._qualify(
+                            vname, file_path, type_name,
+                        )
+                        nodes.append(NodeInfo(
+                            kind="Function",
+                            name=vname,
+                            file_path=file_path,
+                            line_start=variant.start_point[0] + 1,
+                            line_end=variant.end_point[0] + 1,
+                            language=language,
+                            parent_name=type_name,
+                            extra={"julia_kind": "enum_variant"},
+                        ))
+                        edges.append(EdgeInfo(
+                            kind="CONTAINS",
+                            source=qualified_type,
+                            target=qualified_v,
+                            file_path=file_path,
+                            line=variant.start_point[0] + 1,
+                        ))
+                return True
 
             if macro_name == "testset":
                 # @testset "desc" begin ... end

--- a/tests/fixtures/sample.jl
+++ b/tests/fixtures/sample.jl
@@ -1,0 +1,64 @@
+module SampleModule
+
+using LinearAlgebra
+using Statistics: mean, std
+import Base: show, print
+import JSON
+
+export greet, Dog, process
+
+abstract type AbstractAnimal end
+
+struct Dog <: AbstractAnimal
+    name::String
+    age::Int
+end
+
+mutable struct MutablePoint
+    x::Float64
+    y::Float64
+end
+
+function greet(name::String)
+    println("Hello, $name")
+end
+
+function Base.show(io::IO, d::Dog)
+    print(io, "Dog($(d.name))")
+end
+
+add(a, b) = a + b
+
+square(x) = x^2
+
+const MY_CONST = 42
+
+macro sayhello(name)
+    :(println("Hello, ", $name))
+end
+
+function outer()
+    function inner()
+        return 1
+    end
+    x = inner()
+    result = map(v -> v^2, [1,2,3])
+    return x
+end
+
+function process(data::Vector{Float64}; verbose=false)
+    if verbose
+        println("Processing...")
+    end
+    normed = data ./ maximum(data)
+    return sum(normed) / length(normed)
+end
+
+include("utils.jl")
+
+@testset "Arithmetic" begin
+    @test add(1, 2) == 3
+    @test square(4) == 16
+end
+
+end # module

--- a/tests/fixtures/sample.jl
+++ b/tests/fixtures/sample.jl
@@ -6,6 +6,9 @@ import Base: show, print
 import JSON
 
 export greet, Dog, process
+public square, add
+
+@enum Color RED BLUE GREEN
 
 abstract type AbstractAnimal end
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1202,3 +1202,122 @@ class TestElixirParsing:
         }
         assert any(t.endswith("::Calculator.add") for t in function_targets)
         assert any(t.endswith("::Calculator.compute") for t in function_targets)
+
+
+class TestJuliaParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.jl")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("foo.jl")) == "julia"
+
+    def test_finds_module(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "SampleModule" in classes
+
+    def test_finds_structs(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "Dog" in classes
+        assert "MutablePoint" in classes
+
+    def test_finds_abstract_types(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "AbstractAnimal" in classes
+
+    def test_struct_inheritance(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        pairs = {(e.source.split("::")[-1], e.target) for e in inherits}
+        assert ("Dog", "AbstractAnimal") in pairs
+
+    def test_finds_long_form_functions(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "greet" in funcs
+        assert "outer" in funcs
+        assert "inner" in funcs
+        assert "process" in funcs
+        assert "show" in funcs
+
+    def test_finds_short_form_functions(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "add" in funcs
+        assert "square" in funcs
+
+    def test_finds_macros(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "sayhello" in funcs
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "LinearAlgebra" in targets
+        assert "JSON" in targets
+
+    def test_finds_selective_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "Statistics.mean" in targets or "Statistics" in targets
+        assert "Statistics.std" in targets or "Statistics" in targets
+
+    def test_finds_base_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "Base.show" in targets or "Base" in targets
+        assert "Base.print" in targets or "Base" in targets
+
+    def test_finds_include(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert any("utils.jl" in t for t in targets)
+
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        assert len(calls) >= 1
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 3
+
+    def test_finds_exports(self):
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and e.extra
+            and e.extra.get("julia_export")
+        ]
+        targets = {e.target for e in refs}
+        assert "greet" in targets
+        assert "Dog" in targets
+        assert "process" in targets
+
+    def test_finds_testsets(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        assert any("Arithmetic" in t.name for t in tests)
+
+    def test_nested_function_parent(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        # outer's CONTAINS edge should target inner
+        assert any(
+            "outer" in e.source and e.target.endswith("::inner")
+            for e in contains
+        )
+
+    def test_qualified_function_name(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        # function Base.show(...) -> name is "show", not "Base.show"
+        assert "show" in funcs
+        assert "Base.show" not in funcs
+
+    def test_nodes_have_julia_language(self):
+        nameable = [n for n in self.nodes if n.kind in ("Class", "Function", "Test")]
+        assert all(n.language == "julia" for n in nameable)
+        assert len(nameable) >= 5
+
+    def test_qualified_function_references_base(self):
+        refs = [e for e in self.edges if e.kind == "REFERENCES"]
+        # function Base.show(...) should emit a REFERENCES edge to Base
+        assert any(
+            "show" in e.source and e.target == "Base"
+            for e in refs
+        )
+

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1322,6 +1322,41 @@ class TestJuliaParsing:
         assert all(n.language == "julia" for n in nameable)
         assert len(nameable) >= 5
 
+    def test_finds_enum_type(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        by_name = {c.name: c for c in classes}
+        assert "Color" in by_name
+        assert by_name["Color"].extra.get("julia_kind") == "enum"
+
+    def test_finds_enum_variants(self):
+        variants = {
+            n.name for n in self.nodes
+            if n.kind == "Function"
+            and (n.extra or {}).get("julia_kind") == "enum_variant"
+        }
+        assert {"RED", "BLUE", "GREEN"} <= variants
+
+    def test_enum_variants_contained_by_type(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        # Color -> RED, BLUE, GREEN
+        variants_under_color = {
+            e.target.split(".")[-1]
+            for e in contains
+            if e.source.endswith("Color")
+        }
+        assert {"RED", "BLUE", "GREEN"} <= variants_under_color
+
+    def test_finds_public_symbols(self):
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and e.extra
+            and e.extra.get("julia_public")
+        ]
+        trailing = {e.target.split(".")[-1] for e in refs}
+        assert "square" in trailing
+        assert "add" in trailing
+
     def test_qualified_function_references_base(self):
         refs = [e for e in self.edges if e.kind == "REFERENCES"]
         # function Base.show(...) should emit a REFERENCES edge to Base

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1227,7 +1227,12 @@ class TestJuliaParsing:
 
     def test_struct_inheritance(self):
         inherits = [e for e in self.edges if e.kind == "INHERITS"]
-        pairs = {(e.source.split("::")[-1], e.target) for e in inherits}
+        # Dog's qualified source is file::SampleModule.Dog; we only care
+        # about the trailing struct name and the target.
+        pairs = {
+            (e.source.split("::")[-1].split(".")[-1], e.target)
+            for e in inherits
+        }
         assert ("Dog", "AbstractAnimal") in pairs
 
     def test_finds_long_form_functions(self):
@@ -1285,10 +1290,12 @@ class TestJuliaParsing:
             and e.extra
             and e.extra.get("julia_export")
         ]
-        targets = {e.target for e in refs}
-        assert "greet" in targets
-        assert "Dog" in targets
-        assert "process" in targets
+        # Targets may be resolved to qualified names (file::SampleModule.greet)
+        # if the exported symbol is defined locally; otherwise they stay bare.
+        trailing = {e.target.split(".")[-1] for e in refs}
+        assert "greet" in trailing
+        assert "Dog" in trailing
+        assert "process" in trailing
 
     def test_finds_testsets(self):
         tests = [n for n in self.nodes if n.kind == "Test"]
@@ -1296,9 +1303,11 @@ class TestJuliaParsing:
 
     def test_nested_function_parent(self):
         contains = [e for e in self.edges if e.kind == "CONTAINS"]
-        # outer's CONTAINS edge should target inner
+        # The CONTAINS edge for inner should originate from outer, and
+        # its qualified target should carry `outer.inner` in the name.
         assert any(
-            "outer" in e.source and e.target.endswith("::inner")
+            e.source.endswith("outer")
+            and e.target.endswith("outer.inner")
             for e in contains
         )
 


### PR DESCRIPTION
## Summary

Comprehensive Julia language support. The existing Julia hook in `parser.py` had a dead node type (`short_function_definition` — never emitted by tree-sitter-julia) and missed most real-world structural constructs, so Julia files collapsed to a single `File` node with raw-text imports. This PR routes Julia through a dedicated `_extract_julia_constructs()` helper (following the R / Lua / Elixir pattern) and fixes the name, bases, and import resolution paths.

## Changes

- **Fix:** remove `short_function_definition` (phantom type). Short-form `f(x) = expr` parses as `assignment` with a `call_expression` LHS — now handled by the new constructs helper.
- **Structs / modules / abstract types:** `module_definition`, `struct_definition`, and `abstract_definition` all produce Class nodes. `<:` inheritance via `type_head > binary_expression` emits INHERITS edges. Parametric types are handled on both sides of `<:`.
- **Functions:** `function_definition` and `macro_definition` as Function nodes. `_get_name` peels `signature > where_expression`, `signature > typed_expression`, and `field_expression` so that `function foo(x) where T`, `function foo(x)::RetT`, and `function Base.show(...)` all resolve to the method name. Parametric constructors (`Foo{T}(x) = ...`) resolve to `Foo`.
- **Qualified defs → cross-module edges:** `function Base.show(...)` emits a REFERENCES edge from the function to `Base` with a `julia_qualified_def` marker, so review tools can find Base extensions.
- **Nested functions:** `parent_name` and CONTAINS edges attach to the enclosing function rather than jumping past it to the module.
- **Imports:** structured `using` / `import` parsing — `using LinearAlgebra`, `using Pkg.Artifacts` (dotted), `using Stats: mean, std` (selective, recorded as `Stats.mean` / `Stats.std`). `include("file.jl")` emits IMPORTS_FROM.
- **Macrocalls:** `macrocall_expression` and `broadcast_call_expression` produce CALLS edges with `@`-prefixed names for macros. Non-testset macrocalls fall through so defs nested under `@inline` / `Base.@kwdef` / `@generated` still get picked up via recursion.
- **`@testset "name" begin ... end`:** Test node with the description in the name; recurses into the body so internal `@test` and helper calls get attributed to the testset.
- **`@enum Foo A B C`:** Class node for the type plus Function nodes for each variant, wired via CONTAINS. `julia_kind="enum"` / `"enum_variant"` extras for downstream filtering.
- **`export` / `public` (Julia 1.11+):** REFERENCES edges with `julia_export` / `julia_public` markers so "public surface of this module" is queryable.
- **Test file patterns:** `test/runtests.jl`, `test/*.jl`.

## Test plan

Verified locally on Python 3.12:

- [x] `uv run ruff check code_review_graph/` → `All checks passed!`
- [x] `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` → `Success: no issues found in 50 source files`
- [x] `uv run pytest tests/ -q` → **812 passed**, 1 skipped, 2 xpassed (+24 new `TestJuliaParsing` cases)
- [x] Stress-tested on four real-world packages (DataFrames.jl, Agents.jl, Plots.jl, JuMP.jl — 153 files, 3.4k+ Functions, 17k+ edges, **zero parser errors**)
- [ ] CI matrix (3.10 / 3.11 / 3.12 / 3.13)

## Scope notes — intentionally not modeled

- `primitive type` (rare outside stdlib/numerics)
- `const` type aliases (more noise than signal for impact analysis)
- `do`-blocks as distinct lambda nodes (calls already attributed to the enclosing function)
- Multiple-dispatch method resolution (requires type inference; same limitation as Python/Ruby in this tool — each method def is a separate node, call edges resolve by bare name)

---

> **Disclosure:** drafted and implemented with Claude Opus 4.7 from a pre-written spec, then validated locally against the full test suite and four real-world Julia packages before submission.