### PR TITLE
fix: restore Java parser fixes (#275/#278/#280), GDScript support (#316), and refresh stdio banner test

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4095,7 +4095,23 @@ class CodeParser:
                     for arg in child.children:
                         if arg.type in ("identifier", "attribute"):
                             bases.append(arg.text.decode("utf-8", errors="replace"))
-        elif language in ("java", "csharp", "kotlin"):
+        elif language == "java":
+            # Java: superclass and super_interfaces wrap the keyword
+            # (extends/implements) around type_identifier children.
+            # Taking .text would include the keyword (e.g. "implements Foo").
+            # Drill into the children to extract bare type names.
+            for child in node.children:
+                if child.type == "superclass":
+                    for sub in child.children:
+                        if sub.type in ("type_identifier", "generic_type"):
+                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                elif child.type == "super_interfaces":
+                    for sub in child.children:
+                        if sub.type == "type_list":
+                            for ident in sub.children:
+                                if ident.type in ("type_identifier", "generic_type"):
+                                    bases.append(ident.text.decode("utf-8", errors="replace"))
+        elif language in ("csharp", "kotlin"):
             # Look for superclass/interfaces in extends/implements clauses
             for child in node.children:
                 if child.type in (

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4015,6 +4015,16 @@ class CodeParser:
             for child in node.children:
                 if child.type == "field_identifier":
                     return child.text.decode("utf-8", errors="replace")
+        # Java methods: tree-sitter-java puts type_identifier or generic_type
+        # (return type) before identifier (method name).  Must run before
+        # the generic loop, which would match the return type's
+        # type_identifier (e.g. "String", "ConfigBean").
+        # Constructors are fine — they have no return type node.
+        # Kotlin is unaffected: its syntax places the name before the type.
+        if language == "java" and node.type == "method_declaration":
+            for child in node.children:
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
         # Swift extensions: name is inside user_type > type_identifier
         # (e.g. `extension MyClass: Protocol { ... }`)
         if language == "swift" and node.type == "class_declaration":

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3766,6 +3766,38 @@ class CodeParser:
             # ``dart:core`` / ``dart:async`` etc. are SDK libraries we do
             # not track; fall through to return None.
 
+        elif language == "java":
+            # ``import com.example.pkg.ClassName;`` — convert dot-notation
+            # to a relative path and walk up from the caller's directory to
+            # find the source root.  Wildcards (``import pkg.*``) and static
+            # member imports (``import static pkg.Class.member``) that don't
+            # resolve as-is are retried after dropping the last segment
+            # (the member name).
+            if module.endswith(".*"):
+                return None  # wildcard import — can't resolve to one file
+            rel_path = module.replace(".", "/") + ".java"
+            current = caller_dir
+            while True:
+                target = current / rel_path
+                if target.is_file():
+                    return str(target.resolve())
+                if current == current.parent:
+                    break
+                current = current.parent
+            # Static import: ``pkg.Class.member`` — strip member, try again
+            dot = module.rfind(".")
+            if dot > 0:
+                class_module = module[:dot]
+                rel_path2 = class_module.replace(".", "/") + ".java"
+                current = caller_dir
+                while True:
+                    target = current / rel_path2
+                    if target.is_file():
+                        return str(target.resolve())
+                    if current == current.parent:
+                        break
+                    current = current.parent
+
         return None
 
     def _find_dart_pubspec_root(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -172,6 +172,9 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "zig": ["container_declaration"],
     "powershell": ["class_statement"],
     "julia": ["struct_definition", "abstract_definition"],
+    # GDScript: inner classes use ``class Name:`` (class_definition); the
+    # file-level ``class_name Name`` gives the script itself an identity.
+    "gdscript": ["class_definition", "class_name_statement"],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -222,6 +225,8 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
         "function_definition",
         "short_function_definition",
     ],
+    # GDScript: ``func name(args) -> ReturnType:`` — includes ``static func``.
+    "gdscript": ["function_definition"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -262,6 +267,11 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "powershell": [],
     # Julia: import/using are import_statement nodes.
     "julia": ["import_statement", "using_statement"],
+    # GDScript has no ``import`` keyword. The closest analogue is
+    # ``extends OtherClass`` / ``extends "res://path.gd"``, which establishes
+    # a hard dependency on the parent script. preload()/load() calls remain
+    # as ordinary CALLS edges.
+    "gdscript": ["extends_statement"],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -300,6 +310,9 @@ _CALL_TYPES: dict[str, list[str]] = {
     "zig": ["call_expression", "builtin_call_expr"],
     "powershell": ["command_expression"],
     "julia": ["call_expression"],
+    # GDScript: bare calls produce ``call``; ``obj.method()`` is an
+    # ``attribute`` node whose right-hand side is an ``attribute_call``.
+    "gdscript": ["call", "attribute_call"],
 }
 
 # Patterns that indicate a test function
@@ -4311,6 +4324,25 @@ class CodeParser:
             val = _find_string_literal(node)
             if val:
                 imports.append(val)
+        elif language == "gdscript":
+            # ``extends Node`` → type > identifier("Node")
+            # ``extends "res://path.gd"`` → string literal
+            # ``extends SomeClass.Nested`` → type node (keep full text)
+            for child in node.children:
+                if child.type == "type":
+                    txt = child.text.decode("utf-8", errors="replace").strip()
+                    if txt:
+                        imports.append(txt)
+                elif child.type == "string":
+                    val = child.text.decode("utf-8", errors="replace").strip("'\"")
+                    if val:
+                        imports.append(val)
+                elif child.type == "identifier":
+                    # Fallback: some grammar variants expose the parent type as
+                    # a bare identifier next to the ``extends`` keyword.
+                    txt = child.text.decode("utf-8", errors="replace")
+                    if txt and txt != "extends":
+                        imports.append(txt)
         else:
             # Fallback: just record the text
             imports.append(text)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,7 +59,7 @@ class TestServeMainTransport:
 
         monkeypatch.setattr(crg_main.mcp, "run", fake_run)
         crg_main.main(repo_root=None)
-        assert calls == [{"transport": "stdio"}]
+        assert calls == [{"transport": "stdio", "show_banner": False}]
 
     def test_http_calls_mcp_run_with_host_port(self, monkeypatch):
         calls: list[dict] = []


### PR DESCRIPTION
Follow-up to #361 / #362. Same silent-revert pattern, three more victims.

## What this PR does

Five cherry-picks onto `main`, preserving authorship:

| Commit | PR | Author | Tests restored |
|---|---|---|---|
| `8104eb7` | #278 | @krmahadevan | 3 Java inheritance/import-edge tests |
| `9a88f20` | #275 | @krmahadevan | 1 Java method-name test |
| `088c281` | #280 | @krmahadevan | 2 Java import-resolution tests |
| `112a442` | #316 | @Mornor | 9 GDScript tests |
| (new) | — | — | 1 stdio-transport assertion refresh |

Plus a 1-line test fix: `TestServeMainTransport.test_stdio_calls_mcp_run_stdio` was asserting `calls == [{"transport": "stdio"}]` but PR #290 (`cc169af`) had added `show_banner=False` to the production call without updating the test. Refreshed the assertion to match.

## Why these were failing

Same root cause as #362: the `3cf31ec` / `cb9d25a` `chore: resolve merge conflicts with main` commits accepted the stale feature-branch side of `parser.py` for the ReScript PR (#323) and Julia PR (#319). Both feature branches forked from `db2d2df` — before the Java/GDScript fixes landed — so `git merge` auto-resolved the Java and GDScript hunks in favour of the side that never had them. See #361 for the full pattern.

## Test results

```bash
# Before (upstream/main @ b0f8527)
60 failed, 1015 passed, 1 skipped, 2 xpassed, 6 errors

# After (this branch, independent of #362)
45 failed, 1030 passed, 1 skipped, 2 xpassed, 6 errors
```

**15 failures fixed.** Remaining 45+6 are explicitly out of scope:
- 39 covered by sibling PR #362 (Julia, shebang, module-scope CALLS, Databricks CRLF).
- 1 PHP `test_finds_calls` — genuine PHP parser bug (namespace resolution returns `\dirname` instead of the user's call). Separate issue.
- 1 `test_module_scope_calls_in_notebook` / similar stragglers — covered by #362.
- 6 `TestApplyToolFilter` errors — `FastMCP._tool_manager` private-API bug from `a3a043b`. Separate issue.

**This PR and #362 are independent and can be merged in either order.** Applying both together yields the full 60 → ≤8 improvement.

## Quality gate

- ✅ `uv run ruff check code_review_graph/parser.py tests/test_main.py`
- ✅ `uv run pytest tests/test_multilang.py::TestJavaParsing tests/test_multilang.py::TestJavaImportResolution tests/test_multilang.py::TestGDScriptParsing tests/test_main.py::TestServeMainTransport` — 25 passed

## Conflict resolution notes

- `parser.py` `EXTENSION_TO_LANGUAGE`: kept **both** `.res`/`.resi` (ReScript, HEAD) and `.gd` (GDScript, cherry-pick side).
- `tests/test_multilang.py`: kept HEAD side (preserves `TestJuliaParsing` class and ReScript cross-module resolver tests that the cherry-pick side did not have).

cc @tirth8205 — second restoration PR for the same merge-resolution bug tracked in #361. @krmahadevan @Mornor — pinging as original authors; please flag if I misread any intent during the cherry-pick.