### PR TITLE
feat: add OpenCode user-level plugin to install command

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -224,6 +224,7 @@ def _handle_init(args: argparse.Namespace) -> None:
         install_cursor_hooks,
         install_git_hook,
         install_hooks,
+        install_opencode_plugin,
         install_qoder_skills,
     )
 
@@ -273,6 +274,14 @@ def _handle_init(args: argparse.Namespace) -> None:
                 print(f"Installed Cursor hooks in {hooks_path}")
             except Exception as exc:
                 logger.warning("Could not install Cursor hooks: %s", exc)
+
+    # OpenCode plugin (user-level, gated by same detect() as MCP config)
+    if not skip_hooks and target in ("all", "opencode") and PLATFORMS["opencode"]["detect"]():
+        try:
+            plugin_path = install_opencode_plugin()
+            print(f"Installed OpenCode plugin in {plugin_path}")
+        except Exception as exc:
+            logger.warning("Could not install OpenCode plugin: %s", exc)
 
     print()
     print("Next steps:")

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -981,3 +981,108 @@ def install_qoder_skills(repo_root: Path) -> Path | None:
         logger.info("Installed %d skill(s) to %s", installed_count, qoder_skills_dir)
         return qoder_skills_dir
     return None
+
+
+# --- OpenCode plugin ---
+
+
+def _opencode_plugin_content() -> str:
+    """Return TypeScript source for the OpenCode user-level plugin.
+
+    The plugin hooks into three OpenCode events to mirror the Claude Code
+    hook behaviors:
+
+    1. ``file.edited`` — runs ``code-review-graph update --skip-flows``
+    2. ``session.created`` — runs ``code-review-graph status``
+    3. ``tool.execute.before`` — when the tool is a shell command starting
+       with ``git commit``, runs ``code-review-graph detect-changes --brief``
+
+    All handlers use try/catch so errors never break the editor session.
+    The plugin uses Bun's ``$`` shell API (provided by OpenCode's plugin
+    context) for subprocess execution.
+    """
+    return """\
+import type { Plugin } from "@opencode-ai/plugin"
+
+/**
+ * code-review-graph plugin for OpenCode.
+ *
+ * Keeps the knowledge graph up-to-date and surfaces status
+ * information automatically during coding sessions.
+ *
+ * Installed by: code-review-graph install --platform opencode
+ */
+
+// Helper: run a shell command quietly, swallowing errors.
+async function run($: any, cmd: string): Promise<string> {
+  try {
+    const result = await $`${cmd}`.quiet()
+    return result.stdout?.toString().trim() ?? ""
+  } catch {
+    return ""
+  }
+}
+
+export default (app: any) => {
+  // 1. Auto-update graph after file edits
+  app.on("file.edited", async ({ $ }: { $: any }) => {
+    try {
+      await $`code-review-graph update --skip-flows`.quiet()
+    } catch {
+      // Swallow — graph may not be built yet for this project.
+    }
+  })
+
+  // 2. Show graph status when a new session starts
+  app.on("session.created", async ({ $ }: { $: any }) => {
+    try {
+      const result = await $`code-review-graph status`.quiet()
+      const output = result.stdout?.toString().trim()
+      if (output) {
+        console.log("[code-review-graph]", output)
+      }
+    } catch {
+      // Swallow — not every project has a graph.
+    }
+  })
+
+  // 3. Detect changes before git commit commands
+  app.on("tool.execute.before", async (ctx: any) => {
+    try {
+      const input = ctx?.input ?? ctx?.params ?? {}
+      const cmd =
+        input.command ?? input.cmd ?? input.content ?? ""
+      if (typeof cmd === "string" && /^git\\s+commit/i.test(cmd)) {
+        const result =
+          await ctx.$`code-review-graph detect-changes --brief`.quiet()
+        const output = result.stdout?.toString().trim()
+        if (output) {
+          console.log("[code-review-graph] Pre-commit analysis:\\n" + output)
+        }
+      }
+    } catch {
+      // Swallow — never block a commit.
+    }
+  })
+}
+"""
+
+
+def install_opencode_plugin() -> Path:
+    """Install the OpenCode user-level plugin for code-review-graph.
+
+    Writes ``~/.config/opencode/plugins/crg-plugin.ts``.  Creates the
+    directories if they don't exist.  If the file already exists it is
+    overwritten (the plugin is self-contained and idempotent).
+
+    Returns:
+        Path to the plugin file that was written.
+    """
+    plugins_dir = Path.home() / ".config" / "opencode" / "plugins"
+    plugin_path = plugins_dir / "crg-plugin.ts"
+
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    plugin_path.write_text(_opencode_plugin_content(), encoding="utf-8")
+    logger.info("Wrote OpenCode plugin: %s", plugin_path)
+
+    return plugin_path

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -22,6 +22,7 @@ from code_review_graph.skills import (
     _detect_serve_command,
     _in_poetry_project,
     _in_uv_project,
+    _opencode_plugin_content,
     generate_cursor_hooks_config,
     generate_hooks_config,
     generate_skills,
@@ -30,6 +31,7 @@ from code_review_graph.skills import (
     install_cursor_hooks,
     install_git_hook,
     install_hooks,
+    install_opencode_plugin,
     install_platform_configs,
 )
 
@@ -1074,3 +1076,118 @@ class TestDetectServeCommand:
         monkeypatch.setattr("code_review_graph.skills.sys.executable", str(fake_python))
         monkeypatch.setattr("code_review_graph.skills.Path.home", staticmethod(lambda: tmp_path))
         assert _in_uv_project() is False
+
+
+class TestOpenCodePluginContent:
+    """Tests for _opencode_plugin_content()."""
+
+    def test_returns_non_empty_string(self):
+        content = _opencode_plugin_content()
+        assert isinstance(content, str)
+        assert len(content) > 100
+
+    def test_has_plugin_type_import(self):
+        content = _opencode_plugin_content()
+        assert "import type" in content
+        assert "@opencode-ai/plugin" in content
+
+    def test_has_default_export(self):
+        content = _opencode_plugin_content()
+        assert "export default" in content
+
+    def test_hooks_file_edited_event(self):
+        content = _opencode_plugin_content()
+        assert '"file.edited"' in content
+        assert "code-review-graph update --skip-flows" in content
+
+    def test_hooks_session_created_event(self):
+        content = _opencode_plugin_content()
+        assert '"session.created"' in content
+        assert "code-review-graph status" in content
+
+    def test_hooks_tool_execute_before_event(self):
+        content = _opencode_plugin_content()
+        assert '"tool.execute.before"' in content
+        assert "code-review-graph detect-changes --brief" in content
+
+    def test_has_git_commit_detection(self):
+        """Pre-commit hook should match git commit commands."""
+        content = _opencode_plugin_content()
+        assert "git" in content
+        assert "commit" in content
+
+    def test_all_handlers_have_try_catch(self):
+        """Every event handler must use try/catch for graceful failure."""
+        content = _opencode_plugin_content()
+        # Count the three event registrations and ensure catch blocks
+        assert content.count("} catch") >= 3
+
+
+class TestInstallOpenCodePlugin:
+    """Tests for install_opencode_plugin()."""
+
+    def test_creates_plugin_file(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            result = install_opencode_plugin()
+        plugin_path = tmp_path / ".config" / "opencode" / "plugins" / "crg-plugin.ts"
+        assert plugin_path.exists()
+        assert result == plugin_path
+
+    def test_plugin_file_has_correct_content(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            result = install_opencode_plugin()
+        content = result.read_text(encoding="utf-8")
+        assert "export default" in content
+        assert "file.edited" in content
+
+    def test_creates_parent_directories(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            install_opencode_plugin()
+        plugins_dir = tmp_path / ".config" / "opencode" / "plugins"
+        assert plugins_dir.is_dir()
+
+    def test_overwrites_existing_plugin(self, tmp_path):
+        plugins_dir = tmp_path / ".config" / "opencode" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        old_plugin = plugins_dir / "crg-plugin.ts"
+        old_plugin.write_text("// old version")
+
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            install_opencode_plugin()
+
+        content = old_plugin.read_text()
+        assert "// old version" not in content
+        assert "export default" in content
+
+    def test_idempotent(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            install_opencode_plugin()
+            result = install_opencode_plugin()
+        content = result.read_text()
+        assert "export default" in content
+        # Only one default export in the file
+        assert content.count("export default") == 1
+
+    def test_plugin_is_typescript(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            result = install_opencode_plugin()
+        assert result.suffix == ".ts"
+
+    def test_preserves_other_plugins(self, tmp_path):
+        plugins_dir = tmp_path / ".config" / "opencode" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        other_plugin = plugins_dir / "other-plugin.ts"
+        other_plugin.write_text("// other plugin")
+
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            install_opencode_plugin()
+
+        assert other_plugin.exists()
+        assert other_plugin.read_text() == "// other plugin"
+
+    def test_file_is_utf8(self, tmp_path):
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            result = install_opencode_plugin()
+        # Should be readable as UTF-8 without errors
+        content = result.read_text(encoding="utf-8")
+        assert len(content) > 0


### PR DESCRIPTION
## Summary

This PR applies the changes from #198 (by @imkarrer) onto current main, resolving the merge conflicts.

- Adds `_opencode_plugin_content()` returning a TypeScript plugin that mirrors Claude Code hook behaviors
- Adds `install_opencode_plugin()` writing `~/.config/opencode/plugins/crg-plugin.ts`
- `_handle_init()` in `cli.py` now calls `install_opencode_plugin()` when `--platform opencode` or `--platform all` is used (unless `--no-hooks` is passed), gated by `PLATFORMS["opencode"]["detect"]()`
- 16 new tests in `TestOpenCodePluginContent` and `TestInstallOpenCodePlugin`

Closes #198. Closes #36.

## Plugin Behaviors

| OpenCode Event | Behavior |
|---|---|
| `file.edited` | Runs `code-review-graph update --skip-flows` |
| `session.created` | Runs `code-review-graph status` and logs output |
| `tool.execute.before` (git commit) | Runs `code-review-graph detect-changes --brief` and logs output |

## Test plan

- [x] `uv run pytest tests/test_skills.py` — 88 passed (16 new tests)
- [x] `uv run ruff check code_review_graph/cli.py code_review_graph/skills.py` — no new errors
- [x] mypy — no new errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)