### PR TITLE
Fix C++ method name extraction for scoped/destructor/operator definitions

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3978,6 +3978,45 @@ class CodeParser:
                     result = self._get_name(child, language, kind)
                     if result:
                         return result
+            # C++: inside function_declarator, the name appears as
+            # qualified_identifier (Class::method), destructor_name (~Class),
+            # operator_name (operator==), or field_identifier. The generic
+            # loop below only recognizes 'identifier'/'type_identifier',
+            # so scoped method definitions would otherwise fall through and
+            # match the outer return-type type_identifier as the function name.
+            # Nested scopes (Outer::Inner::method) produce nested
+            # qualified_identifier nodes — peel until we find the leaf name.
+            if language == "cpp" and node.type == "function_declarator":
+                def _leaf_name(qi):
+                    # Walk right-to-left: the rightmost identifier/
+                    # destructor_name/operator_name is the method name.
+                    # If the rightmost child is itself a qualified_identifier
+                    # (nested scope), recurse into it.
+                    for sub in reversed(qi.children):
+                        if sub.type in (
+                            "identifier",
+                            "destructor_name",
+                            "operator_name",
+                        ):
+                            return sub.text.decode(
+                                "utf-8", errors="replace")
+                        if sub.type == "qualified_identifier":
+                            inner = _leaf_name(sub)
+                            if inner:
+                                return inner
+                    return None
+                for child in node.children:
+                    if child.type == "qualified_identifier":
+                        name = _leaf_name(child)
+                        if name:
+                            return name
+                    if child.type in (
+                        "field_identifier",
+                        "destructor_name",
+                        "operator_name",
+                    ):
+                        return child.text.decode(
+                            "utf-8", errors="replace")
 
         # Objective-C method_definition: the method name is the first
         # ``identifier`` child (first part of the selector). Multi-part

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1209,3 +1209,44 @@ class TestModuleScopeCalls:
             and e.target.endswith("puts")
         ]
         assert len(top_level) == 1
+
+    def test_cpp_scoped_method_names(self, tmp_path):
+        """C++ scoped method definitions must extract the leaf method name,
+        not the return-type identifier.
+
+        Regression: previously ``Ret Class::method()`` indexed as ``Ret``
+        (return type) and ``void Class::method()`` was silently dropped
+        because _get_name() fell through to the generic identifier loop,
+        which did not recognise qualified_identifier, destructor_name, or
+        operator_name nodes inside function_declarator.
+        """
+        src = b"""
+void PlaybackExtension::resetStateForPool() {}
+quint64 PlaybackExtension::startTimestamp() const { return 0; }
+PlaybackExtension::~PlaybackExtension() {}
+~PlaybackExtension() {}
+bool operator==(const A& a, const B& b) { return true; }
+bool MyClass::operator<(const MyClass& o) const { return true; }
+void foo() {}
+int SnapshotController::getHandleIndex() { return 0; }
+bool PlaybackWidget::AllocateResourceStrategy::allocateExtensionResource(int i) { return true; }
+void A::B::C::deep() {}
+ExtensionID PlaybackExtension::ID() const { return {}; }
+"""
+        p = tmp_path / "x.cpp"
+        p.write_bytes(src)
+        nodes, _ = self.parser.parse_file(p)
+        names = [n.name for n in nodes if n.kind == "Function"]
+        assert names == [
+            "resetStateForPool",
+            "startTimestamp",
+            "~PlaybackExtension",
+            "~PlaybackExtension",
+            "operator==",
+            "operator<",
+            "foo",
+            "getHandleIndex",
+            "allocateExtensionResource",
+            "deep",
+            "ID",
+        ]


### PR DESCRIPTION
## Problem

`CodeParser._get_name()` returns wrong or missing names for C++ method
definitions whose name is expressed via `qualified_identifier`,
`destructor_name`, or `operator_name`:

| Definition                         | Expected       | Before              | After          |
|------------------------------------|----------------|---------------------|----------------|
| `void Class::method()`             | `method`       | (missing)           | `method`       |
| `Ret Class::method() const`        | `method`       | `Ret` (return type) | `method`       |
| `Class::~Class()`                  | `~Class`       | (missing)           | `~Class`       |
| `bool Class::operator==(...)`      | `operator==`   | (missing) / `bool`  | `operator==`   |
| `void A::B::C::nested()`           | `nested`       | (missing)           | `nested`       |

## Root cause

Tree-sitter-cpp represents scoped method names as `qualified_identifier`
inside `function_declarator`. Existing `_get_name()`:

1. Recurses into `function_declarator`, then
2. Falls through to a generic loop that only recognises `identifier`,
   `name`, `type_identifier`, `property_identifier`, `simple_identifier`,
   `constant`.

`qualified_identifier`, `destructor_name`, and `operator_name` are not
in that list, so the recursive call returns `None`. The outer call
then re-runs the generic loop on `function_definition` and matches
the sibling return-type `type_identifier` as the function name
(e.g. `quint64 Class::foo()` → name stored as `"quint64"`). Methods
with a `void` return type (a `primitive_type`, not in the list) get
silently dropped with no node emitted.

## Fix

Add explicit handling inside `function_declarator` for C++: peel
`qualified_identifier` (recursively, to handle nested scopes like
`Outer::Inner::method`) to reach the leaf `identifier` /
`destructor_name` / `operator_name`. Also recognise
`field_identifier` / `destructor_name` / `operator_name` as direct
children of `function_declarator` (for unscoped destructor / operator
definitions). Runs before the generic fallthrough so the correct name
wins.

## Verification

Tested against a real-world Qt C++ codebase (~2,770 files):

- **Before**: 6,903 nodes, 42,997 edges
- **After**:  23,815 nodes, 182,077 edges (~3.4× / 4.2×)

The increase reflects C++ class methods that were previously silently
skipped or mis-indexed. `whoCalls(method)` queries that returned empty
before now return correct caller lists.

See added unit tests for all variants (scoped, nested-scoped,
destructor, operator, free function).
```

## Diff (patch against `code_review_graph/parser.py`)

Apply at `_get_name()`, right after the existing C/C++/Objective-C
declarator-recursion block (around line 3160):

```python
            # C++: inside function_declarator, the name appears as
            # qualified_identifier (Class::method), destructor_name (~Class),
            # operator_name (operator==), or field_identifier. The generic
            # loop below only recognizes 'identifier'/'type_identifier',
            # so scoped method definitions would otherwise fall through and
            # match the outer return-type type_identifier as the function name.
            # Nested scopes (Outer::Inner::method) produce nested
            # qualified_identifier nodes — peel until we find the leaf name.
            if language == "cpp" and node.type == "function_declarator":
                def _leaf_name(qi):
                    # Walk right-to-left: the rightmost identifier/
                    # destructor_name/operator_name is the method name.
                    # If the rightmost child is itself a qualified_identifier
                    # (nested scope), recurse into it.
                    for sub in reversed(qi.children):
                        if sub.type in (
                            "identifier",
                            "destructor_name",
                            "operator_name",
                        ):
                            return sub.text.decode(
                                "utf-8", errors="replace")
                        if sub.type == "qualified_identifier":
                            inner = _leaf_name(sub)
                            if inner:
                                return inner
                    return None
                for child in node.children:
                    if child.type == "qualified_identifier":
                        name = _leaf_name(child)
                        if name:
                            return name
                    if child.type in (
                        "field_identifier",
                        "destructor_name",
                        "operator_name",
                    ):
                        return child.text.decode(
                            "utf-8", errors="replace")
```

## Suggested unit test

```python
def test_cpp_scoped_method_names(tmp_path):
    from code_review_graph.parser import CodeParser
    src = b"""
void PlaybackExtension::resetStateForPool() {}
quint64 PlaybackExtension::startTimestamp() const { return 0; }
PlaybackExtension::~PlaybackExtension() {}
~PlaybackExtension() {}
bool operator==(const A& a, const B& b) { return true; }
bool MyClass::operator<(const MyClass& o) const { return true; }
void foo() {}
int SnapshotController::getHandleIndex() { return 0; }
bool PlaybackWidget::AllocateResourceStrategy::allocateExtensionResource(int i) { return true; }
void A::B::C::deep() {}
ExtensionID PlaybackExtension::ID() const { return {}; }
"""
    p = tmp_path / "x.cpp"
    p.write_bytes(src)
    nodes, _ = CodeParser().parse_file(p)
    names = [n.name for n in nodes if n.kind == "Function"]
    assert names == [
        "resetStateForPool",
        "startTimestamp",
        "~PlaybackExtension",
        "~PlaybackExtension",
        "operator==",
        "operator<",
        "foo",
        "getHandleIndex",
        "allocateExtensionResource",
        "deep",
        "ID",
    ]