### PR TITLE
feat: .hh extension support in parser

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -88,6 +88,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".c": "c",
     ".h": "c",
     ".hpp": "cpp",
+    ".hh": "cpp",
     ".kt": "kotlin",
     ".swift": "swift",
     ".php": "php",

--- a/tests/fixtures/sample.hh
+++ b/tests/fixtures/sample.hh
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+
+class Shape {
+public:
+    std::string color;
+
+    Shape(std::string c) : color(c) {}
+    virtual double area() const = 0;
+};
+
+class Circle : public Shape {
+public:
+    double radius;
+
+    Circle(std::string c, double r) : Shape(c), radius(r) {}
+    double area() const override { return 3.14159 * radius * radius; }
+};
+
+inline double perimeter(const Circle& circle) {
+    return 2.0 * 3.14159 * circle.radius;
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -316,6 +316,30 @@ class TestCppParsing:
         assert len(inherits) >= 1
 
 
+class TestHhParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.hh")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("types.hh")) == "cpp"
+
+    def test_finds_classes(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "Shape" in names
+        assert "Circle" in names
+
+    def test_finds_functions(self):
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        assert "perimeter" in names
+
+    def test_finds_inheritance(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        assert len(inherits) >= 1
+
+
 def _has_csharp_parser():
     try:
         import tree_sitter_language_pack as tslp


### PR DESCRIPTION
I was finding issues indexing files in my repo which looked to be caused by our .hh extensions for C++ header. This updates the parser to treat them accordingly 