### PR TITLE
feat: make remote code execution configurable via env var

### DIFF
--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -66,10 +66,12 @@ class LocalEmbeddingProvider(EmbeddingProvider):
         if self._model is None:
             try:
                 from sentence_transformers import SentenceTransformer
+                # Check environment variable, default to False to prevent RCE
+                allow_remote_code = os.environ.get("CRG_ALLOW_REMOTE_CODE", "0").lower() in ("1", "true", "yes")
+
                 self._model = SentenceTransformer(
                     self._model_name,
-                    trust_remote_code=True,
-                    model_kwargs={"trust_remote_code": True},
+                    trust_remote_code=allow_remote_code,
                 )
             except ImportError:
                 raise ImportError(

--- a/uv.lock
+++ b/uv.lock
@@ -411,6 +411,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'eval'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0,<1" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=3.0.0,<4" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0,<3" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0" },
     { name = "tree-sitter", specifier = ">=0.23.0,<1" },
     { name = "tree-sitter-language-pack", specifier = ">=0.3.0,<1" },


### PR DESCRIPTION
# 🛡️ Security: Fix Remote Code Execution (RCE) vulnerability in embeddings

## Overview
This document summarizes the security fix implemented to prevent potential Remote Code Execution (RCE) when loading local embedding models.

## The Issue
The `LocalEmbeddingProvider` was previously configured to instantiate `SentenceTransformer` with the `trust_remote_code=True` flag hardcoded. 

**Risk Level: Critical**
- **Vulnerability**: Remote Code Execution (RCE)
- **Vector**: Maliciously crafted models hosted on remote registries (like HuggingFace Hub).
- **Impact**: Loading a compromised model would allow it to execute arbitrary Python code on the host machine with the same permissions as the application.

## The Solution
We have implemented a **"Secure by Default"** policy for model loading.

### 1. Disabled Default Trust
The hardcoded `trust_remote_code=True` has been removed. The application now defaults to `False`, which prevents the execution of any untrusted code bundled with a model.

### 2. Introduced Explicit Opt-in
Users who intentionally need to use models that require custom remote code can now do so via a new environment variable:

- **Variable**: `CRG_ALLOW_REMOTE_CODE`
- **Accepted Values**: `1`, `true`, or `yes`
- **Default**: `0` (Disabled)

### 3. Implementation Details
The fix was applied in `code_review_graph/embeddings.py`. The logic now checks the environment variable before passing the flag to the `SentenceTransformer` constructor:

```python
# Check environment variable, default to False to prevent RCE
allow_remote_code = os.environ.get("CRG_ALLOW_REMOTE_CODE", "0").lower() in ("1", "true", "yes")

self._model = SentenceTransformer(
    self._model_name,
    trust_remote_code=allow_remote_code,
)
```