### PR TITLE
fix(parsing): auto-select thread pool on Windows MCP stdio (closes #46, #136)

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -51,6 +51,7 @@ def parse_git_diff_ranges(
         result = subprocess.run(
             ["git", "diff", "--unified=0", base, "--"],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             errors="replace",
@@ -92,6 +93,7 @@ def parse_svn_diff_ranges(
         result = subprocess.run(
             cmd,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             errors="replace",

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path, PurePosixPath
 from typing import Callable, Optional
@@ -21,6 +22,37 @@ from .graph import GraphStore
 from .parser import CodeParser
 
 _MAX_PARSE_WORKERS = int(os.environ.get("CRG_PARSE_WORKERS", str(min(os.cpu_count() or 4, 8))))
+
+
+def _select_executor_kind() -> str:
+    """Return 'process' or 'thread' for parallel parsing.
+
+    Defaults to ``process`` (the original behavior, fastest on Linux/macOS).
+    Auto-switches to ``thread`` when running on Windows with stdin not
+    attached to a TTY — that combination indicates an MCP/stdio host, where
+    ``ProcessPoolExecutor`` workers inherit the parent's pipe handles and
+    leak as zombies after the pool closes (issues #46, #136).
+
+    Override explicitly with ``CRG_PARSE_EXECUTOR={process,thread}``.
+
+    Tree-sitter parsing in the worker releases the GIL during native
+    parsing, so the speedup loss for falling back to threads is small
+    (typically <30% on the full-build path) and the trade is worth it
+    to avoid the deadlock + zombie process accumulation.
+    """
+    explicit = os.environ.get("CRG_PARSE_EXECUTOR", "").strip().lower()
+    if explicit in ("process", "thread"):
+        return explicit
+    if sys.platform == "win32" and not sys.stdin.isatty():
+        return "thread"
+    return "process"
+
+
+def _make_executor(max_workers: int):
+    """Construct the parallel-parse executor selected by [_select_executor_kind]."""
+    if _select_executor_kind() == "thread":
+        return concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    return concurrent.futures.ProcessPoolExecutor(max_workers=max_workers)
 
 logger = logging.getLogger(__name__)
 
@@ -774,11 +806,12 @@ def full_build(
             if i % 50 == 0 or i == file_count:
                 logger.info("Progress: %d/%d files parsed", i, file_count)
     else:
-        # Parallel parsing — store calls remain serial (SQLite single-writer)
+        # Parallel parsing — store calls remain serial (SQLite single-writer).
+        # Executor kind auto-selected: process on Linux/macOS/Windows-TTY,
+        # thread on Windows-MCP-stdio to avoid pipe-handle inheritance
+        # deadlock (issues #46, #136). Override via CRG_PARSE_EXECUTOR env.
         args_list = [(rel_path, str(repo_root)) for rel_path in files]
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=_MAX_PARSE_WORKERS,
-        ) as executor:
+        with _make_executor(_MAX_PARSE_WORKERS) as executor:
             for i, (rel_path, nodes, edges, error, fhash) in enumerate(
                 executor.map(_parse_single_file, args_list, chunksize=20),
                 1,
@@ -904,10 +937,9 @@ def incremental_update(
                 logger.warning("Error parsing %s: %s", rel_path, e)
                 errors.append({"file": rel_path, "error": str(e)})
     else:
+        # See full-build comment above for executor kind rationale.
         args_list = [(rel_path, str(repo_root)) for rel_path in to_parse]
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=_MAX_PARSE_WORKERS,
-        ) as executor:
+        with _make_executor(_MAX_PARSE_WORKERS) as executor:
             for rel_path, nodes, edges, error, fhash in executor.map(
                 _parse_single_file,
                 args_list,

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -365,6 +365,7 @@ def _git_branch_info(repo_root: Path) -> tuple[str, str]:
         result = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -377,6 +378,7 @@ def _git_branch_info(repo_root: Path) -> tuple[str, str]:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -456,6 +458,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         result = subprocess.run(
             ["git", "diff", "--name-only", base, "--"],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -465,6 +468,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
             result = subprocess.run(
                 ["git", "diff", "--name-only", "--cached"],
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
@@ -528,6 +532,7 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
         result = subprocess.run(
             ["git", "status", "--porcelain"],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -573,6 +578,7 @@ def get_all_tracked_files(
         result = subprocess.run(
             cmd,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,

--- a/code_review_graph/tools/context.py
+++ b/code_review_graph/tools/context.py
@@ -18,7 +18,7 @@ def _has_git_changes(root: Path, base: str) -> bool:
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", base, "--"],
-            capture_output=True, text=True,
+            capture_output=True, stdin=subprocess.DEVNULL, text=True,
             cwd=str(root), timeout=10,
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -26,7 +26,7 @@ def _has_git_changes(root: Path, base: str) -> bool:
         # Also check staged/unstaged
         result2 = subprocess.run(
             ["git", "status", "--porcelain"],
-            capture_output=True, text=True,
+            capture_output=True, stdin=subprocess.DEVNULL, text=True,
             cwd=str(root), timeout=10,
         )
         return bool(result2.stdout.strip())


### PR DESCRIPTION
## Summary

`ProcessPoolExecutor` in `incremental.py` deadlocks / leaks zombie workers when the package runs under a Windows MCP stdio host (Claude Code, Cursor, etc.). The existing `asyncio.to_thread` wrapper in `main.py` only avoids event-loop deadlock — the worker leak in tear-down is unaddressed.

After repeated MCP graph queries, accumulated zombies (~20 across an hour-long session in my repro) eventually wedge stdio.

## Root cause

`spawn` is the only multiprocessing start method on Windows. Workers spawned from a process whose stdin/stdout are pipes connected to a parent (the MCP host) inherit those handles. When the pool closes, the workers can't detach the inherited pipes cleanly and remain in a hung state. The CLI path (`uvx code-review-graph update`) is unaffected because stdin is a TTY.

## Fix

Auto-select the executor at runtime:

- `process` (default, original behavior) — Linux, macOS, Windows-TTY.
- `thread` — when `sys.platform == "win32"` AND `not sys.stdin.isatty()` (the MCP profile).
- Override with `CRG_PARSE_EXECUTOR={process,thread}` for any environment.

Tree-sitter parsers release the GIL during native parsing, so `ThreadPoolExecutor` keeps a meaningful chunk of the parallelism. Measured on a 202-file Flutter+Dart+SQL repo: full build 1.9s under thread pool with full postprocess (FTS + flows + communities). Comparable to the prior Linux-fork numbers I saw on similar repos.

## Repro environment

- Windows 11 Pro (10.0.26100)
- Python 3.13.x
- crg 2.3.2 from pypi via `uvx code-review-graph serve`
- MCP host: Claude Code

Before: every other MCP build call would hang for minutes, leaving \`uvx\`+python zombies. Status / read-only tools eventually became unresponsive too.
After: builds complete in seconds, no zombies, MCP stays healthy across full sessions.

## Trade-offs

- Slight perf cost on Windows MCP: parsing is now thread-bound. Tree-sitter natives release the GIL, but Python-level setup per file (subset of total work) is serialized. In my repro <30% slower than process pool would have been; vs. the prior "minutes-or-deadlock" path it's a major win.
- Linux/macOS unchanged.
- Windows-TTY (CLI) unchanged.

## Backwards compatibility

No public API changes. New env var `CRG_PARSE_EXECUTOR` is optional. Default behavior preserved on every platform that already worked.

Happy to iterate on the auto-detect heuristic (e.g., detecting "running as MCP" more directly) if you have a preferred signal.