### PR TITLE
fix: extract correct function name for C++ scoped definitions

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3975,6 +3975,13 @@ class CodeParser:
         if language in ("c", "cpp", "objc") and kind == "function":
             for child in node.children:
                 if child.type in ("function_declarator", "pointer_declarator"):
+                    # Scoped names like Foo::bar use qualified_identifier; take
+                    # the rightmost identifier/field_identifier after the last ::.
+                    for sub in child.children:
+                        if sub.type == "qualified_identifier":
+                            for qsub in reversed(sub.children):
+                                if qsub.type in ("identifier", "field_identifier"):
+                                    return qsub.text.decode("utf-8", errors="replace")
                     result = self._get_name(child, language, kind)
                     if result:
                         return result
@@ -4010,11 +4017,13 @@ class CodeParser:
                     for sub in child.children:
                         if sub.type == "type_identifier":
                             return sub.text.decode("utf-8", errors="replace")
-        # Most languages use a 'name' child
+        # Most languages use a 'name' child.
+        # field_identifier covers C++ class member function names inside
+        # function_declarator (e.g. virtual std::string get_name() = 0).
         for child in node.children:
             if child.type in (
                 "identifier", "name", "type_identifier", "property_identifier",
-                "simple_identifier", "constant",
+                "simple_identifier", "constant", "field_identifier",
             ):
                 return child.text.decode("utf-8", errors="replace")
         # For Go type declarations, look for type_spec

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1209,3 +1209,80 @@ class TestModuleScopeCalls:
             and e.target.endswith("puts")
         ]
         assert len(top_level) == 1
+
+class TestCppScopedFunctionName:
+    """Regression tests for C++ scoped function name extraction.
+
+    See: https://github.com/tirth8205/code-review-graph/issues/395
+    """
+
+    def test_scoped_function_with_type_identifier_return(self, tmp_path):
+        """bufferlist OSDService::get_inc_map(...) should extract 'get_inc_map'."""
+        src = tmp_path / "osd_service.cpp"
+        src.write_text(
+            "bufferlist OSDService::get_inc_map(epoch_t e) {\n"
+            "  bufferlist bl;\n"
+            "  return bl;\n"
+            "}\n"
+        )
+        p = CodeParser()
+        nodes, _ = p.parse_file(src)
+        fns = [n for n in nodes if n.kind == "Function"]
+        assert len(fns) == 1
+        assert fns[0].name == "get_inc_map"
+
+    def test_scoped_function_with_qualified_return(self, tmp_path):
+        """std::string OSDMap::get_pool_name(...) should extract 'get_pool_name'."""
+        src = tmp_path / "osd_map.cpp"
+        src.write_text(
+            "std::string OSDMap::get_pool_name(int64_t pool_id) const {\n"
+            '  return "";\n'
+            "}\n"
+        )
+        p = CodeParser()
+        nodes, _ = p.parse_file(src)
+        fns = [n for n in nodes if n.kind == "Function"]
+        assert len(fns) == 1
+        assert fns[0].name == "get_pool_name"
+
+    def test_scoped_function_with_primitive_return_still_works(self, tmp_path):
+        """int OSD::handle_osd_map(...) was already correct; verify no regression."""
+        src = tmp_path / "osd.cpp"
+        src.write_text(
+            "int OSD::handle_osd_map(MOSDMap *m) {\n"
+            "  return 0;\n"
+            "}\n"
+        )
+        p = CodeParser()
+        nodes, _ = p.parse_file(src)
+        fns = [n for n in nodes if n.kind == "Function"]
+        assert len(fns) == 1
+        assert fns[0].name == "handle_osd_map"
+
+    def test_unscoped_function_with_type_identifier_return(self, tmp_path):
+        """static std::string _make_key(...) should extract '_make_key'."""
+        src = tmp_path / "util.cpp"
+        src.write_text(
+            "static std::string _make_key(const std::string& prefix) {\n"
+            "  return prefix;\n"
+            "}\n"
+        )
+        p = CodeParser()
+        nodes, _ = p.parse_file(src)
+        fns = [n for n in nodes if n.kind == "Function"]
+        assert len(fns) == 1
+        assert fns[0].name == "_make_key"
+
+    def test_scoped_function_string_return(self, tmp_path):
+        """string RGWDedupProcessor::get_obj_fingerprint(...) should extract the method name."""
+        src = tmp_path / "rgw_dedup.cpp"
+        src.write_text(
+            "string RGWDedupProcessor::get_obj_fingerprint(const rgw_obj& obj) {\n"
+            '  return "";\n'
+            "}\n"
+        )
+        p = CodeParser()
+        nodes, _ = p.parse_file(src)
+        fns = [n for n in nodes if n.kind == "Function"]
+        assert len(fns) == 1
+        assert fns[0].name == "get_obj_fingerprint"


### PR DESCRIPTION
## Summary

- Fix C++ function name extraction for scoped definitions (`ClassName::method_name`) where the return type is a non-primitive type. Previously, the return type was incorrectly extracted as the function name.
- Add `field_identifier` to the generic name loop for C++ class member function declarations.

## Problem

```cpp
std::string OSDMap::get_pool_name(int64_t pool_id) const { ... }
bufferlist OSDService::get_inc_map(epoch_t e) { ... }
string RGWDedupProcessor::get_obj_fingerprint(const rgw_obj& obj) { ... }
```

| Function | Before | After |
|---|---|---|
| `std::string OSDMap::get_pool_name(...)` | `OSDMap` ❌ | `get_pool_name` ✅ |
| `bufferlist OSDService::get_inc_map(...)` | `bufferlist` ❌ | `get_inc_map` ✅ |
| `string RGWDedupProcessor::get_obj_fingerprint(...)` | `string` ❌ | `get_obj_fingerprint` ✅ |
| `int OSD::handle_osd_map(...)` | `handle_osd_map` ✅ | `handle_osd_map` ✅ |

## Root Cause

`_get_name` recurses into `function_declarator` for C++, but `qualified_identifier` nodes (used for scoped names like `Foo::bar`) are not handled by the generic identifier loop. The recursion returns `None` and the outer loop matches the return type's `type_identifier` first.

## Fix

Detect `qualified_identifier` inside `function_declarator` and take the rightmost `identifier`/`field_identifier` (the actual method name after the last `::`).

## Test plan

- [x] 5 new regression tests in `TestCppScopedFunctionName` covering scoped functions with `type_identifier`, `qualified_identifier`, `primitive_type` return types, and unscoped functions
- [x] All existing C++ parsing tests pass (`test_multilang.py`, `test_parser.py`, `test_visualization.cpp`)

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)