### PR TITLE
parser: detect files under __tests__/ as tests

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -319,6 +319,7 @@ _TEST_FILE_PATTERNS = [
     re.compile(r".*\.spec\.[jt]sx?$"),
     re.compile(r".*_test\.go$"),
     re.compile(r"tests?/"),
+    re.compile(r"[\\/]__tests__[\\/]"),
     re.compile(r".*_test\.dart$"),
     re.compile(r"test[_-].*\.[rR]$"),
     re.compile(r"tests/testthat/"),

--- a/tests/fixtures/__tests__/UserService.ts
+++ b/tests/fixtures/__tests__/UserService.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { UserRepository, UserService } from '../sample_typescript';
+
+describe('UserService (under __tests__/)', () => {
+  it('constructs a service', () => {
+    const service = new UserService();
+    expect(service).toBeDefined();
+  });
+
+  it('returns undefined for missing user', () => {
+    const service = new UserService();
+    const user = service.getUser(999);
+    expect(user).toBeUndefined();
+  });
+});

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -664,8 +664,13 @@ class TestCodeParser:
     def test_jest_tests_dir_produces_test_nodes(self):
         """A vitest-style file under __tests__/ should yield Test nodes
         and TESTED_BY edges, the same as a *.test.ts file."""
-        path = FIXTURES / "__tests__" / "UserService.ts"
-        nodes, edges = self.parser.parse_file(path)
+        fixture_path = FIXTURES / "__tests__" / "UserService.ts"
+        fixture_code = fixture_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "src" / "__tests__" / "UserService.ts"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(fixture_code, encoding="utf-8")
+            nodes, edges = self.parser.parse_file(path)
         tests = [n for n in nodes if n.kind == "Test"]
         test_names = {t.name for t in tests}
         assert any(n.startswith("describe") or n.startswith("describe:") for n in test_names), (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -648,6 +648,35 @@ class TestCodeParser:
             f"All edges: {[(e.kind, e.source, e.target) for e in edges]}"
         )
 
+    # --- __tests__/ directory recognition (Jest convention) ---
+    # Consistency fix: flows.py and refactor.py already recognize __tests__/
+    # but parser.py did not, so files there did not produce Test nodes.
+
+    def test_jest_tests_dir_detected_as_test_file(self):
+        """A file under __tests__/ should be classified as a test file even
+        when the filename itself has no .test./.spec. marker."""
+        from code_review_graph.parser import _is_test_file
+        assert _is_test_file("src/__tests__/UserService.ts")
+        assert _is_test_file("src\\__tests__\\UserService.ts")
+        # Negative: __tests__ as a substring without path separators must not match
+        assert not _is_test_file("my__tests__notdir.ts")
+
+    def test_jest_tests_dir_produces_test_nodes(self):
+        """A vitest-style file under __tests__/ should yield Test nodes
+        and TESTED_BY edges, the same as a *.test.ts file."""
+        path = FIXTURES / "__tests__" / "UserService.ts"
+        nodes, edges = self.parser.parse_file(path)
+        tests = [n for n in nodes if n.kind == "Test"]
+        test_names = {t.name for t in tests}
+        assert any(n.startswith("describe") or n.startswith("describe:") for n in test_names), (
+            f"Expected describe Test node, got: {test_names}"
+        )
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1, (
+            f"Expected TESTED_BY edges from __tests__/ file, got none. "
+            f"Edges: {[(e.kind, e.source, e.target) for e in edges]}"
+        )
+
     def test_non_test_file_describe_not_special(self):
         """describe() in a non-test file should NOT create Test nodes."""
         import tempfile


### PR DESCRIPTION
## Summary

Brings `parser.py` test-file detection in line with `flows.py` and `refactor.py`, which already recognize Jest's `__tests__/` directory convention. Without this fix, a file like `src/__tests__/UserService.ts` was treated as a test by criticality scoring and dead-code analysis but never produced `Test` nodes or `TESTED_BY` edges.

## What changed

- `code_review_graph/parser.py`: add `re.compile(r\"[\\/]__tests__[\\/]\")` to `_TEST_FILE_PATTERNS` (same regex already used in `flows.py:141` and `refactor.py:203`)
- `tests/fixtures/__tests__/UserService.ts`: new fixture under a `__tests__/` directory with no `.test.` / `.spec.` marker in the filename — only the directory should trigger detection
- `tests/test_parser.py`: two regression tests (`test_jest_tests_dir_detected_as_test_file`, `test_jest_tests_dir_produces_test_nodes`)

## Risk

Minimal. Adding a pattern only adds detection — it cannot make a previously-detected test stop being detected. The regex is already in production use elsewhere in the codebase.

## Test plan

- [x] `uv run pytest tests/test_parser.py -k jest_tests_dir -v` — 2/2 passing
- [x] `uv run pytest tests/test_parser.py -k vitest -v` — adjacent test detection unchanged (4/4 passing)
- [x] Verified no new failures vs. `main` baseline (18 pre-existing Windows-only failures present on both)