### PR TITLE
parser: recognize Mocha TDD suite() as a test runner

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -331,6 +331,9 @@ _TEST_FILE_PATTERNS = [
 _TEST_RUNNER_NAMES = frozenset({
     "describe", "it", "test", "beforeEach", "afterEach",
     "beforeAll", "afterAll",
+    # Mocha TDD interface: `suite` is the describe-equivalent.
+    # `test`, the it-equivalent, is already covered above.
+    "suite",
 })
 
 # Annotations/decorators that mark test methods (JUnit, TestNG, etc.)

--- a/tests/fixtures/sample_mocha.test.ts
+++ b/tests/fixtures/sample_mocha.test.ts
@@ -1,0 +1,16 @@
+// Mocha TDD interface: enabled via `mocha --ui tdd`.
+// `suite` is the describe-equivalent and `test` is the it-equivalent.
+import { UserRepository, UserService } from './sample_typescript';
+
+suite('UserService (mocha TDD)', () => {
+  test('constructs a service', () => {
+    const service = new UserService();
+    if (!service) throw new Error('expected service');
+  });
+
+  test('returns undefined for unknown id', () => {
+    const service = new UserService();
+    const user = service.getUser(404);
+    if (user !== undefined) throw new Error('expected undefined');
+  });
+});

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -648,6 +648,28 @@ class TestCodeParser:
             f"All edges: {[(e.kind, e.source, e.target) for e in edges]}"
         )
 
+    # --- Mocha TDD interface (suite/test) ---
+    # Mocha's TDD UI uses `suite()` instead of `describe()`. The `test()`
+    # function is already recognized; this verifies `suite()` is too.
+
+    def test_mocha_tdd_suite_produces_test_nodes(self):
+        """A *.test.ts file using `suite()` should produce Test nodes
+        and TESTED_BY edges, the same as a describe()-based file."""
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_mocha.test.ts")
+        tests = [n for n in nodes if n.kind == "Test"]
+        test_names = {t.name for t in tests}
+        assert any(n.startswith("suite") or n.startswith("suite:") for n in test_names), (
+            f"Expected suite Test node, got: {test_names}"
+        )
+        assert any(n.startswith("test:") for n in test_names), (
+            f"Expected test Test node, got: {test_names}"
+        )
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1, (
+            f"Expected TESTED_BY edges, got none. "
+            f"Edges: {[(e.kind, e.source, e.target) for e in edges]}"
+        )
+
     def test_non_test_file_describe_not_special(self):
         """describe() in a non-test file should NOT create Test nodes."""
         import tempfile


### PR DESCRIPTION
## Summary

Adds `suite` to `_TEST_RUNNER_NAMES` so files using Mocha's TDD interface (`mocha --ui tdd`) produce `Test` nodes for their top-level groupings. `test()` (the `it`-equivalent) was already recognized; `suite()` (the `describe`-equivalent) was not, leaving Mocha TDD codebases partially supported.

## What changed

- `code_review_graph/parser.py`: add `"suite"` to `_TEST_RUNNER_NAMES`
- `tests/fixtures/sample_mocha.test.ts`: new fixture using `suite()` + `test()`
- `tests/test_parser.py`: regression test `test_mocha_tdd_suite_produces_test_nodes`

## Risk

Low. Detection still requires the file to match a test-file pattern (`_is_test_file(file_path) and name in _TEST_RUNNER_NAMES`), so a stray `suite()` call in production code is unaffected. Only added one name — deliberately did not add `setup`/`teardown` because those names are too generic and could false-positive on helper functions inside test files.

## Test plan

- [x] `uv run pytest tests/test_parser.py -k mocha -v` — passing
- [x] `uv run pytest tests/test_parser.py -k vitest -v` — adjacent describe()/it() detection unchanged (4/4)
- [x] No new failures vs. `main` baseline