### PR TITLE
parser: emit REFERENCES edges for Python callback arguments (#363)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3113,6 +3113,11 @@ class CodeParser:
     # AST node types for array/list containers.
     _ARRAY_TYPES = frozenset({"array", "list"})
 
+    # AST node types for call argument containers. JS/TS uses ``arguments``;
+    # Python uses ``argument_list``. Both share the same identifier-child shape
+    # for bare-identifier callbacks like ``executor.submit(my_handler)``.
+    _ARGUMENTS_TYPES = frozenset({"arguments", "argument_list"})
+
     # Names that are almost certainly not function references (constants,
     # common primitives).  All-uppercase identifiers and very short names
     # are excluded by a length/casing heuristic in the method itself.
@@ -3185,7 +3190,7 @@ class CodeParser:
             return
 
         # --- Callback arguments (identifier args inside call_expression) ---
-        if node_type == "arguments":
+        if node_type in self._ARGUMENTS_TYPES:
             self._ref_from_arguments(
                 child, source, language, file_path, caller, edges, imap, dnames,
             )

--- a/tests/fixtures/sample_callback_refs.py
+++ b/tests/fixtures/sample_callback_refs.py
@@ -1,0 +1,35 @@
+"""Fixture for issue #363: function references in callback positions.
+
+Each `*_callback` function is passed as a bare-identifier argument to
+another call. They are never invoked with parens, so without REFERENCES
+edge tracking they would be flagged as dead code.
+"""
+from concurrent.futures import ThreadPoolExecutor
+
+
+def executor_callback():
+    return "submitted"
+
+
+def filter_callback(item):
+    return item > 0
+
+
+def map_callback(item):
+    return item * 2
+
+
+def trigger_executor():
+    with ThreadPoolExecutor() as executor:
+        future = executor.submit(executor_callback)
+        return future
+
+
+def trigger_filter():
+    items = [1, -2, 3, -4]
+    return list(filter(filter_callback, items))
+
+
+def trigger_map():
+    items = [1, 2, 3]
+    return list(map(map_callback, items))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -648,6 +648,54 @@ class TestCodeParser:
             f"All edges: {[(e.kind, e.source, e.target) for e in edges]}"
         )
 
+    # --- Python callback REFERENCES (#363) ---
+    # Functions passed as bare-identifier arguments (executor.submit(fn),
+    # filter(fn, xs), map(fn, xs), df.apply(fn), ...) should produce
+    # REFERENCES edges so dead-code detection does not flag them as unused.
+    # Pre-fix: only the JS/TS `arguments` node type triggered the
+    # _ref_from_arguments dispatcher; Python's `argument_list` was ignored.
+
+    def test_python_callback_references_emitted(self):
+        """A function passed as a bare identifier to another call should
+        produce a REFERENCES edge from the calling function to it."""
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_callback_refs.py")
+        refs = [e for e in edges if e.kind == "REFERENCES"]
+        ref_target_names = {e.target.rsplit("::", 1)[-1] for e in refs}
+        for callback in ("executor_callback", "filter_callback", "map_callback"):
+            assert callback in ref_target_names, (
+                f"Expected REFERENCES edge to {callback}, got targets: "
+                f"{ref_target_names}"
+            )
+
+    def test_python_callback_references_not_treated_as_dead(self):
+        """End-to-end: with REFERENCES edges in place, find_dead_code
+        should not flag callback functions as dead."""
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.refactor import find_dead_code
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "graph.db"
+            store = GraphStore(db_path)
+            try:
+                nodes, edges = self.parser.parse_file(
+                    FIXTURES / "sample_callback_refs.py"
+                )
+                store.store_file_nodes_edges(
+                    str(FIXTURES / "sample_callback_refs.py"),
+                    nodes, edges, "",
+                )
+                dead = find_dead_code(store)
+                dead_names = {d["name"] for d in dead}
+                for callback in (
+                    "executor_callback", "filter_callback", "map_callback",
+                ):
+                    assert callback not in dead_names, (
+                        f"{callback} was flagged as dead but is used as a "
+                        f"callback. Dead names: {dead_names}"
+                    )
+            finally:
+                store.close()
+
     def test_non_test_file_describe_not_special(self):
         """describe() in a non-test file should NOT create Test nodes."""
         import tempfile


### PR DESCRIPTION
Closes #363 (Python portion).

## Summary

`find_dead_code` already considers REFERENCES edges incoming to a node when deciding whether to flag it as dead. But for Python, those edges were never being produced for the most common callback shapes — `executor.submit(handler)`, `filter(predicate, xs)`, `map(transform, xs)`, `df.apply(fn)`, returned inner functions, etc. — so callback functions were systematically reported as unused.

## Root cause

In `code_review_graph/parser.py`, `_extract_value_references` dispatches on the AST node type wrapping a call's arguments:

```python
if node_type == \"arguments\":          # JS/TS only — Python is \"argument_list\"
    self._ref_from_arguments(...)
```

Python's tree-sitter grammar uses `argument_list`. The dispatcher never fired for Python, so `_ref_from_arguments` (which already knows how to walk identifier children) was never invoked.

## Fix

One-line change in intent: introduce a frozenset of accepted argument-container node types and dispatch on membership.

```python
_ARGUMENTS_TYPES = frozenset({\"arguments\", \"argument_list\"})

if node_type in self._ARGUMENTS_TYPES:
    self._ref_from_arguments(...)
```

Mirrors the existing `_PAIR_TYPES` / `_ARRAY_TYPES` style in the same class.

## Why this doesn't add noise

`_ref_from_arguments` only emits when the argument is a bare `identifier`, and `_emit_reference_if_known` further gates emission on the name being locally defined or imported. So `print(x)` where `x` is a local variable does not produce a spurious REFERENCES edge to a function named `x` in some other file.

## What this does not fix

- Keyword-argument callbacks (`executor.submit(callable=h)`) — `keyword_argument` is a different child shape; out of scope for this PR
- Function references in module-level assignments (`HANDLERS = my_func`) — handled by `_ref_from_assignment` already
- Other languages with first-class functions (Ruby `Symbol#to_proc`, Go function values, etc.) — separate work

## Test plan

New fixture `tests/fixtures/sample_callback_refs.py` covers the three patterns called out in the issue body (executor.submit, filter, map). Two regression tests in `tests/test_parser.py`:

- `test_python_callback_references_emitted` — asserts REFERENCES edges land on `executor_callback`, `filter_callback`, `map_callback`
- `test_python_callback_references_not_treated_as_dead` — end-to-end check: parses the fixture, stores in a real `GraphStore`, runs `find_dead_code`, verifies the three callback functions are NOT in the dead list

Verified locally:
- [x] `uv run pytest tests/test_parser.py -k python_callback -v` — 2/2 passing
- [x] `uv run pytest tests/test_parser.py -k \"value_ref or callback or reference\" -q` — 13/13 passing (existing JS/TS REFERENCES tests unchanged)
- [x] `uv run ruff check code_review_graph/parser.py tests/fixtures/sample_callback_refs.py` — clean
- [x] No new failures vs `main` baseline (Windows-only `PermissionError` cluster pre-exists on both)