### PR TITLE
fix(windows): pass stdin=DEVNULL to git/svn subprocesses to prevent MCP hang (closes #401)

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -56,6 +56,7 @@ def parse_git_diff_ranges(
             errors="replace",
             cwd=repo_root,
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             logger.warning("git diff failed (rc=%d): %s", result.returncode, result.stderr[:200])
@@ -97,6 +98,7 @@ def parse_svn_diff_ranges(
             errors="replace",
             cwd=repo_root,
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             logger.warning("svn diff failed (rc=%d): %s", result.returncode, result.stderr[:200])

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -336,6 +336,7 @@ def _git_branch_info(repo_root: Path) -> tuple[str, str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             branch = result.stdout.strip()
@@ -348,6 +349,7 @@ def _git_branch_info(repo_root: Path) -> tuple[str, str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             sha = result.stdout.strip()
@@ -365,6 +367,7 @@ def _svn_revision_info(repo_root: Path) -> tuple[str, str]:
             ["svn", "info", "--non-interactive"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             cwd=str(repo_root), timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             for line in result.stdout.splitlines():
@@ -427,6 +430,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
@@ -436,6 +440,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
                 text=True,
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
+                stdin=subprocess.DEVNULL,
             )
         files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
         return files
@@ -456,6 +461,7 @@ def _get_svn_changed_files(repo_root: Path, rev_range: str | None = None) -> lis
                 ["svn", "diff", "--summarize", "--non-interactive", "-r", rev_range],
                 capture_output=True, text=True, encoding="utf-8", errors="replace",
                 cwd=str(repo_root), timeout=_GIT_TIMEOUT,
+                stdin=subprocess.DEVNULL,
             )
             if result.returncode != 0:
                 logger.warning("svn diff --summarize failed (rc=%d): %s",
@@ -472,6 +478,7 @@ def _get_svn_changed_files(repo_root: Path, rev_range: str | None = None) -> lis
                 ["svn", "status", "--non-interactive"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace",
                 cwd=str(repo_root), timeout=_GIT_TIMEOUT,
+                stdin=subprocess.DEVNULL,
             )
             files = []
             for line in result.stdout.splitlines():
@@ -499,6 +506,7 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         files = []
         for line in result.stdout.splitlines():
@@ -544,6 +552,7 @@ def get_all_tracked_files(
             text=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
         return [f.strip() for f in result.stdout.splitlines() if f.strip()]
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -561,6 +570,7 @@ def _get_svn_all_tracked_files(repo_root: Path) -> list[str]:
             ["svn", "list", "--recursive", "--non-interactive"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             cwd=str(repo_root), timeout=60,  # svn list queries the server
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             # svn list returns paths relative to the WC URL; directories end with "/"

--- a/code_review_graph/tools/context.py
+++ b/code_review_graph/tools/context.py
@@ -20,6 +20,7 @@ def _has_git_changes(root: Path, base: str) -> bool:
             ["git", "diff", "--name-only", base, "--"],
             capture_output=True, text=True,
             cwd=str(root), timeout=10,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0 and result.stdout.strip():
             return True
@@ -28,6 +29,7 @@ def _has_git_changes(root: Path, base: str) -> bool:
             ["git", "status", "--porcelain"],
             capture_output=True, text=True,
             cwd=str(root), timeout=10,
+            stdin=subprocess.DEVNULL,
         )
         return bool(result2.stdout.strip())
     except (FileNotFoundError, subprocess.TimeoutExpired):


### PR DESCRIPTION
## Closes #401

### Problem
On Windows, when CRG runs as an MCP server (stdio transport, e.g. via Claude Code or Cursor), the `git`/`svn` subprocesses spawned by `tools/context.py`, `changes.py`, and `incremental.py` inherit the parent's stdin — which is bound to the MCP request pipe. The child blocks reading from this pipe (Windows console-handle behavior) and never exits. The MCP tool call (`get_minimal_context_tool`, `detect_changes_tool`, `get_changed_files`, etc.) hangs indefinitely. From the user's view Claude Code freezes; only ESC breaks out. `claude doctor` itself times out spawning CRG for the same reason.

### Repro
Reproduces on Claude Code 2.1.126 + CRG 2.3.2 + FastMCP 2.14.7 + Windows 11.

Direct server-side stdio test (`printf '<init>\n<list>\n' | code-review-graph serve`) returns the full tools list in ~1.5s — the subprocess hang is invisible at that level because the bare `initialize` handshake fires no git call. Only when an actual MCP tool calls `get_minimal_context_tool → _has_git_changes → subprocess.run(["git", ...])` does the inherited stdin pipe deadlock the child.

### Fix
Add `stdin=subprocess.DEVNULL` to every `subprocess.run([...git...])` and `subprocess.run([...svn...])` call so the child gets an empty stdin instead of inheriting the MCP pipe. POSIX-safe — `DEVNULL` works identically on Linux/macOS (no behavioural change there).

**14 call sites patched across 3 files:**
- `code_review_graph/tools/context.py`    (2 git calls)
- `code_review_graph/changes.py`          (1 git, 1 svn)
- `code_review_graph/incremental.py`      (6 git, 4 svn)

### Verified
After this patch:
- `mcp__code-review-graph__get_minimal_context_tool` returns in **<2s** with full graph context on Windows 11 + Claude Code 2.1.126.
- Before: hangs >60s, user must ESC.

Likely also addresses related Windows hang reports: #46, #136, #189.

### Why now
The issue was reported 2026-04-29 (#401). I hit it head-on while integrating CRG with Claude Code on a real project (DreamJob.AI) and traced it through:
1. Server-side stdio test passes in 1.5s ✓
2. Tool call from Claude Code hangs forever ✗
3. `claude doctor` also hangs (exit 143)
4. `tasklist` shows multiple zombie `git`/`code-review-graph` processes after each hang attempt
5. Reading `tools/context.py` revealed the missing `stdin=subprocess.DEVNULL` on the subprocess.run calls

Happy to iterate on review feedback. Tested locally for 30+ MCP tool calls without a single hang after the patch.