### PR TITLE
feat: --auto-watch flag to embed watcher inside MCP server process

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -7,7 +7,8 @@ Usage:
     code-review-graph update [--base BASE]
     code-review-graph watch
     code-review-graph status
-    code-review-graph serve [--http] [--host ADDR] [--port PORT]
+    code-review-graph serve [--auto-watch] [--http] [--host ADDR] [--port PORT]
+    code-review-graph mcp [--auto-watch]
     code-review-graph visualize
     code-review-graph wiki
     code-review-graph detect-changes [--base BASE] [--brief]
@@ -513,12 +514,17 @@ def main() -> None:
     detect_cmd.add_argument("--brief", action="store_true", help="Show brief summary only")
     detect_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
 
-    # serve
+    # serve / mcp
     serve_cmd = sub.add_parser(
         "serve",
         help="Start MCP server (stdio by default, or HTTP on localhost with --http)",
     )
     serve_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    serve_cmd.add_argument(
+        "--auto-watch",
+        action="store_true",
+        help="Start filesystem watch in a daemon thread while MCP server runs",
+    )
     serve_cmd.add_argument(
         "--tools", default=None,
         help=(
@@ -545,6 +551,14 @@ def main() -> None:
         default=None,
         metavar="PORT",
         help="Port for --http (default: 5555)",
+    )
+
+    mcp_cmd = sub.add_parser("mcp", help="Alias for serve")
+    mcp_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    mcp_cmd.add_argument(
+        "--auto-watch",
+        action="store_true",
+        help="Start filesystem watch in a daemon thread while MCP server runs",
     )
 
     # daemon
@@ -632,25 +646,30 @@ def main() -> None:
         _print_banner()
         return
 
-    if args.command == "serve":
+    if args.command in ("serve", "mcp"):
         from .main import main as serve_main
 
-        if args.port is not None and not args.http:
-            serve_cmd.error("--port requires --http")
-        if args.host is not None and not args.http:
-            serve_cmd.error("--host requires --http")
-        if args.http:
-            host = args.host if args.host is not None else "127.0.0.1"
-            port = args.port if args.port is not None else 5555
-            serve_main(
-                repo_root=args.repo,
-                transport="streamable-http",
-                host=host,
-                port=port,
-                tools=args.tools,
-            )
+        auto_watch = getattr(args, "auto_watch", False)
+        if args.command == "serve":
+            if args.port is not None and not args.http:
+                serve_cmd.error("--port requires --http")
+            if args.host is not None and not args.http:
+                serve_cmd.error("--host requires --http")
+            if args.http:
+                host = args.host if args.host is not None else "127.0.0.1"
+                port = args.port if args.port is not None else 5555
+                serve_main(
+                    repo_root=args.repo,
+                    auto_watch=auto_watch,
+                    transport="streamable-http",
+                    host=host,
+                    port=port,
+                    tools=args.tools,
+                )
+            else:
+                serve_main(repo_root=args.repo, auto_watch=auto_watch, tools=args.tools)
         else:
-            serve_main(repo_root=args.repo, tools=args.tools)
+            serve_main(repo_root=args.repo, auto_watch=auto_watch)
         return
 
     if args.command == "daemon":

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1101,3 +1101,29 @@ def watch(
         observer.stop()
     observer.join()
     logger.info("Watch stopped.")
+
+
+def start_watch_thread(
+    repo_root: Path,
+    store: GraphStore,
+    daemon: bool = True,
+) -> threading.Thread | None:
+    """Start watch mode in a background thread.
+
+    Returns the started thread, or None if watchdog is unavailable.
+    """
+    try:
+        import watchdog  # noqa: F401
+    except ImportError:
+        logger.warning("watchdog not installed; auto-watch disabled")
+        return None
+
+    thread = threading.Thread(
+        target=watch,
+        args=(repo_root, store),
+        daemon=daemon,
+        name="crg-watch",
+    )
+    thread.start()
+    logger.info("Auto-watch started for %s", repo_root)
+    return thread

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -9,7 +9,9 @@ by default).
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
+from pathlib import Path
 from typing import Optional
 
 from fastmcp import FastMCP
@@ -53,6 +55,11 @@ from .tools import (
     run_postprocess,
     semantic_search_nodes,
 )
+
+from .graph import GraphStore
+from .incremental import find_project_root, get_db_path, start_watch_thread
+
+logger = logging.getLogger(__name__)
 
 # NOTE: Thread-safe for stdio MCP (single-threaded). If adding HTTP/SSE
 # transport with concurrent requests, replace with contextvars.ContextVar.
@@ -952,6 +959,7 @@ def _apply_tool_filter(tools: str | None = None) -> None:
 def main(
     repo_root: str | None = None,
     tools: str | None = None,
+    auto_watch: bool = False,
     *,
     transport: str = "stdio",
     host: str | None = None,
@@ -972,26 +980,41 @@ def main(
         tools: Comma-separated list of tool names to expose.
             Falls back to ``CRG_TOOLS`` env var.  When unset, all
             tools are available.
+        auto_watch: Start filesystem watcher in a background daemon thread
+            while the MCP server runs.
         transport: ``"stdio"`` (default) or ``"streamable-http"`` for local HTTP.
         host: Bind address when using HTTP (required for HTTP; set by CLI).
         port: Port when using HTTP (required for HTTP; set by CLI).
     """
     global _default_repo_root
-    _default_repo_root = repo_root
+    root = Path(repo_root) if repo_root else find_project_root()
+    _default_repo_root = str(root)
     _apply_tool_filter(tools)
+
+    watch_store: GraphStore | None = None
+    if auto_watch:
+        watch_store = GraphStore(get_db_path(root))
+        thread = start_watch_thread(root, watch_store, daemon=True)
+        if thread is None:
+            logger.warning("Auto-watch was requested but could not be started")
+
     if sys.platform == "win32":
-        import asyncio
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    if transport == "stdio":
-        # Stdio MCP must keep stdout strictly JSON-RPC. FastMCP's banner/update
-        # notices corrupt the handshake stream on clients like Codex CLI.
-        mcp.run(transport="stdio", show_banner=False)
-    elif transport == "streamable-http":
-        if host is None or port is None:
-            raise ValueError("streamable-http transport requires host and port")
-        mcp.run(transport="streamable-http", host=host, port=port)
-    else:
-        raise ValueError(f"unsupported transport: {transport!r}")
+
+    try:
+        if transport == "stdio":
+            # Stdio MCP must keep stdout strictly JSON-RPC. FastMCP's banner/update
+            # notices corrupt the handshake stream on clients like Codex CLI.
+            mcp.run(transport="stdio", show_banner=False)
+        elif transport == "streamable-http":
+            if host is None or port is None:
+                raise ValueError("streamable-http transport requires host and port")
+            mcp.run(transport="streamable-http", host=host, port=port)
+        else:
+            raise ValueError(f"unsupported transport: {transport!r}")
+    finally:
+        if watch_store is not None:
+            watch_store.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
-"""Tests for CLI helpers."""
+"""Tests for CLI helpers and MCP serve command wiring."""
 
 import logging
+import sys
 from importlib.metadata import PackageNotFoundError
+from unittest.mock import MagicMock, patch
 
 from code_review_graph import cli
 
@@ -17,3 +19,56 @@ def test_get_version_logs_and_falls_back_to_dev(monkeypatch, caplog):
 
     assert version == "dev"
     assert "Package metadata unavailable" in caplog.text
+
+
+class TestServeCommand:
+    def test_serve_passes_auto_watch_flag(self):
+        argv = [
+            "code-review-graph",
+            "serve",
+            "--repo",
+            "repo-root",
+            "--auto-watch",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.main.main") as mock_serve:
+                cli.main()
+
+        mock_serve.assert_called_once_with(
+            repo_root="repo-root",
+            auto_watch=True,
+            tools=None,
+        )
+
+    def test_mcp_alias_maps_to_serve(self):
+        argv = [
+            "code-review-graph",
+            "mcp",
+            "--repo",
+            "repo-root",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.main.main") as mock_serve:
+                cli.main()
+
+        mock_serve.assert_called_once_with(
+            repo_root="repo-root",
+            auto_watch=False,
+        )
+
+
+class TestWatchInteraction:
+    def test_watch_exits_when_lock_is_held(self):
+        argv = ["code-review-graph", "watch", "--repo", "repo-root"]
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch("code_review_graph.incremental.watch") as mock_watch:
+                        mock_watch.side_effect = RuntimeError("watcher already running")
+                        try:
+                            cli.main()
+                            assert False, "Expected SystemExit"
+                        except SystemExit as exc:
+                            assert exc.code == 1

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -20,6 +20,7 @@ from code_review_graph.incremental import (
     get_db_path,
     get_staged_and_unstaged,
     incremental_update,
+    start_watch_thread,
 )
 
 
@@ -740,5 +741,31 @@ class TestMultiHopDependents:
                 "DependentList.truncated should be False when the "
                 "expansion completed without hitting the cap"
             )
+        finally:
+            store.close()
+
+
+class TestStartWatchThread:
+    @patch("code_review_graph.incremental.watch")
+    def test_starts_background_thread(self, mock_watch, tmp_path):
+        """start_watch_thread returns a running thread when watchdog is available."""
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            thread = start_watch_thread(tmp_path, store, daemon=True)
+            assert thread is not None
+            assert thread.daemon is True
+            assert thread.is_alive()
+        finally:
+            store.close()
+
+    def test_returns_none_when_watchdog_unavailable(self, tmp_path):
+        """start_watch_thread returns None when watchdog is not installed."""
+        db_path = tmp_path / "graph.db"
+        store = GraphStore(db_path)
+        try:
+            with patch.dict("sys.modules", {"watchdog": None}):
+                thread = start_watch_thread(tmp_path, store, daemon=True)
+            assert thread is None
         finally:
             store.close()


### PR DESCRIPTION
## Summary

This PR brings in the `--auto-watch` feature from PR #130 (originally by @Dhruv-Darji), cleanly rebased on top of main (including PR #367 crg-daemon).

**Original PR**: #130 by @Dhruv-Darji — could not be directly merged due to conflicts with main.

### Changes

- **`cli.py`**: Add `--auto-watch` flag to `serve` command; add `mcp` as an alias for `serve`
- **`main.py`**: Add `auto_watch: bool = False` parameter; when enabled, starts a background watchdog thread via `start_watch_thread()` and closes the store on shutdown
- **`incremental.py`**: Add `start_watch_thread()` — starts `watch()` in a daemon thread; returns `None` if watchdog is not installed
- **`tests/test_cli.py`**: Add `TestServeCommand` (auto-watch flag wiring, mcp alias) and `TestWatchInteraction` (lock-held exit)
- **`tests/test_incremental.py`**: Add `TestStartWatchThread` (happy path + watchdog-unavailable fallback)

### Usage

```bash
# Start MCP server with embedded filesystem watcher
code-review-graph serve --auto-watch

# mcp is an alias for serve
code-review-graph mcp --auto-watch

# HTTP transport still works
code-review-graph serve --http --port 5555
```

## Test plan
- [ ] `uv run pytest tests/test_cli.py tests/test_incremental.py -v`
- [ ] `uv run code-review-graph serve --auto-watch` starts MCP with background watcher
- [ ] `uv run code-review-graph mcp` works as alias for `serve`
- [ ] `uv run code-review-graph serve --http --port 5555` still works
- [ ] Watchdog unavailable: `auto_watch=True` logs a warning and proceeds

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)