### PR TITLE
tests: add Bun test fixture for bun:test runtime regression coverage

### DIFF
--- a/tests/fixtures/sample_bun.test.ts
+++ b/tests/fixtures/sample_bun.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, test, expect, beforeEach } from 'bun:test';
+import { UserRepository, UserService } from './sample_typescript';
+
+describe('UserService (bun)', () => {
+  let repo: UserRepository;
+
+  beforeEach(() => {
+    repo = new UserRepository();
+  });
+
+  it('constructs a service with a repository', () => {
+    const service = new UserService();
+    expect(service).toBeDefined();
+  });
+
+  it('finds a user by id', () => {
+    const service = new UserService();
+    const user = service.getUser(123);
+    expect(user).toBeUndefined();
+  });
+
+  test('creates a user via the service', () => {
+    const service = new UserService();
+    const created = service.createUser('alice', 'alice@example.com');
+    expect(created.name).toBe('alice');
+  });
+});

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -696,6 +696,29 @@ class TestCodeParser:
             finally:
                 store.close()
 
+    # --- Bun test detection (regression: bun:test uses identical runner names) ---
+
+    def test_bun_test_detection(self):
+        """A .test.ts file importing from 'bun:test' should produce Test nodes."""
+        nodes, _ = self.parser.parse_file(FIXTURES / "sample_bun.test.ts")
+        tests = [n for n in nodes if n.kind == "Test"]
+        test_names = {t.name for t in tests}
+        assert any(n.startswith("describe") or n.startswith("describe:") for n in test_names), (
+            f"Expected describe Test node, got: {test_names}"
+        )
+        assert any(n.startswith("it:") or n.startswith("test:") for n in test_names), (
+            f"Expected it/test Test node, got: {test_names}"
+        )
+
+    def test_bun_tested_by_edges(self):
+        """TESTED_BY edges should be generated from bun tests to production code."""
+        _, edges = self.parser.parse_file(FIXTURES / "sample_bun.test.ts")
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1, (
+            f"Expected TESTED_BY edges, got none. "
+            f"All edges: {[(e.kind, e.source, e.target) for e in edges]}"
+        )
+
     def test_non_test_file_describe_not_special(self):
         """describe() in a non-test file should NOT create Test nodes."""
         import tempfile


### PR DESCRIPTION
Resolves #421 - fork PR had conflicts with main. This is the conflict-resolved version.

Cherry-picked from Pr1ncePS2002/code-review-graph@3add902, keeping both sides of the conflict (Python callback reference tests from main + Bun test fixture tests from PR).

Co-authored-by: Prince <psingh80436@gmail.com>