### PR TITLE
parser: recognize Mocha TDD suite() as a test runner

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -347,6 +347,9 @@ _TEST_FILE_PATTERNS = [
 _TEST_RUNNER_NAMES = frozenset({
     "describe", "it", "test", "beforeEach", "afterEach",
     "beforeAll", "afterAll",
+    # Mocha TDD interface: `suite` is the describe-equivalent.
+    # `test`, the it-equivalent, is already covered above.
+    "suite",
 })
 
 # Annotations/decorators that mark test methods (JUnit, TestNG, etc.)

--- a/tests/fixtures/sample_mocha.test.ts
+++ b/tests/fixtures/sample_mocha.test.ts
@@ -1,0 +1,16 @@
+// Mocha TDD interface: enabled via `mocha --ui tdd`.
+// `suite` is the describe-equivalent and `test` is the it-equivalent.
+import { UserRepository, UserService } from './sample_typescript';
+
+suite('UserService (mocha TDD)', () => {
+  test('constructs a service', () => {
+    const service = new UserService();
+    if (!service) throw new Error('expected service');
+  });
+
+  test('returns undefined for unknown id', () => {
+    const service = new UserService();
+    const user = service.getUser(404);
+    if (user !== undefined) throw new Error('expected undefined');
+  });
+});

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -753,6 +753,29 @@ class TestCodeParser:
             f"Edges: {[(e.kind, e.source, e.target) for e in edges]}"
         )
 
+    # --- Mocha TDD interface (suite/test) ---
+    # Mocha's TDD UI uses `suite()` instead of `describe()`. The `test()`
+    # function is already recognized; this verifies `suite()` is too.
+
+    def test_mocha_tdd_suite_produces_test_nodes(self):
+        """A *.test.ts file using `suite()` should produce Test nodes
+        and TESTED_BY edges, the same as a describe()-based file."""
+        nodes, edges = self.parser.parse_file(FIXTURES / "sample_mocha.test.ts")
+        tests = [n for n in nodes if n.kind == "Test"]
+        test_names = {t.name for t in tests}
+        assert any(n.startswith("suite") or n.startswith("suite:") for n in test_names), (
+            f"Expected suite Test node, got: {test_names}"
+        )
+        assert any(n.startswith("test:") for n in test_names), (
+            f"Expected test Test node, got: {test_names}"
+        )
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1, (
+            f"Expected TESTED_BY edges, got none. "
+            f"Edges: {[(e.kind, e.source, e.target) for e in edges]}"
+        )
+
+
     def test_non_test_file_describe_not_special(self):
     def test_non_test_file_describe_not_special(self):
         """describe() in a non-test file should NOT create Test nodes."""


### PR DESCRIPTION
Resolves #423 - fork PR had conflicts with main. This is the conflict-resolved version.

Cherry-picked from Pr1ncePS2002/code-review-graph@540fc99, keeping all test sections (callback refs, Bun tests, __tests__/ dir recognition, and new Mocha TDD suite() tests).

Co-authored-by: Prince <psingh80436@gmail.com>