### PR TITLE
feat: add verilog/system-verilog support

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -323,7 +323,9 @@ _CALL_TYPES: dict[str, list[str]] = {
     "zig": ["call_expression", "builtin_call_expr"],
     "powershell": ["command_expression"],
     "julia": ["call_expression"],
-    "verilog": ["module_instantiation", "function_subroutine_call", "subroutine_call", "system_tf_call"],
+    "verilog": [
+        "module_instantiation", "function_subroutine_call", "subroutine_call", "system_tf_call"
+        ],
 }
 
 # Patterns that indicate a test function

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -127,6 +127,11 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".resi": "rescript",
     ".gd": "gdscript",
     ".nix": "nix",
+    # SystemVerilog/Verilog
+    ".sv": "verilog",
+    ".svh": "verilog",
+    ".v": "verilog",
+    ".vh": "verilog",
 }
 
 # Tree-sitter node type mappings per language
@@ -177,6 +182,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "zig": ["container_declaration"],
     "powershell": ["class_statement"],
     "julia": ["struct_definition", "abstract_definition"],
+    "verilog": ["module_declaration", "interface_declaration", "class_declaration"],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -230,6 +236,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
         "function_definition",
         "short_function_definition",
     ],
+    "verilog": ["task_declaration", "function_declaration", "always_construct"],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -274,6 +281,7 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "powershell": [],
     # Julia: import/using are import_statement nodes.
     "julia": ["import_statement", "using_statement"],
+    "verilog": ["package_import_declaration"],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -315,6 +323,7 @@ _CALL_TYPES: dict[str, list[str]] = {
     "zig": ["call_expression", "builtin_call_expr"],
     "powershell": ["command_expression"],
     "julia": ["call_expression"],
+    "verilog": ["module_instantiation", "function_subroutine_call", "subroutine_call", "system_tf_call"],
 }
 
 # Patterns that indicate a test function
@@ -3809,39 +3818,48 @@ class CodeParser:
             )
             return True
 
-        if call_name and enclosing_func:
-            caller = self._qualify(
-                enclosing_func, file_path, enclosing_class,
-            )
-
-            # Java method_invocation: extract actual method name and receiver
-            # separately so the Spring DI resolver can rewrite the target.
-            call_extra: dict = {}
-            if language == "java" and child.type == "method_invocation":
-                method_name, receiver = self._get_java_method_and_receiver(child)
-                if method_name:
-                    call_name = method_name
-                if receiver:
-                    call_extra["receiver"] = receiver
-
-            # When a receiver is present, skip scope-based resolution: the method
-            # lives on the receiver's type, not in the current file's scope.
-            # The spring_resolver post-pass will do the correct cross-type lookup.
-            if call_extra.get("receiver"):
-                target = call_name
-            else:
-                target = self._resolve_call_target(
-                    call_name, file_path, language,
-                    import_map or {}, defined_names or set(),
+        # For Verilog module instantiations, create CALLS edges from the enclosing module
+        # (enclosing_class), not just from functions
+        if call_name:
+            caller = None
+            if enclosing_func:
+                caller = self._qualify(
+                    enclosing_func, file_path, enclosing_class,
                 )
-            edges.append(EdgeInfo(
-                kind="CALLS",
-                source=caller,
-                target=target,
-                file_path=file_path,
-                line=child.start_point[0] + 1,
-                extra=call_extra,
-            ))
+            elif language == "verilog" and enclosing_class:
+                # Verilog module instantiation happen at module level
+                caller = self._qualify(
+                    enclosing_class, file_path, None
+                )
+            if caller:
+                # Java method_invocation: extract actual method name and receiver
+                # separately so the Spring DI resolver can rewrite the target.
+                call_extra: dict = {}
+                if language == "java" and child.type == "method_invocation":
+                    method_name, receiver = self._get_java_method_and_receiver(child)
+                    if method_name:
+                        call_name = method_name
+                    if receiver:
+                        call_extra["receiver"] = receiver
+
+                # When a receiver is present, skip scope-based resolution: the method
+                # lives on the receiver's type, not in the current file's scope.
+                # The spring_resolver post-pass will do the correct cross-type lookup.
+                if call_extra.get("receiver"):
+                    target = call_name
+                else:
+                    target = self._resolve_call_target(
+                        call_name, file_path, language,
+                        import_map or {}, defined_names or set(),
+                    )
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=caller,
+                    target=target,
+                    file_path=file_path,
+                    line=child.start_point[0] + 1,
+                    extra=call_extra,
+                ))
 
         return False
 
@@ -4893,6 +4911,13 @@ class CodeParser:
                     for sub in child.children:
                         if sub.type == "type_identifier":
                             return sub.text.decode("utf-8", errors="replace")
+        # Verilog/SystemVerilog: module/interface names are nested under module_header
+        if language == "verilog" and node.type in ("module_declaration", "interface_declaration"):
+            for child in node.children:
+                if child.type in ("module_header", "interface_header"):
+                    for sub in child.children:
+                        if sub.type == "simple_identifier":
+                            return sub.text.decode("utf-8", errors="replace")
         # Most languages use a 'name' child.
         # field_identifier covers C++ class member function names inside
         # function_declarator (e.g. virtual std::string get_name() = 0).
@@ -5180,6 +5205,14 @@ class CodeParser:
             val = _find_string_literal(node)
             if val:
                 imports.append(val)
+        elif language == "verilog":
+            # import pkg::*; or import pkg::item;
+            # Node structure: package_import_declaration > package_import_item > package_identifier
+            for child in node.children:
+                if child.type == "package_import_item":
+                    for subchild in child.children:
+                        if subchild.type == "package_identifier":
+                            imports.append(subchild.text.decode("utf-8", errors="replace"))
         else:
             # Fallback: just record the text
             imports.append(text)
@@ -5225,6 +5258,12 @@ class CodeParser:
                     # command_name wraps a word — get its text
                     txt = child.text.decode("utf-8", errors="replace").strip()
                     return txt or None
+            return None
+
+        # Verilog/SystemVerilog: module_instantiation's first child is the module name
+        if language == "verilog" and node.type == "module_instantiation":
+            if first.type == "simple_identifier":
+                return first.text.decode("utf-8", errors="replace")
             return None
 
         # Solidity wraps call targets in an 'expression' node – unwrap it

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4913,13 +4913,41 @@ class CodeParser:
                     for sub in child.children:
                         if sub.type == "type_identifier":
                             return sub.text.decode("utf-8", errors="replace")
-        # Verilog/SystemVerilog: module/interface names are nested under module_header
-        if language == "verilog" and node.type in ("module_declaration", "interface_declaration"):
-            for child in node.children:
-                if child.type in ("module_header", "interface_header"):
-                    for sub in child.children:
-                        if sub.type == "simple_identifier":
-                            return sub.text.decode("utf-8", errors="replace")
+        # Verilog/SystemVerilog: names are nested differently per construct type.
+        if language == "verilog":
+            # module_declaration: name is in module_header > simple_identifier
+            if node.type == "module_declaration":
+                for child in node.children:
+                    if child.type == "module_header":
+                        for sub in child.children:
+                            if sub.type == "simple_identifier":
+                                return sub.text.decode("utf-8", errors="replace")
+            # interface_declaration: name is in interface_ansi_header > interface_identifier
+            if node.type == "interface_declaration":
+                for child in node.children:
+                    if child.type in ("interface_header", "interface_ansi_header"):
+                        for sub in child.children:
+                            if sub.type == "simple_identifier":
+                                return sub.text.decode("utf-8", errors="replace")
+                            if sub.type == "interface_identifier":
+                                for ss in sub.children:
+                                    if ss.type == "simple_identifier":
+                                        return ss.text.decode("utf-8", errors="replace")
+                                return sub.text.decode("utf-8", errors="replace")
+            # task_declaration: name is in task_body_declaration > task_identifier
+            if node.type == "task_declaration":
+                for child in node.children:
+                    if child.type == "task_body_declaration":
+                        for sub in child.children:
+                            if sub.type == "task_identifier":
+                                return sub.text.decode("utf-8", errors="replace")
+            # function_declaration: name is in function_body_declaration > function_identifier
+            if node.type == "function_declaration":
+                for child in node.children:
+                    if child.type == "function_body_declaration":
+                        for sub in child.children:
+                            if sub.type == "function_identifier":
+                                return sub.text.decode("utf-8", errors="replace")
         # Most languages use a 'name' child.
         # field_identifier covers C++ class member function names inside
         # function_declarator (e.g. virtual std::string get_name() = 0).

--- a/tests/fixtures/sample.sv
+++ b/tests/fixtures/sample.sv
@@ -1,0 +1,77 @@
+// sample.sv - SystemVerilog fixture for parser tests
+`timescale 1ns / 1ps
+
+// File-level package import
+import utils_pkg::*;
+
+// Interface declaration
+interface BusIf #(parameter int WIDTH = 8);
+    logic [WIDTH-1:0] data;
+    logic             valid;
+    logic             ready;
+    modport master(output data, valid, input ready);
+    modport slave(input data, valid, output ready);
+endinterface
+
+// Submodule to be instantiated by FIFOController
+module Adder #(parameter int WIDTH = 8) (input logic [WIDTH-1:0] a, b, output logic [WIDTH-1:0] sum);
+    assign sum = a + b;
+endmodule
+
+// Main module with tasks, functions, always blocks, and module instantiation
+// Parameters on one line to avoid grammar parse errors
+module FIFOController #(parameter int DEPTH = 16, parameter int WIDTH = 8) (
+    input  logic             clk,
+    input  logic             rst_n,
+    input  logic [WIDTH-1:0] data_in,
+    input  logic             wr_en,
+    input  logic             rd_en,
+    output logic [WIDTH-1:0] data_out,
+    output logic             full,
+    output logic             empty
+);
+
+    // Intra-module package import
+    import arith_pkg::counter_t;
+
+    logic [WIDTH-1:0]       mem [0:DEPTH-1];
+    logic [$clog2(DEPTH):0] wr_ptr, rd_ptr, count;
+
+    // Module instantiation - creates CALLS edge from FIFOController to Adder
+    Adder #(.WIDTH(WIDTH)) ptr_adder (.a(wr_ptr[WIDTH-1:0]), .b(rd_ptr[WIDTH-1:0]), .sum());
+
+    // Task declaration
+    task automatic do_write(input logic [WIDTH-1:0] din);
+        mem[wr_ptr] <= din;
+        wr_ptr <= wr_ptr + 1;
+        count  <= count + 1;
+    endtask
+
+    // Function declaration
+    function automatic logic is_full();
+        return (count >= DEPTH);
+    endfunction
+
+    // Always block (sequential logic) - flattened to avoid nested begin/end
+    // grammar limitation: if(x) begin..end inside else begin..end causes parse errors
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            wr_ptr <= 0;
+            rd_ptr <= 0;
+            count  <= 0;
+        end
+        if (rst_n && wr_en && !full)  do_write(data_in);
+        if (rst_n && rd_en && !empty) begin
+            data_out <= mem[rd_ptr];
+            rd_ptr   <= rd_ptr + 1;
+            count    <= count - 1;
+        end
+    end
+
+    // Always block (combinational logic)
+    always_comb begin
+        full  = is_full();
+        empty = (count == 0);
+    end
+
+endmodule

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2396,3 +2396,80 @@ class TestKafkaParsing:
         kafka = [e for e in self.edges if e.kind in ("CONSUMES", "PRODUCES")]
         bare_sources = {e.source.split("::")[-1].split(".")[0] for e in kafka}
         assert "OrderEvent" not in bare_sources
+
+
+# ---------------------------------------------------------------------------
+# Verilog / SystemVerilog
+# ---------------------------------------------------------------------------
+
+
+def _has_verilog_parser():
+    try:
+        import tree_sitter_language_pack as tslp
+        tslp.get_parser("verilog")
+        return True
+    except (LookupError, ImportError):
+        return False
+
+
+@pytest.mark.skipif(not _has_verilog_parser(), reason="verilog tree-sitter grammar not installed")
+class TestVerilogParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.sv")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("top.sv")) == "verilog"
+        assert self.parser.detect_language(Path("pkg.svh")) == "verilog"
+        assert self.parser.detect_language(Path("cpu.v")) == "verilog"
+        assert self.parser.detect_language(Path("header.vh")) == "verilog"
+
+    def test_finds_modules(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "FIFOController" in names
+        assert "Adder" in names
+
+    def test_finds_interfaces(self):
+        classes = [n for n in self.nodes if n.kind == "Class"]
+        names = {c.name for c in classes}
+        assert "BusIf" in names
+
+    def test_finds_tasks(self):
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        assert "do_write" in names
+
+    def test_finds_functions_in_module(self):
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        assert "is_full" in names
+
+    def test_task_and_function_parent_is_module(self):
+        funcs = {f.name: f for f in self.nodes if f.kind == "Function"}
+        assert funcs["do_write"].parent_name == "FIFOController"
+        assert funcs["is_full"].parent_name == "FIFOController"
+
+    def test_finds_package_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "utils_pkg" in targets
+        assert "arith_pkg" in targets
+
+    def test_module_instantiation_creates_call_edge(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("Adder" in t for t in targets)
+
+    def test_module_instantiation_caller_is_enclosing_module(self):
+        # module_instantiation CALLS must be attributed to the containing
+        # module, not a function — Verilog-specific fallback in _extract_calls.
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        adder_calls = [e for e in calls if "Adder" in e.target]
+        assert adder_calls, "Expected a CALLS edge for Adder instantiation"
+        assert any("FIFOController" in e.source for e in adder_calls)
+
+    def test_file_node_language(self):
+        file_nodes = [n for n in self.nodes if n.kind == "File"]
+        assert len(file_nodes) == 1
+        assert file_nodes[0].language == "verilog"


### PR DESCRIPTION
Resolves #428 - fork PR had conflicts with main. This is the conflict-resolved version.

Cherry-picked from chuanseng-ng/code-review-graph feature/add-sv-support branch (commits 94e1e93, 7aa18cc, 25c2bf0, 4f8124b), keeping all existing functionality (Nix, Java Spring DI, C++ scoped methods) alongside new Verilog support.

Changes:
- Adds .sv, .svh, .v, .vh file extension mappings to "verilog" language
- Parses module, interface, task, function constructs in SystemVerilog/Verilog
- Creates CALLS edges for module instantiations (attributed to enclosing module)
- Creates IMPORTS_FROM edges for package imports
- Adds sample.sv fixture and TestVerilogParsing test class

Co-authored-by: Ng Chuan Seng <waelectriz@gmail.com>