### PR TITLE
fix: d3.select("svg") selects legend inline SVG instead of main canvas

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -856,7 +856,7 @@ function moveTooltip(ev) {
 }
 function hideTooltip() { tooltip.classList.remove("visible"); }
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()
@@ -1756,7 +1756,7 @@ function hideTooltip() { tooltip.classList.remove("visible"); }
 
 /* --- SVG setup --- */
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()


### PR DESCRIPTION
## Problem

In the generated `graph.html`, the `<nav id="legend">` section uses inline `<svg>` elements (16×16 icons) for node type legends. The main canvas `<svg id="graph-svg">` appears later in the DOM. The JavaScript code uses `d3.select("svg")` which selects the **first** `<svg>` element in the DOM — the small legend icon — causing the entire graph to be rendered inside that tiny icon.

## Fix

Replace `d3.select("svg")` with `d3.select("#graph-svg")` at both occurrences in `code_review_graph/visualization.py`:
- Line 859
- Line 1759

The main canvas SVG already has `id="graph-svg"` defined, so this is a minimal, safe change.

## Testing

1. Run `code-review-graph visualize` to generate `graph.html`
2. Open `graph.html` in a browser
3. Graph now renders correctly in the main canvas area

Closes #450