### PR TITLE
fix: accept .svn directories in repo root validation

### DIFF
--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -130,9 +130,9 @@ def load_config(path: Path | None = None) -> DaemonConfig:
             logger.warning("Skipping repo %s — directory does not exist", repo_path)
             continue
 
-        if not (repo_path / ".git").exists() and not (repo_path / ".code-review-graph").exists():
+        if not (repo_path / ".git").exists() and not (repo_path / ".svn").exists() and not (repo_path / ".code-review-graph").exists():
             logger.warning(
-                "Skipping repo %s — no .git or .code-review-graph directory found",
+                "Skipping repo %s — no .git, .svn, or .code-review-graph directory found",
                 repo_path,
             )
             continue
@@ -222,8 +222,8 @@ def add_repo_to_config(
     if not resolved.is_dir():
         raise ValueError(f"Not a directory: {resolved}")
 
-    if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
-        raise ValueError(f"No .git or .code-review-graph directory in {resolved}")
+    if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
+        raise ValueError(f"No .git, .svn, or .code-review-graph directory in {resolved}")
 
     effective_alias = alias or resolved.name
 

--- a/code_review_graph/registry.py
+++ b/code_review_graph/registry.py
@@ -76,10 +76,10 @@ class Registry:
         resolved = Path(path).resolve()
         if not resolved.is_dir():
             raise ValueError(f"Path is not a directory: {resolved}")
-        if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
+        if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
             raise ValueError(
                 f"Path does not look like a repository "
-                f"(no .git or .code-review-graph): {resolved}"
+                f"(no .git, .svn, or .code-review-graph): {resolved}"
             )
 
         with self._lock:

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -61,19 +61,25 @@ _BUILTIN_CALL_NAMES: set[str] = {
 def _validate_repo_root(path: "Path | str") -> Path:
     """Validate that a path is a plausible project root.
 
-    Ensures the path is an existing directory that contains a ``.git``
-    or ``.code-review-graph`` directory, preventing arbitrary file-system
-    traversal via the ``repo_root`` parameter.
+    Ensures the path is an existing directory that contains a ``.git``,
+    ``.svn``, or ``.code-review-graph`` directory, preventing arbitrary
+    file-system traversal via the ``repo_root`` parameter.
     """
     resolved = Path(path).resolve()
     if not resolved.is_dir():
         raise ValueError(
             f"repo_root is not an existing directory: {resolved}"
         )
-    if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
+    has_vcs = (
+        (resolved / ".git").exists()
+        or (resolved / ".svn").exists()
+        or (resolved / ".code-review-graph").exists()
+    )
+    if not has_vcs:
         raise ValueError(
-            f"repo_root does not look like a project root (no .git or "
-            f".code-review-graph directory found): {resolved}"
+            f"repo_root does not look like a project root "
+            f"(no .git, .svn, or .code-review-graph directory found): "
+            f"{resolved}"
         )
     return resolved
 


### PR DESCRIPTION
The repo root validation in _validate_repo_root() and related functions only checked for .git and .code-review-graph directories. This caused all MCP tools to reject SVN working copies at the validation gate, even though the core SVN support (incremental.py, changes.py) was already implemented in v2.3.3 via PR #255.

Add .svn directory checks to:
- tools/_common.py:_validate_repo_root() (MCP tool entry point)
- daemon.py (daemon skip logic and register validation)
- registry.py (register command validation)