### PR TITLE
fix: skip unavailable tree-sitter parsers

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple, Optional
-
-import tree_sitter_language_pack as tslp
 
 from .tsconfig_resolver import TsconfigResolver
 
@@ -42,6 +43,49 @@ _SQL_KEYWORDS: frozenset[str] = frozenset({
 })
 
 logger = logging.getLogger(__name__)
+
+_PARSER_LOAD_TIMEOUT_SECONDS = float(os.environ.get("CRG_PARSER_LOAD_TIMEOUT_SECONDS", "5"))
+_UNAVAILABLE_LANGUAGES: set[str] = set()
+
+
+def _parser_load_probe_succeeds(
+    language: str,
+    timeout_seconds: float = _PARSER_LOAD_TIMEOUT_SECONDS,
+) -> bool:
+    """Return whether a tree-sitter language can be loaded without hanging.
+
+    Some binary bindings in tree-sitter-language-pack can hang during native
+    module import on specific platform/Python combinations. Probe in a child
+    process first so the main build can skip only that language instead of
+    blocking the whole repository graph build until an outer timeout kills it.
+    """
+    code = (
+        "from tree_sitter_language_pack import get_parser\n"
+        "import sys\n"
+        "get_parser(sys.argv[1])\n"
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", code, language],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("tree-sitter parser probe failed for %s: %s", language, exc)
+        return False
+    if completed.returncode != 0:
+        logger.debug(
+            "tree-sitter parser probe unavailable for %s: %s",
+            language,
+            completed.stderr.strip(),
+        )
+        return False
+    return True
+
 
 # ---------------------------------------------------------------------------
 # Data models for extracted entities
@@ -788,11 +832,20 @@ class CodeParser:
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
 
     def _get_parser(self, language: str):  # type: ignore[arg-type]
+        if language in _UNAVAILABLE_LANGUAGES:
+            return None
         if language not in self._parsers:
+            if not _parser_load_probe_succeeds(language):
+                _UNAVAILABLE_LANGUAGES.add(language)
+                logger.warning("Skipping unavailable tree-sitter parser for %s", language)
+                return None
             try:
+                import tree_sitter_language_pack as tslp
+
                 self._parsers[language] = tslp.get_parser(language)  # type: ignore[arg-type]
             except (LookupError, ValueError, ImportError) as exc:
                 # language not packaged, or grammar load failed
+                _UNAVAILABLE_LANGUAGES.add(language)
                 logger.debug("tree-sitter parser unavailable for %s: %s", language, exc)
                 return None
         return self._parsers[language]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,10 @@
 """Tests for the Tree-sitter parser module."""
 
+import subprocess
 import tempfile
 from pathlib import Path
 
+from code_review_graph import parser as parser_module
 from code_review_graph.parser import CodeParser
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -10,7 +12,24 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestCodeParser:
     def setup_method(self):
+        parser_module._UNAVAILABLE_LANGUAGES.clear()
         self.parser = CodeParser()
+
+    def teardown_method(self):
+        parser_module._UNAVAILABLE_LANGUAGES.clear()
+
+    def test_parser_probe_timeout_marks_language_unavailable(self, monkeypatch):
+        """A hanging tree-sitter binding import must skip that language, not hang builds."""
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+        monkeypatch.setattr(parser_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(parser_module, "_UNAVAILABLE_LANGUAGES", set())
+
+        assert parser_module._parser_load_probe_succeeds("tsx", timeout_seconds=0.01) is False
+        assert CodeParser()._get_parser("tsx") is None
+        assert parser_module._UNAVAILABLE_LANGUAGES == {"tsx"}
 
     def test_detect_language_python(self):
         assert self.parser.detect_language(Path("foo.py")) == "python"


### PR DESCRIPTION
## Summary
- lazily load `tree_sitter_language_pack` parsers instead of importing the package at module import time
- probe parser loading in a short child process before loading it in the main graph build
- mark only the failing language unavailable when a parser load hangs/fails, allowing the rest of the repository graph build to continue

## Why
On macOS with `tree-sitter-language-pack==0.13.0`, loading the TSX binding can hang inside `tree_sitter_language_pack.get_parser("tsx")`. Because parser loading previously happened in the main process, one broken language binding could block the entire graph build until an outer timeout killed it.

This change makes that failure language-scoped: the affected language is skipped, while all other languages still contribute graph context.

## Verification
- `uv run python -X faulthandler -m pytest tests/test_parser.py::TestCodeParser::test_parser_probe_timeout_marks_language_unavailable -q -p no:asyncio`
- `uv run python -m py_compile code_review_graph/parser.py tests/test_parser.py`
- `git diff --check`
- local smoke against a mixed repo where the installed CLI hangs on TSX:
  - baseline installed `code-review-graph build --skip-flows`: timed out after 10s
  - patched source via `PYTHONPATH` with `CRG_PARSER_LOAD_TIMEOUT_SECONDS=1`: completed in ~1.9s, produced 640 nodes / 6555 edges while skipping unavailable `tsx`

Note: `ruff check` currently hangs in my local dev environment even with `--no-cache`; no lint output was produced.