### PR TITLE
fix(eval): Use larger, reproducible test commits to fix unreliable token efficiency evaluation

### DIFF
--- a/code_review_graph/eval/configs/express.yaml
+++ b/code_review_graph/eval/configs/express.yaml
@@ -5,12 +5,12 @@ language: javascript
 size_category: small
 
 test_commits:
-  - sha: 925a1dff1e42f1b393c977b8b77757fcf633e09f
-    description: "fix: bump qs minimum to ^6.14.2 for CVE-2026-2391"
-    changed_files: 1
-  - sha: b4ab7d65d7724d9309b6faaaf82ad492da2a6d35
-    description: "test: include edge case tests for res.type()"
-    changed_files: 1
+  - sha: f41d09a3cf0592b65a1359495b65d3d7cf949c50
+    description: "remove app.router and refactor middleware processing"
+    changed_files: 15
+  - sha: cec5780db4f07a61e21e139e38af20b02dd5ae3a
+    description: "Use router module for routing"
+    changed_files: 11
 
 entry_points:
   - "lib/application.js::app.handle"

--- a/code_review_graph/eval/configs/fastapi.yaml
+++ b/code_review_graph/eval/configs/fastapi.yaml
@@ -5,12 +5,12 @@ language: python
 size_category: medium
 
 test_commits:
-  - sha: fa3588c38c7473aca7536b12d686102de4b0f407
-    description: "Fix typo for client_secret in OAuth2 form docstrings"
-    changed_files: 1
-  - sha: 0227991a01e61bf5cdd93cc00e9e243f52b47a4a
-    description: "Exclude spam comments from statistics in scripts/people.py"
-    changed_files: 1
+  - sha: 22381558446c5d1ac376680a6581dd63b3a04119
+    description: "Add support for Server Sent Events (#15030)"
+    changed_files: 23
+  - sha: 749cefdeb1428ba5c3911b03c4a72993f7eb3747
+    description: "Add support for streaming JSON Lines and binary data with `yield` (#15022)"
+    changed_files: 21
 
 entry_points:
   - "fastapi/applications.py::FastAPI"

--- a/code_review_graph/eval/configs/flask.yaml
+++ b/code_review_graph/eval/configs/flask.yaml
@@ -5,12 +5,12 @@ language: python
 size_category: small
 
 test_commits:
-  - sha: fbb6f0bc4c60a0bada0e03c3480d0ccf30a3c1df
-    description: "all teardown callbacks are called despite errors"
+  - sha: c2705ffd9ce1dc8476cb29eaf5ff5d4c719852d9
+    description: "merge app and request context"
+    changed_files: 36
+  - sha: 0ec7f713d679ceed2c605e62ac5d38d579f29fa0
+    description: "Split the App and Blueprint into Sansio and IO parts"
     changed_files: 10
-  - sha: a29f88ce6f2f9843bd6fcbbfce1390a2071965d6
-    description: "document that headers must be set before streaming"
-    changed_files: 4
 
 entry_points:
   - "src/flask/app.py::Flask.wsgi_app"

--- a/code_review_graph/eval/configs/gin.yaml
+++ b/code_review_graph/eval/configs/gin.yaml
@@ -5,15 +5,15 @@ language: go
 size_category: small
 
 test_commits:
-  - sha: 052d1a79aafe3f04078a2716f8e77d4340308383
-    description: "feat(render): add PDF renderer and tests"
-    changed_files: 5
-  - sha: 472d086af2acd924cb4b9d7be0525f7d790f69bc
-    description: "fix(tree): panic in findCaseInsensitivePathRec with RedirectFixedPath"
-    changed_files: 2
-  - sha: 5c00df8afadd06cc5be530dde00fe6d9fa4a2e4a
-    description: "fix(render): write content length in Data.Render"
-    changed_files: 2
+  - sha: 0a192fb0fa0127eac08cf24c624b92048ed823f6
+    description: "Tons of unit tests"
+    changed_files: 26
+  - sha: ac0ad2fed865d40a0adc1ac3ccaadc3acff5db4b
+    description: "Improves unit tests"
+    changed_files: 14
+  - sha: 0feaf8cbd80da13be634b13fd28bfb2d6e357839
+    description: "Split examples to alone repo (#1776)"
+    changed_files: 64
 
 entry_points:
   - "gin.go::Engine"

--- a/code_review_graph/eval/configs/httpx.yaml
+++ b/code_review_graph/eval/configs/httpx.yaml
@@ -5,12 +5,12 @@ language: python
 size_category: small
 
 test_commits:
-  - sha: ae1b9f66238f75ced3ced5e4485408435de10768
-    description: "Expose FunctionAuth in __all__"
-    changed_files: 3
-  - sha: b55d4635701d9dc22928ee647880c76b078ba3f2
-    description: "Upgrade Python type checker mypy"
-    changed_files: 4
+  - sha: 8e36f2bc685dfbe43cd7503bc1c422a6ed6e05a5
+    description: "Introduce new SSLContext API & escalate deprecations. (#3319)"
+    changed_files: 29
+  - sha: ee37a762ef6378ed16681a3452f494a5640d98de
+    description: "Reintroduce sync API. (#735)"
+    changed_files: 18
 
 entry_points:
   - "httpx/_client.py::Client"

--- a/code_review_graph/eval/configs/nextjs.yaml
+++ b/code_review_graph/eval/configs/nextjs.yaml
@@ -5,12 +5,12 @@ language: python
 size_category: medium
 
 test_commits:
-  - sha: 528801f841e519567ef54d6e52e9b9831d162e1b
-    description: "feat: add multi-platform MCP server installation support"
-    changed_files: 3
-  - sha: 84bde35459c52e1e0c4b25c6c4799743021e0fc7
-    description: "feat: add Google Antigravity platform support for MCP install"
-    changed_files: 2
+  - sha: 91083cb3b48229dd9d69c5e5c63cb59ca8a46822
+    description: "feat: community detection, flow analysis, and dead code improvements (#249)"
+    changed_files: 11
+  - sha: e4e9f0a1b30ba05b82a4cd17e5e00b0edd9adfd5
+    description: "fix: 11 open bugs post-v2.2.3 (parser, ignores, fastmcp CVE, Windows, VS Code) (#222)"
+    changed_files: 22
 
 entry_points:
   - "code_review_graph/cli.py::cli"

--- a/code_review_graph/eval/configs/nextjs.yaml
+++ b/code_review_graph/eval/configs/nextjs.yaml
@@ -1,25 +1,26 @@
 name: nextjs
-url: https://github.com/tirth8205/code-review-graph
+url: https://github.com/vercel/next.js
 commit: HEAD
-language: python
-size_category: medium
+language: typescript
+size_category: large
 
 test_commits:
-  - sha: 91083cb3b48229dd9d69c5e5c63cb59ca8a46822
-    description: "feat: community detection, flow analysis, and dead code improvements (#249)"
-    changed_files: 11
-  - sha: e4e9f0a1b30ba05b82a4cd17e5e00b0edd9adfd5
-    description: "fix: 11 open bugs post-v2.2.3 (parser, ignores, fastmcp CVE, Windows, VS Code) (#222)"
-    changed_files: 22
+  - sha: d81d5ab7dfbd003bd6b26390b75ee93d43729020
+    description: "Proof of concept: task eviction after snapshot for turbo-tasks-backend (#91790)"
+    changed_files: 34
+  - sha: d86e19772824281969a6a619e7d91be43663f91d
+    description: "Support configuring a default instant validation level (#93301)"
+    changed_files: 266
 
 entry_points:
-  - "code_review_graph/cli.py::cli"
-  - "code_review_graph/main.py::main"
+  - "packages/next/src/server/next-server.ts::NextNodeServer"
+  - "packages/next/src/server/base-server.ts::Server"
+  - "packages/next/src/client/app-bootstrap.ts::appBootstrap"
 
 search_queries:
-  - query: "GraphStore nodes"
-    expected: "code_review_graph/graph.py::GraphStore"
-  - query: "parse AST"
-    expected: "code_review_graph/parser.py::CodeParser"
-  - query: "full build"
-    expected: "code_review_graph/incremental.py::full_build"
+  - query: "NextNodeServer"
+    expected: "packages/next/src/server/next-server.ts::NextNodeServer"
+  - query: "appBootstrap hydrate"
+    expected: "packages/next/src/client/app-bootstrap.ts::appBootstrap"
+  - query: "getRSCModuleInformation"
+    expected: "packages/next/src/build/analysis/get-page-static-info.ts::getRSCModuleInformation"


### PR DESCRIPTION
# Problem

Current token efficiency benchmark uses several test commits that are not suitable for reliable evaluation.

There are two main problems:

## 1. Some test commits are too small

Several configured commits only change one or a few files, with very small diffs. This makes the token saving efficiency result less meaningful because the benchmark does not test realistic code review workloads.

Token efficiency should be measured against commits with enough changed files and lines to show whether graph-based review context is actually useful at review scale.

## 2. Some commits are unavailable in the cloned test repositories

A few configured SHAs cannot be found in the local cloned repositories under evaluate/test_repos. When this happens, the benchmark falls back to testing against HEAD~1..HEAD instead of the intended commit.

This hurts reproducibility because the benchmark result then depends on the current repository state, not the commit declared in the eval config.


1. test commits for `fastapi` are not found in the cloned repository
https://github.com/tirth8205/code-review-graph/blob/52cf3bc63ee77c8b204fb809791a5f212e83a2de/code_review_graph/eval/configs/fastapi.yaml#L1-L13

This is because `git clone --depth 50` is used when cloning the test repositories. 

https://github.com/hy2850/code-review-graph/blob/52cf3bc63ee77c8b204fb809791a5f212e83a2de/code_review_graph/eval/runner.py#L75-L78


2. Ineval config for `nextjs`, url was pointing to `code-review-graph`, not `nextjs`

https://github.com/tirth8205/code-review-graph/blob/52cf3bc63ee77c8b204fb809791a5f212e83a2de/code_review_graph/eval/configs/nextjs.yaml#L1-L2

# Fix

Commit f6b14e12ea39800ebaf7f2be5b1b235e6e019f39 addresses this by replacing the problematic test commits with commits that:

- exist in the corresponding cloned repositories
- have their parent commit available locally
- include larger diffs suitable for token efficiency evaluation
- generally cover 10+ changed files and 1000+ total changed lines

This makes the token efficiency benchmark more representative and reproducible.

<br>

### as-is) current test commits (see how small changed_files and diff size are)

Config | SHA | changed_files | Diff size
-- | -- | -- | --
express.yaml | 925a1dff1e42f1b393c977b8b77757fcf633e09f | 1 | +1 -1
express.yaml | b4ab7d65d7724d9309b6faaaf82ad492da2a6d35 | 1 | +69 -0
fastapi.yaml | fa3588c38c7473aca7536b12d686102de4b0f407 | 1 | not found locally
fastapi.yaml | 0227991a01e61bf5cdd93cc00e9e243f52b47a4a | 1 | not found locally
flask.yaml | fbb6f0bc4c60a0bada0e03c3480d0ccf30a3c1df | 10 | +194 -80
flask.yaml | a29f88ce6f2f9843bd6fcbbfce1390a2071965d6 | 4 | +55 -8
gin.yaml | 052d1a79aafe3f04078a2716f8e77d4340308383 | 5 | +76 -0
gin.yaml | 472d086af2acd924cb4b9d7be0525f7d790f69bc | 2 | +159 -1
gin.yaml | 5c00df8afadd06cc5be530dde00fe6d9fa4a2e4a | 2 | +38 -1
httpx.yaml | ae1b9f66238f75ced3ced5e4485408435de10768 | 3 | +6 -1
httpx.yaml | b55d4635701d9dc22928ee647880c76b078ba3f2 | 4 | +9 -9
nextjs.yaml | 528801f841e519567ef54d6e52e9b9831d162e1b (repo url in yaml was pointing to code-review-graph, not nextjs) | 3 | not found locally
nextjs.yaml | 84bde35459c52e1e0c4b25c6c4799743021e0fc7 (repo url in yaml was pointing to code-review-graph, not nextjs) | 2 | not found locally

### to-be) fixed test commits (+10 file changes, +1000 total line changes)

Config | SHA | changed_files | Diff size (+N -M) |
-- | -- | -- | -- |
express.yaml | f41d09a3cf0592b65a1359495b65d3d7cf949c50 | 15 | +822 -507 | 
express.yaml | cec5780db4f07a61e21e139e38af20b02dd5ae3a | 11 | +29 -1039 | 
fastapi.yaml | 22381558446c5d1ac376680a6581dd63b3a04119 | 23 | +1681 -37 | 
fastapi.yaml | 749cefdeb1428ba5c3911b03c4a72993f7eb3747 | 21 | +1168 -71 | 
| flask.yaml | c2705ffd9ce1dc8476cb29eaf5ff5d4c719852d9 | 36 | +779 -1007 |
| flask.yaml | 0ec7f713d679ceed2c605e62ac5d38d579f29fa0 | 10 | +1622 -1353 | 
| gin.yaml | 0a192fb0fa0127eac08cf24c624b92048ed823f6 | 26 | +1477 -86 |
| gin.yaml | ac0ad2fed865d40a0adc1ac3ccaadc3acff5db4b | 14 | +775 -615 | 
| gin.yaml | 0feaf8cbd80da13be634b13fd28bfb2d6e357839 | 64 | +25 -2393 | 
| httpx.yaml | 8e36f2bc685dfbe43cd7503bc1c422a6ed6e05a5 | 29 | +533 -947 | 
| httpx.yaml | ee37a762ef6378ed16681a3452f494a5640d98de | 18 | +1215 -370 | 
| nextjs.yaml | d81d5ab7dfbd003bd6b26390b75ee93d43729020 | 34 | +2989 -407 | 
| nextjs.yaml | d86e19772824281969a6a619e7d91be43663f91d | 266 | +2789 -572 | 