### PR TITLE
fix: Fix graph path lookup for review and impact tools

### DIFF
--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -85,6 +85,52 @@ def _get_store(repo_root: str | None = None) -> tuple[GraphStore, Path]:
     return GraphStore(db_path), root
 
 
+def _resolve_graph_file_paths(
+    store: GraphStore, root: Path, file_paths: list[str],
+) -> list[str]:
+    """Resolve user-facing file paths to the paths stored in the graph.
+
+    Graphs may contain absolute paths, repo-relative paths, or cwd-relative
+    paths depending on how they were built. Tool inputs are usually relative to
+    repo root, so exact matching alone can miss existing graph nodes.
+    """
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        if path not in seen:
+            resolved.append(path)
+            seen.add(path)
+
+    for file_path in file_paths:
+        raw = file_path.replace("\\", "/")
+        candidates = [raw]
+        path = Path(file_path)
+        if path.is_absolute():
+            try:
+                candidates.append(str(path.resolve().relative_to(root)).replace("\\", "/"))
+            except ValueError:
+                pass
+        else:
+            candidates.append(str(root / path))
+
+        for candidate in candidates:
+            if store.get_nodes_by_file(candidate):
+                add(candidate)
+
+        suffixes = []
+        for candidate in candidates:
+            normalized = candidate.replace("\\", "/")
+            if normalized not in suffixes:
+                suffixes.append(normalized)
+
+        for suffix in suffixes:
+            for matched_path in store.get_files_matching(suffix):
+                add(matched_path)
+
+    return resolved
+
+
 def compact_response(
     summary: str,
     key_entities: list[str] | None = None,

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -11,7 +11,7 @@ from ..graph import _sanitize_name, edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_db_path, get_staged_and_unstaged
 from ..search import hybrid_search
-from ._common import _BUILTIN_CALL_NAMES, _get_store
+from ._common import _BUILTIN_CALL_NAMES, _get_store, _resolve_graph_file_paths
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +72,8 @@ def get_impact_radius(
                 "total_impacted": 0,
             }
 
-        # Convert to absolute paths for graph lookup
-        abs_files = [str(root / f) for f in changed_files]
+        # Resolve user-facing paths to the file paths stored in the graph.
+        abs_files = _resolve_graph_file_paths(store, root, changed_files)
         result = store.get_impact_radius(
             abs_files, max_depth=max_depth, max_nodes=max_results
         )
@@ -186,26 +186,29 @@ def query_graph(
                 "results": [], "edges": [],
             }
 
-        # Resolve target - try as-is, then as absolute path, then search
-        node = store.get_node(target)
-        if not node:
-            abs_target = str(root / target)
-            node = store.get_node(abs_target)
-        if not node:
-            # Search by name
-            candidates = store.search_nodes(target, limit=5)
-            if len(candidates) == 1:
-                node = candidates[0]
-                target = node.qualified_name
-            elif len(candidates) > 1:
-                return {
-                    "status": "ambiguous",
-                    "summary": (
-                        f"Multiple matches for '{target}'. "
-                        "Please use a qualified name."
-                    ),
-                    "candidates": [node_to_dict(c) for c in candidates],
-                }
+        # Resolve target - try as-is, then as absolute path, then search.
+        # file_summary targets are paths, so skip broad node search.
+        node = None
+        if pattern != "file_summary":
+            node = store.get_node(target)
+            if not node:
+                abs_target = str(root / target)
+                node = store.get_node(abs_target)
+            if not node:
+                # Search by name
+                candidates = store.search_nodes(target, limit=5)
+                if len(candidates) == 1:
+                    node = candidates[0]
+                    target = node.qualified_name
+                elif len(candidates) > 1:
+                    return {
+                        "status": "ambiguous",
+                        "summary": (
+                            f"Multiple matches for '{target}'. "
+                            "Please use a qualified name."
+                        ),
+                        "candidates": [node_to_dict(c) for c in candidates],
+                    }
 
         if not node and pattern != "file_summary":
             return {
@@ -303,10 +306,10 @@ def query_graph(
                         edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":
-            abs_path = str(root / target)
-            file_nodes = store.get_nodes_by_file(abs_path)
-            for n in file_nodes:
-                results.append(node_to_dict(n))
+            graph_paths = _resolve_graph_file_paths(store, root, [target])
+            for graph_path in graph_paths:
+                for n in store.get_nodes_by_file(graph_path):
+                    results.append(node_to_dict(n))
 
         summary = (
             f"Found {len(results)} result(s) "

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -11,7 +11,7 @@ from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_staged_and_unstaged
-from ._common import _get_store
+from ._common import _get_store, _resolve_graph_file_paths
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +65,8 @@ def get_review_context(
                 "context": {},
             }
 
-        abs_files = [str(root / f) for f in changed_files]
-        impact = store.get_impact_radius(abs_files, max_depth=max_depth)
+        graph_files = _resolve_graph_file_paths(store, root, changed_files)
+        impact = store.get_impact_radius(graph_files, max_depth=max_depth)
 
         if detail_level == "minimal":
             impacted_count = len(impact["impacted_nodes"])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,8 +13,11 @@ from code_review_graph.tools import (
     get_community_func,
     get_docs_section,
     get_flow,
+    get_impact_radius,
+    get_review_context,
     list_communities_func,
     list_flows,
+    query_graph,
 )
 
 
@@ -149,6 +152,93 @@ class TestTools:
         edges = self.store.search_edges_by_target_name("helper")
         assert len(edges) == 1
         assert edges[0].source_qualified == "/repo/main.py::process"
+
+
+def _seed_repo_relative_graph(root: Path) -> None:
+    """Seed graph data with cwd-relative paths, as eval repos currently do."""
+    graph_dir = root / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    stored_path = "fixtures/sample_repo/src/app.py"
+    try:
+        store.upsert_node(NodeInfo(
+            kind="File",
+            name=stored_path,
+            file_path=stored_path,
+            line_start=1,
+            line_end=6,
+            language="python",
+        ))
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="handle",
+            file_path=stored_path,
+            line_start=1,
+            line_end=3,
+            language="python",
+        ))
+        store.commit()
+    finally:
+        store.close()
+
+
+class TestGraphPathResolution:
+    def test_get_review_context_resolves_repo_relative_changed_file(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = get_review_context(
+            changed_files=["src/app.py"],
+            repo_root=str(repo),
+            include_source=False,
+        )
+
+        changed = result["context"]["graph"]["changed_nodes"]
+        assert any(n["name"] == "handle" for n in changed)
+
+    def test_get_impact_radius_resolves_repo_relative_changed_file(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = get_impact_radius(
+            changed_files=["src/app.py"],
+            repo_root=str(repo),
+        )
+
+        assert any(n["name"] == "handle" for n in result["changed_nodes"])
+
+    def test_file_summary_resolves_repo_relative_target(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = query_graph(
+            pattern="file_summary",
+            target="src/app.py",
+            repo_root=str(repo),
+        )
+
+        assert any(n["name"] == "handle" for n in result["results"])
 
 
 class TestGetDocsSection:


### PR DESCRIPTION
## Summary

This PR fixes graph lookups for review and impact tools when the file paths passed by the user do not exactly match the file paths stored in the graph database.

The issue showed up while comparing `git diff <sha>^ <sha>` with `get_review_context(changed_files=...)` for eval test commits. Even when the graph DB was populated, `get_review_context` often returned:

```text
0 changed nodes / 0 impacted nodes / 0 edges
```

That made the graph payload look empty and caused review context to fall back mostly to source snippets.

## Root Cause

`get_review_context` and related tools converted changed files into absolute paths before graph lookup:

```python
abs_files = [str(root / f) for f in changed_files]
impact = store.get_impact_radius(abs_files, max_depth=max_depth)
```

However, existing graph DBs may store file paths in different formats depending on how they were built, for example:
- repo-relative paths
- absolute paths
- cwd-relative paths such as `evaluate/test_repos/fastapi/fastapi/routing.py`

Because `get_nodes_by_file()` requires an exact file path match, a valid changed file like:

```text
fastapi/routing.py
```

could fail to match both:

```text
/code-review-graph/evaluate/test_repos/fastapi/fastapi/routing.py
```

and the stored graph path:

```text
evaluate/test_repos/fastapi/fastapi/routing.py
```

So the graph store had nodes, but the lookup path format prevented them from being found.

## Fix

This PR adds path resolution before graph lookup.

The new resolver maps user-facing changed file paths to the actual path format stored in the graph by checking:
- the raw input path
- absolute path variants
- repo-relative variants
- graph paths matched by suffix

The resolver is then used by:
- `get_review_context`
- `get_impact_radius`
- `query_graph(..., pattern="file_summary")`

This makes the tools robust to graph DBs built with different path styles.

## Evidence

Before this fix, graph lookup returned zero graph payload for many eval commits:

| repo | SHA | before | after path resolution |
| --- | --- | ---: | ---: |
| express | `f41d09a3` | `0/0/0` | `209/473/510` |
| express | `cec5780d` | `0/0/0` | `200/472/425` |
| fastapi | `22381558` | `0/0/0` | `162/500/494` |
| fastapi | `749cefde` | `0/0/0` | `161/500/527` |
| flask | `c2705ffd` | `0/0/0` | `386/403/1106` |
| flask | `0ec7f713` | `0/0/0` | `195/388/741` |
| gin | `0a192fb0` | `0/0/0` | `877/252/1964` |
| gin | `ac0ad2fe` | `0/0/0` | `577/255/1415` |
| httpx | `8e36f2bc` | `0/0/0` | `484/482/1284` |
| httpx | `ee37a762` | `0/0/0` | `119/500/701` |
| nextjs | `d81d5ab7` | `0/0/0` | `1192/500/3067` |
| nextjs | `d86e1977` | `0/0/0` | `1154/500/2469` |

Format: `changed nodes / impacted nodes / edges`.

(One commit, `gin 0feaf8cb`, still resolves to `0/0/0` because it mostly
removes or splits example files that are not represented as current graph nodes)

## Why This Matters

Without this fix, `get_review_context` can incorrectly report that a change has no graph impact even when the graph contains matching nodes.

This affects:
- review context quality
- impact radius results
- file summary queries
- token efficiency analysis that compares graph context with raw diffs

After this fix, graph-based review tools can use the existing graph data instead of silently falling back to empty graph payloads.

## Test Plan
- Added regression coverage for graph DBs that store cwd-relative file paths.
- Verified `get_review_context` resolves repo-relative changed files to stored
  graph paths.
- Verified `get_impact_radius` resolves changed file paths before graph lookup.
- Verified `query_graph(..., pattern="file_summary")` resolves file paths
  consistently.
