### PR TITLE
fix: prompt Message wrapping + add detail_level=minimal to get_architecture_overview

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -549,6 +549,7 @@ def get_community_tool(
 @mcp.tool()
 def get_architecture_overview_tool(
     repo_root: Optional[str] = None,
+    detail_level: str = "standard",
 ) -> dict:
     """Generate an architecture overview based on community structure.
 
@@ -558,8 +559,15 @@ def get_architecture_overview_tool(
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        detail_level: "standard" (default) returns full per-edge detail;
+                      "minimal" drops community member lists and
+                      aggregates cross-community edges to one row per
+                      community pair (typical reduction: 600KB → <5KB).
     """
-    return get_architecture_overview_func(repo_root=_resolve_repo_root(repo_root))
+    return get_architecture_overview_func(
+        repo_root=_resolve_repo_root(repo_root),
+        detail_level=detail_level,
+    )
 
 
 @mcp.tool()

--- a/code_review_graph/prompts.py
+++ b/code_review_graph/prompts.py
@@ -12,6 +12,8 @@ detail_level="minimal" first patterns with get_minimal_context entry point.
 
 from __future__ import annotations
 
+from fastmcp.prompts.prompt import Message
+
 _TOKEN_EFFICIENCY_PREAMBLE = (  # nosec B105 — prompt template, not a password
     """\
 ## Rules for Token-Efficient Graph Usage
@@ -29,143 +31,129 @@ expand on high-risk items.
 )
 
 
-def review_changes_prompt(base: str = "HEAD~1") -> list[dict]:
+def _user(content: str) -> list[Message]:
+    """Wrap content as a single-message user prompt.
+
+    fastmcp >=3.2 rejects raw dicts in prompt return values; each message
+    must be a ``Message`` instance (or a plain ``str``). We standardise on
+    ``Message`` so role is explicit and future multi-turn prompts compose
+    naturally.
+    """
+    return [Message(role="user", content=content)]
+
+
+def review_changes_prompt(base: str = "HEAD~1") -> list[Message]:
     """Pre-commit review workflow.
 
     Args:
         base: Git ref to diff against. Default: HEAD~1.
     """
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                f"## Review Workflow\n"
-                f'1. Call `get_minimal_context(task="review changes against '
-                f'{base}")` to get risk overview.\n'
-                f'2. If risk is "low": call '
-                f'`detect_changes(detail_level="minimal")` → report summary '
-                f"+ any test gaps.\n"
-                f'3. If risk is "medium" or "high":\n'
-                f'   a. Call `detect_changes(detail_level="standard")` for '
-                f"full change list.\n"
-                f"   b. For each high-risk function, call "
-                f'`query_graph(pattern="callers_of", target=<func>, '
-                f'detail_level="minimal")`.\n'
-                f'   c. Call `get_affected_flows(detail_level="minimal")` '
-                f"only if >3 changed functions.\n"
-                f"4. Summarize: risk level, what changed, test gaps, "
-                f"specific improvements needed.\n\n"
-                f"Do NOT call get_review_context unless you need source code "
-                f"snippets for a specific function."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        f"## Review Workflow\n"
+        f'1. Call `get_minimal_context(task="review changes against '
+        f'{base}")` to get risk overview.\n'
+        f'2. If risk is "low": call '
+        f'`detect_changes(detail_level="minimal")` → report summary '
+        f"+ any test gaps.\n"
+        f'3. If risk is "medium" or "high":\n'
+        f'   a. Call `detect_changes(detail_level="standard")` for '
+        f"full change list.\n"
+        f"   b. For each high-risk function, call "
+        f'`query_graph(pattern="callers_of", target=<func>, '
+        f'detail_level="minimal")`.\n'
+        f'   c. Call `get_affected_flows(detail_level="minimal")` '
+        f"only if >3 changed functions.\n"
+        f"4. Summarize: risk level, what changed, test gaps, "
+        f"specific improvements needed.\n\n"
+        f"Do NOT call get_review_context unless you need source code "
+        f"snippets for a specific function."
+    )
 
 
-def architecture_map_prompt() -> list[dict]:
+def architecture_map_prompt() -> list[Message]:
     """Architecture documentation workflow."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Architecture Mapping Workflow\n"
-                '1. Call `get_minimal_context(task="map architecture")`.\n'
-                '2. Call `get_architecture_overview(detail_level="minimal")` '
-                "for community coupling summary.\n"
-                '3. Call `list_flows(detail_level="minimal")` for critical '
-                "flow names + criticality scores.\n"
-                "4. Only call `get_community(name=<X>, "
-                'detail_level="standard")` for the 1-2 communities the user '
-                "is most interested in.\n"
-                "5. Produce a concise Mermaid diagram showing communities as "
-                "boxes and key flows as arrows."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Architecture Mapping Workflow\n"
+        '1. Call `get_minimal_context(task="map architecture")`.\n'
+        '2. Call `get_architecture_overview(detail_level="minimal")` '
+        "for community coupling summary.\n"
+        '3. Call `list_flows(detail_level="minimal")` for critical '
+        "flow names + criticality scores.\n"
+        "4. Only call `get_community(name=<X>, "
+        'detail_level="standard")` for the 1-2 communities the user '
+        "is most interested in.\n"
+        "5. Produce a concise Mermaid diagram showing communities as "
+        "boxes and key flows as arrows."
+    )
 
 
-def debug_issue_prompt(description: str = "") -> list[dict]:
+def debug_issue_prompt(description: str = "") -> list[Message]:
     """Guided debugging workflow.
 
     Args:
         description: Description of the issue to debug.
     """
     desc_part = description or "<description>"
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Debug Workflow\n"
-                f'1. Call `get_minimal_context(task="debug: '
-                f'{desc_part}")`.\n'
-                "2. Call `semantic_search_nodes(query=<keywords from "
-                'description>, detail_level="minimal", limit=5)`.\n'
-                "3. For the top 1-2 results, call "
-                '`query_graph(pattern="callers_of", target=<name>, '
-                'detail_level="minimal")`.\n'
-                "4. If the issue involves execution flow: call "
-                "`get_flow(name=<relevant flow>)` for the single most "
-                "relevant flow.\n"
-                "5. Only call `get_review_context` or `get_impact_radius` "
-                "if you need to trace the blast radius of a specific change."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Debug Workflow\n"
+        f'1. Call `get_minimal_context(task="debug: '
+        f'{desc_part}")`.\n'
+        "2. Call `semantic_search_nodes(query=<keywords from "
+        'description>, detail_level="minimal", limit=5)`.\n'
+        "3. For the top 1-2 results, call "
+        '`query_graph(pattern="callers_of", target=<name>, '
+        'detail_level="minimal")`.\n'
+        "4. If the issue involves execution flow: call "
+        "`get_flow(name=<relevant flow>)` for the single most "
+        "relevant flow.\n"
+        "5. Only call `get_review_context` or `get_impact_radius` "
+        "if you need to trace the blast radius of a specific change."
+    )
 
 
-def onboard_developer_prompt() -> list[dict]:
+def onboard_developer_prompt() -> list[Message]:
     """New developer orientation workflow."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Onboarding Workflow\n"
-                '1. Call `get_minimal_context(task="onboard developer")`.\n'
-                "2. Call `list_graph_stats()` for technology overview.\n"
-                '3. Call `get_architecture_overview(detail_level="minimal")` '
-                "for the 30-second mental model.\n"
-                '4. Call `list_communities(detail_level="minimal")` — '
-                "present as a table of module names + sizes.\n"
-                '5. Call `list_flows(detail_level="minimal")` — highlight '
-                "the top 3 critical flows.\n"
-                "6. Only drill into a specific community or flow if the "
-                "developer asks."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Onboarding Workflow\n"
+        '1. Call `get_minimal_context(task="onboard developer")`.\n'
+        "2. Call `list_graph_stats()` for technology overview.\n"
+        '3. Call `get_architecture_overview(detail_level="minimal")` '
+        "for the 30-second mental model.\n"
+        '4. Call `list_communities(detail_level="minimal")` — '
+        "present as a table of module names + sizes.\n"
+        '5. Call `list_flows(detail_level="minimal")` — highlight '
+        "the top 3 critical flows.\n"
+        "6. Only drill into a specific community or flow if the "
+        "developer asks."
+    )
 
 
-def pre_merge_check_prompt(base: str = "HEAD~1") -> list[dict]:
+def pre_merge_check_prompt(base: str = "HEAD~1") -> list[Message]:
     """PR readiness check workflow.
 
     Args:
         base: Git ref to diff against. Default: HEAD~1.
     """
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Pre-Merge Check Workflow\n"
-                '1. Call `get_minimal_context(task="pre-merge check")`.\n'
-                '2. Call `detect_changes(detail_level="minimal")` for risk '
-                "score and test gaps.\n"
-                "3. If risk > 0.4: call "
-                '`get_affected_flows(detail_level="minimal")`.\n'
-                "4. If test_gap_count > 0: call "
-                '`query_graph(pattern="tests_for", '
-                'target=<each untested function>, detail_level="minimal")` '
-                "for up to 3 functions.\n"
-                '5. Call `refactor(mode="dead_code", '
-                'detail_level="minimal")` to check for newly dead code.\n'
-                "6. Only call `find_large_functions` or `get_impact_radius` "
-                "if risk > 0.7.\n"
-                "7. Output: GO/NO-GO recommendation with 1-sentence "
-                "justification + list of required follow-ups."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Pre-Merge Check Workflow\n"
+        '1. Call `get_minimal_context(task="pre-merge check")`.\n'
+        '2. Call `detect_changes(detail_level="minimal")` for risk '
+        "score and test gaps.\n"
+        "3. If risk > 0.4: call "
+        '`get_affected_flows(detail_level="minimal")`.\n'
+        "4. If test_gap_count > 0: call "
+        '`query_graph(pattern="tests_for", '
+        'target=<each untested function>, detail_level="minimal")` '
+        "for up to 3 functions.\n"
+        '5. Call `refactor(mode="dead_code", '
+        'detail_level="minimal")` to check for newly dead code.\n'
+        "6. Only call `find_large_functions` or `get_impact_radius` "
+        "if risk > 0.7.\n"
+        "7. Output: GO/NO-GO recommendation with 1-sentence "
+        "justification + list of required follow-ups."
+    )

--- a/code_review_graph/tools/community_tools.py
+++ b/code_review_graph/tools/community_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from ..communities import get_architecture_overview, get_communities
@@ -144,8 +145,52 @@ def get_community_func(
 # ---------------------------------------------------------------------------
 
 
+_MINIMAL_COMMUNITY_FIELDS = ("id", "name", "size", "cohesion", "dominant_language")
+
+
+def _minimal_overview(overview: dict[str, Any]) -> dict[str, Any]:
+    """Compress overview for ``detail_level="minimal"``.
+
+    The full overview can exceed 600KB on medium repos because it embeds
+    every community's member list and every individual cross-community
+    edge. Minimal mode drops member lists and aggregates the edge list
+    to one row per community pair with a count and the top edge kinds —
+    enough to spot coupling smells without exploding token budgets.
+    """
+    communities = [
+        {k: c[k] for k in _MINIMAL_COMMUNITY_FIELDS if k in c}
+        for c in overview.get("communities", [])
+    ]
+    id_to_name = {c["id"]: c["name"] for c in communities if "id" in c}
+
+    edge_pair_counts: Counter[tuple[int, int]] = Counter()
+    edge_pair_kinds: dict[tuple[int, int], Counter[str]] = {}
+    for e in overview.get("cross_community_edges", []):
+        # Use canonical (low, high) ordering so A↔B and B↔A aggregate together.
+        a, b = e["source_community"], e["target_community"]
+        pair = (a, b) if a <= b else (b, a)
+        edge_pair_counts[pair] += 1
+        edge_pair_kinds.setdefault(pair, Counter())[e["edge_kind"]] += 1
+
+    cross_pairs = [
+        {
+            "source_community": id_to_name.get(a, f"community-{a}"),
+            "target_community": id_to_name.get(b, f"community-{b}"),
+            "edge_count": count,
+            "top_kinds": [k for k, _ in edge_pair_kinds[(a, b)].most_common(3)],
+        }
+        for (a, b), count in edge_pair_counts.most_common()
+    ]
+    return {
+        "communities": communities,
+        "cross_community_edges": cross_pairs,
+        "warnings": overview.get("warnings", []),
+    }
+
+
 def get_architecture_overview_func(
     repo_root: str | None = None,
+    detail_level: str = "standard",
 ) -> dict[str, Any]:
     """Generate an architecture overview based on community structure.
 
@@ -155,6 +200,11 @@ def get_architecture_overview_func(
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        detail_level: "standard" (default) returns the full overview
+                      including per-edge cross-community detail;
+                      "minimal" drops community member lists and
+                      aggregates edges to one row per community pair
+                      (typical reduction: 600KB → <5KB).
 
     Returns:
         Architecture overview with communities, cross-community edges,
@@ -163,14 +213,21 @@ def get_architecture_overview_func(
     store, root = _get_store(repo_root)
     try:
         overview = get_architecture_overview(store)
+        if detail_level == "minimal":
+            overview = _minimal_overview(overview)
         n_communities = len(overview["communities"])
         n_cross = len(overview["cross_community_edges"])
         n_warnings = len(overview["warnings"])
+        cross_label = (
+            "community pairs"
+            if detail_level == "minimal"
+            else "cross-community edges"
+        )
         result = {
             "status": "ok",
             "summary": (
                 f"Architecture: {n_communities} communities, "
-                f"{n_cross} cross-community edges, "
+                f"{n_cross} {cross_label}, "
                 f"{n_warnings} warning(s)"
             ),
             **overview,

--- a/tests/test_integration_v2.py
+++ b/tests/test_integration_v2.py
@@ -326,8 +326,8 @@ class TestV2Integration:
         prompt_messages = review_changes_prompt(base="HEAD~1")
         assert isinstance(prompt_messages, list)
         assert len(prompt_messages) > 0
-        assert prompt_messages[0]["role"] == "user"
-        assert "detect_changes" in prompt_messages[0]["content"]
+        assert prompt_messages[0].role == "user"
+        assert "detect_changes" in prompt_messages[0].content.text
 
         # ---- Step 10: generate_wiki ----
         with tempfile.TemporaryDirectory() as wiki_dir:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,5 +1,7 @@
 """Tests for MCP prompt templates."""
 
+from fastmcp.prompts.prompt import Message
+
 from code_review_graph.prompts import (
     architecture_map_prompt,
     debug_issue_prompt,
@@ -7,6 +9,11 @@ from code_review_graph.prompts import (
     pre_merge_check_prompt,
     review_changes_prompt,
 )
+
+
+def _text(msg: Message) -> str:
+    """Extract the text content from a fastmcp Message."""
+    return msg.content.text
 
 
 class TestReviewChangesPrompt:
@@ -18,29 +25,29 @@ class TestReviewChangesPrompt:
     def test_message_has_role_and_content(self):
         result = review_changes_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_default_base(self):
         result = review_changes_prompt()
-        assert "HEAD~1" in result[0]["content"]
+        assert "HEAD~1" in _text(result[0])
 
     def test_custom_base(self):
         result = review_changes_prompt(base="main")
-        assert "main" in result[0]["content"]
+        assert "main" in _text(result[0])
 
     def test_mentions_detect_changes(self):
         result = review_changes_prompt()
-        assert "detect_changes" in result[0]["content"]
+        assert "detect_changes" in _text(result[0])
 
     def test_mentions_affected_flows(self):
         result = review_changes_prompt()
-        assert "affected_flows" in result[0]["content"]
+        assert "affected_flows" in _text(result[0])
 
     def test_mentions_test_gaps(self):
         result = review_changes_prompt()
-        assert "test" in result[0]["content"].lower()
+        assert "test" in _text(result[0]).lower()
 
 
 class TestArchitectureMapPrompt:
@@ -52,17 +59,17 @@ class TestArchitectureMapPrompt:
     def test_message_has_role_and_content(self):
         result = architecture_map_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_mentions_communities(self):
         result = architecture_map_prompt()
-        assert "communities" in result[0]["content"].lower()
+        assert "communities" in _text(result[0]).lower()
 
     def test_mentions_mermaid(self):
         result = architecture_map_prompt()
-        assert "Mermaid" in result[0]["content"]
+        assert "Mermaid" in _text(result[0])
 
 
 class TestDebugIssuePrompt:
@@ -74,26 +81,26 @@ class TestDebugIssuePrompt:
     def test_message_has_role_and_content(self):
         result = debug_issue_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_includes_description(self):
         result = debug_issue_prompt(description="login fails with 500 error")
-        assert "login fails with 500 error" in result[0]["content"]
+        assert "login fails with 500 error" in _text(result[0])
 
     def test_empty_description(self):
         result = debug_issue_prompt()
-        content = result[0]["content"]
+        content = _text(result[0])
         assert "debug" in content.lower()
 
     def test_mentions_search(self):
         result = debug_issue_prompt(description="test issue")
-        assert "semantic_search_nodes" in result[0]["content"]
+        assert "semantic_search_nodes" in _text(result[0])
 
     def test_mentions_get_minimal_context(self):
         result = debug_issue_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
 
 class TestOnboardDeveloperPrompt:
@@ -105,21 +112,21 @@ class TestOnboardDeveloperPrompt:
     def test_message_has_role_and_content(self):
         result = onboard_developer_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_mentions_stats(self):
         result = onboard_developer_prompt()
-        assert "list_graph_stats" in result[0]["content"]
+        assert "list_graph_stats" in _text(result[0])
 
     def test_mentions_architecture(self):
         result = onboard_developer_prompt()
-        assert "architecture" in result[0]["content"].lower()
+        assert "architecture" in _text(result[0]).lower()
 
     def test_mentions_critical_flows(self):
         result = onboard_developer_prompt()
-        assert "critical" in result[0]["content"].lower()
+        assert "critical" in _text(result[0]).lower()
 
 
 class TestPreMergeCheckPrompt:
@@ -131,14 +138,14 @@ class TestPreMergeCheckPrompt:
     def test_message_has_role_and_content(self):
         result = pre_merge_check_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_default_base(self):
         result = pre_merge_check_prompt()
         # The pre-merge prompt is now generic (doesn't embed the base ref)
-        assert "pre-merge" in result[0]["content"].lower()
+        assert "pre-merge" in _text(result[0]).lower()
 
     def test_custom_base(self):
         # pre_merge_check_prompt still accepts base but the workflow
@@ -149,15 +156,15 @@ class TestPreMergeCheckPrompt:
 
     def test_mentions_risk_scoring(self):
         result = pre_merge_check_prompt()
-        assert "risk" in result[0]["content"].lower()
+        assert "risk" in _text(result[0]).lower()
 
     def test_mentions_test_gaps(self):
         result = pre_merge_check_prompt()
-        assert "tests_for" in result[0]["content"]
+        assert "tests_for" in _text(result[0])
 
     def test_mentions_dead_code(self):
         result = pre_merge_check_prompt()
-        assert "dead_code" in result[0]["content"]
+        assert "dead_code" in _text(result[0])
 
 
 class TestTokenEfficiencyPreamble:
@@ -165,21 +172,21 @@ class TestTokenEfficiencyPreamble:
 
     def test_review_has_preamble(self):
         result = review_changes_prompt()
-        assert "get_minimal_context" in result[0]["content"]
-        assert "detail_level" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
+        assert "detail_level" in _text(result[0])
 
     def test_architecture_has_preamble(self):
         result = architecture_map_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_debug_has_preamble(self):
         result = debug_issue_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_onboard_has_preamble(self):
         result = onboard_developer_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_pre_merge_has_preamble(self):
         result = pre_merge_check_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -703,6 +703,38 @@ class TestCommunityTools:
         assert "communities" in result["summary"]
         assert "cross-community edges" in result["summary"]
 
+    def test_get_architecture_overview_minimal_drops_members(self):
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        assert result["status"] == "ok"
+        for c in result["communities"]:
+            assert "members" not in c
+            assert "name" in c and "size" in c and "cohesion" in c
+
+    def test_get_architecture_overview_minimal_aggregates_edges(self):
+        std = get_architecture_overview_func(repo_root=str(self.root))
+        minimal = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        # Minimal edges are pair-aggregated, so count is <= standard's
+        # per-edge count.
+        assert len(minimal["cross_community_edges"]) <= len(
+            std["cross_community_edges"]
+        )
+        for pair in minimal["cross_community_edges"]:
+            assert "source_community" in pair
+            assert "target_community" in pair
+            assert "edge_count" in pair
+            assert pair["edge_count"] >= 1
+            assert isinstance(pair["top_kinds"], list)
+
+    def test_get_architecture_overview_minimal_summary_label(self):
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        assert "community pairs" in result["summary"]
+
 
 class TestBuildPostprocess:
     """Tests for postprocess parameter in build_or_update_graph."""


### PR DESCRIPTION
## Summary

Two independent fixes, both surfaced from the same MCP slash-command failure (`/code-review-graph:architecture_map`):

### 1. fastmcp ≥3.2 prompt Message wrapping (regression fix)

fastmcp 3.2.4 stopped accepting raw `dict` messages in prompt return values:

```
McpError: messages[0] must be Message or str, got dict.
Use Message({'role': 'user', 'content': '...'}) to wrap the value.
```

This breaks **all 5 MCP prompt templates** (`review_changes`, `architecture_map`, `debug_issue`, `onboard_developer`, `pre_merge_check`) since they return `list[dict]`.

Fix: wrap each message via `fastmcp.prompts.prompt.Message` so role is explicit and future multi-turn prompts compose naturally. Added a tiny `_user()` helper to keep the five templates uniform.

### 2. `get_architecture_overview` `detail_level="minimal"` (token-efficiency)

The default output embeds every community's full `members` list *and* every individual cross-community edge. On a 2,878-node repo (`ebm-copilot` — TS/Python/Bash/R, 390 files) this measured **655KB** — over the MCP tool output token cap, forcing fallback-to-file and defeating the whole point of the token-efficient API.

The token-efficiency preamble already tells the LLM to call `get_architecture_overview(detail_level="minimal")` first, but `minimal` wasn't actually a supported value — so this PR finally makes the prompt's own contract work.

`minimal` mode:
- communities → keep only `{id, name, size, cohesion, dominant_language}`, drop `members`
- cross_community_edges → aggregate by `(source_community, target_community)` pair → `{source_community (name), target_community (name), edge_count, top_kinds}`
- warnings → unchanged

Measured on ebm-copilot:

| mode | size | reduction |
|------|------|-----------|
| standard | 655 KB | — |
| minimal | 5.4 KB | **120×** |

Output stays useful — the top pair `v1-route ↔ services-list` (318 `CALLS` edges) immediately surfaces the hottest coupling.

## Test plan

- [x] `uv run pytest tests/test_prompts.py` — 34 passed (updated to assert `msg.role` / `msg.content.text`)
- [x] `uv run pytest tests/test_tools.py` — 3 new cases for minimal mode (drops members, aggregates pairs, summary label)
- [x] `uv run pytest tests/test_integration_v2.py` — step 9 updated for Message attribute access
- [x] Full suite: 1233 passed, 1 skipped, 2 xpassed. The 6 remaining failures are pre-existing pytest-asyncio plugin issues in `tests/test_main.py::TestApplyToolFilter` (the test file uses `@pytest.mark.asyncio` but `pytest-asyncio` is not a dev dep — out of scope here).
- [x] `uvx ruff check` on changed files — clean.
- [x] End-to-end: `architecture_map` prompt now renders through fastmcp's in-process `Client` (verified the exact MCP path the slash command uses).
- [x] Smoke test on real `ebm-copilot` graph confirms the 120× reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)