### PR TITLE
fix: include docs/ in wheel and look up bundled copy at runtime

### DIFF
--- a/code_review_graph/tools/docs.py
+++ b/code_review_graph/tools/docs.py
@@ -109,15 +109,27 @@ def get_docs_section(
 
     search_roots: list[Path] = []
 
+    # Wheel install: docs are packaged inside code_review_graph/docs.
+    in_pkg_docs = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "LLM-OPTIMIZED-REFERENCE.md"
+    )
     if repo_root:
         try:
             search_roots.append(_validate_repo_root(Path(repo_root)))
         except ValueError:
             pass
-    else:
-        search_roots.append(find_project_root())
+    elif in_pkg_docs.exists():
+        in_pkg_root = in_pkg_docs.parent.parent
+        search_roots.append(in_pkg_root)
 
-    # Fallback: package directory (for uvx/pip installs)
+    if not repo_root:
+        project_root = find_project_root()
+        if project_root not in search_roots:
+            search_roots.append(project_root)
+
+    # Editable/source-tree fallback: docs live next to code_review_graph/.
     pkg_docs = (
         Path(__file__).parent.parent.parent
         / "docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["code_review_graph"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"docs/LLM-OPTIMIZED-REFERENCE.md" = "code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md"
+
 [tool.hatch.build.targets.sdist]
 include = [
     "code_review_graph/",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import code_review_graph.tools.docs as docs_module
 from code_review_graph.graph import GraphStore, _sanitize_name, node_to_dict
 from code_review_graph.parser import EdgeInfo, NodeInfo
 from code_review_graph.tools import (
@@ -188,6 +189,37 @@ class TestGetDocsSection:
         assert result["status"] in ("ok", "not_found")
         if result["status"] == "ok":
             assert len(result["content"]) > 0
+
+    def test_source_tree_docs_lookup_from_outside_repo(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+
+        result = get_docs_section(section_name="usage")
+
+        assert result["status"] == "ok"
+        assert len(result["content"]) > 0
+
+    def test_packaged_docs_lookup_from_outside_repo(self, tmp_path, monkeypatch):
+        package_dir = tmp_path / "site-packages" / "code_review_graph"
+        tools_dir = package_dir / "tools"
+        docs_dir = package_dir / "docs"
+        tools_dir.mkdir(parents=True)
+        docs_dir.mkdir()
+        (docs_dir / "LLM-OPTIMIZED-REFERENCE.md").write_text(
+            '<section name="usage">packaged docs</section>\n',
+            encoding="utf-8",
+        )
+        work_dir = tmp_path / "elsewhere"
+        work_dir.mkdir()
+
+        monkeypatch.chdir(work_dir)
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+        monkeypatch.setattr(docs_module, "__file__", str(tools_dir / "docs.py"))
+
+        result = docs_module.get_docs_section("usage")
+
+        assert result["status"] == "ok"
+        assert result["content"] == "packaged docs"
 
 
 class TestFindLargeFunctions:


### PR DESCRIPTION
## Summary

`get_docs_section` (used by `docs` and `suggested_questions` MCP tools) only searched filesystem-relative paths. After `pipx install code-review-graph==2.3.2`, the wheel didn't include `docs/LLM-OPTIMIZED-REFERENCE.md`, so both tools returned `status: error, reason: docs_not_found` outside a checked-out repo.

Two changes:

1. `pyproject.toml`: `tool.hatch.build.targets.wheel.force-include` ships `docs/LLM-OPTIMIZED-REFERENCE.md` to `code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md` inside the wheel.
2. `tools/docs.py`: when no `repo_root` is passed, check the in-package `code_review_graph/docs/` first; fall back to source-tree `docs/` next to the package. Both paths now resolve.

This PR is scoped to bug 1 of #480; bug 2 (`suggested_questions` returning role-`user` dicts) is already addressed in 4b6293f.

## Why this matters

#480 surfaces a hard failure for pipx/uvx users on 2.3.2. The wheel layout is the root cause — `tool.hatch.build.targets.wheel.packages = ["code_review_graph"]` doesn't pick up top-level `docs/`. Force-include in `pyproject.toml` ships the file in the wheel at a path the runtime can find. 2 new tests assert both the source-tree path and the bundled-wheel path resolve from outside any repo.

closes #480

AI was used for assistance.
