### PR TITLE
fix(cli): honor skip postprocess flags

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -322,21 +322,6 @@ def _handle_init(args: argparse.Namespace) -> None:
     print("  2. Restart your AI coding tool to pick up the new config")
 
 
-def _cli_post_process(store: GraphStore) -> None:
-    """Run post-build pipeline and print a summary line for each step."""
-    from .postprocessing import run_post_processing
-
-    pp = run_post_processing(store)
-    if pp.get("signatures_computed"):
-        print(f"Signatures: {pp['signatures_computed']} nodes")
-    if pp.get("fts_indexed"):
-        print(f"FTS indexed: {pp['fts_indexed']} nodes")
-    if pp.get("flows_detected") is not None:
-        print(f"Flows: {pp['flows_detected']}")
-    if pp.get("communities_detected") is not None:
-        print(f"Communities: {pp['communities_detected']}")
-
-
 def _handle_data_dir_option(args, repo_root: Path) -> None:
     """Handle --data-dir option by updating registry if specified."""
     if hasattr(args, "data_dir") and args.data_dir:
@@ -923,7 +908,6 @@ def main() -> None:
             print(f"Full build: {parsed} files, {nodes} nodes, {edges} edges (postprocess={pp})")
             if result.get("errors"):
                 print(f"Errors: {len(result['errors'])}")
-            _cli_post_process(store)
 
         elif args.command == "update":
             pp = (
@@ -947,8 +931,6 @@ def main() -> None:
                 f"{nodes} nodes, {edges} edges"
                 f" (postprocess={pp})"
             )
-            if result.get("files_updated", 0) > 0:
-                _cli_post_process(store)
 
         elif args.command == "status":
             stats = store.get_stats()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,4 +132,5 @@ norecursedirs = ["tests/fixtures"]
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "pytest-asyncio>=0.23,<1",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,78 @@ class TestWatchInteraction:
                             assert False, "Expected SystemExit"
                         except SystemExit as exc:
                             assert exc.code == 1
+
+
+class TestBuildUpdateCommands:
+    def test_build_skip_postprocess_does_not_run_extra_cli_postprocess(self):
+        argv = [
+            "code-review-graph",
+            "build",
+            "--skip-postprocess",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_parsed": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "none",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ) as mock_postprocess:
+                            cli.main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=True,
+            repo_root="repo-root",
+            postprocess="none",
+        )
+        mock_postprocess.assert_not_called()
+
+    def test_update_skip_flows_does_not_run_extra_cli_postprocess(self):
+        argv = [
+            "code-review-graph",
+            "update",
+            "--skip-flows",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_updated": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "minimal",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ) as mock_postprocess:
+                            cli.main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=False,
+            repo_root="repo-root",
+            base="HEAD~1",
+            postprocess="minimal",
+        )
+        mock_postprocess.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,7 @@ wiki = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -420,7 +421,10 @@ requires-dist = [
 provides-extras = ["embeddings", "google-embeddings", "communities", "eval", "wiki", "all", "enrichment", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4.2" }]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23,<1" },
+]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## Summary

Fix the `build` and `update` CLI commands so their post-processing flags are honored.

Previously, the CLI passed the selected postprocess level into `build_or_update_graph(...)`, but then ran the older full CLI post-processing pipeline afterward. As a result:

- `code-review-graph build --skip-postprocess` still ran full post-processing.
- `code-review-graph update --skip-flows` still ran flow/community post-processing.
- CLI output could report `postprocess=none` or `postprocess=minimal` while doing more work than requested.

This PR removes the extra CLI post-processing pass and relies on `build_or_update_graph(...)` as the source of truth for `none`, `minimal`, and `full` post-processing behavior.

## Changes

- Remove the extra `_cli_post_process(...)` calls after `build_or_update_graph(...)`.
- Remove the now-unused `_cli_post_process` helper.
- Add CLI regression coverage for:
  - `build --skip-postprocess`
  - `update --skip-flows`
- Add `pytest-asyncio` to the `uv` dev dependency group so `uv run python -m pytest` installs the async test plugin used by the existing test suite.

## Validation

```bash
uv run python -m pytest
```

Result:

```text
1238 passed, 1 skipped, 2 xpassed in 16.79s
```
