### PR TITLE
feat(cli): add 'uninstall' command (closes #482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`code-review-graph uninstall` command** ([#482](https://github.com/tirth8205/code-review-graph/issues/482)): symmetric counterpart to `install` that walks the full inventory of artifacts `install` creates and removes them. Per-repo it removes the `.code-review-graph/` data directory, the generated `.claude/skills/`, `.gemini/skills/`, and `.qoder/skills/` directories, our pre-commit hook block (preserving any user hooks), the `.code-review-graph/` line in `.gitignore`, and the `<!-- code-review-graph MCP tools -->` section from `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.windsurfrules`, `QODER.md`, and the GitHub Copilot instruction file. User-level it removes `~/.code-review-graph/` (registry + daemon state + logs), the OpenCode plugin, and our entry from every MCP / hooks config we ever write (Codex TOML, Cursor, Windsurf, Zed, Continue, Antigravity, Qwen, Copilot CLI). Surgical edits preserve unrelated entries — uninstalling code-review-graph never deletes another tool's MCP server or hook. Supports `--dry-run`, `--yes`, `--keep-data`, `--keep-user-configs`, `--repo PATH`, and `--all-repos`.
+
 ## [2.3.3] - 2026-05-08
 
 Large additive release accumulated since v2.3.2 — 141 non-merge commits, 8 new languages/extensions, 5 new platform install targets, 6 new framework call resolvers, comprehensive Windows hardening, VS Code accessibility pass, and a full sweep of community PRs.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ Build the code review graph for this project
 
 The initial build takes ~10 seconds for a 500-file project. After that, the graph updates automatically on every file edit and git commit.
 
+### Uninstalling
+
+Decided to stop using code-review-graph? A single command removes every artifact `install` ever wrote — graph database, generated skills, MCP entries, hooks, and the user-level registry — without touching unrelated entries other tools have written into the same config files.
+
+```sh
+code-review-graph uninstall              # preview + confirm, then clean current repo + ~/
+code-review-graph uninstall --dry-run    # show every planned action, change nothing
+code-review-graph uninstall --yes        # skip the confirmation prompt
+code-review-graph uninstall --all-repos  # also sweep every repo in the registry
+code-review-graph uninstall --keep-data  # only remove configs, keep the graph DB
+code-review-graph uninstall --keep-user-configs --repo .  # only clean this repo
+```
+
+MCP entries, hook entries, and instruction-file sections are edited surgically: only the `code-review-graph` entry is removed; other servers, hooks, and content survive untouched.
+
 
 ## How It Works
 

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -3,6 +3,8 @@
 Usage:
     code-review-graph install
     code-review-graph init
+    code-review-graph uninstall [--repo PATH] [--all-repos] [--keep-data]
+                                [--keep-user-configs] [--dry-run] [--yes]
     code-review-graph build [--base BASE]
     code-review-graph update [--base BASE]
     code-review-graph watch
@@ -440,6 +442,39 @@ def main() -> None:
         help="Target platform for MCP config (default: all detected)",
     )
 
+    # uninstall
+    uninstall_cmd = sub.add_parser(
+        "uninstall",
+        help=(
+            "Remove files installed by code-review-graph "
+            "(MCP configs, hooks, skills, graph DB, registry)."
+        ),
+    )
+    uninstall_cmd.add_argument(
+        "--repo", default=None,
+        help="Repository root to clean up (default: current directory).",
+    )
+    uninstall_cmd.add_argument(
+        "--all-repos", action="store_true",
+        help="Also clean up every repo in ~/.code-review-graph/registry.json.",
+    )
+    uninstall_cmd.add_argument(
+        "--keep-data", action="store_true",
+        help="Keep the .code-review-graph/ data directories (only remove configs).",
+    )
+    uninstall_cmd.add_argument(
+        "--keep-user-configs", action="store_true",
+        help="Skip user-level (~/) configs; only clean the target repo(s).",
+    )
+    uninstall_cmd.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would be removed without changing anything.",
+    )
+    uninstall_cmd.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip the confirmation prompt.",
+    )
+
     # build
     build_cmd = sub.add_parser("build", help="Full graph build (re-parse all files)")
     build_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
@@ -809,6 +844,59 @@ def main() -> None:
             )
             print(f"\nCompleted {len(results)} benchmark(s).")
             print("Run 'code-review-graph eval --report' to generate tables.")
+        return
+
+    if args.command == "uninstall":
+        from .uninstall import run as run_uninstall
+
+        target_repo = Path(args.repo).expanduser().resolve() if args.repo else None
+        # Always do a dry-run first so we can show the user what we are
+        # about to do; ask for confirmation unless --yes (or --dry-run
+        # which doesn't need one).
+        preview = run_uninstall(
+            repo=target_repo,
+            all_repos=args.all_repos,
+            keep_data=args.keep_data,
+            keep_user_configs=args.keep_user_configs,
+            dry_run=True,
+        )
+        print("code-review-graph uninstall — planned actions:")
+        if not preview.removed_paths and not preview.edited_paths:
+            print("  (nothing to do — no code-review-graph artifacts found)")
+            return
+        for line in preview.removed_paths:
+            print(f"  delete  {line}")
+        for line in preview.edited_paths:
+            print(f"  edit    {line}")
+        for line in preview.skipped_paths:
+            print(f"  skip    {line}")
+        if args.dry_run:
+            print()
+            print("[dry-run] No changes made. Re-run without --dry-run to apply.")
+            return
+        if not args.yes and not _confirm_yes_no(
+            "\nProceed with uninstall?",
+            default_yes=False,
+        ):
+            print("Aborted.")
+            return
+        result = run_uninstall(
+            repo=target_repo,
+            all_repos=args.all_repos,
+            keep_data=args.keep_data,
+            keep_user_configs=args.keep_user_configs,
+            dry_run=False,
+        )
+        print()
+        print(
+            f"Done. Removed {len(result.removed_paths)} path(s), "
+            f"edited {len(result.edited_paths)} config(s)."
+        )
+        if result.errors:
+            print("Errors:")
+            for err in result.errors:
+                print(f"  {err}")
+            sys.exit(1)
         return
 
     if args.command in ("init", "install"):

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -1,0 +1,685 @@
+"""Reverses the artifacts installed by ``code-review-graph install``.
+
+This module powers the ``code-review-graph uninstall`` CLI command. It walks
+the full inventory of files that ``install`` creates and either deletes them
+(when the file is wholly owned by code-review-graph) or surgically removes
+our entries from shared configuration files (e.g. ``.mcp.json``,
+``.codex/config.toml``, ``CLAUDE.md``) — preserving any other content the
+user has added.
+
+The design follows three principles:
+
+1. **Conservative by default.** A dry-run summary is printed before anything
+   is removed; the user must confirm (or pass ``--yes``).
+2. **Surgical edits for shared configs.** We never delete a file that may
+   contain non-CRG entries. Only the ``code-review-graph`` entry is
+   removed; if removing it leaves the container empty we also tidy that up.
+3. **Comprehensive inventory.** Every path that any ``install_*`` helper in
+   :mod:`code_review_graph.skills` can write is enumerated here so a single
+   ``uninstall`` cleans up the entire footprint.
+
+The implementation is intentionally side-effect-free until ``run()`` is
+called and the caller passes ``dry_run=False``. Each step records itself
+in the returned :class:`UninstallReport` so the CLI can print a structured
+summary.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Marker used by skills.py when appending the MCP tools section to
+# CLAUDE.md and the other instruction files. The marker line and
+# everything below it (to EOF) is what install writes; we strip the
+# same span on uninstall.
+_INSTRUCTION_MARKER = "<!-- code-review-graph MCP tools -->"
+
+# Marker used in the git pre-commit hook so we can recognise our own
+# entry and remove it without nuking user-defined hooks.
+_GIT_HOOK_MARKER = "# Installed by code-review-graph."
+
+# All instruction files install can touch, mirroring skills.py.
+_INSTRUCTION_FILES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "GEMINI.md",
+    ".cursorrules",
+    ".windsurfrules",
+    "QODER.md",
+    ".kiro/steering/code-review-graph.md",
+    ".github/code-review-graph.instruction.md",
+)
+
+
+@dataclass
+class UninstallReport:
+    """Structured record of what an uninstall did (or would do)."""
+
+    removed_paths: list[str] = field(default_factory=list)
+    edited_paths: list[str] = field(default_factory=list)
+    skipped_paths: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total_actions(self) -> int:
+        return len(self.removed_paths) + len(self.edited_paths)
+
+
+# ---------------------------------------------------------------------------
+# Path discovery
+# ---------------------------------------------------------------------------
+
+
+def _zed_settings_path() -> Path:
+    """Mirror :func:`code_review_graph.skills._zed_settings_path`."""
+    if platform.system() == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Zed" / "settings.json"
+    return Path.home() / ".config" / "zed" / "settings.json"
+
+
+def _user_artifacts() -> list[tuple[Path, str]]:
+    """Return ``[(path, kind)]`` for every user-level artifact install may write.
+
+    ``kind`` is one of:
+
+    * ``"dir"``         — directory to delete wholesale.
+    * ``"file"``        — file to delete wholesale (we own the whole file).
+    * ``"json_mcp"``    — JSON config; remove our entry under one of the
+      standard MCP keys (``mcpServers`` / ``servers`` / ``context_servers``).
+    * ``"toml_codex"``  — ``~/.codex/config.toml`` — remove ``[mcp_servers.code-review-graph]``.
+    * ``"json_hooks"``  — generic JSON hooks file; remove entries whose
+      ``command`` references ``code-review-graph``.
+    """
+    home = Path.home()
+    return [
+        # The user-level registry / daemon state / logs directory. This is
+        # entirely ours, so it goes wholesale.
+        (home / ".code-review-graph", "dir"),
+        # MCP server configs (JSON).
+        (home / ".cursor" / "mcp.json", "json_mcp"),
+        (home / ".codeium" / "windsurf" / "mcp_config.json", "json_mcp"),
+        (_zed_settings_path(), "json_mcp"),
+        (home / ".continue" / "config.json", "json_mcp"),
+        (home / ".gemini" / "antigravity" / "mcp_config.json", "json_mcp"),
+        (home / ".qwen" / "settings.json", "json_mcp"),
+        (home / ".copilot" / "mcp-config.json", "json_mcp"),
+        # Codex MCP config (TOML).
+        (home / ".codex" / "config.toml", "toml_codex"),
+        # Codex / Cursor hooks (JSON).
+        (home / ".codex" / "hooks.json", "json_hooks"),
+        (home / ".cursor" / "hooks.json", "json_hooks"),
+        # Cursor hook scripts directory — wholly ours (install always
+        # writes the three scripts here).
+        (home / ".cursor" / "hooks", "dir"),
+        # OpenCode plugin file — wholly ours.
+        (home / ".config" / "opencode" / "plugins" / "crg-plugin.ts", "file"),
+    ]
+
+
+def _per_repo_artifacts(repo_root: Path) -> list[tuple[Path, str]]:
+    """Return ``[(path, kind)]`` for every per-repo artifact."""
+    return [
+        # Local graph database directory (the big one — usually the most
+        # storage the user reclaims).
+        (repo_root / ".code-review-graph", "dir"),
+        # Legacy DB file from older versions.
+        (repo_root / ".code-review-graph.db", "file"),
+        (repo_root / ".code-review-graph.db-wal", "file"),
+        (repo_root / ".code-review-graph.db-shm", "file"),
+        # Workspace-level MCP configs.
+        (repo_root / ".mcp.json", "json_mcp"),
+        (repo_root / ".opencode.json", "json_mcp"),
+        (repo_root / ".cursor" / "mcp.json", "json_mcp"),
+        (repo_root / ".qoder" / "mcp.json", "json_mcp"),
+        (repo_root / ".kiro" / "settings" / "mcp.json", "json_mcp"),
+        (repo_root / ".vscode" / "mcp.json", "json_mcp"),
+        # Hooks (workspace-level).
+        (repo_root / ".claude" / "settings.json", "json_hooks"),
+        (repo_root / ".qoder" / "settings.json", "json_hooks"),
+        (repo_root / ".gemini" / "settings.json", "json_hooks"),
+        # Generated skills directories — wholly ours.
+        (repo_root / ".claude" / "skills" / "explore-codebase", "dir"),
+        (repo_root / ".claude" / "skills" / "review-changes", "dir"),
+        (repo_root / ".claude" / "skills" / "debug-issue", "dir"),
+        (repo_root / ".claude" / "skills" / "refactor-safely", "dir"),
+        (repo_root / ".qoder" / "skills", "dir"),
+        (repo_root / ".gemini" / "skills" / "explore-codebase", "dir"),
+        (repo_root / ".gemini" / "skills" / "review-changes", "dir"),
+        (repo_root / ".gemini" / "skills" / "debug-issue", "dir"),
+        (repo_root / ".gemini" / "skills" / "refactor-safely", "dir"),
+        # Gemini CLI hook scripts.
+        (repo_root / ".gemini" / "hooks" / "crg-session-start.sh", "file"),
+        (repo_root / ".gemini" / "hooks" / "crg-update.sh", "file"),
+        # Pre-commit hook (surgical — preserve user hooks).
+        (repo_root / ".git" / "hooks" / "pre-commit", "git_hook"),
+    ] + [
+        (repo_root / name, "instruction") for name in _INSTRUCTION_FILES
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Surgical edits
+# ---------------------------------------------------------------------------
+
+_MCP_KEYS = ("mcpServers", "servers", "context_servers")
+_ENTRY_NAME = "code-review-graph"
+
+
+def _strip_jsonc(raw: str) -> str:
+    """Strip ``//`` comments and trailing commas (Zed-style JSONC)."""
+    stripped = re.sub(r"//.*?$", "", raw, flags=re.MULTILINE)
+    stripped = re.sub(r",(\s*[}\]])", r"\1", stripped)
+    return stripped
+
+
+def _remove_mcp_entry(path: Path, report: UninstallReport, *, dry_run: bool) -> None:
+    """Remove ``code-review-graph`` from a JSON MCP config file.
+
+    Preserves all other servers and top-level keys. If the file becomes
+    *empty of meaningful content* (i.e. only an empty ``mcpServers``
+    object remains), we leave it alone — the user may want to keep their
+    empty file.
+    """
+    if not path.exists():
+        return
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(_strip_jsonc(raw))
+    except (json.JSONDecodeError, OSError) as exc:
+        report.skipped_paths.append(f"{path} (unparseable: {exc})")
+        return
+
+    changed = False
+    for key in _MCP_KEYS:
+        if key not in data:
+            continue
+        container = data[key]
+        if isinstance(container, dict) and _ENTRY_NAME in container:
+            del container[_ENTRY_NAME]
+            changed = True
+        elif isinstance(container, list):
+            new_list = [
+                s for s in container
+                if not (isinstance(s, dict) and s.get("name") == _ENTRY_NAME)
+            ]
+            if len(new_list) != len(container):
+                data[key] = new_list
+                changed = True
+
+    if not changed:
+        return
+
+    if dry_run:
+        report.edited_paths.append(f"{path} (would remove '{_ENTRY_NAME}' MCP entry)")
+        return
+
+    try:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        report.edited_paths.append(f"{path} (removed '{_ENTRY_NAME}' MCP entry)")
+    except OSError as exc:
+        report.errors.append(f"{path}: write failed ({exc})")
+
+
+def _remove_codex_toml_entry(
+    path: Path, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Remove ``[mcp_servers.code-review-graph]`` (and its body) from ``config.toml``.
+
+    The Codex config is hand-edited TOML with our own
+    ``_merge_toml_mcp_server`` writer in :mod:`skills`. To stay
+    dependency-light we do a textual removal of the exact section
+    ``[mcp_servers.code-review-graph]`` and every following line until the
+    next ``[section]`` header or EOF.
+    """
+    if not path.exists():
+        return
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        report.errors.append(f"{path}: read failed ({exc})")
+        return
+
+    header = f"[mcp_servers.{_ENTRY_NAME}]"
+    if header not in text:
+        return
+
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    dropping = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == header:
+            dropping = True
+            continue
+        if dropping and stripped.startswith("[") and stripped.endswith("]"):
+            dropping = False
+        if not dropping:
+            out.append(line)
+
+    new_text = "".join(out).rstrip() + "\n"
+    if new_text == text:
+        return
+
+    if dry_run:
+        report.edited_paths.append(f"{path} (would remove [mcp_servers.{_ENTRY_NAME}])")
+        return
+
+    try:
+        path.write_text(new_text, encoding="utf-8")
+        report.edited_paths.append(f"{path} (removed [mcp_servers.{_ENTRY_NAME}])")
+    except OSError as exc:
+        report.errors.append(f"{path}: write failed ({exc})")
+
+
+def _hook_entry_is_ours(entry: Any) -> bool:
+    """Return True if a hooks-config entry was installed by us.
+
+    Hooks come in two shapes across the various platforms:
+
+    * ``{"command": "...code-review-graph..."}``
+    * ``{"matcher": "...", "hooks": [{"command": "...code-review-graph..."}]}``
+    """
+    if not isinstance(entry, dict):
+        return False
+    cmd = entry.get("command")
+    if isinstance(cmd, str) and "code-review-graph" in cmd:
+        return True
+    nested = entry.get("hooks")
+    if isinstance(nested, list):
+        for h in nested:
+            if isinstance(h, dict):
+                hc = h.get("command", "")
+                if isinstance(hc, str) and "code-review-graph" in hc:
+                    return True
+    return False
+
+
+def _remove_hook_entries(
+    path: Path, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Remove our hook entries from a JSON hooks config (settings.json / hooks.json)."""
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError) as exc:
+        report.skipped_paths.append(f"{path} (unparseable: {exc})")
+        return
+
+    hooks_obj = data.get("hooks")
+    if not isinstance(hooks_obj, dict):
+        return
+
+    changed = False
+    for event_name, arr in list(hooks_obj.items()):
+        if not isinstance(arr, list):
+            continue
+        new_arr = [entry for entry in arr if not _hook_entry_is_ours(entry)]
+        if len(new_arr) != len(arr):
+            hooks_obj[event_name] = new_arr
+            changed = True
+        if not new_arr:
+            del hooks_obj[event_name]
+            changed = True
+
+    if not changed:
+        return
+
+    # Tidy up an empty top-level "hooks" object so we don't leave
+    # noise behind.
+    if not hooks_obj:
+        del data["hooks"]
+
+    if dry_run:
+        report.edited_paths.append(f"{path} (would remove code-review-graph hook entries)")
+        return
+
+    try:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        report.edited_paths.append(f"{path} (removed code-review-graph hook entries)")
+    except OSError as exc:
+        report.errors.append(f"{path}: write failed ({exc})")
+
+
+def _remove_instruction_section(
+    path: Path, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Remove the ``<!-- code-review-graph MCP tools -->`` section.
+
+    ``install`` always appends the section to EOF and never inserts it in
+    the middle, so we delete from the marker line to EOF. If after the
+    edit the file is empty (or whitespace-only), we remove the file.
+    """
+    if not path.exists():
+        return
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        report.errors.append(f"{path}: read failed ({exc})")
+        return
+
+    if _INSTRUCTION_MARKER not in text:
+        return
+
+    idx = text.find(_INSTRUCTION_MARKER)
+    new_text = text[:idx].rstrip() + "\n"
+
+    if dry_run:
+        if new_text.strip():
+            report.edited_paths.append(f"{path} (would remove MCP tools section)")
+        else:
+            report.removed_paths.append(f"{path} (would delete — only contained our section)")
+        return
+
+    try:
+        if not new_text.strip():
+            path.unlink()
+            report.removed_paths.append(str(path))
+        else:
+            path.write_text(new_text, encoding="utf-8")
+            report.edited_paths.append(f"{path} (removed MCP tools section)")
+    except OSError as exc:
+        report.errors.append(f"{path}: write failed ({exc})")
+
+
+def _remove_git_hook(
+    path: Path, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Remove our pre-commit block from ``.git/hooks/pre-commit``.
+
+    The hook installer either creates a fresh file (whose first line is
+    a shebang followed by our marker block) or appends our block to an
+    existing hook. We recognise our block by the ``_GIT_HOOK_MARKER``
+    comment line; we drop that line and every subsequent line until we
+    leave the contiguous block we added.
+    """
+    if not path.exists():
+        return
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        report.errors.append(f"{path}: read failed ({exc})")
+        return
+
+    if _GIT_HOOK_MARKER not in text:
+        return
+
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    dropping = False
+    for line in lines:
+        if _GIT_HOOK_MARKER in line:
+            dropping = True
+            continue
+        if dropping:
+            # Our block runs from the marker through the next blank line
+            # (or EOF). The installed snippet is:
+            #
+            #   # Installed by code-review-graph. ...
+            #   if command -v code-review-graph >/dev/null 2>&1; then
+            #       code-review-graph update || true
+            #       code-review-graph detect-changes --brief || true
+            #   fi
+            #
+            # so we stop dropping after the ``fi`` line.
+            if line.strip() == "fi":
+                dropping = False
+                continue
+            continue
+        out.append(line)
+
+    new_text = "".join(out).rstrip()
+    # If only the shebang remains (or nothing), delete the file: a hook
+    # with only ``#!/bin/sh`` is functionally empty and creates a
+    # confusing artifact.
+    meaningful = "\n".join(
+        ln for ln in new_text.splitlines() if ln.strip() and not ln.strip().startswith("#!")
+    ).strip()
+
+    if dry_run:
+        if meaningful:
+            report.edited_paths.append(f"{path} (would remove code-review-graph block)")
+        else:
+            report.removed_paths.append(f"{path} (would delete — only contained our block)")
+        return
+
+    try:
+        if not meaningful:
+            path.unlink()
+            report.removed_paths.append(str(path))
+        else:
+            path.write_text(new_text + "\n", encoding="utf-8")
+            report.edited_paths.append(f"{path} (removed code-review-graph block)")
+    except OSError as exc:
+        report.errors.append(f"{path}: write failed ({exc})")
+
+
+def _remove_gitignore_entry(
+    repo_root: Path, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Remove the ``.code-review-graph/`` line (and its banner) from .gitignore.
+
+    Mirrors :func:`code_review_graph.incremental.ensure_repo_gitignore_excludes_crg`,
+    which inserts ``# Added by code-review-graph`` followed by
+    ``.code-review-graph/``.
+    """
+    gi = repo_root / ".gitignore"
+    if not gi.exists():
+        return
+    try:
+        text = gi.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        report.errors.append(f"{gi}: read failed ({exc})")
+        return
+
+    lines = text.splitlines()
+    new_lines: list[str] = []
+    skip_next = False
+    changed = False
+    for line in lines:
+        if skip_next:
+            skip_next = False
+            if line.strip() in (".code-review-graph", ".code-review-graph/"):
+                changed = True
+                continue
+            new_lines.append(line)
+            continue
+        if line.strip() == "# Added by code-review-graph":
+            # The very next line is the entry we wrote; drop both.
+            skip_next = True
+            changed = True
+            continue
+        if line.strip() in (".code-review-graph", ".code-review-graph/"):
+            changed = True
+            continue
+        new_lines.append(line)
+
+    if not changed:
+        return
+
+    new_text = "\n".join(new_lines).rstrip() + "\n"
+
+    if dry_run:
+        if new_text.strip():
+            report.edited_paths.append(f"{gi} (would remove .code-review-graph/ entry)")
+        else:
+            report.removed_paths.append(f"{gi} (would delete — file would be empty)")
+        return
+
+    try:
+        if not new_text.strip():
+            gi.unlink()
+            report.removed_paths.append(str(gi))
+        else:
+            gi.write_text(new_text, encoding="utf-8")
+            report.edited_paths.append(f"{gi} (removed .code-review-graph/ entry)")
+    except OSError as exc:
+        report.errors.append(f"{gi}: write failed ({exc})")
+
+
+# ---------------------------------------------------------------------------
+# Whole-file/dir removal
+# ---------------------------------------------------------------------------
+
+
+def _remove_path(
+    path: Path, kind: str, report: UninstallReport, *, dry_run: bool,
+) -> None:
+    """Delete a path that is wholly owned by code-review-graph."""
+    if not path.exists() and not path.is_symlink():
+        return
+
+    if dry_run:
+        report.removed_paths.append(f"{path} ({kind})")
+        return
+
+    try:
+        if kind == "dir":
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        report.removed_paths.append(str(path))
+    except OSError as exc:
+        report.errors.append(f"{path}: remove failed ({exc})")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _process_repo(
+    repo_root: Path,
+    report: UninstallReport,
+    *,
+    dry_run: bool,
+    keep_data: bool,
+) -> None:
+    """Walk per-repo artifacts and remove or edit each one."""
+    for path, kind in _per_repo_artifacts(repo_root):
+        if keep_data and kind == "dir" and path.name == ".code-review-graph":
+            report.skipped_paths.append(f"{path} (kept: --keep-data)")
+            continue
+        if kind in ("dir", "file"):
+            _remove_path(path, kind, report, dry_run=dry_run)
+        elif kind == "json_mcp":
+            _remove_mcp_entry(path, report, dry_run=dry_run)
+        elif kind == "json_hooks":
+            _remove_hook_entries(path, report, dry_run=dry_run)
+        elif kind == "instruction":
+            _remove_instruction_section(path, report, dry_run=dry_run)
+        elif kind == "git_hook":
+            _remove_git_hook(path, report, dry_run=dry_run)
+    _remove_gitignore_entry(repo_root, report, dry_run=dry_run)
+
+
+def _process_user(
+    report: UninstallReport,
+    *,
+    dry_run: bool,
+    keep_data: bool,
+) -> None:
+    """Walk user-level artifacts and remove or edit each one."""
+    for path, kind in _user_artifacts():
+        if keep_data and kind == "dir" and path.name == ".code-review-graph":
+            report.skipped_paths.append(f"{path} (kept: --keep-data)")
+            continue
+        if kind in ("dir", "file"):
+            _remove_path(path, kind, report, dry_run=dry_run)
+        elif kind == "json_mcp":
+            _remove_mcp_entry(path, report, dry_run=dry_run)
+        elif kind == "json_hooks":
+            _remove_hook_entries(path, report, dry_run=dry_run)
+        elif kind == "toml_codex":
+            _remove_codex_toml_entry(path, report, dry_run=dry_run)
+
+
+def collect_repo_roots(
+    explicit_repo: Path | None,
+    *,
+    all_repos: bool,
+) -> list[Path]:
+    """Determine which repository roots to clean up.
+
+    Resolution rules:
+
+    * ``explicit_repo`` takes precedence and is always returned (alone).
+    * Otherwise we always include the current working directory.
+    * With ``all_repos=True`` we additionally include every path
+      registered in ``~/.code-review-graph/registry.json``.
+    """
+    if explicit_repo is not None:
+        return [explicit_repo.resolve()]
+
+    roots: list[Path] = [Path(os.getcwd()).resolve()]
+    if all_repos:
+        # Lazy import — keeps uninstall importable in environments where
+        # the registry module's deps aren't available.
+        try:
+            from .registry import Registry
+
+            registry = Registry()
+            for entry in registry.list_repos():
+                p = Path(entry["path"]).resolve()
+                if p not in roots:
+                    roots.append(p)
+                # Also clean up any external data_dir the user pointed
+                # the repo at.
+                data_dir = entry.get("data_dir")
+                if data_dir:
+                    dp = Path(data_dir).resolve()
+                    if dp.exists() and dp not in roots:
+                        roots.append(dp)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("Could not load registry: %s", exc)
+    return roots
+
+
+def run(
+    *,
+    repo: Path | None = None,
+    all_repos: bool = False,
+    keep_data: bool = False,
+    keep_user_configs: bool = False,
+    dry_run: bool = False,
+) -> UninstallReport:
+    """Perform the uninstall and return a structured report.
+
+    Args:
+        repo: Specific repository root to clean. When ``None`` we use
+            the current working directory.
+        all_repos: When True, also sweep every repo in the registry
+            (in addition to ``repo``/CWD).
+        keep_data: Skip removal of ``.code-review-graph/`` directories
+            (per-repo and user-level). Useful when the user only wants
+            to disable the tool but keep the graph cached.
+        keep_user_configs: Skip the user-level pass entirely. Useful
+            when only cleaning a single project.
+        dry_run: Report planned actions without making changes.
+
+    Returns:
+        :class:`UninstallReport` describing the actions taken (or
+        planned).
+    """
+    report = UninstallReport()
+
+    for root in collect_repo_roots(repo, all_repos=all_repos):
+        if not root.exists():
+            report.skipped_paths.append(f"{root} (missing)")
+            continue
+        _process_repo(root, report, dry_run=dry_run, keep_data=keep_data)
+
+    if not keep_user_configs:
+        _process_user(report, dry_run=dry_run, keep_data=keep_data)
+
+    return report

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,387 @@
+"""Tests for ``code_review_graph.uninstall``.
+
+These tests exercise the full uninstall workflow by:
+
+1. Building a fake repository with every artifact ``install`` could write.
+2. Building a fake user home (via ``monkeypatch.setattr(Path, "home", ...)``)
+   with every user-level artifact ``install`` could write.
+3. Running ``uninstall.run(dry_run=True)`` and confirming nothing changes
+   but every expected action is reported.
+4. Running ``uninstall.run()`` and confirming the artifacts are gone or
+   surgically edited.
+
+Where surgical edits are involved we deliberately include unrelated entries
+(other MCP servers, other hooks, other content in instruction files) and
+assert they survive — that is the entire point of "uninstall must not
+nuke the user's other tools".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from code_review_graph import uninstall
+
+# ---------------------------------------------------------------------------
+# Helpers — build fake artifacts that match what skills.py writes
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def fake_repo(tmp_path: Path) -> Path:
+    """Build a repository with every per-repo artifact install creates."""
+    repo = tmp_path / "fake-repo"
+    repo.mkdir()
+    # Local DB dir.
+    (repo / ".code-review-graph").mkdir()
+    (repo / ".code-review-graph" / "graph.db").write_bytes(b"\x00")
+    # Legacy DB file.
+    (repo / ".code-review-graph.db").write_bytes(b"\x00")
+    # Workspace MCP configs — mixed with an unrelated server we must keep.
+    _write_json(
+        repo / ".mcp.json",
+        {
+            "mcpServers": {
+                "code-review-graph": {"command": "code-review-graph", "args": ["serve"]},
+                "other-tool": {"command": "other-tool"},
+            }
+        },
+    )
+    _write_json(
+        repo / ".opencode.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}}},
+    )
+    _write_json(
+        repo / ".cursor" / "mcp.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}, "keepme": {"command": "y"}}},
+    )
+    _write_json(
+        repo / ".qoder" / "mcp.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}}},
+    )
+    _write_json(
+        repo / ".kiro" / "settings" / "mcp.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}}},
+    )
+    _write_json(
+        repo / ".vscode" / "mcp.json",
+        {"servers": {"code-review-graph": {"command": "x"}}},
+    )
+    # Hooks — claude settings has user hooks too that must survive.
+    _write_json(
+        repo / ".claude" / "settings.json",
+        {
+            "model": "claude-sonnet",
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": "Edit|Write|Bash",
+                        "hooks": [{"type": "command", "command": "code-review-graph update"}],
+                    },
+                    {
+                        "matcher": "Edit",
+                        "hooks": [{"type": "command", "command": "user-custom-hook"}],
+                    },
+                ]
+            },
+        },
+    )
+    _write_json(
+        repo / ".gemini" / "settings.json",
+        {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "bash .gemini/hooks/crg-session-start.sh",
+                        }],
+                    }
+                ]
+            }
+        },
+    )
+    # Skills — generated.
+    for name in ("explore-codebase", "review-changes", "debug-issue", "refactor-safely"):
+        (repo / ".claude" / "skills" / name).mkdir(parents=True, exist_ok=True)
+        (repo / ".claude" / "skills" / name / "skill.md").write_text("body")
+        (repo / ".gemini" / "skills" / name).mkdir(parents=True, exist_ok=True)
+        (repo / ".gemini" / "skills" / name / "SKILL.md").write_text("body")
+    (repo / ".qoder" / "skills" / "explore-codebase").mkdir(parents=True)
+    (repo / ".qoder" / "skills" / "explore-codebase" / "SKILL.md").write_text("body")
+    # Gemini hook scripts.
+    (repo / ".gemini" / "hooks").mkdir(parents=True, exist_ok=True)
+    (repo / ".gemini" / "hooks" / "crg-session-start.sh").write_text("#!/bin/sh")
+    (repo / ".gemini" / "hooks" / "crg-update.sh").write_text("#!/bin/sh")
+    # Git pre-commit hook — installed alongside a user hook.
+    git_hooks = repo / ".git" / "hooks"
+    git_hooks.mkdir(parents=True)
+    (git_hooks / "pre-commit").write_text(
+        "#!/bin/sh\n"
+        "echo \"user hook still here\"\n"
+        "# Installed by code-review-graph. Remove this file to disable.\n"
+        "if command -v code-review-graph >/dev/null 2>&1; then\n"
+        "    code-review-graph update || true\n"
+        "    code-review-graph detect-changes --brief || true\n"
+        "fi\n"
+    )
+    # Instruction files — append our marker section.
+    _write_text(
+        repo / "CLAUDE.md",
+        "# Project instructions\n\nDo something useful.\n\n"
+        "<!-- code-review-graph MCP tools -->\nstuff added by install\n",
+    )
+    _write_text(
+        repo / "AGENTS.md",
+        "<!-- code-review-graph MCP tools -->\nonly our content\n",
+    )
+    # .gitignore with our entry.
+    _write_text(
+        repo / ".gitignore",
+        "node_modules/\n# Added by code-review-graph\n.code-review-graph/\n",
+    )
+    return repo
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a fake ``~`` and point ``Path.home()`` at it."""
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    # User-level registry / data dir.
+    (home / ".code-review-graph").mkdir()
+    (home / ".code-review-graph" / "registry.json").write_text("{}")
+    # User-level MCP configs.
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}, "other": {"command": "y"}}},
+    )
+    _write_json(
+        home / ".continue" / "config.json",
+        {"mcpServers": [{"name": "code-review-graph", "command": "x"},
+                        {"name": "keep-me", "command": "y"}]},
+    )
+    _write_json(
+        home / ".qwen" / "settings.json",
+        {"mcpServers": {"code-review-graph": {"command": "x"}}},
+    )
+    _write_json(
+        home / ".copilot" / "mcp-config.json",
+        {"servers": {"code-review-graph": {"command": "x"}}},
+    )
+    # Codex MCP config (TOML) — interleaved with another server we must keep.
+    codex_dir = home / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text(
+        "[mcp_servers.other]\n"
+        "command = \"other\"\n"
+        "\n"
+        "[mcp_servers.code-review-graph]\n"
+        "command = \"code-review-graph\"\n"
+        "args = [\"serve\"]\n"
+        "\n"
+        "[other_section]\n"
+        "value = 1\n"
+    )
+    # Codex hooks.
+    _write_json(
+        codex_dir / "hooks.json",
+        {"hooks": {"PostToolUse": [{"hooks": [
+            {"type": "command", "command": "code-review-graph update"}
+        ]}]}},
+    )
+    # Cursor hooks + scripts.
+    _write_json(
+        home / ".cursor" / "hooks.json",
+        {"version": 1, "hooks": {"afterEdit": [{"command": "code-review-graph update"}]}},
+    )
+    (home / ".cursor" / "hooks").mkdir(parents=True, exist_ok=True)
+    (home / ".cursor" / "hooks" / "crg.sh").write_text("#!/bin/sh")
+    # OpenCode plugin.
+    (home / ".config" / "opencode" / "plugins").mkdir(parents=True)
+    (home / ".config" / "opencode" / "plugins" / "crg-plugin.ts").write_text("// plugin")
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Dry-run behavior
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_mutate(fake_repo: Path, fake_home: Path) -> None:
+    before_repo = sorted(p.relative_to(fake_repo).as_posix() for p in fake_repo.rglob("*"))
+    before_home = sorted(p.relative_to(fake_home).as_posix() for p in fake_home.rglob("*"))
+
+    report = uninstall.run(repo=fake_repo, dry_run=True)
+
+    after_repo = sorted(p.relative_to(fake_repo).as_posix() for p in fake_repo.rglob("*"))
+    after_home = sorted(p.relative_to(fake_home).as_posix() for p in fake_home.rglob("*"))
+
+    assert before_repo == after_repo, "dry-run modified the repo"
+    assert before_home == after_home, "dry-run modified ~"
+    assert report.total_actions > 0
+
+
+# ---------------------------------------------------------------------------
+# Per-repo cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_repo_data_dir_is_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    assert not (fake_repo / ".code-review-graph").exists()
+    assert not (fake_repo / ".code-review-graph.db").exists()
+
+
+def test_keep_data_preserves_data_dirs(fake_repo: Path, fake_home: Path) -> None:
+    report = uninstall.run(repo=fake_repo, keep_data=True, keep_user_configs=True)
+    assert (fake_repo / ".code-review-graph").exists()
+    # And it should be reported as skipped, not removed.
+    skipped = "\n".join(report.skipped_paths)
+    assert ".code-review-graph (kept: --keep-data)" in skipped
+
+
+def test_mcp_entry_removed_other_servers_preserved(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    data = json.loads((fake_repo / ".mcp.json").read_text())
+    assert "code-review-graph" not in data["mcpServers"]
+    assert "other-tool" in data["mcpServers"], "unrelated MCP server was deleted"
+
+
+def test_cursor_workspace_mcp_preserves_unrelated(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    data = json.loads((fake_repo / ".cursor" / "mcp.json").read_text())
+    assert "code-review-graph" not in data["mcpServers"]
+    assert "keepme" in data["mcpServers"]
+
+
+def test_claude_settings_keeps_user_hooks(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    data = json.loads((fake_repo / ".claude" / "settings.json").read_text())
+    # The model setting must survive.
+    assert data["model"] == "claude-sonnet"
+    # The user-custom hook must survive; the code-review-graph one must be gone.
+    remaining = data.get("hooks", {}).get("PostToolUse", [])
+    commands = [
+        h["command"]
+        for entry in remaining
+        for h in entry.get("hooks", [])
+    ]
+    assert "user-custom-hook" in commands
+    assert "code-review-graph update" not in commands
+
+
+def test_generated_skills_dirs_are_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    for name in ("explore-codebase", "review-changes", "debug-issue", "refactor-safely"):
+        assert not (fake_repo / ".claude" / "skills" / name).exists()
+        assert not (fake_repo / ".gemini" / "skills" / name).exists()
+
+
+def test_pre_commit_hook_preserves_user_lines(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    hook = (fake_repo / ".git" / "hooks" / "pre-commit").read_text()
+    assert "user hook still here" in hook
+    assert "code-review-graph" not in hook
+    assert "Installed by code-review-graph" not in hook
+
+
+def test_instruction_section_removed_other_content_kept(
+    fake_repo: Path, fake_home: Path,
+) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    claude_md = fake_repo / "CLAUDE.md"
+    assert claude_md.exists(), "CLAUDE.md should survive — it has non-CRG content"
+    text = claude_md.read_text()
+    assert "Project instructions" in text
+    assert "<!-- code-review-graph MCP tools -->" not in text
+
+
+def test_agents_md_deleted_when_only_our_content(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    assert not (fake_repo / "AGENTS.md").exists()
+
+
+def test_gitignore_entry_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    gi = (fake_repo / ".gitignore").read_text()
+    assert "node_modules/" in gi
+    assert ".code-review-graph" not in gi
+    assert "Added by code-review-graph" not in gi
+
+
+# ---------------------------------------------------------------------------
+# User-level cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_user_registry_dir_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo)
+    assert not (fake_home / ".code-review-graph").exists()
+
+
+def test_user_cursor_mcp_only_our_entry_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo)
+    data = json.loads((fake_home / ".cursor" / "mcp.json").read_text())
+    assert "code-review-graph" not in data["mcpServers"]
+    assert "other" in data["mcpServers"]
+
+
+def test_continue_array_format_keeps_unrelated(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo)
+    data = json.loads((fake_home / ".continue" / "config.json").read_text())
+    names = [s["name"] for s in data["mcpServers"]]
+    assert "code-review-graph" not in names
+    assert "keep-me" in names
+
+
+def test_codex_toml_entry_removed_others_kept(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo)
+    text = (fake_home / ".codex" / "config.toml").read_text()
+    assert "[mcp_servers.code-review-graph]" not in text
+    assert "[mcp_servers.other]" in text
+    assert "[other_section]" in text
+
+
+def test_opencode_plugin_file_removed(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo)
+    assert not (fake_home / ".config" / "opencode" / "plugins" / "crg-plugin.ts").exists()
+
+
+def test_keep_user_configs_skips_user_level(fake_repo: Path, fake_home: Path) -> None:
+    uninstall.run(repo=fake_repo, keep_user_configs=True)
+    # User-level files must be untouched.
+    assert (fake_home / ".code-review-graph").exists()
+    data = json.loads((fake_home / ".cursor" / "mcp.json").read_text())
+    assert "code-review-graph" in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# No-op behavior
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_in_clean_repo_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "empty-home")
+    (tmp_path / "empty-home").mkdir()
+    clean_repo = tmp_path / "clean"
+    clean_repo.mkdir()
+    report = uninstall.run(repo=clean_repo)
+    assert report.removed_paths == []
+    assert report.edited_paths == []
+    assert report.errors == []


### PR DESCRIPTION
# PR: feat(cli): add `uninstall` command to remove all installed artifacts

Closes #482.

## Summary

`code-review-graph install` writes a lot of files: a graph database, generated skills, MCP configs across 14 platforms, hooks at both repo and user level, and an injected section in seven different instruction files. Issue #482 asks for a symmetric way to remove all of it.

This PR adds `code-review-graph uninstall`.

## What it does

**Per-repo**

- Removes the `.code-review-graph/` data directory and the legacy `.code-review-graph.db` file.
- Removes generated skill directories under `.claude/skills/`, `.gemini/skills/`, and `.qoder/skills/`.
- Removes our pre-commit hook block (and only ours — user lines and other hooks in the same file are preserved).
- Removes the `.code-review-graph/` entry from `.gitignore`.
- Removes the `<!-- code-review-graph MCP tools -->` section from `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.windsurfrules`, `QODER.md`, the Kiro steering file, and the GitHub Copilot instruction file. If a file contained only our section, the file is deleted.

**User-level**

- Removes `~/.code-review-graph/` (registry, daemon state, watch.toml, logs).
- Removes `~/.config/opencode/plugins/crg-plugin.ts` and the user-level Cursor hook scripts directory.
- Removes our entry from every MCP / hooks config we write: Codex (TOML), Cursor, Windsurf, Zed, Continue, Antigravity, Qwen, Copilot CLI.

**Surgical edits, not nukes**

Every shared config file is edited rather than deleted. Only the `code-review-graph` entry is removed; other MCP servers, hooks, and content stay untouched. The tests pin this contract explicitly.

## Flags

```
code-review-graph uninstall              # preview + confirm, then clean current repo + ~/
code-review-graph uninstall --dry-run    # show every planned action, change nothing
code-review-graph uninstall --yes        # skip the confirmation prompt
code-review-graph uninstall --repo PATH  # target a specific repo (default: cwd)
code-review-graph uninstall --all-repos  # also sweep every repo in the registry
code-review-graph uninstall --keep-data  # only remove configs, keep the graph DB
code-review-graph uninstall --keep-user-configs  # only clean the target repo(s)
```

## Tests

`tests/test_uninstall.py` adds 18 tests covering:

- Dry-run leaves the filesystem byte-identical.
- Per-repo data dir / legacy DB removal.
- `--keep-data` preserves the data dir and reports it as skipped.
- MCP entry removal preserves unrelated servers (workspace and user level).
- Claude `settings.json` keeps user-defined hooks and non-hook keys.
- Generated skill directories are removed.
- Pre-commit hook preserves preexisting user lines.
- Instruction-file section removal preserves other content; the file is deleted only when nothing else remains.
- `.gitignore`: our entry removed, user entries preserved.
- Codex `config.toml`: our section removed, other sections kept.
- Continue array-format MCP config: our entry removed by name.
- `--keep-user-configs` skips the user-level pass.
- A clean repo is a no-op.

All 18 pass; existing tests in `test_cli`, `test_cli_install`, `test_skills`, and `test_registry` still pass (the four pre-existing failures in `test_incremental.py` are an environmental tree-sitter mismatch unrelated to this change).

## Files changed

```
 CHANGELOG.md                   |   3 +
 README.md                      |  15 +
 code_review_graph/cli.py       |  88 ++++++
 code_review_graph/uninstall.py | 685 +++++++++++++++++++++++++++++++++++
 tests/test_uninstall.py        | 387 ++++++++++++++++++++
 5 files changed, 1178 insertions(+)
```
