### PR TITLE
Drain stdin in generated hook commands to avoid BrokenPipeError

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -560,6 +560,7 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 f" && code-review-graph update --skip-flows"
                                 f" --repo {repo_arg}"
@@ -577,6 +578,7 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 f" && code-review-graph status --repo {repo_arg}"
                                 " || echo 'Not a git repo, skipping'"
@@ -601,6 +603,7 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph update --skip-flows"
                                 " || true"
@@ -618,6 +621,7 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import stat
 import sys
 from pathlib import Path
@@ -121,6 +122,7 @@ class TestGenerateHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "update" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert 0 < inner["timeout"] <= 600
 
     def test_has_session_start(self):
@@ -131,6 +133,7 @@ class TestGenerateHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "status" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert 0 < inner["timeout"] <= 600
 
     def test_does_not_emit_invalid_pre_commit_hook(self):
@@ -278,6 +281,7 @@ class TestGenerateCodexHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "update" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -288,7 +292,36 @@ class TestGenerateCodexHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "status" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert inner["statusMessage"] == "Checking code-review-graph status"
+
+
+    def test_post_tool_use_command_handles_large_stdin_payload(self, tmp_path):
+        config = generate_codex_hooks_config(tmp_path)
+        cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+
+        payload = ("x" * 1024 + "\n") * 20000
+        proc = subprocess.Popen(
+            ["bash", "-lc", cmd],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=tmp_path,
+        )
+
+        broken_pipe = None
+        try:
+            assert proc.stdin is not None
+            proc.stdin.write(payload)
+            proc.stdin.close()
+        except BrokenPipeError as exc:  # pragma: no cover - regression guard
+            broken_pipe = exc
+
+        proc.stdin = None
+        stdout, stderr = proc.communicate()
+        assert broken_pipe is None, f"hook command raised BrokenPipeError: {stderr}"
+        assert proc.returncode == 0, stderr
 
     def test_commands_do_not_pin_a_specific_repo_path(self, tmp_path):
         config = generate_codex_hooks_config(tmp_path / "repo with spaces")


### PR DESCRIPTION
## Summary

Fixes #493.

Generated Codex and Claude hook commands currently do not consume hook event JSON from stdin before running `code-review-graph` commands. When a hook event contains a large payload, the hook command can exit successfully while the caller is still writing stdin, which causes `Broken pipe` / `EPIPE` errors in Codex.

This PR makes the generated hook commands explicitly drain stdin before running the existing git and `code-review-graph` commands.

## Changes

- Prefix generated Claude hook commands with `cat >/dev/null || true;`
- Prefix generated Codex hook commands with `cat >/dev/null || true;`
- Apply the stdin drain to both `PostToolUse` and `SessionStart` generated commands
- Add a regression test that writes a large stdin payload to the generated `PostToolUse` command and verifies it exits successfully without `BrokenPipeError`

## Why

The hook command itself may still return exit code `0`, but the parent process can fail while writing hook stdin if the hook exits before consuming the payload. Draining stdin keeps the hook behavior non-blocking while avoiding the caller-side broken pipe error.

Cursor/Gemini hook scripts already consume stdin, so this also makes the Codex/Claude generated hooks consistent with the existing integrations.

## Testing

- Ran `pytest tests/test_skills.py`
- Verified the new large-stdin regression test passes
- Verified the generated hook command exits with code `0` and no `BrokenPipeError`