### PR TITLE
fix(parser): detect Rust #[test] attribute and emit Test-kind nodes

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -449,6 +449,10 @@ _TEST_RUNNER_NAMES = frozenset({
 _TEST_ANNOTATIONS = frozenset({
     "Test", "ParameterizedTest", "RepeatedTest", "TestFactory",
     "org.junit.Test", "org.junit.jupiter.api.Test",
+    # Rust: built-in `#[test]` plus common async-runtime + framework
+    # variants. Stripped of the `#[ ]` wrapper before lookup.
+    "test", "tokio::test", "async_std::test",
+    "rstest", "rstest::rstest", "proptest",
 })
 
 # Spring stereotype annotations that mark classes as managed beans
@@ -4341,6 +4345,23 @@ class CodeParser:
                 if sib.type == "decorator":
                     text = sib.text.decode("utf-8", errors="replace")
                     deco_list.append(text.lstrip("@").strip())
+        # Rust: attributes are preceding siblings of function_item, not
+        # children. Walk back through `attribute_item` nodes and strip the
+        # `#[ ]` (or `#![ ]`) wrapper.
+        if language == "rust":
+            sib = child.prev_sibling
+            while sib is not None and sib.type == "attribute_item":
+                text = sib.text.decode("utf-8", errors="replace").strip()
+                if text.startswith("#!["):
+                    inner = text[3:].rstrip()
+                elif text.startswith("#["):
+                    inner = text[2:].rstrip()
+                else:
+                    inner = text
+                if inner.endswith("]"):
+                    inner = inner[:-1]
+                deco_list.append(inner.strip())
+                sib = sib.prev_sibling
         if deco_list:
             decorators = tuple(deco_list)
 

--- a/tests/fixtures/sample_rust.rs
+++ b/tests/fixtures/sample_rust.rs
@@ -44,3 +44,26 @@ pub fn create_user(repo: &mut impl Repository, name: &str, email: &str) -> User 
     repo.save(user.clone());
     user
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_repo_is_empty() {
+        let repo = InMemoryRepo::new();
+        assert!(repo.find_by_id(1).is_none());
+    }
+
+    #[test]
+    fn create_user_saves_to_repo() {
+        let mut repo = InMemoryRepo::new();
+        let user = create_user(&mut repo, "alice", "a@b.c");
+        assert_eq!(user.name, "alice");
+    }
+
+    #[tokio::test]
+    async fn async_test_is_detected() {
+        assert!(true);
+    }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -113,6 +113,26 @@ class TestRustParsing:
         calls = [e for e in self.edges if e.kind == "CALLS"]
         assert len(calls) >= 3
 
+    def test_detects_test_attribute(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        names = {t.name for t in tests}
+        assert "new_repo_is_empty" in names
+        assert "create_user_saves_to_repo" in names
+        assert all(t.is_test for t in tests)
+
+    def test_detects_tokio_test_attribute(self):
+        tests = {n.name for n in self.nodes if n.kind == "Test"}
+        assert "async_test_is_detected" in tests
+
+    def test_non_test_functions_not_misclassified(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "create_user" in funcs
+        assert "new" in funcs
+        # `create_user` carries no `#[test]` — must stay Function.
+        for n in self.nodes:
+            if n.name == "create_user":
+                assert not n.is_test
+
 
 class TestJavaParsing:
     def setup_method(self):


### PR DESCRIPTION
## Summary

Closes #502.

Rust `#[test]` functions were indexed as `kind="Function"` with `is_test=False`. `tests_for(...)` returned 0 edges for any Rust target, `detect_changes` flagged every test fn as untested, and test-gap counts were inflated by one per real test.

## Root cause

Three compounding gaps in `code_review_graph/parser.py`:

1. **`_extract_function` doesn't read Rust attributes.** Decorators are collected only for Java/Kotlin/C# (via `modifiers` child) and Python (via `decorated_definition` parent). In tree-sitter-rust, attributes are **preceding siblings** of `function_item` in the enclosing scope, not children — so `decorators` was always `()` for Rust.
2. **`_TEST_ANNOTATIONS` missing Rust entries.** Only JUnit annotations were listed.
3. **Fixture had no `#[test]` fn.** `tests/fixtures/sample_rust.rs` had zero `#[test]` functions and `TestRustParsing` never asserted on `kind == "Test"`, so the bug shipped invisible to the suite.

## Changes

- `code_review_graph/parser.py`
  - In `_extract_function`, walk `attribute_item` preceding siblings when `language == "rust"`, strip `#[ ]` / `#![ ]` wrapping, and append the inner text to `deco_list`.
  - Extend `_TEST_ANNOTATIONS` with `test`, `tokio::test`, `async_std::test`, `rstest`, `rstest::rstest`, `proptest`.
- `tests/fixtures/sample_rust.rs` — add `#[cfg(test)] mod tests { ... }` with `#[test]` and `#[tokio::test]` functions.
- `tests/test_multilang.py::TestRustParsing` — three new assertions:
  - `test_detects_test_attribute` — `#[test]` fns produce `kind="Test"`.
  - `test_detects_tokio_test_attribute` — `#[tokio::test]` likewise.
  - `test_non_test_functions_not_misclassified` — non-annotated fns stay `kind="Function"`, guarding against over-broad attribute matching.

## Test plan

- [x] `pytest tests/test_multilang.py::TestRustParsing -v` — 8/8 pass (5 existing + 3 new).
- [x] `pytest tests/test_multilang.py tests/test_parser.py` — 406 passed, no regressions.
- [x] Verified on an external Rust crate (a small CLI with `#[cfg(test)] mod tests` in `src/`): before patch, 0 Test-kind nodes; after patch, every `#[test]` fn correctly tagged Test, every non-annotated fn (incl. a `fn parse(...)` helper inside the test module) stays Function.

## Notes

- Derive macros like `#[derive(Debug, Clone)]` get added to the decorator list too — they don't match any entry in `_TEST_ANNOTATIONS`, so no false positives.
- `#[cfg_attr(test, test)]` and other conditional wrappers are out of scope; covered by the literal `#[test]` path that's overwhelmingly common.