### PR TITLE
feat: add CodeBuddy platform support

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_CHOICES = [
     "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
     "continue", "opencode", "antigravity", "gemini-cli", "qwen", "kiro", "qoder",
-    "copilot", "copilot-cli", "all",
+    "copilot", "copilot-cli", "codebuddy", "all",
 ]
 
 
@@ -239,6 +239,8 @@ def _handle_init(args: argparse.Namespace) -> None:
         install_hooks,
         install_opencode_plugin,
         install_qoder_skills,
+        install_codebuddy_hooks,
+        install_codebuddy_skills,
     )
 
     if not skip_skills:
@@ -278,6 +280,12 @@ def _handle_init(args: argparse.Namespace) -> None:
         qoder_skills_dir = install_qoder_skills(repo_root)
         if qoder_skills_dir:
             print(f"Installed Qoder skills to {qoder_skills_dir}")
+
+    # Install CodeBuddy skills (project-level)
+    if not skip_skills and target in ("codebuddy", "all"):
+        codebuddy_skills_dir = install_codebuddy_skills(repo_root)
+        print(f"Installed CodeBuddy skills in {codebuddy_skills_dir}")
+
     if not skip_hooks and target in ("codex", "all"):
         hooks_path = install_codex_hooks(repo_root)
         print(f"Installed Codex hooks in {hooks_path}")
@@ -315,6 +323,17 @@ def _handle_init(args: argparse.Namespace) -> None:
             print(f"Installed OpenCode plugin in {plugin_path}")
         except Exception as exc:
             logger.warning("Could not install OpenCode plugin: %s", exc)
+
+    # CodeBuddy hooks (project-level .codebuddy/settings.json)
+    if not skip_hooks and target in ("codebuddy", "all"):
+        try:
+            codebuddy_settings = install_codebuddy_hooks(repo_root)
+            print(f"Installed CodeBuddy hooks in {codebuddy_settings}")
+            git_hook = install_git_hook(repo_root)
+            if git_hook:
+                print(f"Installed git pre-commit hook in {git_hook}")
+        except Exception as exc:
+            logger.warning("Could not install CodeBuddy hooks: %s", exc)
 
     print()
     print("Next steps:")

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -145,6 +145,14 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "format": "object",
         "needs_type": True,
     },
+    "codebuddy": {
+        "name": "CodeBuddy",
+        "config_path": lambda root: root / ".codebuddy" / "mcp.json",
+        "key": "mcpServers",
+        "detect": lambda: (Path.home() / ".codebuddy").exists(),
+        "format": "object",
+        "needs_type": True,
+    },
 }
 
 
@@ -919,6 +927,7 @@ _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     ".cursorrules": ("cursor",),
     ".windsurfrules": ("windsurf",),
     "QODER.md": ("qoder",),
+    "CODEBUDDY.md": ("codebuddy",),
     ".kiro/steering/code-review-graph.md": ("kiro",),
     ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
 }
@@ -1443,3 +1452,136 @@ def install_opencode_plugin() -> Path:
     logger.info("Wrote OpenCode plugin: %s", plugin_path)
 
     return plugin_path
+
+
+# --- CodeBuddy hooks + skills ---
+
+
+def generate_codebuddy_hooks_config(repo_root: Path) -> dict[str, Any]:
+    """Generate CodeBuddy hooks configuration for .codebuddy/settings.json.
+
+    Uses the same hook schema as Claude Code (PostToolUse / SessionStart),
+    since CodeBuddy Code shares the hooks format with Claude Code.
+    """
+    repo_arg = json.dumps(repo_root.resolve().as_posix())
+    return {
+        "hooks": {
+            "PostToolUse": [
+                {
+                    "matcher": "Edit|Write|Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                "git rev-parse --git-dir >/dev/null 2>&1"
+                                f" && code-review-graph update --skip-flows"
+                                f" --repo {repo_arg}"
+                                " || true"
+                            ),
+                            "timeout": 30,
+                        },
+                    ],
+                },
+            ],
+            "SessionStart": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                "git rev-parse --git-dir >/dev/null 2>&1"
+                                f" && code-review-graph status --repo {repo_arg}"
+                                " || echo 'Not a git repo, skipping'"
+                            ),
+                            "timeout": 10,
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+
+def install_codebuddy_hooks(repo_root: Path) -> Path:
+    """Write hooks config to .codebuddy/settings.json.
+
+    Merges new hook entries into existing settings, preserving both
+    non-hook configuration and user-defined hooks.  A backup of the
+    original file is created before any modifications.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        Path to the settings.json file that was written.
+    """
+    settings_dir = repo_root / ".codebuddy"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+
+    existing: dict[str, Any] = {}
+    if settings_path.exists():
+        try:
+            existing = json.loads(settings_path.read_text(encoding="utf-8", errors="replace"))
+            backup_path = settings_dir / "settings.json.bak"
+            shutil.copy2(settings_path, backup_path)
+            logger.info("Backed up existing CodeBuddy settings to %s", backup_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Could not read existing %s: %s", settings_path, exc)
+
+    hooks_config = generate_codebuddy_hooks_config(repo_root)
+    existing_hooks = existing.get("hooks", {})
+    if not isinstance(existing_hooks, dict):
+        logger.warning("Existing CodeBuddy hooks config is not a dict; replacing with defaults")
+        existing_hooks = {}
+
+    merged_hooks = dict(existing_hooks)
+    for hook_name, hook_entries in hooks_config.get("hooks", {}).items():
+        if isinstance(merged_hooks.get(hook_name), list):
+            merged_list = list(merged_hooks[hook_name])
+            for entry in hook_entries:
+                if entry not in merged_list:
+                    merged_list.append(entry)
+            merged_hooks[hook_name] = merged_list
+        else:
+            merged_hooks[hook_name] = hook_entries
+
+    existing["hooks"] = merged_hooks
+
+    settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    logger.info("Wrote CodeBuddy hooks config: %s", settings_path)
+    return settings_path
+
+
+def install_codebuddy_skills(repo_root: Path) -> Path:
+    """Install skills to CodeBuddy's project-level skills directory.
+
+    CodeBuddy expects skills in .codebuddy/skills/{skillName}/skill.md format.
+    Skills use the same content as Claude Code skills.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        Path to the CodeBuddy skills directory.
+    """
+    skills_dir = repo_root / ".codebuddy" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename, skill in _SKILLS.items():
+        skill_name = filename.removesuffix(".md")
+        skill_subdir = skills_dir / skill_name
+        skill_subdir.mkdir(parents=True, exist_ok=True)
+        skill_path = skill_subdir / "skill.md"
+        content = (
+            "---\n"
+            f"name: {skill['name']}\n"
+            f"description: {skill['description']}\n"
+            "---\n\n"
+            f"{skill['body']}\n"
+        )
+        skill_path.write_text(content, encoding="utf-8")
+        logger.info("Wrote CodeBuddy skill: %s", skill_path)
+
+    return skills_dir

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -96,3 +96,45 @@ def test_handle_init_cursor_installs_cursor_hooks(monkeypatch, tmp_path, capsys)
 
     assert called["cursor_hooks"] is True
     assert "Installed Cursor hooks" in out
+
+
+def test_handle_init_codebuddy_installs_hooks_and_skills(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        "code_review_graph.incremental.find_repo_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.ensure_repo_gitignore_excludes_crg",
+        lambda repo_root: "created",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.skills.install_platform_configs",
+        lambda repo_root, target, dry_run=False: ["CodeBuddy"],
+    )
+
+    called = {"codebuddy_hooks": False, "codebuddy_skills": False, "git_hook": False}
+
+    def _install_codebuddy_hooks(repo_root):
+        called["codebuddy_hooks"] = True
+        return repo_root / ".codebuddy" / "settings.json"
+
+    def _install_codebuddy_skills(repo_root):
+        called["codebuddy_skills"] = True
+        return repo_root / ".codebuddy" / "skills"
+
+    def _install_git_hook(repo_root):
+        called["git_hook"] = True
+        return repo_root / ".git" / "hooks" / "pre-commit"
+
+    monkeypatch.setattr("code_review_graph.skills.install_codebuddy_hooks", _install_codebuddy_hooks)
+    monkeypatch.setattr("code_review_graph.skills.install_codebuddy_skills", _install_codebuddy_skills)
+    monkeypatch.setattr("code_review_graph.skills.install_git_hook", _install_git_hook)
+
+    _handle_init(_args(tmp_path, "codebuddy"))
+    out = capsys.readouterr().out
+
+    assert called["codebuddy_hooks"] is True
+    assert called["codebuddy_skills"] is True
+    assert called["git_hook"] is True
+    assert "Installed CodeBuddy hooks" in out
+    assert "Installed CodeBuddy skills" in out

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -425,7 +425,7 @@ class TestInjectPlatformInstructionsFiltering:
         updated = inject_platform_instructions(tmp_path, target="all")
         assert set(updated) == {
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
-            "QODER.md", ".kiro/steering/code-review-graph.md",
+            "QODER.md", "CODEBUDDY.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
         }
 
@@ -433,7 +433,7 @@ class TestInjectPlatformInstructionsFiltering:
         updated = inject_platform_instructions(tmp_path)
         assert set(updated) == {
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
-            "QODER.md", ".kiro/steering/code-review-graph.md",
+            "QODER.md", "CODEBUDDY.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
         }
 


### PR DESCRIPTION
## Summary

- Add CodeBuddy (https://www.codebuddy.ai) as a supported platform
- MCP config, hooks, skills installation, and platform instruction file
- CLI target `--target codebuddy` for install command

Closes #504

## Changes

- `code_review_graph/cli.py` — Add `codebuddy` target, install hooks + skills during init
- `code_review_graph/skills.py` — Platform config, `generate_codebuddy_hooks_config()`, `install_codebuddy_hooks()`, `install_codebuddy_skills()`, `CODEBUDDY.md` instruction file mapping
- `tests/test_cli_install.py` — Test for CodeBuddy install flow
- `tests/test_skills.py` — Update expected file sets to include `CODEBUDDY.md`

## Test plan

- [x] `pytest tests/test_skills.py` — 139 passed
- [x] `pytest tests/test_cli_install.py` — 3 passed
- [x] Full suite: 1231 passed (6 pre-existing async failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)