### PR TITLE
fix(windows): pre-warm sentence-transformers in main thread to prevent semantic_search deadlock (closes #507)

### DIFF
--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -65,6 +65,50 @@ class EmbeddingProvider(ABC):
 LOCAL_DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
 
+# Process-wide cache of loaded sentence-transformer models, keyed by model name.
+# Populated by ``prewarm_local_embeddings()`` at server startup (see ``main.main``)
+# and by ``LocalEmbeddingProvider._get_model`` on first lazy load. Sharing the
+# loaded model across ``LocalEmbeddingProvider`` instances avoids re-importing
+# ``sentence_transformers`` + ``torch`` from worker threads, which deadlocks
+# ``semantic_search_nodes_tool`` on Windows stdio MCP (#385 fixed the peer
+# tools via ``asyncio.to_thread``; this cache fixes the remaining case where
+# torch DLL / OpenMP init runs inside an executor thread).
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+def prewarm_local_embeddings(model_name: str | None = None) -> None:
+    """Eagerly load the local sentence-transformer model on the calling thread.
+
+    Call this from the **main thread** before entering an asyncio event loop
+    (e.g. before ``mcp.run()``) on Windows to prevent a deadlock where lazy-
+    loading ``sentence_transformers`` + ``torch`` inside a FastMCP executor
+    worker thread blocks indefinitely on DLL init / OpenMP thread-pool
+    registration.
+
+    No-op when ``sentence-transformers`` is not installed (cloud-provider
+    setups remain unaffected) or when the configured model is already cached.
+
+    Args:
+        model_name: Optional override; falls back to the ``CRG_EMBEDDING_MODEL``
+            environment variable and then to ``LOCAL_DEFAULT_MODEL``.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer  # noqa: F401
+    except ImportError:
+        return  # cloud-only setup: nothing to pre-warm
+
+    resolved = model_name or os.environ.get(
+        "CRG_EMBEDDING_MODEL", LOCAL_DEFAULT_MODEL
+    )
+    if resolved in _MODEL_CACHE:
+        return
+
+    try:
+        _MODEL_CACHE[resolved] = LocalEmbeddingProvider(resolved)._get_model()
+    except Exception as exc:  # pragma: no cover — best-effort startup hook
+        logger.warning("prewarm_local_embeddings(%s) skipped: %s", resolved, exc)
+
+
 class LocalEmbeddingProvider(EmbeddingProvider):
     def __init__(self, model_name: str | None = None) -> None:
         self._model_name = model_name or os.environ.get(
@@ -74,6 +118,12 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 
     def _get_model(self):
         if self._model is None:
+            # Check the process-wide cache first — populated either by a prior
+            # provider instance or by ``prewarm_local_embeddings`` at startup.
+            cached = _MODEL_CACHE.get(self._model_name)
+            if cached is not None:
+                self._model = cached
+                return self._model
             try:
                 from sentence_transformers import SentenceTransformer
                 # Check environment variable, default to False to prevent RCE
@@ -84,6 +134,7 @@ class LocalEmbeddingProvider(EmbeddingProvider):
                     self._model_name,
                     trust_remote_code=allow_remote_code,
                 )
+                _MODEL_CACHE[self._model_name] = self._model
             except ImportError:
                 raise ImportError(
                     "sentence-transformers not installed. "

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -1024,6 +1024,15 @@ def main(
 
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        # Pre-warm sentence-transformers on the main thread before fastmcp's
+        # event loop starts. Lazy-loading ``torch`` + tokenizers inside an
+        # executor worker thread deadlocks ``semantic_search_nodes_tool`` on
+        # Windows stdio MCP (DLL init / OpenMP thread-pool registration grabs
+        # locks the loop needs). #385 added ``asyncio.to_thread`` to peer
+        # tools but cannot fix this case — the dangerous initialization has
+        # to happen on the main thread before any worker thread is spawned.
+        from .embeddings import prewarm_local_embeddings
+        prewarm_local_embeddings()
 
     try:
         if transport == "stdio":


### PR DESCRIPTION
## Closes #507

### Problem

`semantic_search_nodes_tool` deadlocks indefinitely on Windows stdio MCP at scale (8 k+ embeddings) even after #385's `asyncio.to_thread` fix on peer tools. The remaining hazard is lazy-importing `sentence_transformers` + `torch` **inside** a FastMCP executor worker thread — torch's Windows DLL init and OpenMP thread-pool registration grab locks the event loop also needs, freezing the call. Other CRG tools (returning in < 0.2 s) are unaffected because they don't load ML libraries on first use.

See #507 for full empirical repro (PID idle at CPU 2.8 s for 120 + s; timeout).

### Fix

A 60-line patch across two files: a module-level model cache + a `prewarm_local_embeddings()` helper that loads the configured local embedding model **on the main thread before `mcp.run()` starts**. Worker threads then only access the already-warm module, and the deadlock cannot manifest.

**`code_review_graph/embeddings.py`** (+ 51 lines):
- `_MODEL_CACHE: dict[str, Any]` — process-wide cache shared across `LocalEmbeddingProvider` instances
- `prewarm_local_embeddings(model_name=None)` — best-effort startup hook; no-op when `sentence-transformers` isn't installed (cloud-provider setups unaffected); idempotent
- `LocalEmbeddingProvider._get_model()` — consults the cache first, populates it on lazy load

**`code_review_graph/main.py`** (+ 9 lines):
- Inside the existing `if sys.platform == "win32":` guard (same place as the `WindowsSelectorEventLoopPolicy` fix already present), call `prewarm_local_embeddings()` right after the event-loop policy is set

### Verified

Windows 11 + Python 3.13 + CRG 2.3.3 + FastMCP 2.14.7, repo with 8 058 embedded nodes, captured via subprocess MCP stdio harness with per-3 s progress trace:

| | Before this patch | After this patch |
|---|---|---|
| Main-thread model load | — | ~ 6 s (one-time at boot) |
| First semantic_search **cold** | deadlock @ CPU 2.8 s for 120 + s → timeout | **0.30 s** |
| Subsequent semantic_search **warm** | — | **0.23 s** |

Reproduced across 4 independent cold MCP spawns. Cold-call latency: 0.30 / 0.31 / 0.32 / 0.36 s. No deadlock observed after patch.

### Alternatives considered

| Approach | Result |
|---|---|
| Wrap `semantic_search_nodes_tool` in `asyncio.to_thread` | CPU climbs (2.8 → 5 s) then idle again; deadlock persists — the worker thread is still in fastmcp's executor pool where torch DLL init still hangs |
| `TOKENIZERS_PARALLELISM=false` env var | No effect — the deadlock occurs before tokenizer use |
| numpy-based `_cosine_similarity` rewrite | Legitimate perf improvement at scale but **does NOT** fix the deadlock (the deadlock occurs before any cosine call). Happy to file as a separate perf PR if welcome. |

The dangerous initialization has to complete on the **main thread before any worker thread is spawned**. This patch ensures that.

### Compatibility

- **Cloud-only setups** (Google / MiniMax / OpenAI): the `ImportError` no-op branch fires; existing behaviour unchanged.
- **Non-Windows users**: the pre-warm sits inside the existing `sys.platform == "win32"` guard alongside the `WindowsSelectorEventLoopPolicy` workaround — zero behaviour change.
- **`embed_graph_tool`** and other already-asyncio.to_thread'd tools: still work the same; they just hit the cache on the second call instead of re-importing.

### Why now

Reproduced on a real project (DreamJob.AI) integrating CRG with Claude Code. After tracing the deadlock empirically (see #507 for the captured trace), the fix was small enough that it felt worth offering back. Same place as PR #425 — Windows + stdio MCP edge cases — should round out the Windows hardening story.

Happy to iterate on review.