### PR TITLE
feat: add web explorer lsp and editor telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ code-review-graph build            # Parse entire codebase
 code-review-graph update           # Incremental update (changed files only)
 code-review-graph status           # Graph statistics
 code-review-graph watch            # Auto-update on file changes
+code-review-graph watch --json-events  # Emit machine-readable watch events
+code-review-graph web              # Start local browser graph explorer
+axon web                           # Same web explorer via the short alias
+axon-web                           # Dedicated web explorer entry point
+code-review-graph lsp              # Start Language Server Protocol server
 code-review-graph visualize        # Generate interactive HTML graph
 code-review-graph visualize --format graphml   # Export as GraphML
 code-review-graph visualize --format svg       # Export as SVG
@@ -318,6 +323,24 @@ restart dead watchers. No external dependencies required.
 
 See [docs/COMMANDS.md](docs/COMMANDS.md#standalone-daemon-cli-crg-daemon) for the
 full config reference and all available options.
+
+</details>
+
+<details>
+<summary><strong>Browser explorer and editor integrations</strong></summary>
+<br>
+
+Build the graph, then start the local web UI:
+
+```bash
+code-review-graph build
+axon web --repo . --host 127.0.0.1 --port 8765
+# Open http://127.0.0.1:8765/
+```
+
+`axon-web --repo . --host 127.0.0.1 --port 8765` is equivalent. The browser explorer reads the local SQLite graph, supports search, node inspection, query and impact endpoints, receives live update notifications from the graph database, and shows estimated source-vs-graph token savings. It also records local aggregate telemetry for web API operations so the dashboard can show observed request count plus estimated cumulative savings.
+
+For editor integrations, `code-review-graph lsp` starts the stdio Language Server Protocol server. The VS Code extension also supports continuous indexing through `code-review-graph watch --json-events`.
 
 </details>
 

--- a/code-review-graph-vscode/README.md
+++ b/code-review-graph-vscode/README.md
@@ -44,6 +44,8 @@ Open the Command Palette (`Ctrl+Shift+P`) and run **Code Graph: Build Graph**.
 
 The graph database is stored locally at `.code-review-graph/graph.db` and updates automatically on file save.
 
+For continuous background indexing, run **Code Graph: Watch Mode**. The extension starts `code-review-graph watch --json-events`, streams progress to the **Code Graph Watch** output channel, and stops the watcher when the extension deactivates.
+
 ## Commands
 
 | Command | Description |
@@ -61,6 +63,26 @@ The graph database is stored locally at `.code-review-graph/graph.db` and update
 | `Code Graph: Show Graph` | Open the interactive graph visualization |
 | `Code Graph: Compute Embeddings` | Generate vector embeddings for semantic search |
 | `Code Graph: Watch Mode` | Run graph in watch mode for continuous updates |
+
+## Browser UI and LSP
+
+The Python backend also ships a standalone browser explorer:
+
+```bash
+code-review-graph build
+axon web --repo . --host 127.0.0.1 --port 8765
+# Open http://127.0.0.1:8765/
+```
+
+`axon-web --repo . --host 127.0.0.1 --port 8765` starts the same UI.
+
+The browser dashboard includes graph size, estimated source-vs-graph token savings, observed web API request count, and estimated cumulative/average savings. Those estimates use the standard chars/4 approximation and are not model-provider billing data.
+
+Editor integrations can use the stdio Language Server Protocol server:
+
+```bash
+code-review-graph lsp --repo .
+```
 
 ## Settings
 

--- a/code-review-graph-vscode/src/backend/cli.ts
+++ b/code-review-graph-vscode/src/backend/cli.ts
@@ -1,4 +1,5 @@
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
 
@@ -81,9 +82,13 @@ export class CliWrapper {
 
     /**
      * Start the watch daemon for continuous file monitoring.
+     * The caller owns the returned long-running process.
      */
-    async watchGraph(workspaceRoot: string): Promise<CliResult> {
-        return this.exec(['watch'], workspaceRoot);
+    startWatchGraph(workspaceRoot: string): ChildProcess {
+        return spawn(this.cliPath, ['watch', '--json-events'], {
+            cwd: workspaceRoot,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
     }
 
     /**

--- a/code-review-graph-vscode/src/backend/sqlite.ts
+++ b/code-review-graph-vscode/src/backend/sqlite.ts
@@ -182,9 +182,19 @@ export class SqliteReader {
   }
 
   constructor(dbPath: string) {
-    this.db = new Database(dbPath, { readonly: true });
-    this.db.pragma('journal_mode = WAL');
-    this.db.pragma('busy_timeout = 5000');
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      db.pragma('journal_mode = WAL');
+    } catch (err: unknown) {
+      const code = typeof err === 'object' && err !== null && 'code' in err
+        ? String((err as { code?: unknown }).code)
+        : '';
+      if (code !== 'SQLITE_READONLY') {
+        throw err;
+      }
+    }
+    db.pragma('busy_timeout = 5000');
+    this.db = db;
   }
 
   /**

--- a/code-review-graph-vscode/src/extension.ts
+++ b/code-review-graph-vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import type { ChildProcess } from "node:child_process";
 
 import { SqliteReader } from "./backend/sqlite";
 import type { GraphNode } from "./backend/sqlite";
@@ -19,6 +20,8 @@ import { ScmDecorationProvider } from "./features/scmDecorations";
 let sqliteReader: SqliteReader | undefined;
 let autoUpdateTimer: ReturnType<typeof setTimeout> | undefined;
 let scmDecorationProvider: ScmDecorationProvider | undefined;
+let watchProcess: ChildProcess | undefined;
+let watchOutput: vscode.OutputChannel | undefined;
 
 /**
  * Locate the graph database file in the workspace.
@@ -554,13 +557,37 @@ function registerCommands(
         return;
       }
 
-      vscode.window.showInformationMessage("Code Graph: Watch mode started.");
-      const result = await cli.watchGraph(workspaceRoot);
-      if (!result.success) {
-        vscode.window.showErrorMessage(
-          `Code Graph: Watch failed. ${result.stderr}`
-        );
+      if (watchProcess) {
+        watchProcess.kill();
+        watchProcess = undefined;
+        vscode.window.showInformationMessage("Code Graph: Watch mode stopped.");
+        return;
       }
+
+      watchOutput ??= vscode.window.createOutputChannel("Code Graph Watch");
+      watchOutput.appendLine(`Starting watch mode in ${workspaceRoot}`);
+      watchProcess = cli.startWatchGraph(workspaceRoot);
+
+      watchProcess.stdout?.on("data", (data) => {
+        watchOutput?.append(data.toString());
+      });
+      watchProcess.stderr?.on("data", (data) => {
+        watchOutput?.append(data.toString());
+      });
+      watchProcess.on("error", (error) => {
+        watchProcess = undefined;
+        vscode.window.showErrorMessage(`Code Graph: Watch failed. ${error.message}`);
+      });
+      watchProcess.on("close", (code, signal) => {
+        const expectedStop = signal === "SIGTERM" || signal === "SIGKILL";
+        watchProcess = undefined;
+        watchOutput?.appendLine(`Watch stopped with code=${code} signal=${signal ?? ""}`);
+        if (code && !expectedStop) {
+          vscode.window.showWarningMessage(`Code Graph: Watch stopped with code ${code}.`);
+        }
+      });
+
+      vscode.window.showInformationMessage("Code Graph: Watch mode started.");
     })
   );
 
@@ -977,6 +1004,13 @@ export function deactivate(): void {
     clearTimeout(autoUpdateTimer);
     autoUpdateTimer = undefined;
   }
+
+  if (watchProcess) {
+    watchProcess.kill();
+    watchProcess = undefined;
+  }
+  watchOutput?.dispose();
+  watchOutput = undefined;
 
   sqliteReader?.close();
   sqliteReader = undefined;

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -9,6 +9,8 @@ Usage:
     code-review-graph status
     code-review-graph serve [--auto-watch] [--http] [--host ADDR] [--port PORT]
     code-review-graph mcp [--auto-watch]
+    code-review-graph lsp
+    code-review-graph web
     code-review-graph visualize
     code-review-graph wiki
     code-review-graph detect-changes [--base BASE] [--brief]
@@ -103,6 +105,8 @@ def _print_banner() -> None:
     {g}update{r}      Incremental update {d}(changed files only){r}
     {g}watch{r}       Auto-update on file changes
     {g}status{r}      Show graph statistics
+    {g}web{r}         Start axon-web browser explorer
+    {g}lsp{r}         Start graph Language Server Protocol server
     {g}visualize{r}   Generate interactive HTML graph
     {g}wiki{r}        Generate markdown wiki from communities
     {g}detect-changes{r} Analyze change impact {d}(risk-scored review){r}
@@ -502,6 +506,10 @@ def main() -> None:
         default=None,
         help="External directory to store graph database (useful for network shares)"
     )
+    watch_cmd.add_argument(
+        "--json-events", action="store_true",
+        help="Print one JSON event per graph update",
+    )
 
     # status
     status_cmd = sub.add_parser("status", help="Show graph statistics")
@@ -709,6 +717,20 @@ def main() -> None:
         help="Repository path or alias to remove",
     )
 
+    # lsp
+    lsp_cmd = sub.add_parser("lsp", help="Start LSP server (stdio transport)")
+    lsp_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+
+    # web
+    web_cmd = sub.add_parser("web", help="Start axon-web browser explorer")
+    web_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    web_cmd.add_argument("--host", default="127.0.0.1", help="Bind host")
+    web_cmd.add_argument("--port", type=int, default=8765, help="Bind port")
+    web_cmd.add_argument(
+        "--open", action="store_true", dest="open_browser",
+        help="Open the browser after starting the server",
+    )
+
     args = ap.parse_args()
 
     if args.version:
@@ -771,6 +793,21 @@ def main() -> None:
         handler = handlers.get(args.daemon_command)
         if handler:
             handler(args)
+        return
+
+    if args.command == "lsp":
+        from .lsp import main as lsp_main
+        lsp_main(repo_root=args.repo)
+        return
+
+    if args.command == "web":
+        from .web import run_web
+        run_web(
+            repo_root=args.repo,
+            host=getattr(args, "host", "127.0.0.1"),
+            port=getattr(args, "port", 8765),
+            open_browser=getattr(args, "open_browser", False),
+        )
         return
 
     if args.command == "eval":
@@ -986,7 +1023,17 @@ def main() -> None:
             from .postprocessing import run_post_processing
 
             try:
-                watch(repo_root, store, on_files_updated=run_post_processing)
+                if getattr(args, "json_events", False):
+                    def _emit(event):
+                        print(json.dumps(event), flush=True)
+                    watch(
+                        repo_root,
+                        store,
+                        on_files_updated=run_post_processing,
+                        event_sink=_emit,
+                    )
+                else:
+                    watch(repo_root, store, on_files_updated=run_post_processing)
             except RuntimeError as exc:
                 print(f"Error: {exc}", file=sys.stderr)
                 sys.exit(1)

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -17,7 +17,7 @@ import sys
 import threading
 import time
 from pathlib import Path, PurePosixPath
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from .graph import GraphStore
 from .parser import CodeParser
@@ -1068,6 +1068,7 @@ def watch(
     repo_root: Path,
     store: GraphStore,
     on_files_updated: Optional[Callable] = None,
+    event_sink: Callable[[dict[str, Any]], None] | None = None,
 ) -> None:
     """Watch for file changes and auto-update the graph.
 
@@ -1080,6 +1081,8 @@ def watch(
             batch of file updates completes.  Receives the store as its
             only argument.  Used by the CLI to run post-processing
             (FTS, flows, communities) after watch updates.
+        event_sink: Optional callback that receives structured update/error
+            events. Used by editor integrations.
     """
     import threading
 
@@ -1134,8 +1137,21 @@ def watch(
                 store.remove_file_data(event.src_path)
                 store.commit()
                 logger.info("Removed: %s", rel)
+                if event_sink:
+                    event_sink({
+                        "event": "removed",
+                        "file": rel,
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    })
             except Exception as e:
                 logger.error("Error removing %s: %s", rel, e)
+                if event_sink:
+                    event_sink({
+                        "event": "error",
+                        "file": rel,
+                        "error": str(e),
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    })
 
         def _schedule(self, abs_path: str):
             """Add file to pending set and reset the debounce timer."""
@@ -1186,9 +1202,24 @@ def watch(
                     len(nodes),
                     len(edges),
                 )
+                if event_sink:
+                    event_sink({
+                        "event": "updated",
+                        "file": rel,
+                        "nodes": len(nodes),
+                        "edges": len(edges),
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    })
                 return True
             except Exception as e:
                 logger.error("Error updating %s: %s", abs_path, e)
+                if event_sink:
+                    event_sink({
+                        "event": "error",
+                        "file": str(path),
+                        "error": str(e),
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    })
                 return False
 
     handler = GraphUpdateHandler()

--- a/code_review_graph/lsp.py
+++ b/code_review_graph/lsp.py
@@ -1,0 +1,262 @@
+"""Small stdio Language Server Protocol bridge for the graph service."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from .graph import GraphNode
+from .service import GraphService
+
+LSP_SYMBOL_KIND = {
+    "File": 1,
+    "Class": 5,
+    "Function": 12,
+    "Test": 12,
+    "Type": 23,
+}
+
+
+def uri_to_path(uri: str) -> str:
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return uri
+    return unquote(parsed.path)
+
+
+def path_to_uri(path: str) -> str:
+    return Path(path).resolve().as_uri()
+
+
+def _range(node: GraphNode) -> dict[str, Any]:
+    start = max(node.line_start - 1, 0)
+    end = max(node.line_end - 1, start)
+    return {
+        "start": {"line": start, "character": 0},
+        "end": {"line": end, "character": 0},
+    }
+
+
+def _location(node: GraphNode) -> dict[str, Any]:
+    return {"uri": path_to_uri(node.file_path), "range": _range(node)}
+
+
+def _document_symbol(node: GraphNode) -> dict[str, Any]:
+    return {
+        "name": node.name,
+        "detail": node.qualified_name,
+        "kind": LSP_SYMBOL_KIND.get(node.kind, 13),
+        "range": _range(node),
+        "selectionRange": _range(node),
+    }
+
+
+class LspServer:
+    def __init__(self, repo_root: str | None = None) -> None:
+        self.service = GraphService(repo_root)
+        self.shutdown_requested = False
+
+    def close(self) -> None:
+        self.service.close()
+
+    def dispatch(self, method: str, params: dict[str, Any] | None) -> Any:
+        params = params or {}
+        if method == "initialize":
+            return self.initialize()
+        if method == "shutdown":
+            self.shutdown_requested = True
+            return None
+        if method == "exit":
+            raise SystemExit(0 if self.shutdown_requested else 1)
+        if method == "initialized":
+            return None
+        if method == "workspace/symbol":
+            return self.workspace_symbol(params)
+        if method == "textDocument/documentSymbol":
+            return self.document_symbol(params)
+        if method == "textDocument/references":
+            return self.references(params)
+        if method == "textDocument/definition":
+            return self.definition(params)
+        if method == "textDocument/codeLens":
+            return self.code_lens(params)
+        if method == "workspace/executeCommand":
+            return self.execute_command(params)
+        return None
+
+    def initialize(self) -> dict[str, Any]:
+        return {
+            "serverInfo": {"name": "axon-graph-lsp", "version": "0.1.0"},
+            "capabilities": {
+                "definitionProvider": True,
+                "referencesProvider": True,
+                "documentSymbolProvider": True,
+                "workspaceSymbolProvider": True,
+                "codeLensProvider": {"resolveProvider": False},
+                "executeCommandProvider": {
+                    "commands": [
+                        "axon.blastRadius",
+                        "axon.callers",
+                        "axon.callees",
+                    ],
+                },
+            },
+        }
+
+    def workspace_symbol(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        query = str(params.get("query") or "")
+        if not query:
+            return []
+        result = self.service.search(query, limit=100)
+        return [
+            {
+                "name": node["name"],
+                "kind": LSP_SYMBOL_KIND.get(node["kind"], 13),
+                "location": {
+                    "uri": path_to_uri(node["file_path"]),
+                    "range": {
+                        "start": {"line": max(node["line_start"] - 1, 0), "character": 0},
+                        "end": {"line": max(node["line_end"] - 1, 0), "character": 0},
+                    },
+                },
+                "containerName": node.get("parent_name") or node["file_path"],
+            }
+            for node in result["nodes"]
+        ]
+
+    def document_symbol(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        text_document = params.get("textDocument") or {}
+        uri = text_document.get("uri")
+        if not uri:
+            return []
+        summary = self.service.file_summary(uri_to_path(uri))
+        return [
+            _document_symbol(node)
+            for raw in summary["nodes"]
+            if (node := self.service.store.get_node(raw["qualified_name"])) is not None
+            and node.kind != "File"
+        ]
+
+    def references(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        node = self._node_from_position(params)
+        if not node:
+            return []
+        refs = []
+        callers = self.service.callers(node.qualified_name)
+        callees = self.service.callees(node.qualified_name)
+        for edge in callers.get("edges", []) + callees.get("edges", []):
+            endpoint = self.service.store.get_node(edge["source"])
+            if endpoint:
+                refs.append(_location(endpoint))
+            endpoint = self.service.store.get_node(edge["target"])
+            if endpoint:
+                refs.append(_location(endpoint))
+        return refs
+
+    def definition(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        node = self._node_from_position(params)
+        return [_location(node)] if node else []
+
+    def code_lens(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        text_document = params.get("textDocument") or {}
+        uri = text_document.get("uri")
+        if not uri:
+            return []
+        summary = self.service.file_summary(uri_to_path(uri))
+        lenses = []
+        for raw in summary["nodes"]:
+            if raw["kind"] not in ("Function", "Class", "Test"):
+                continue
+            callers = self.service.callers(raw["qualified_name"])
+            title = f"{callers.get('total', 0)} callers"
+            lenses.append({
+                "range": {
+                    "start": {"line": max(raw["line_start"] - 1, 0), "character": 0},
+                    "end": {"line": max(raw["line_start"] - 1, 0), "character": 0},
+                },
+                "command": {
+                    "title": title,
+                    "command": "axon.callers",
+                    "arguments": [raw["qualified_name"]],
+                },
+            })
+        return lenses
+
+    def execute_command(self, params: dict[str, Any]) -> dict[str, Any]:
+        command = params.get("command")
+        args = params.get("arguments") or []
+        target = str(args[0]) if args else ""
+        if command == "axon.callers":
+            return self.service.callers(target)
+        if command == "axon.callees":
+            return self.service.callees(target)
+        if command == "axon.blastRadius":
+            node = self.service.store.get_node(target)
+            if not node:
+                return {"status": "not_found", "target": target}
+            return self.service.impact([node.file_path])
+        return {"status": "error", "error": f"unknown command: {command}"}
+
+    def _node_from_position(self, params: dict[str, Any]) -> GraphNode | None:
+        text_document = params.get("textDocument") or {}
+        position = params.get("position") or {}
+        uri = text_document.get("uri")
+        if not uri:
+            return None
+        return self.service.node_at(uri_to_path(uri), int(position.get("line", 0)) + 1)
+
+
+def _read_message() -> dict[str, Any] | None:
+    headers: dict[str, str] = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        key, _, value = line.decode("ascii", errors="replace").partition(":")
+        headers[key.lower()] = value.strip()
+
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        return None
+    payload = sys.stdin.buffer.read(length)
+    return json.loads(payload.decode("utf-8"))
+
+
+def _write_message(message: dict[str, Any]) -> None:
+    payload = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.flush()
+
+
+def main(repo_root: str | None = None) -> None:
+    server = LspServer(repo_root)
+    try:
+        while True:
+            message = _read_message()
+            if message is None:
+                break
+            msg_id = message.get("id")
+            method = message.get("method")
+            if not method:
+                continue
+            try:
+                result = server.dispatch(method, message.get("params"))
+                if msg_id is not None:
+                    _write_message({"jsonrpc": "2.0", "id": msg_id, "result": result})
+            except SystemExit:
+                raise
+            except Exception as exc:
+                if msg_id is not None:
+                    _write_message({
+                        "jsonrpc": "2.0",
+                        "id": msg_id,
+                        "error": {"code": -32603, "message": str(exc)},
+                    })
+    finally:
+        server.close()

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -252,7 +252,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "r": ["function_definition"],
     "perl": ["subroutine_declaration_statement", "method_declaration_statement"],
     "kotlin": ["function_declaration"],
-    "swift": ["function_declaration"],
+    "swift": ["function_declaration", "protocol_function_declaration"],
     "php": ["function_definition", "method_declaration"],
     "scala": ["function_definition", "function_declaration"],
     # Solidity: events and modifiers use kind="Function" because the graph
@@ -2309,10 +2309,18 @@ class CodeParser:
 
             # --- Imports ---
             if node_type in import_types:
-                self._extract_imports(
-                    child, language, source, file_path, edges,
-                )
-                continue
+                if language == "ruby":
+                    imports = self._extract_import(child, language, source)
+                    if imports:
+                        self._extract_imports(
+                            child, language, source, file_path, edges,
+                        )
+                        continue
+                else:
+                    self._extract_imports(
+                        child, language, source, file_path, edges,
+                    )
+                    continue
 
             # --- Calls ---
             if node_type in call_types:
@@ -6043,6 +6051,19 @@ class CodeParser:
                     for sub in child.children:
                         if sub.type in ("identifier", "type_identifier", "nested_identifier"):
                             bases.append(sub.text.decode("utf-8", errors="replace"))
+        elif language == "swift":
+            for child in node.children:
+                if child.type == "inheritance_specifier":
+                    for sub in child.children:
+                        if sub.type == "user_type":
+                            for ident in sub.children:
+                                if ident.type == "type_identifier":
+                                    bases.append(
+                                        ident.text.decode("utf-8", errors="replace")
+                                    )
+                                    break
+                        elif sub.type == "type_identifier":
+                            bases.append(sub.text.decode("utf-8", errors="replace"))
         elif language == "solidity":
             # contract Foo is Bar, Baz { ... }
             for child in node.children:
@@ -6228,6 +6249,11 @@ class CodeParser:
                 match = re.search(r"""['"](.*?)['"]""", text)
                 if match:
                     imports.append(match.group(1))
+        elif language == "swift":
+            for child in node.children:
+                if child.type == "identifier":
+                    imports.append(child.text.decode("utf-8", errors="replace"))
+                    break
         elif language == "dart":
             # import 'dart:async' or import 'package:flutter/material.dart'
             # Node structure: import_or_export > library_import > import_specification
@@ -6431,6 +6457,12 @@ class CodeParser:
         # Simple call: func_name(args)
         # Kotlin uses "simple_identifier" instead of "identifier".
         if first.type in ("identifier", "simple_identifier"):
+            return first.text.decode("utf-8", errors="replace")
+
+        if language == "ruby" and first.type == "constant":
+            for child in reversed(node.children):
+                if child.type == "identifier":
+                    return child.text.decode("utf-8", errors="replace")
             return first.text.decode("utf-8", errors="replace")
 
         # Perl: function_call_expression / ambiguous_function_call_expression

--- a/code_review_graph/service.py
+++ b/code_review_graph/service.py
@@ -1,0 +1,315 @@
+"""Shared graph service contract for CLI, editor, LSP, and web clients."""
+
+from __future__ import annotations
+
+import time
+from contextlib import AbstractContextManager
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .graph import GraphEdge, GraphNode, GraphStats, GraphStore, edge_to_dict, node_to_dict
+from .incremental import find_project_root, get_db_path
+from .telemetry import estimate_tokens_from_chars, record_event, summarize_events
+
+
+def _normalize_path(path: str | Path, repo_root: Path) -> str:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return str(candidate)
+
+
+def _node_span_contains(node: GraphNode, line: int) -> bool:
+    return node.line_start <= line <= node.line_end
+
+
+class GraphService(AbstractContextManager["GraphService"]):
+    """High-level graph API consumed by all non-MCP product surfaces.
+
+    This class deliberately wraps ``GraphStore`` instead of exposing SQLite
+    details.  Clients should depend on the dictionaries returned here so the
+    persistence layer can evolve independently.
+    """
+
+    def __init__(self, repo_root: str | Path | None = None) -> None:
+        self.repo_root = Path(repo_root) if repo_root else find_project_root()
+        self.repo_root = self.repo_root.resolve()
+        self.db_path = get_db_path(self.repo_root)
+        self.store = GraphStore(self.db_path)
+        self._source_token_cache: tuple[float, float, int, int] | None = None
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.store.close()
+
+    def status(self) -> dict[str, Any]:
+        stats = self.store.get_stats()
+        return {
+            "status": "ok",
+            "repo_root": str(self.repo_root),
+            "db_path": str(self.db_path),
+            "stats": _stats_to_dict(stats),
+            "token_estimate": self.token_estimate(stats=stats),
+            "telemetry": self.telemetry_summary(),
+            "metadata": {
+                "git_branch": self.store.get_metadata("git_branch"),
+                "git_head_sha": self.store.get_metadata("git_head_sha"),
+                "last_build_type": self.store.get_metadata("last_build_type"),
+            },
+        }
+
+    def search(self, query: str, limit: int = 20) -> dict[str, Any]:
+        nodes = self.store.search_nodes(query, limit=max(1, min(limit, 200)))
+        return {
+            "status": "ok",
+            "query": query,
+            "nodes": [node_to_dict(n) for n in nodes],
+        }
+
+    def get_node(self, qualified_name: str) -> dict[str, Any]:
+        node = self.store.get_node(qualified_name)
+        if not node:
+            return {"status": "not_found", "qualified_name": qualified_name}
+        return {"status": "ok", "node": node_to_dict(node)}
+
+    def file_summary(self, file_path: str) -> dict[str, Any]:
+        abs_path = _normalize_path(file_path, self.repo_root)
+        nodes = self.store.get_nodes_by_file(abs_path)
+        if not nodes and str(file_path) != abs_path:
+            nodes = self.store.get_nodes_by_file(str(file_path))
+        return {
+            "status": "ok",
+            "file_path": abs_path,
+            "nodes": [node_to_dict(n) for n in nodes],
+        }
+
+    def node_at(self, file_path: str, line: int) -> GraphNode | None:
+        """Return the most specific graph node containing a 1-based line."""
+        abs_path = _normalize_path(file_path, self.repo_root)
+        nodes = self.store.get_nodes_by_file(abs_path)
+        if not nodes:
+            nodes = self.store.get_nodes_by_file(str(file_path))
+        candidates = [n for n in nodes if _node_span_contains(n, line)]
+        if not candidates:
+            return None
+        return sorted(
+            candidates,
+            key=lambda n: (n.line_end - n.line_start, n.kind == "File"),
+        )[0]
+
+    def callers(self, target: str, limit: int = 100) -> dict[str, Any]:
+        node = self._resolve_node(target)
+        if not node:
+            ambiguous = self._ambiguous_response(target)
+            if ambiguous:
+                return ambiguous
+            return {"status": "not_found", "target": target}
+        edges = [
+            e for e in self.store.get_edges_by_target(node.qualified_name)
+            if e.kind == "CALLS"
+        ]
+        if not edges:
+            edges = self.store.search_edges_by_target_name(node.name)
+        return self._edge_endpoint_response("callers", node, edges, source=True, limit=limit)
+
+    def callees(self, target: str, limit: int = 100) -> dict[str, Any]:
+        node = self._resolve_node(target)
+        if not node:
+            ambiguous = self._ambiguous_response(target)
+            if ambiguous:
+                return ambiguous
+            return {"status": "not_found", "target": target}
+        edges = [
+            e for e in self.store.get_edges_by_source(node.qualified_name)
+            if e.kind == "CALLS"
+        ]
+        return self._edge_endpoint_response("callees", node, edges, source=False, limit=limit)
+
+    def query(self, pattern: str, target: str, limit: int = 100) -> dict[str, Any]:
+        if pattern == "callers_of":
+            return self.callers(target, limit=limit)
+        if pattern == "callees_of":
+            return self.callees(target, limit=limit)
+        if pattern == "file_summary":
+            return self.file_summary(target)
+        return {"status": "error", "error": f"unsupported pattern: {pattern}"}
+
+    def impact(
+        self,
+        changed_files: list[str],
+        max_depth: int = 2,
+        max_results: int = 500,
+    ) -> dict[str, Any]:
+        files = [_normalize_path(f, self.repo_root) for f in changed_files]
+        result = self.store.get_impact_radius(
+            files,
+            max_depth=max(1, min(max_depth, 10)),
+            max_nodes=max(1, min(max_results, 5000)),
+        )
+        return {
+            "status": "ok",
+            "changed_files": changed_files,
+            "changed_nodes": [node_to_dict(n) for n in result["changed_nodes"]],
+            "impacted_nodes": [node_to_dict(n) for n in result["impacted_nodes"]],
+            "impacted_files": result["impacted_files"],
+            "edges": [edge_to_dict(e) for e in result["edges"]],
+            "truncated": result["truncated"],
+            "total_impacted": result["total_impacted"],
+        }
+
+    def graph(self, limit: int = 1000) -> dict[str, Any]:
+        files = self.store.get_all_files()
+        nodes: list[GraphNode] = []
+        for file_path in files:
+            nodes.extend(self.store.get_nodes_by_file(file_path))
+            if len(nodes) >= limit:
+                nodes = nodes[:limit]
+                break
+
+        qns = {n.qualified_name for n in nodes}
+        edges = self.store.get_edges_among(qns)
+        return {
+            "status": "ok",
+            "nodes": [node_to_dict(n) for n in nodes],
+            "edges": [edge_to_dict(e) for e in edges],
+            "truncated": len(nodes) >= limit,
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+
+    def token_estimate(
+        self,
+        graph_limit: int = 250,
+        stats: GraphStats | None = None,
+    ) -> dict[str, Any]:
+        """Estimate full-source versus graph-context token counts.
+
+        This is a local approximation for product telemetry and dashboards,
+        not model-provider billing data.  It uses the common chars/4 heuristic.
+        """
+        source_tokens, missing_files = self._source_token_estimate()
+        graph_payload = {
+            "stats": _stats_to_dict(stats or self.store.get_stats()),
+            "graph": self.graph(limit=graph_limit),
+        }
+        graph_tokens = estimate_tokens_from_chars(
+            len(_stable_json(graph_payload))
+        )
+        saved_tokens = max(source_tokens - graph_tokens, 0)
+        reduction_percent = (
+            round((saved_tokens / source_tokens) * 100, 2)
+            if source_tokens > 0 else 0.0
+        )
+        compression_ratio = (
+            round(source_tokens / graph_tokens, 2)
+            if graph_tokens > 0 else 0.0
+        )
+        return {
+            "status": "estimated",
+            "method": "chars_div_4",
+            "scope": f"indexed source files vs graph overview payload (limit={graph_limit})",
+            "source_tokens": source_tokens,
+            "graph_tokens": graph_tokens,
+            "saved_tokens": saved_tokens,
+            "reduction_percent": reduction_percent,
+            "compression_ratio": compression_ratio,
+            "missing_files": missing_files,
+        }
+
+    def record_telemetry(
+        self,
+        operation: str,
+        payload: dict[str, Any],
+        surface: str = "web",
+    ) -> dict[str, Any]:
+        baseline_tokens, missing_files = self._source_token_estimate()
+        payload_tokens = estimate_tokens_from_chars(len(_stable_json(payload)))
+        return record_event(
+            self.db_path,
+            surface=surface,
+            operation=operation,
+            baseline_tokens=baseline_tokens,
+            payload_tokens=payload_tokens,
+            extra={"missing_files": missing_files},
+        )
+
+    def telemetry_summary(self) -> dict[str, Any]:
+        return summarize_events(self.db_path)
+
+    def _source_token_estimate(self) -> tuple[int, int]:
+        db_mtime = self.db_path.stat().st_mtime if self.db_path.exists() else 0.0
+        now = time.time()
+        if self._source_token_cache:
+            cached_at, cached_mtime, tokens, missing = self._source_token_cache
+            if cached_mtime == db_mtime and now - cached_at < 5:
+                return tokens, missing
+
+        source_bytes = 0
+        missing_files = 0
+        for file_path in self.store.get_all_files():
+            try:
+                source_bytes += Path(file_path).stat().st_size
+            except OSError:
+                missing_files += 1
+        source_tokens = estimate_tokens_from_chars(source_bytes)
+        self._source_token_cache = (now, db_mtime, source_tokens, missing_files)
+        return source_tokens, missing_files
+
+    def _resolve_node(self, target: str) -> GraphNode | None:
+        node = self.store.get_node(target)
+        if node:
+            return node
+        abs_target = _normalize_path(target, self.repo_root)
+        node = self.store.get_node(abs_target)
+        if node:
+            return node
+        matches = self.store.search_nodes(target, limit=2)
+        return matches[0] if len(matches) == 1 else None
+
+    def _ambiguous_response(self, target: str) -> dict[str, Any] | None:
+        candidates = self.store.search_nodes(target, limit=5)
+        if len(candidates) <= 1:
+            return None
+        return {
+            "status": "ambiguous",
+            "target": target,
+            "candidates": [node_to_dict(n) for n in candidates],
+        }
+
+    def _edge_endpoint_response(
+        self,
+        kind: str,
+        node: GraphNode,
+        edges: list[GraphEdge],
+        *,
+        source: bool,
+        limit: int,
+    ) -> dict[str, Any]:
+        capped = edges[: max(1, min(limit, 500))]
+        endpoint_nodes = []
+        for edge in capped:
+            qn = edge.source_qualified if source else edge.target_qualified
+            endpoint = self.store.get_node(qn)
+            if endpoint:
+                endpoint_nodes.append(node_to_dict(endpoint))
+        return {
+            "status": "ok",
+            "kind": kind,
+            "target": node_to_dict(node),
+            "nodes": endpoint_nodes,
+            "edges": [edge_to_dict(e) for e in capped],
+            "truncated": len(edges) > len(capped),
+            "total": len(edges),
+        }
+
+
+def _stats_to_dict(stats: GraphStats) -> dict[str, Any]:
+    return asdict(stats)
+
+
+def _stable_json(payload: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)

--- a/code_review_graph/telemetry.py
+++ b/code_review_graph/telemetry.py
@@ -1,0 +1,132 @@
+"""Local aggregate telemetry for token-efficiency dashboards."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS telemetry_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at REAL NOT NULL,
+    surface TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    estimated_baseline_tokens INTEGER NOT NULL,
+    estimated_payload_tokens INTEGER NOT NULL,
+    estimated_saved_tokens INTEGER NOT NULL,
+    extra TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_created_at
+    ON telemetry_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_operation
+    ON telemetry_events(operation);
+"""
+
+
+def estimate_tokens_from_chars(char_count: int) -> int:
+    if char_count <= 0:
+        return 0
+    return max(1, int(char_count / 4))
+
+
+def record_event(
+    db_path: str | Path,
+    *,
+    surface: str,
+    operation: str,
+    baseline_tokens: int,
+    payload_tokens: int,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    saved_tokens = max(baseline_tokens - payload_tokens, 0)
+    with _connect(db_path) as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO telemetry_events (
+                created_at, surface, operation, estimated_baseline_tokens,
+                estimated_payload_tokens, estimated_saved_tokens, extra
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                time.time(),
+                surface,
+                operation,
+                baseline_tokens,
+                payload_tokens,
+                saved_tokens,
+                json.dumps(extra or {}, separators=(",", ":"), sort_keys=True),
+            ),
+        )
+        conn.commit()
+    return {
+        "status": "ok",
+        "surface": surface,
+        "operation": operation,
+        "estimated_baseline_tokens": baseline_tokens,
+        "estimated_payload_tokens": payload_tokens,
+        "estimated_saved_tokens": saved_tokens,
+    }
+
+
+def summarize_events(db_path: str | Path) -> dict[str, Any]:
+    with _connect(db_path) as conn:
+        _ensure_schema(conn)
+        total = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS request_count,
+                COALESCE(SUM(estimated_baseline_tokens), 0) AS baseline_tokens,
+                COALESCE(SUM(estimated_payload_tokens), 0) AS payload_tokens,
+                COALESCE(SUM(estimated_saved_tokens), 0) AS saved_tokens
+            FROM telemetry_events
+            """
+        ).fetchone()
+        by_operation_rows = conn.execute(
+            """
+            SELECT
+                operation,
+                COUNT(*) AS request_count,
+                COALESCE(SUM(estimated_saved_tokens), 0) AS saved_tokens
+            FROM telemetry_events
+            GROUP BY operation
+            ORDER BY request_count DESC, operation ASC
+            """
+        ).fetchall()
+
+    request_count = int(total["request_count"])
+    saved_tokens = int(total["saved_tokens"])
+    return {
+        "status": "estimated",
+        "method": "chars_div_4",
+        "scope": "observed local API operations",
+        "total_requests": request_count,
+        "estimated_baseline_tokens": int(total["baseline_tokens"]),
+        "estimated_payload_tokens": int(total["payload_tokens"]),
+        "estimated_saved_tokens": saved_tokens,
+        "average_saved_tokens": round(saved_tokens / request_count, 2)
+        if request_count else 0.0,
+        "by_operation": [
+            {
+                "operation": row["operation"],
+                "request_count": int(row["request_count"]),
+                "estimated_saved_tokens": int(row["saved_tokens"]),
+            }
+            for row in by_operation_rows
+        ],
+    }
+
+
+def _connect(db_path: str | Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path), timeout=5)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=1000")
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SCHEMA)

--- a/code_review_graph/web.py
+++ b/code_review_graph/web.py
@@ -1,0 +1,437 @@
+"""Local browser UI and HTTP API for exploring the code graph."""
+
+from __future__ import annotations
+
+import json
+import time
+import webbrowser
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from .service import GraphService
+
+INDEX_HTML = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>axon-web</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f7f4;
+      --panel: #ffffff;
+      --text: #1c1f23;
+      --muted: #69707a;
+      --line: #d8d8d2;
+      --accent: #146c94;
+      --accent-2: #7b4f9f;
+      --warn: #a15c00;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #151719;
+        --panel: #202327;
+        --text: #f1f3f4;
+        --muted: #a3abb5;
+        --line: #3b4046;
+        --accent: #55b6d9;
+        --accent-2: #c59cff;
+        --warn: #f0b35a;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }
+    h1 { margin: 0; font-size: 18px; font-weight: 650; letter-spacing: 0; }
+    main {
+      display: grid;
+      grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
+      min-height: calc(100vh - 57px);
+    }
+    aside {
+      border-right: 1px solid var(--line);
+      background: var(--panel);
+      padding: 14px;
+      overflow: auto;
+    }
+    section { padding: 14px; overflow: auto; }
+    input, select, button {
+      min-height: 34px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--panel);
+      color: var(--text);
+      font: inherit;
+    }
+    input { width: 100%; padding: 0 10px; }
+    button { padding: 0 10px; cursor: pointer; }
+    button.primary { background: var(--accent); border-color: var(--accent); color: white; }
+    .row { display: flex; gap: 8px; align-items: center; margin-bottom: 10px; }
+    .row > * { flex: 1; }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      margin: 10px 0 14px;
+    }
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px;
+      background: color-mix(in srgb, var(--panel) 90%, var(--bg));
+    }
+    .metric strong { display: block; font-size: 18px; }
+    .muted { color: var(--muted); }
+    .list { display: grid; gap: 8px; }
+    .item {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 9px;
+      background: var(--panel);
+      cursor: pointer;
+    }
+    .item:hover { border-color: var(--accent); }
+    .item-title { font-weight: 650; overflow-wrap: anywhere; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 20px;
+      padding: 0 6px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--accent) 15%, transparent);
+      color: var(--accent);
+      font-size: 12px;
+      margin-right: 4px;
+    }
+    .graph {
+      width: 100%;
+      min-height: 520px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--panel);
+      overflow: auto;
+      padding: 12px;
+    }
+    svg { width: 100%; min-width: 780px; height: 520px; }
+    line { stroke: var(--line); stroke-width: 1.2; }
+    circle { fill: var(--accent); }
+    circle.kind-File { fill: var(--muted); }
+    circle.kind-Class { fill: var(--accent-2); }
+    text { fill: var(--text); font-size: 12px; }
+    pre {
+      margin: 12px 0 0;
+      padding: 12px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      overflow: auto;
+      background: var(--panel);
+      white-space: pre-wrap;
+    }
+    @media (max-width: 860px) {
+      main { grid-template-columns: 1fr; }
+      aside { border-right: 0; border-bottom: 1px solid var(--line); }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>axon-web</h1>
+    <div id="repo" class="muted"></div>
+  </header>
+  <main>
+    <aside>
+      <div class="row">
+        <input id="search" placeholder="Search symbols, files, qualified names">
+        <button id="searchBtn" class="primary">Search</button>
+      </div>
+      <div class="row">
+        <input id="impact" placeholder="Impact files, comma-separated">
+        <button id="impactBtn">Impact</button>
+      </div>
+      <div id="stats" class="stats"></div>
+      <div id="results" class="list"></div>
+    </aside>
+    <section>
+      <div class="graph"><svg id="graph"></svg></div>
+      <pre id="details" class="muted">Select a node or run a query.</pre>
+    </section>
+  </main>
+  <script>
+    const $ = (id) => document.getElementById(id);
+    let graphData = {nodes: [], edges: []};
+
+    async function api(path) {
+      const res = await fetch(path);
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    }
+
+    function showDetails(value) {
+      $("details").textContent = JSON.stringify(value, null, 2);
+    }
+
+    function renderStats(status) {
+      $("repo").textContent = status.repo_root || "";
+      const s = status.stats || {};
+      const t = status.token_estimate || {};
+      const telemetry = status.telemetry || {};
+      $("stats").innerHTML = [
+        ["Nodes", formatNumber(s.total_nodes || 0)],
+        ["Edges", formatNumber(s.total_edges || 0)],
+        ["Files", formatNumber(s.files_count || 0)],
+        ["Tokens saved", formatNumber(t.saved_tokens || 0)],
+        ["Reduction", `${t.reduction_percent || 0}%`],
+        ["Source / graph", `${t.compression_ratio || 0}x`],
+        ["API requests", formatNumber(telemetry.total_requests || 0)],
+        ["Est. saved total", formatNumber(telemetry.estimated_saved_tokens || 0)],
+        ["Est. saved avg", formatNumber(Math.round(telemetry.average_saved_tokens || 0))],
+      ].map(([k, v]) => `<div class="metric"><span class="muted">${k}</span><strong>${v}</strong></div>`).join("");
+    }
+
+    function formatNumber(value) {
+      return Number(value || 0).toLocaleString();
+    }
+
+    function renderList(nodes) {
+      $("results").innerHTML = nodes.map((n) => `
+        <div class="item" data-qn="${escapeHtml(n.qualified_name)}">
+          <span class="badge">${escapeHtml(n.kind)}</span>
+          <div class="item-title">${escapeHtml(n.name)}</div>
+          <div class="muted">${escapeHtml(n.file_path)}:${n.line_start}</div>
+        </div>
+      `).join("");
+      document.querySelectorAll(".item").forEach((el) => {
+        el.addEventListener("click", async () => {
+          const qn = el.getAttribute("data-qn");
+          showDetails(await api(`/api/node?qualified_name=${encodeURIComponent(qn)}`));
+        });
+      });
+    }
+
+    function renderGraph(data) {
+      graphData = data;
+      const svg = $("graph");
+      const nodes = data.nodes || [];
+      const edges = data.edges || [];
+      const width = Math.max(780, svg.clientWidth || 780);
+      const height = 520;
+      const radius = Math.min(width, height) * 0.38;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const pos = new Map();
+      nodes.forEach((n, i) => {
+        const angle = (Math.PI * 2 * i) / Math.max(nodes.length, 1);
+        pos.set(n.qualified_name, {
+          x: centerX + Math.cos(angle) * radius,
+          y: centerY + Math.sin(angle) * radius,
+        });
+      });
+      const edgeHtml = edges.map((e) => {
+        const a = pos.get(e.source);
+        const b = pos.get(e.target);
+        if (!a || !b) return "";
+        return `<line x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"></line>`;
+      }).join("");
+      const nodeHtml = nodes.map((n) => {
+        const p = pos.get(n.qualified_name);
+        const label = n.name.length > 28 ? `${n.name.slice(0, 25)}...` : n.name;
+        return `<g data-qn="${escapeHtml(n.qualified_name)}">
+          <circle class="kind-${escapeHtml(n.kind)}" cx="${p.x}" cy="${p.y}" r="${n.kind === "File" ? 5 : 7}"></circle>
+          <text x="${p.x + 9}" y="${p.y + 4}">${escapeHtml(label)}</text>
+        </g>`;
+      }).join("");
+      svg.innerHTML = edgeHtml + nodeHtml;
+      svg.querySelectorAll("g").forEach((el) => {
+        el.addEventListener("click", async () => {
+          showDetails(await api(`/api/node?qualified_name=${encodeURIComponent(el.getAttribute("data-qn"))}`));
+        });
+      });
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? "").replace(/[&<>"']/g, (ch) => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+      }[ch]));
+    }
+
+    async function refresh() {
+      renderStats(await api("/api/status"));
+      renderGraph(await api("/api/graph?limit=250"));
+    }
+
+    $("searchBtn").addEventListener("click", async () => {
+      const q = $("search").value.trim();
+      if (!q) return;
+      const result = await api(`/api/search?q=${encodeURIComponent(q)}`);
+      renderList(result.nodes || []);
+      showDetails(result);
+    });
+    $("search").addEventListener("keydown", (event) => {
+      if (event.key === "Enter") $("searchBtn").click();
+    });
+    $("impactBtn").addEventListener("click", async () => {
+      const files = $("impact").value.trim();
+      if (!files) return;
+      const result = await api(`/api/impact?files=${encodeURIComponent(files)}`);
+      renderList(result.impacted_nodes || []);
+      showDetails(result);
+    });
+
+    const events = new EventSource("/events");
+    events.addEventListener("graph-updated", refresh);
+    refresh().catch((err) => showDetails({status: "error", error: String(err)}));
+  </script>
+</body>
+</html>
+"""
+
+
+class AxonWebHandler(BaseHTTPRequestHandler):
+    service: GraphService
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        try:
+            if parsed.path == "/":
+                self._send_html(INDEX_HTML)
+                return
+            elif parsed.path == "/events":
+                self._send_events()
+                return
+            elif parsed.path == "/api/status":
+                payload = self.service.status()
+                operation = None
+            elif parsed.path == "/api/search":
+                q = query.get("q", [""])[0]
+                limit = int(query.get("limit", ["50"])[0])
+                payload = self.service.search(q, limit=limit)
+                operation = "search"
+            elif parsed.path == "/api/node":
+                qn = query.get("qualified_name", [""])[0]
+                payload = self.service.get_node(qn)
+                operation = "node"
+            elif parsed.path == "/api/query":
+                pattern = query.get("pattern", [""])[0]
+                target = query.get("target", [""])[0]
+                payload = self.service.query(pattern, target)
+                operation = f"query:{pattern or 'unknown'}"
+            elif parsed.path == "/api/impact":
+                raw_files = query.get("files", [""])[0]
+                files = [f.strip() for f in raw_files.split(",") if f.strip()]
+                depth = int(query.get("depth", ["2"])[0])
+                payload = self.service.impact(files, max_depth=depth)
+                operation = "impact"
+            elif parsed.path == "/api/graph":
+                limit = int(query.get("limit", ["1000"])[0])
+                payload = self.service.graph(limit=limit)
+                operation = "graph"
+            else:
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            if operation:
+                self._record_telemetry(operation, payload)
+            self._send_json(payload)
+        except Exception as exc:
+            self._send_json({"status": "error", "error": str(exc)}, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def _send_html(self, content: str) -> None:
+        data = content.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _record_telemetry(self, operation: str, payload: dict[str, Any]) -> None:
+        try:
+            self.service.record_telemetry(operation, payload, surface="web")
+        except Exception:
+            return
+
+    def _send_events(self) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        db_path = Path(self.service.db_path)
+        last_mtime = db_path.stat().st_mtime if db_path.exists() else 0.0
+        while True:
+            try:
+                time.sleep(1)
+                mtime = db_path.stat().st_mtime if db_path.exists() else 0.0
+                if mtime != last_mtime:
+                    last_mtime = mtime
+                    self.wfile.write(b"event: graph-updated\n")
+                    self.wfile.write(b"data: {}\n\n")
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                break
+
+
+def run_web(
+    repo_root: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    open_browser: bool = False,
+) -> None:
+    service = GraphService(repo_root)
+    handler = type("BoundAxonWebHandler", (AxonWebHandler,), {"service": service})
+    httpd = ThreadingHTTPServer((host, port), handler)
+    url = f"http://{host}:{port}/"
+    print(f"axon-web serving {service.repo_root} at {url}")
+    if open_browser:
+        webbrowser.open(url)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+        service.close()
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="axon-web")
+    parser.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port")
+    parser.add_argument("--open", action="store_true", dest="open_browser")
+    args = parser.parse_args()
+    run_web(
+        repo_root=args.repo,
+        host=args.host,
+        port=args.port,
+        open_browser=args.open_browser,
+    )

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -235,6 +235,11 @@ code-review-graph update --base origin/main    # Custom base ref
 # Monitor and inspect
 code-review-graph status                       # Graph statistics
 code-review-graph watch                        # Auto-update on file changes
+code-review-graph watch --json-events          # Watch mode with JSON-line events
+code-review-graph web                          # Start local browser graph explorer
+axon web                                       # Same web explorer via short alias
+axon-web                                       # Dedicated web explorer entry point
+code-review-graph lsp                          # Start Language Server Protocol server
 code-review-graph visualize                    # Generate interactive HTML graph
 
 # Analysis
@@ -306,3 +311,35 @@ automatically reconciles child processes (starting/stopping as repos are
 added or removed). Health checks run every 30 seconds and automatically
 restart dead watchers. No external dependencies (tmux, screen, etc.) are
 required.
+
+## Browser Explorer
+
+```bash
+code-review-graph build
+axon web --repo . --host 127.0.0.1 --port 8765
+# Open http://127.0.0.1:8765/
+```
+
+`code-review-graph web`, `axon web`, and `axon-web` start the same local browser UI. The dashboard shows graph size, estimated source-vs-graph token savings, observed web API request count, and estimated cumulative/average savings. The token estimate uses the standard chars/4 approximation and is not model-provider billing data. Aggregate telemetry is stored locally in `.code-review-graph/graph.db`.
+
+The server exposes:
+
+```text
+GET /api/status
+GET /api/search?q=<query>
+GET /api/node?id=<node_id>
+GET /api/query?type=<pattern>&target=<name>
+GET /api/impact?file=<path>
+GET /api/graph?limit=<n>
+GET /events
+```
+
+`/events` is an SSE stream that emits graph update notifications when the local database changes.
+
+## LSP
+
+```bash
+code-review-graph lsp --repo .
+```
+
+Starts the stdio Language Server Protocol server for editor integrations. Supported capabilities include workspace symbols, document symbols, definitions, references, code lenses, and execute-command handlers for callers, callees, and blast radius.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,11 +9,16 @@
 - **`get_minimal_context`**: Ultra-compact entry point (~100 tokens) with task-based tool routing.
 - **Incremental flow/community updates**: Only re-trace affected flows, skip community re-detection when unaffected.
 - **Visualization aggregation**: Community/file/auto modes with drill-down for 5k+ node graphs.
+- **axon-web browser explorer**: `axon web`, `axon-web`, and `code-review-graph web` start a local graph navigation UI with search, node inspection, query, impact, graph, status, SSE update endpoints, and local aggregate token-savings telemetry.
+- **Language Server Protocol integration**: `code-review-graph lsp` exposes graph-backed workspace symbols, document symbols, definitions, references, code lenses, callers, callees, and blast-radius commands over stdio.
+- **Watch JSON events**: `code-review-graph watch --json-events` emits structured update/removal/error events for editor integrations and background services.
+- **VS Code watch parity**: The VS Code extension can run persistent watch mode, stream CLI output, and stop the watcher on extension deactivation.
+- **Ruby, Swift, and Scala parser hardening**: Ruby constant method calls, Swift imports/inheritance, and existing Scala coverage are included in regression tests.
 - **Token-efficiency benchmarks**: 5 workflow benchmarks in eval framework.
 - **Pre-computed summary tables**: DB schema v6 with `community_summaries`, `flow_snapshots`, `risk_index`.
 - **Configurable limits**: `CRG_MAX_IMPACT_NODES`, `CRG_MAX_IMPACT_DEPTH`, `CRG_DEPENDENT_HOPS`, etc.
 - **Multi-hop dependents**: N-hop dependent discovery (default 2) with 500-file cap.
-- **615 tests** across 22 test files.
+- **623 tests** across 25 test files.
 
 ## v2.1.0
 - **22 MCP tools** (up from 9): 13 new tools for flows, communities, architecture, refactoring, wiki, multi-repo, and risk-scored change detection.
@@ -126,5 +131,6 @@
 ## Privacy & Data
 - All data stays 100% local
 - Graph stored in `.code-review-graph/graph.db` (SQLite), auto-gitignored
-- No telemetry, no network calls
+- No external telemetry; local aggregate web telemetry is stored only in `.code-review-graph/graph.db`
+- No network calls during normal operation
 - Respects `.gitignore` and `.code-review-graphignore`

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -3,7 +3,8 @@
 **License:** MIT (see [LICENSE](../LICENSE) in project root)
 
 **Privacy:**
-- Zero telemetry
+- No external telemetry
+- Local aggregate web telemetry, when using `axon-web`, is stored only in `.code-review-graph/graph.db`
 - All graph data stored locally in `.code-review-graph/graph.db`
 - No network calls during normal operation
 - Optional embeddings model downloaded once from HuggingFace (when using `[embeddings]` extra)

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -27,17 +27,35 @@ Never include full files unless explicitly asked.
 MCP tools (24): get_minimal_context_tool, build_or_update_graph_tool, run_postprocess_tool, get_impact_radius_tool, query_graph_tool, get_review_context_tool, semantic_search_nodes_tool, embed_graph_tool, list_graph_stats_tool, get_docs_section_tool, find_large_functions_tool, list_flows_tool, get_flow_tool, get_affected_flows_tool, list_communities_tool, get_community_tool, get_architecture_overview_tool, detect_changes_tool, refactor_tool, apply_refactor_tool, generate_wiki_tool, get_wiki_page_tool, list_repos_tool, cross_repo_search_tool
 MCP prompts (5): review_changes, architecture_map, debug_issue, onboard_developer, pre_merge_check
 Skills: build-graph, review-delta, review-pr
-CLI: code-review-graph [install|init|build|update|status|watch|visualize|serve|wiki|detect-changes|postprocess|register|unregister|repos|eval]
+CLI: code-review-graph [install|init|build|update|status|watch|web|lsp|visualize|serve|wiki|detect-changes|postprocess|register|unregister|repos|eval]
+Aliases: axon [same commands], axon-web [web explorer]
 Token efficiency: All tools support detail_level="minimal" for compact output. Always call get_minimal_context_tool first.
 </section>
 
 <section name="legal">
-MIT license. 100% local. No telemetry. DB file: .code-review-graph/graph.db
+MIT license. 100% local. No external telemetry. DB file: .code-review-graph/graph.db
 </section>
 
 <section name="watch">
 Run: code-review-graph watch (auto-updates graph on file save via watchdog)
+Structured events: code-review-graph watch --json-events emits JSON lines for updated, removed, and error events.
 Or use PostToolUse (Write|Edit|Bash) hooks for automatic background updates.
+</section>
+
+<section name="web">
+Run: code-review-graph build && axon web --repo . --host 127.0.0.1 --port 8765
+Open: http://127.0.0.1:8765/
+Equivalent entry point: axon-web --repo . --host 127.0.0.1 --port 8765
+Endpoints: /api/status, /api/search, /api/node, /api/query, /api/impact, /api/graph, /events
+Use for local browser graph navigation, search, node inspection, impact lookup, live graph update notifications, estimated source-vs-graph token savings, and local aggregate web API telemetry.
+Token estimate: /api/status returns token_estimate and telemetry using chars/4; it is dashboard guidance, not model-provider billing data.
+</section>
+
+<section name="lsp">
+Run: code-review-graph lsp --repo .
+Transport: stdio Language Server Protocol.
+Capabilities: workspace symbols, document symbols, definitions, references, code lenses, callers, callees, blast radius.
+Use for editor integrations such as VS Code.
 </section>
 
 <section name="embeddings">

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Shipped
 
-### v2.2.0
+### v2.2.x
 - Multi-repo watch daemon (`crg-daemon` / `code-review-graph daemon`)
 - TOML-based daemon configuration (`~/.code-review-graph/watch.toml`)
 - Child process management: one `code-review-graph watch` process per repo
@@ -11,6 +11,12 @@
 - Health checking with automatic restart of dead watchers
 - Standalone `crg-daemon` CLI entry point (7 subcommands)
 - Integrated `daemon` subcommand group in main CLI
+- axon-web local browser explorer (`code-review-graph web`, `axon web`, `axon-web`)
+- Language Server Protocol integration (`code-review-graph lsp`)
+- VS Code persistent watch mode with structured CLI event handling
+- Watch mode JSON events (`code-review-graph watch --json-events`)
+- Shared graph service layer for CLI, web, LSP, and editor integrations
+- Ruby, Swift, and Scala regression coverage for parser parity
 
 ### v2.0.0
 - 22 MCP tools (up from 9) and 5 MCP prompts
@@ -68,7 +74,7 @@
 
 - GitHub PR bot integration
 - Team sync (shared graph via git-tracked DB)
-- SSE/HTTP MCP transport for multi-client access
+- SSE/HTTP MCP transport for multi-client MCP access
 - Performance optimization for monorepos (>50k files)
 
 ## Ongoing

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -62,14 +62,44 @@ code-review-graph watch
 ```
 Auto-updates the graph on every file save. Zero manual work.
 
-### 5. Visualize the graph (optional)
+For tools that need structured progress events, use:
+
+```bash
+code-review-graph watch --json-events
+```
+
+Each update, removal, or error is written as one JSON line on stdout. The VS Code extension uses this mode for continuous background indexing.
+
+### 5. Explore the graph in the browser (optional)
+```bash
+code-review-graph build
+axon web --repo . --host 127.0.0.1 --port 8765
+# Open http://127.0.0.1:8765/
+```
+
+You can also run the dedicated entry point:
+
+```bash
+axon-web --repo . --host 127.0.0.1 --port 8765
+```
+
+The web explorer is a local browser UI for graph navigation. It reads `.code-review-graph/graph.db`, exposes search, node, query, impact, graph, and status endpoints, streams graph update notifications to the page, and displays estimated source-vs-graph token savings. It also records local aggregate telemetry for web API operations, so the dashboard can show observed request count plus estimated cumulative and average savings. Token estimates use the standard chars/4 approximation and are dashboard guidance, not model-provider billing data.
+
+### 6. Export a static graph (optional)
 ```bash
 code-review-graph visualize
 open .code-review-graph/graph.html
 ```
 Interactive D3.js force-directed graph. Starts collapsed (File nodes only) — click a file to expand its children. Use the search bar to filter, and click legend edge types to toggle visibility.
 
-### 6. Semantic search (optional)
+### 7. Start the LSP server (optional)
+```bash
+code-review-graph lsp --repo .
+```
+
+The Language Server Protocol server runs over stdio for editor integrations. It exposes workspace symbols, document symbols, definitions, references, code lenses, and commands for callers, callees, and blast-radius lookup.
+
+### 8. Semantic search (optional)
 ```bash
 pip install "code-review-graph[embeddings]"
 ```
@@ -77,25 +107,25 @@ Then use `embed_graph_tool` to compute vectors. `semantic_search_nodes_tool` aut
 
 Embedding providers: Local (sentence-transformers), Google Gemini, MiniMax. Configure via `CRG_EMBEDDING_MODEL` env var.
 
-### 7. Detect changes with risk scoring (v2)
+### 9. Detect changes with risk scoring (v2)
 ```
 Ask Claude: "Review my recent changes with risk scoring"
 ```
 Uses `detect_changes_tool` to map diffs to affected functions, flows, communities, and test gaps.
 
-### 8. Explore architecture (v2)
+### 10. Explore architecture (v2)
 ```
 Ask Claude: "Show me the architecture of this project"
 ```
 Uses `get_architecture_overview_tool` for community-based architecture map with coupling warnings.
 
-### 9. Generate wiki (v2)
+### 11. Generate wiki (v2)
 ```bash
 code-review-graph wiki
 ```
 Creates markdown wiki pages for each detected community in `.code-review-graph/wiki/`.
 
-### 10. Multi-repo search (v2)
+### 12. Multi-repo search (v2)
 ```bash
 code-review-graph register /path/to/other/repo --alias mylib
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ Issues = "https://github.com/tirth8205/code-review-graph/issues"
 [project.scripts]
 code-review-graph = "code_review_graph.cli:main"
 crg-daemon = "code_review_graph.daemon_cli:main"
+axon = "code_review_graph.cli:main"
+axon-web = "code_review_graph.web:main"
 
 [project.optional-dependencies]
 embeddings = [
@@ -112,6 +114,7 @@ select = ["E", "F", "I", "N", "W"]
 
 [tool.ruff.lint.per-file-ignores]
 "code_review_graph/visualization.py" = ["E501"]  # embedded HTML/JS template
+"code_review_graph/web.py" = ["E501"]  # embedded HTML/JS template
 "tests/fixtures/sample_databricks_export.py" = ["F841", "W292"]  # intentional fixture patterns
 "tests/fixtures/sample_notebook.ipynb" = ["F401", "I001"]  # fixture imports: intentionally unused, split across cells
 "tests/test_multilang.py" = ["E501"]  # long assertions with explanatory comments

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,0 +1,13 @@
+"""Tests for the stdio LSP bridge helpers."""
+
+from code_review_graph.lsp import path_to_uri, uri_to_path
+
+
+def test_file_uri_roundtrip(tmp_path):
+    path = tmp_path / "example.py"
+    path.write_text("def f():\n    pass\n", encoding="utf-8")
+
+    uri = path_to_uri(str(path))
+
+    assert uri.startswith("file://")
+    assert uri_to_path(uri) == str(path)

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -388,6 +388,15 @@ class TestRubyParsing:
         names = {f.name for f in funcs}
         assert "initialize" in names or "find_by_id" in names or "save" in names
 
+    def test_finds_imports_and_calls(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        assert {e.target for e in imports} == {"json"}
+
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert "puts" in targets
+        assert any("save" in target for target in targets)
+
 
 class TestPHPParsing:
     def setup_method(self):
@@ -528,6 +537,17 @@ class TestSwiftParsing:
         assert "String" in targets
         # extension InMemoryRepo: CustomStringConvertible
         assert "CustomStringConvertible" in targets
+
+    def test_finds_imports_inheritance_and_calls(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        assert {e.target for e in imports} == {"Foundation"}
+
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        assert {e.target for e in inherits} >= {"UserRepository"}
+
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("save" in target for target in targets)
 
 
 class TestScalaParsing:
@@ -905,7 +925,8 @@ class TestPerlParsing:
     def test_finds_calls(self):
         calls = [e for e in self.edges if e.kind == "CALLS"]
         targets = {e.target for e in calls}
-        assert any(t == "speak" or t.endswith("::speak") for t in targets)  # $self->speak() — method_call_expression
+        # $self->speak() method_call_expression
+        assert any(t == "speak" or t.endswith("::speak") for t in targets)
         assert "bless" in targets  # ambiguous_function_call_expression
 
     def test_finds_contains(self):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,112 @@
+"""Tests for the shared graph service contract."""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.parser import EdgeInfo, NodeInfo
+from code_review_graph.service import GraphService
+
+
+class TestGraphService:
+    def setup_method(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmpdir.name)
+        self.db_path = self.root / ".code-review-graph" / "graph.db"
+        self.store = GraphStore(self.db_path)
+        self._seed_data()
+        self.store.close()
+
+    def teardown_method(self):
+        self.tmpdir.cleanup()
+
+    def _seed_data(self):
+        (self.root / "auth.py").write_text(
+            "def login():\n    return 'ok'\n" + "# auth context\n" * 200,
+            encoding="utf-8",
+        )
+        (self.root / "main.py").write_text(
+            "from auth import login\n\ndef run():\n    return login()\n"
+            + "# main context\n" * 200,
+            encoding="utf-8",
+        )
+        self.store.upsert_node(NodeInfo(
+            kind="File", name=str(self.root / "auth.py"),
+            file_path=str(self.root / "auth.py"),
+            line_start=1, line_end=30, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="login",
+            file_path=str(self.root / "auth.py"),
+            line_start=5, line_end=10, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="File", name=str(self.root / "main.py"),
+            file_path=str(self.root / "main.py"),
+            line_start=1, line_end=20, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="run",
+            file_path=str(self.root / "main.py"),
+            line_start=3, line_end=8, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="login_view",
+            file_path=str(self.root / "main.py"),
+            line_start=10, line_end=12, language="python",
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS",
+            source=str(self.root / "main.py") + "::run",
+            target=str(self.root / "auth.py") + "::login",
+            file_path=str(self.root / "main.py"),
+            line=5,
+        ))
+        self.store.commit()
+
+    def test_status_and_search(self):
+        with GraphService(self.root) as service:
+            status = service.status()
+            assert status["status"] == "ok"
+            assert status["stats"]["total_nodes"] == 5
+            assert status["token_estimate"]["status"] == "estimated"
+            assert status["token_estimate"]["source_tokens"] > 0
+            assert status["token_estimate"]["graph_tokens"] > 0
+            assert status["telemetry"]["status"] == "estimated"
+            assert status["telemetry"]["total_requests"] == 0
+
+            results = service.search("login")
+            assert results["nodes"][0]["name"] == "login"
+
+    def test_records_local_telemetry(self):
+        with GraphService(self.root) as service:
+            payload = service.search("login")
+            event = service.record_telemetry("search", payload)
+
+            assert event["status"] == "ok"
+            summary = service.telemetry_summary()
+            assert summary["total_requests"] == 1
+            assert summary["estimated_saved_tokens"] >= 0
+            assert summary["by_operation"][0]["operation"] == "search"
+
+    def test_callers_and_impact(self):
+        with GraphService(self.root) as service:
+            callers = service.callers(str(self.root / "auth.py") + "::login")
+            assert callers["status"] == "ok"
+            assert callers["nodes"][0]["name"] == "run"
+
+            impact = service.impact(["auth.py"])
+            names = {n["name"] for n in impact["impacted_nodes"]}
+            assert "run" in names
+
+    def test_ambiguous_query_reports_candidates(self):
+        with GraphService(self.root) as service:
+            result = service.callers("login")
+            assert result["status"] == "ambiguous"
+            assert len(result["candidates"]) == 2
+
+    def test_node_at_prefers_smallest_span(self):
+        with GraphService(self.root) as service:
+            node = service.node_at("auth.py", 6)
+            assert node is not None
+            assert node.name == "login"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,14 @@
+"""Tests for axon-web HTTP handler helpers."""
+
+from code_review_graph.web import INDEX_HTML
+
+
+def test_index_html_has_api_bootstrap():
+    assert "axon-web" in INDEX_HTML
+    assert "/api/status" in INDEX_HTML
+    assert "/api/graph" in INDEX_HTML
+    assert "Tokens saved" in INDEX_HTML
+    assert "token_estimate" in INDEX_HTML
+    assert "API requests" in INDEX_HTML
+    assert "telemetry" in INDEX_HTML
+    assert "EventSource" in INDEX_HTML


### PR DESCRIPTION
## Summary
- add shared graph service, local axon-web browser explorer, and stdio LSP server
- add VS Code persistent watch integration and JSON watch events
- harden Ruby/Swift parser coverage and add local aggregate token-savings telemetry
- update README and docs for web, LSP, VS Code, watch mode, telemetry, and roadmap status

## Validation
- uv run pytest: 624 passed, 5 skipped, 2 xpassed
- uv run ruff check touched Python files/tests: passed
- npm --prefix code-review-graph-vscode run lint: passed
- npm --prefix code-review-graph-vscode run compile: passed
- npm --prefix code-review-graph-vscode test: exit code 0
- direct sqlite.test.ts runner: 23 passed, 0 failed