### PR TITLE
Prepare focused 2.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+## [2.3.4] - 2026-05-25
+
+Focused reliability and token-efficiency release for MCP/CLI review workflows. No breaking changes.
+
+### Added
+
+- **Estimated context savings metadata** for graph-filtered review/impact/architecture responses. The new `context_savings` field is intentionally compact (`estimated`, `saved_tokens`, `saved_percent`) and uses the existing conservative character-count approximation rather than claiming exact tokenization.
+- **CLI estimated savings line** for `code-review-graph detect-changes --brief`; full JSON output includes the same compact `context_savings` metadata.
+
+### Changed
+
+- **Architecture overview is compact by default**: `get_architecture_overview_tool` now defaults to `detail_level="minimal"`, dropping per-community member lists and aggregating cross-community edges by community pair. Full per-edge output remains available with `detail_level="standard"`.
+- **Bounded change analysis**: `detect_changes_tool` can now cap very large changed-function and transitive-test frontiers with `CRG_MAX_CHANGED_FUNCS` and `CRG_MAX_TRANSITIVE_FRONTIER`, and can return a structured timeout error via `CRG_TOOL_TIMEOUT`.
+
+### Fixed
+
+- **Windows semantic search deadlock** (#508/#507): local embedding models are pre-warmed on the main thread on Windows before FastMCP starts worker dispatch.
+- **Rust test detection** (#503/#502): Rust `#[test]` and common async test attributes now produce `Test` nodes.
+- **Generated hook stdin handling** (#494/#493): Codex and Claude hook commands drain stdin to avoid caller-side broken pipes on large hook payloads.
+- **Cross-file callers** (#486/#472): `callers_of` now returns cross-file callers even when same-file callers exist.
+- **Graph path lookup** (#469): review, impact, and file-summary tools resolve user-facing paths to the path format stored in the graph.
+- **Bundled MCP docs** (#485/#480): `get_docs_section` can load the packaged `LLM-OPTIMIZED-REFERENCE.md` from installed wheels.
+- **Local embedding provider availability** (#484/#448): missing `sentence-transformers` now reports local provider unavailability instead of silently producing zero embeddings.
+- **Dead-code response fields** (#481/#447): dead-code results now include `file_path`, `relative_path`, and `language` while preserving the legacy `file` key.
+- **SVN root validation** (#456): MCP/daemon/registry root validation now accepts `.svn` working copies consistently.
+- **CLI postprocess flags** (#487): `build --skip-postprocess` and `update --skip-flows` no longer run an extra full post-processing pass.
+
+### Documentation
+
+- Updated stale release-facing version references for 2.3.4.
+- Replaced fragile language-count wording with current broad language and notebook support wording.
+- Added the missing VS Code extension `0.2.2` changelog entry without changing the extension package version.
+
+### Tests
+
+- Added regression coverage for compact architecture overview output and #476 mitigation.
+- Added tests for estimated context savings calculation, compact metadata shape, MCP metadata, CLI brief/JSON output, Rust test parsing, hook stdin draining, graph path resolution, dead-code fields, SVN root validation, CLI postprocess flags, embedding availability, and bounded detect-changes behavior.
+
 ## [2.3.3] - 2026-05-08
 
 Large additive release accumulated since v2.3.2 — 141 non-merge commits, 8 new languages/extensions, 5 new platform install targets, 6 new framework call resolvers, comprehensive Windows hardening, VS Code accessibility pass, and a full sweep of community PRs.

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ Large monorepos are where token waste is most painful. The graph cuts through th
   <img src="diagrams/diagram6_monorepo_funnel.png" alt="Next.js monorepo: 27,732 files funnelled through code-review-graph down to ~15 files — 49x fewer tokens" width="80%" />
 </p>
 
-### 24 languages + Jupyter notebooks
+### Broad language coverage + Jupyter notebooks
 
 <p align="center">
-  <img src="diagrams/diagram9_language_coverage.png" alt="24 languages organized by category: Web, Backend, Systems, Mobile, Scripting, Config (Nix), plus Jupyter/Databricks notebook support" width="90%" />
+  <img src="diagrams/diagram9_language_coverage.png" alt="Language coverage organized by category: Web, Backend, Systems, Mobile, Scripting, Config, plus Jupyter and Databricks notebook support" width="90%" />
 </p>
 
-Full Tree-sitter grammar support for functions, classes, imports, call sites, inheritance, and test detection in every language. Includes Zig, PowerShell, Julia, Svelte SFC, and flake-aware Nix support. Plus Jupyter/Databricks notebook parsing (`.ipynb`) with multi-language cell support (Python, R, SQL), and Perl XS files (`.xs`).
+Full Tree-sitter grammar support for functions, classes, imports, call sites, inheritance, and test detection across the parser surface. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
 ---
 
@@ -130,6 +130,8 @@ All numbers come from the automated evaluation runner against 6 real open-source
 <br>
 
 The graph replaces reading entire source files with a compact structural context covering blast radius, dependency chains, and test coverage gaps.
+
+In v2.3.4, review and impact tools also return a compact `context_savings` estimate so MCP clients and CLI users can see the approximate context saved without adding bulky before/after dumps. The value is deliberately labelled estimated because it uses a conservative character-count approximation rather than model-specific tokenization.
 
 | Repo | Commits | Avg Naive Tokens | Avg Graph Tokens | Reduction |
 |------|--------:|-----------------:|----------------:|----------:|
@@ -195,7 +197,7 @@ The blast-radius analysis never misses an actually impacted file (perfect recall
 | Feature | Details |
 |---------|---------|
 | **Incremental updates** | Re-parses only changed files. Subsequent updates complete in under 2 seconds. |
-| **24 languages + notebooks** | Python, TypeScript/TSX, JavaScript, Vue, Svelte, Go, Rust, Java, Scala, C#, Ruby, Kotlin, Swift, PHP, Solidity, C/C++, Dart, R, Perl, Lua, Zig, PowerShell, Julia, Nix, Jupyter/Databricks (.ipynb) |
+| **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
 | **Blast-radius analysis** | Shows exactly which functions, classes, and files are affected by any change |
 | **Auto-update hooks** | Graph updates on every file edit and git commit without manual intervention |
 | **Semantic search** | Optional vector embeddings via sentence-transformers, Google Gemini, MiniMax, or any OpenAI-compatible endpoint (real OpenAI, Azure, new-api, LiteLLM, vLLM, LocalAI) |
@@ -209,6 +211,7 @@ The blast-radius analysis never misses an actually impacted file (perfect recall
 | **Export formats** | GraphML (Gephi/yEd), Neo4j Cypher, Obsidian vault with wikilinks, SVG static graph |
 | **Graph diff** | Compare graph snapshots over time: new/removed nodes, edges, community changes |
 | **Token benchmarking** | Measure naive full-corpus tokens vs graph query tokens with per-question ratios |
+| **Estimated context savings** | Compact `context_savings` metadata on relevant MCP/CLI review outputs, labelled as estimated and kept to three small fields |
 | **Memory loop** | Persist Q&A results as markdown for re-ingestion, so the graph grows from queries |
 | **Community auto-split** | Oversized communities (>25% of graph) are recursively split via Leiden |
 | **Execution flows** | Trace call chains from entry points, sorted by weighted criticality |

--- a/code-review-graph-vscode/CHANGELOG.md
+++ b/code-review-graph-vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.2 - 2026-04-11
+
+### Fixed
+- Compatible with VS Code 1.115 / Electron 39 by updating the extension SQLite dependency stack.
+
 ## 0.2.1 — 2026-04-08
 
 ### Fixed

--- a/code_review_graph/__init__.py
+++ b/code_review_graph/__init__.py
@@ -8,7 +8,7 @@ from .context_savings import (
     format_context_savings,
 )
 
-__version__ = "2.3.3"
+__version__ = "2.3.4"
 
 __all__ = [
     "__version__",

--- a/code_review_graph/__init__.py
+++ b/code_review_graph/__init__.py
@@ -1,3 +1,20 @@
 """Code Review Graph - MCP server for persistent incremental code knowledge graphs."""
 
+from .context_savings import (
+    attach_context_savings,
+    estimate_context_savings,
+    estimate_file_tokens,
+    estimate_tokens,
+    format_context_savings,
+)
+
 __version__ = "2.3.3"
+
+__all__ = [
+    "__version__",
+    "attach_context_savings",
+    "estimate_context_savings",
+    "estimate_file_tokens",
+    "estimate_tokens",
+    "format_context_savings",
+]

--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -315,6 +315,12 @@ def analyze_changes(
         if n.kind in ("Function", "Test", "Class")
     ]
 
+    # Cap to prevent O(N*M) query explosion on large PRs.
+    _max_funcs = int(os.environ.get("CRG_MAX_CHANGED_FUNCS", "500"))
+    funcs_truncated = len(changed_funcs) > _max_funcs
+    if funcs_truncated:
+        changed_funcs = changed_funcs[:_max_funcs]
+
     # Compute per-node risk scores.
     node_risks: list[dict[str, Any]] = []
     for node in changed_funcs:
@@ -359,6 +365,11 @@ def analyze_changes(
     if test_gaps:
         gap_names = [g["name"] for g in test_gaps[:5]]
         summary_parts.append(f"  - Untested: {', '.join(gap_names)}")
+    if funcs_truncated:
+        summary_parts.append(
+            f"  - Warning: analysis capped at {_max_funcs} functions "
+            f"(set CRG_MAX_CHANGED_FUNCS to adjust)"
+        )
 
     return {
         "summary": "\n".join(summary_parts),
@@ -367,4 +378,5 @@ def analyze_changes(
         "affected_flows": affected["affected_flows"],
         "test_gaps": test_gaps,
         "review_priorities": review_priorities,
+        "functions_truncated": funcs_truncated,
     }

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -322,21 +322,6 @@ def _handle_init(args: argparse.Namespace) -> None:
     print("  2. Restart your AI coding tool to pick up the new config")
 
 
-def _cli_post_process(store: GraphStore) -> None:
-    """Run post-build pipeline and print a summary line for each step."""
-    from .postprocessing import run_post_processing
-
-    pp = run_post_processing(store)
-    if pp.get("signatures_computed"):
-        print(f"Signatures: {pp['signatures_computed']} nodes")
-    if pp.get("fts_indexed"):
-        print(f"FTS indexed: {pp['fts_indexed']} nodes")
-    if pp.get("flows_detected") is not None:
-        print(f"Flows: {pp['flows_detected']}")
-    if pp.get("communities_detected") is not None:
-        print(f"Communities: {pp['communities_detected']}")
-
-
 def _handle_data_dir_option(args, repo_root: Path) -> None:
     """Handle --data-dir option by updating registry if specified."""
     if hasattr(args, "data_dir") and args.data_dir:
@@ -923,7 +908,6 @@ def main() -> None:
             print(f"Full build: {parsed} files, {nodes} nodes, {edges} edges (postprocess={pp})")
             if result.get("errors"):
                 print(f"Errors: {len(result['errors'])}")
-            _cli_post_process(store)
 
         elif args.command == "update":
             pp = (
@@ -947,8 +931,6 @@ def main() -> None:
                 f"{nodes} nodes, {edges} edges"
                 f" (postprocess={pp})"
             )
-            if result.get("files_updated", 0) > 0:
-                _cli_post_process(store)
 
         elif args.command == "status":
             stats = store.get_stats()

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1046,6 +1046,11 @@ def main() -> None:
             print(f"Output: {wiki_dir}")
 
         elif args.command == "detect-changes":
+            from .context_savings import (
+                attach_context_savings,
+                estimate_file_tokens,
+                format_context_savings,
+            )
             from .changes import analyze_changes
             from .incremental import get_changed_files, get_staged_and_unstaged
 
@@ -1063,8 +1068,17 @@ def main() -> None:
                     repo_root=str(repo_root),
                     base=base,
                 )
+                attach_context_savings(
+                    result,
+                    original_tokens=estimate_file_tokens(repo_root, changed),
+                )
                 if args.brief:
                     print(result.get("summary", "No summary available."))
+                    savings_line = format_context_savings(
+                        result.get("context_savings")
+                    )
+                    if savings_line:
+                        print(savings_line)
                 else:
                     print(json.dumps(result, indent=2, default=str))
 

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -43,10 +43,6 @@ import os
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .graph import GraphStore
 
 logger = logging.getLogger(__name__)
 
@@ -1046,12 +1042,12 @@ def main() -> None:
             print(f"Output: {wiki_dir}")
 
         elif args.command == "detect-changes":
+            from .changes import analyze_changes
             from .context_savings import (
                 attach_context_savings,
                 estimate_file_tokens,
                 format_context_savings,
             )
-            from .changes import analyze_changes
             from .incremental import get_changed_files, get_staged_and_unstaged
 
             base = args.base

--- a/code_review_graph/context_savings.py
+++ b/code_review_graph/context_savings.py
@@ -1,0 +1,111 @@
+"""Compact estimated context savings helpers.
+
+The project intentionally labels these values as estimates: the helper uses a
+conservative character-count approximation instead of model-specific tokenizers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(value: Any) -> int:
+    """Estimate token count with a conservative 4 chars/token approximation."""
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(
+            value,
+            default=str,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    if not text:
+        return 0
+    return max(1, (len(text) + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN)
+
+
+def estimate_file_tokens(repo_root: Path, files: Iterable[str]) -> int:
+    """Estimate tokens for changed files using file sizes, not file contents."""
+    total = 0
+    root = repo_root.resolve()
+    for file_name in files:
+        path = Path(file_name)
+        full_path = path if path.is_absolute() else root / path
+        try:
+            if full_path.is_file():
+                total += max(
+                    1,
+                    (full_path.stat().st_size + CHARS_PER_TOKEN - 1)
+                    // CHARS_PER_TOKEN,
+                )
+        except OSError:
+            continue
+    return total
+
+
+def estimate_context_savings(
+    *,
+    original_context: Any | None = None,
+    returned_context: Any | None = None,
+    original_tokens: int | None = None,
+    returned_tokens: int | None = None,
+) -> dict[str, int | bool] | None:
+    """Return tiny savings metadata, or None when no baseline is available."""
+    baseline = (
+        original_tokens
+        if original_tokens is not None
+        else estimate_tokens(original_context)
+    )
+    returned = (
+        returned_tokens
+        if returned_tokens is not None
+        else estimate_tokens(returned_context)
+    )
+
+    if baseline <= 0:
+        return None
+
+    saved = max(0, baseline - returned)
+    percent = round((saved / baseline) * 100) if baseline else 0
+    return {
+        "estimated": True,
+        "saved_tokens": int(saved),
+        "saved_percent": int(percent),
+    }
+
+
+def attach_context_savings(
+    result: dict[str, Any],
+    *,
+    original_context: Any | None = None,
+    original_tokens: int | None = None,
+    returned_context: Any | None = None,
+    returned_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Attach compact ``context_savings`` metadata when it can be estimated."""
+    estimate = estimate_context_savings(
+        original_context=original_context,
+        returned_context=result if returned_context is None else returned_context,
+        original_tokens=original_tokens,
+        returned_tokens=returned_tokens,
+    )
+    if estimate is not None:
+        result["context_savings"] = estimate
+    return result
+
+
+def format_context_savings(estimate: dict[str, Any] | None) -> str | None:
+    """Format a one-line human summary for CLI output."""
+    if not estimate:
+        return None
+    saved = int(estimate.get("saved_tokens", 0))
+    percent = int(estimate.get("saved_percent", 0))
+    return f"Estimated context saved: ~{saved:,} tokens (~{percent}%)"

--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -130,9 +130,9 @@ def load_config(path: Path | None = None) -> DaemonConfig:
             logger.warning("Skipping repo %s — directory does not exist", repo_path)
             continue
 
-        if not (repo_path / ".git").exists() and not (repo_path / ".code-review-graph").exists():
+        if not (repo_path / ".git").exists() and not (repo_path / ".svn").exists() and not (repo_path / ".code-review-graph").exists():
             logger.warning(
-                "Skipping repo %s — no .git or .code-review-graph directory found",
+                "Skipping repo %s — no .git, .svn, or .code-review-graph directory found",
                 repo_path,
             )
             continue
@@ -222,8 +222,8 @@ def add_repo_to_config(
     if not resolved.is_dir():
         raise ValueError(f"Not a directory: {resolved}")
 
-    if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
-        raise ValueError(f"No .git or .code-review-graph directory in {resolved}")
+    if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
+        raise ValueError(f"No .git, .svn, or .code-review-graph directory in {resolved}")
 
     effective_alias = alias or resolved.name
 

--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -130,7 +130,12 @@ def load_config(path: Path | None = None) -> DaemonConfig:
             logger.warning("Skipping repo %s — directory does not exist", repo_path)
             continue
 
-        if not (repo_path / ".git").exists() and not (repo_path / ".svn").exists() and not (repo_path / ".code-review-graph").exists():
+        has_repo_marker = (
+            (repo_path / ".git").exists()
+            or (repo_path / ".svn").exists()
+            or (repo_path / ".code-review-graph").exists()
+        )
+        if not has_repo_marker:
             logger.warning(
                 "Skipping repo %s — no .git, .svn, or .code-review-graph directory found",
                 repo_path,
@@ -222,7 +227,12 @@ def add_repo_to_config(
     if not resolved.is_dir():
         raise ValueError(f"Not a directory: {resolved}")
 
-    if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
+    has_repo_marker = (
+        (resolved / ".git").exists()
+        or (resolved / ".svn").exists()
+        or (resolved / ".code-review-graph").exists()
+    )
+    if not has_repo_marker:
         raise ValueError(f"No .git, .svn, or .code-review-graph directory in {resolved}")
 
     effective_alias = alias or resolved.name

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -65,6 +65,50 @@ class EmbeddingProvider(ABC):
 LOCAL_DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
 
+# Process-wide cache of loaded sentence-transformer models, keyed by model name.
+# Populated by ``prewarm_local_embeddings()`` at server startup (see ``main.main``)
+# and by ``LocalEmbeddingProvider._get_model`` on first lazy load. Sharing the
+# loaded model across ``LocalEmbeddingProvider`` instances avoids re-importing
+# ``sentence_transformers`` + ``torch`` from worker threads, which deadlocks
+# ``semantic_search_nodes_tool`` on Windows stdio MCP (#385 fixed the peer
+# tools via ``asyncio.to_thread``; this cache fixes the remaining case where
+# torch DLL / OpenMP init runs inside an executor thread).
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+def prewarm_local_embeddings(model_name: str | None = None) -> None:
+    """Eagerly load the local sentence-transformer model on the calling thread.
+
+    Call this from the **main thread** before entering an asyncio event loop
+    (e.g. before ``mcp.run()``) on Windows to prevent a deadlock where lazy-
+    loading ``sentence_transformers`` + ``torch`` inside a FastMCP executor
+    worker thread blocks indefinitely on DLL init / OpenMP thread-pool
+    registration.
+
+    No-op when ``sentence-transformers`` is not installed (cloud-provider
+    setups remain unaffected) or when the configured model is already cached.
+
+    Args:
+        model_name: Optional override; falls back to the ``CRG_EMBEDDING_MODEL``
+            environment variable and then to ``LOCAL_DEFAULT_MODEL``.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer  # noqa: F401
+    except ImportError:
+        return  # cloud-only setup: nothing to pre-warm
+
+    resolved = model_name or os.environ.get(
+        "CRG_EMBEDDING_MODEL", LOCAL_DEFAULT_MODEL
+    )
+    if resolved in _MODEL_CACHE:
+        return
+
+    try:
+        _MODEL_CACHE[resolved] = LocalEmbeddingProvider(resolved)._get_model()
+    except Exception as exc:  # pragma: no cover — best-effort startup hook
+        logger.warning("prewarm_local_embeddings(%s) skipped: %s", resolved, exc)
+
+
 class LocalEmbeddingProvider(EmbeddingProvider):
     def __init__(self, model_name: str | None = None) -> None:
         self._model_name = model_name or os.environ.get(
@@ -74,6 +118,12 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 
     def _get_model(self):
         if self._model is None:
+            # Check the process-wide cache first — populated either by a prior
+            # provider instance or by ``prewarm_local_embeddings`` at startup.
+            cached = _MODEL_CACHE.get(self._model_name)
+            if cached is not None:
+                self._model = cached
+                return self._model
             try:
                 from sentence_transformers import SentenceTransformer
                 # Check environment variable, default to False to prevent RCE
@@ -84,6 +134,7 @@ class LocalEmbeddingProvider(EmbeddingProvider):
                     self._model_name,
                     trust_remote_code=allow_remote_code,
                 )
+                _MODEL_CACHE[self._model_name] = self._model
             except ImportError:
                 raise ImportError(
                     "sentence-transformers not installed. "

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -704,6 +704,8 @@ def get_provider(
             return None
 
     # Default: local
+    if not _check_available():
+        return None
     try:
         return LocalEmbeddingProvider(model_name=model)
     except ImportError:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -366,7 +367,7 @@ class GraphStore:
         return [self._row_to_edge(r) for r in rows]
 
     def get_transitive_tests(
-        self, qualified_name: str, max_depth: int = 1,
+        self, qualified_name: str, max_depth: int = 1, max_frontier: int | None = None,
     ) -> list[dict]:
         """Find tests covering a node, including indirect (transitive) coverage.
 
@@ -375,7 +376,13 @@ class GraphStore:
            then collect TESTED_BY edges on each callee.
 
         Returns a list of dicts with node fields plus ``indirect: bool``.
+
+        ``max_frontier`` caps the CALLS fan-out per BFS hop to prevent O(N*M)
+        query explosion on hub functions in large graphs. Defaults to
+        ``CRG_MAX_TRANSITIVE_FRONTIER`` env var (50 if unset).
         """
+        if max_frontier is None:
+            max_frontier = int(os.environ.get("CRG_MAX_TRANSITIVE_FRONTIER", "50"))
         conn = self._conn
         seen: set[str] = set()
         results: list[dict] = []
@@ -447,6 +454,8 @@ class GraphStore:
                     (qn,),
                 ).fetchall():
                     next_frontier.add(row["target_qualified"])
+            if len(next_frontier) > max_frontier:
+                next_frontier = set(list(next_frontier)[:max_frontier])
             for callee in next_frontier:
                 for row in conn.execute(
                     "SELECT source_qualified FROM edges "

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -1032,6 +1032,15 @@ def main(
 
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        # Pre-warm sentence-transformers on the main thread before fastmcp's
+        # event loop starts. Lazy-loading ``torch`` + tokenizers inside an
+        # executor worker thread deadlocks ``semantic_search_nodes_tool`` on
+        # Windows stdio MCP (DLL init / OpenMP thread-pool registration grabs
+        # locks the loop needs). #385 added ``asyncio.to_thread`` to peer
+        # tools but cannot fix this case — the dangerous initialization has
+        # to happen on the main thread before any worker thread is spawned.
+        from .embeddings import prewarm_local_embeddings
+        prewarm_local_embeddings()
 
     try:
         if transport == "stdio":

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -598,12 +599,28 @@ async def detect_changes_tool(
         detail_level: "standard" for full output, "minimal" for
             token-efficient summary. Default: standard.
     """
-    return await asyncio.to_thread(
+    coro = asyncio.to_thread(
         detect_changes_func,
         base=base, changed_files=changed_files,
         include_source=include_source, max_depth=max_depth,
         repo_root=_resolve_repo_root(repo_root), detail_level=detail_level,
     )
+    tool_timeout = int(os.environ.get("CRG_TOOL_TIMEOUT", "0"))
+    if tool_timeout > 0:
+        try:
+            return await asyncio.wait_for(coro, timeout=tool_timeout)
+        except asyncio.TimeoutError:
+            message = (
+                f"detect_changes_tool timed out after {tool_timeout}s. "
+                "Reduce scope with CRG_MAX_CHANGED_FUNCS / CRG_MAX_TRANSITIVE_FRONTIER, "
+                "or increase CRG_TOOL_TIMEOUT."
+            )
+            return {
+                "status": "error",
+                "error": message,
+                "summary": message,
+            }
+    return await coro
 
 
 @mcp.tool()

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -549,6 +549,7 @@ def get_community_tool(
 @mcp.tool()
 def get_architecture_overview_tool(
     repo_root: Optional[str] = None,
+    detail_level: str = "minimal",
 ) -> dict:
     """Generate an architecture overview based on community structure.
 
@@ -558,8 +559,15 @@ def get_architecture_overview_tool(
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        detail_level: "minimal" (default) drops community member lists
+                      and aggregates cross-community edges to one row per
+                      community pair (typical reduction: 600KB -> <5KB);
+                      "standard" returns full per-edge detail.
     """
-    return get_architecture_overview_func(repo_root=_resolve_repo_root(repo_root))
+    return get_architecture_overview_func(
+        repo_root=_resolve_repo_root(repo_root),
+        detail_level=detail_level,
+    )
 
 
 @mcp.tool()

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -449,6 +449,10 @@ _TEST_RUNNER_NAMES = frozenset({
 _TEST_ANNOTATIONS = frozenset({
     "Test", "ParameterizedTest", "RepeatedTest", "TestFactory",
     "org.junit.Test", "org.junit.jupiter.api.Test",
+    # Rust: built-in `#[test]` plus common async-runtime + framework
+    # variants. Stripped of the `#[ ]` wrapper before lookup.
+    "test", "tokio::test", "async_std::test",
+    "rstest", "rstest::rstest", "proptest",
 })
 
 # Spring stereotype annotations that mark classes as managed beans
@@ -4341,6 +4345,23 @@ class CodeParser:
                 if sib.type == "decorator":
                     text = sib.text.decode("utf-8", errors="replace")
                     deco_list.append(text.lstrip("@").strip())
+        # Rust: attributes are preceding siblings of function_item, not
+        # children. Walk back through `attribute_item` nodes and strip the
+        # `#[ ]` (or `#![ ]`) wrapper.
+        if language == "rust":
+            sib = child.prev_sibling
+            while sib is not None and sib.type == "attribute_item":
+                text = sib.text.decode("utf-8", errors="replace").strip()
+                if text.startswith("#!["):
+                    inner = text[3:].rstrip()
+                elif text.startswith("#["):
+                    inner = text[2:].rstrip()
+                else:
+                    inner = text
+                if inner.endswith("]"):
+                    inner = inner[:-1]
+                deco_list.append(inner.strip())
+                sib = sib.prev_sibling
         if deco_list:
             decorators = tuple(deco_list)
 

--- a/code_review_graph/prompts.py
+++ b/code_review_graph/prompts.py
@@ -12,6 +12,8 @@ detail_level="minimal" first patterns with get_minimal_context entry point.
 
 from __future__ import annotations
 
+from fastmcp.prompts.prompt import Message
+
 _TOKEN_EFFICIENCY_PREAMBLE = (  # nosec B105 — prompt template, not a password
     """\
 ## Rules for Token-Efficient Graph Usage
@@ -29,143 +31,129 @@ expand on high-risk items.
 )
 
 
-def review_changes_prompt(base: str = "HEAD~1") -> list[dict]:
+def _user(content: str) -> list[Message]:
+    """Wrap content as a single-message user prompt.
+
+    fastmcp >=3.2 rejects raw dicts in prompt return values; each message
+    must be a ``Message`` instance (or a plain ``str``). We standardise on
+    ``Message`` so role is explicit and future multi-turn prompts compose
+    naturally.
+    """
+    return [Message(role="user", content=content)]
+
+
+def review_changes_prompt(base: str = "HEAD~1") -> list[Message]:
     """Pre-commit review workflow.
 
     Args:
         base: Git ref to diff against. Default: HEAD~1.
     """
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                f"## Review Workflow\n"
-                f'1. Call `get_minimal_context(task="review changes against '
-                f'{base}")` to get risk overview.\n'
-                f'2. If risk is "low": call '
-                f'`detect_changes(detail_level="minimal")` → report summary '
-                f"+ any test gaps.\n"
-                f'3. If risk is "medium" or "high":\n'
-                f'   a. Call `detect_changes(detail_level="standard")` for '
-                f"full change list.\n"
-                f"   b. For each high-risk function, call "
-                f'`query_graph(pattern="callers_of", target=<func>, '
-                f'detail_level="minimal")`.\n'
-                f'   c. Call `get_affected_flows(detail_level="minimal")` '
-                f"only if >3 changed functions.\n"
-                f"4. Summarize: risk level, what changed, test gaps, "
-                f"specific improvements needed.\n\n"
-                f"Do NOT call get_review_context unless you need source code "
-                f"snippets for a specific function."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        f"## Review Workflow\n"
+        f'1. Call `get_minimal_context(task="review changes against '
+        f'{base}")` to get risk overview.\n'
+        f'2. If risk is "low": call '
+        f'`detect_changes(detail_level="minimal")` → report summary '
+        f"+ any test gaps.\n"
+        f'3. If risk is "medium" or "high":\n'
+        f'   a. Call `detect_changes(detail_level="standard")` for '
+        f"full change list.\n"
+        f"   b. For each high-risk function, call "
+        f'`query_graph(pattern="callers_of", target=<func>, '
+        f'detail_level="minimal")`.\n'
+        f'   c. Call `get_affected_flows(detail_level="minimal")` '
+        f"only if >3 changed functions.\n"
+        f"4. Summarize: risk level, what changed, test gaps, "
+        f"specific improvements needed.\n\n"
+        f"Do NOT call get_review_context unless you need source code "
+        f"snippets for a specific function."
+    )
 
 
-def architecture_map_prompt() -> list[dict]:
+def architecture_map_prompt() -> list[Message]:
     """Architecture documentation workflow."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Architecture Mapping Workflow\n"
-                '1. Call `get_minimal_context(task="map architecture")`.\n'
-                '2. Call `get_architecture_overview(detail_level="minimal")` '
-                "for community coupling summary.\n"
-                '3. Call `list_flows(detail_level="minimal")` for critical '
-                "flow names + criticality scores.\n"
-                "4. Only call `get_community(name=<X>, "
-                'detail_level="standard")` for the 1-2 communities the user '
-                "is most interested in.\n"
-                "5. Produce a concise Mermaid diagram showing communities as "
-                "boxes and key flows as arrows."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Architecture Mapping Workflow\n"
+        '1. Call `get_minimal_context(task="map architecture")`.\n'
+        '2. Call `get_architecture_overview(detail_level="minimal")` '
+        "for community coupling summary.\n"
+        '3. Call `list_flows(detail_level="minimal")` for critical '
+        "flow names + criticality scores.\n"
+        "4. Only call `get_community(name=<X>, "
+        'detail_level="standard")` for the 1-2 communities the user '
+        "is most interested in.\n"
+        "5. Produce a concise Mermaid diagram showing communities as "
+        "boxes and key flows as arrows."
+    )
 
 
-def debug_issue_prompt(description: str = "") -> list[dict]:
+def debug_issue_prompt(description: str = "") -> list[Message]:
     """Guided debugging workflow.
 
     Args:
         description: Description of the issue to debug.
     """
     desc_part = description or "<description>"
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Debug Workflow\n"
-                f'1. Call `get_minimal_context(task="debug: '
-                f'{desc_part}")`.\n'
-                "2. Call `semantic_search_nodes(query=<keywords from "
-                'description>, detail_level="minimal", limit=5)`.\n'
-                "3. For the top 1-2 results, call "
-                '`query_graph(pattern="callers_of", target=<name>, '
-                'detail_level="minimal")`.\n'
-                "4. If the issue involves execution flow: call "
-                "`get_flow(name=<relevant flow>)` for the single most "
-                "relevant flow.\n"
-                "5. Only call `get_review_context` or `get_impact_radius` "
-                "if you need to trace the blast radius of a specific change."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Debug Workflow\n"
+        f'1. Call `get_minimal_context(task="debug: '
+        f'{desc_part}")`.\n'
+        "2. Call `semantic_search_nodes(query=<keywords from "
+        'description>, detail_level="minimal", limit=5)`.\n'
+        "3. For the top 1-2 results, call "
+        '`query_graph(pattern="callers_of", target=<name>, '
+        'detail_level="minimal")`.\n'
+        "4. If the issue involves execution flow: call "
+        "`get_flow(name=<relevant flow>)` for the single most "
+        "relevant flow.\n"
+        "5. Only call `get_review_context` or `get_impact_radius` "
+        "if you need to trace the blast radius of a specific change."
+    )
 
 
-def onboard_developer_prompt() -> list[dict]:
+def onboard_developer_prompt() -> list[Message]:
     """New developer orientation workflow."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Onboarding Workflow\n"
-                '1. Call `get_minimal_context(task="onboard developer")`.\n'
-                "2. Call `list_graph_stats()` for technology overview.\n"
-                '3. Call `get_architecture_overview(detail_level="minimal")` '
-                "for the 30-second mental model.\n"
-                '4. Call `list_communities(detail_level="minimal")` — '
-                "present as a table of module names + sizes.\n"
-                '5. Call `list_flows(detail_level="minimal")` — highlight '
-                "the top 3 critical flows.\n"
-                "6. Only drill into a specific community or flow if the "
-                "developer asks."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Onboarding Workflow\n"
+        '1. Call `get_minimal_context(task="onboard developer")`.\n'
+        "2. Call `list_graph_stats()` for technology overview.\n"
+        '3. Call `get_architecture_overview(detail_level="minimal")` '
+        "for the 30-second mental model.\n"
+        '4. Call `list_communities(detail_level="minimal")` — '
+        "present as a table of module names + sizes.\n"
+        '5. Call `list_flows(detail_level="minimal")` — highlight '
+        "the top 3 critical flows.\n"
+        "6. Only drill into a specific community or flow if the "
+        "developer asks."
+    )
 
 
-def pre_merge_check_prompt(base: str = "HEAD~1") -> list[dict]:
+def pre_merge_check_prompt(base: str = "HEAD~1") -> list[Message]:
     """PR readiness check workflow.
 
     Args:
         base: Git ref to diff against. Default: HEAD~1.
     """
-    return [
-        {
-            "role": "user",
-            "content": (
-                f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
-                "## Pre-Merge Check Workflow\n"
-                '1. Call `get_minimal_context(task="pre-merge check")`.\n'
-                '2. Call `detect_changes(detail_level="minimal")` for risk '
-                "score and test gaps.\n"
-                "3. If risk > 0.4: call "
-                '`get_affected_flows(detail_level="minimal")`.\n'
-                "4. If test_gap_count > 0: call "
-                '`query_graph(pattern="tests_for", '
-                'target=<each untested function>, detail_level="minimal")` '
-                "for up to 3 functions.\n"
-                '5. Call `refactor(mode="dead_code", '
-                'detail_level="minimal")` to check for newly dead code.\n'
-                "6. Only call `find_large_functions` or `get_impact_radius` "
-                "if risk > 0.7.\n"
-                "7. Output: GO/NO-GO recommendation with 1-sentence "
-                "justification + list of required follow-ups."
-            ),
-        }
-    ]
+    return _user(
+        f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
+        "## Pre-Merge Check Workflow\n"
+        '1. Call `get_minimal_context(task="pre-merge check")`.\n'
+        '2. Call `detect_changes(detail_level="minimal")` for risk '
+        "score and test gaps.\n"
+        "3. If risk > 0.4: call "
+        '`get_affected_flows(detail_level="minimal")`.\n'
+        "4. If test_gap_count > 0: call "
+        '`query_graph(pattern="tests_for", '
+        'target=<each untested function>, detail_level="minimal")` '
+        "for up to 3 functions.\n"
+        '5. Call `refactor(mode="dead_code", '
+        'detail_level="minimal")` to check for newly dead code.\n'
+        "6. Only call `find_large_functions` or `get_impact_radius` "
+        "if risk > 0.7.\n"
+        "7. Output: GO/NO-GO recommendation with 1-sentence "
+        "justification + list of required follow-ups."
+    )

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -15,7 +15,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from .flows import _has_framework_decorator, _matches_entry_name
 from .graph import GraphStore, _sanitize_name
@@ -241,6 +241,7 @@ def find_dead_code(
     store: GraphStore,
     kind: Optional[str] = None,
     file_pattern: Optional[str] = None,
+    root: Optional[Union[str, Path]] = None,
 ) -> list[dict[str, Any]]:
     """Find functions/classes with no callers, no test refs, no importers, and no references.
 
@@ -260,10 +261,11 @@ def find_dead_code(
         store: The GraphStore instance.
         kind: Optional filter (e.g. ``"Function"`` or ``"Class"``).
         file_pattern: Optional file-path substring filter.
+        root: Optional repo root path for computing ``relative_path``.
 
     Returns:
-        List of dead-code dicts with name, qualified_name, kind, file, line,
-        and a top-level ``caveats`` note.
+        List of dead-code dicts with name, qualified_name, kind, file_path,
+        relative_path, line, and language fields.
     """
     # Query candidate nodes.
     candidates = store.get_nodes_by_kind(
@@ -555,12 +557,22 @@ def find_dead_code(
                             break
 
             if not has_callers:
+                if root:
+                    try:
+                        rel = str(Path(node.file_path).relative_to(root))
+                    except ValueError:
+                        rel = node.file_path
+                else:
+                    rel = node.file_path
                 dead.append({
                     "name": _sanitize_name(node.name),
                     "qualified_name": _sanitize_name(node.qualified_name),
                     "kind": node.kind,
                     "file": node.file_path,
+                    "file_path": node.file_path,
+                    "relative_path": rel,
                     "line": node.line_start,
+                    "language": node.language,
                 })
 
     logger.info("find_dead_code: found %d dead symbols", len(dead))

--- a/code_review_graph/registry.py
+++ b/code_review_graph/registry.py
@@ -76,10 +76,10 @@ class Registry:
         resolved = Path(path).resolve()
         if not resolved.is_dir():
             raise ValueError(f"Path is not a directory: {resolved}")
-        if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
+        if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
             raise ValueError(
                 f"Path does not look like a repository "
-                f"(no .git or .code-review-graph): {resolved}"
+                f"(no .git, .svn, or .code-review-graph): {resolved}"
             )
 
         with self._lock:

--- a/code_review_graph/registry.py
+++ b/code_review_graph/registry.py
@@ -76,7 +76,12 @@ class Registry:
         resolved = Path(path).resolve()
         if not resolved.is_dir():
             raise ValueError(f"Path is not a directory: {resolved}")
-        if not (resolved / ".git").exists() and not (resolved / ".svn").exists() and not (resolved / ".code-review-graph").exists():
+        has_repo_marker = (
+            (resolved / ".git").exists()
+            or (resolved / ".svn").exists()
+            or (resolved / ".code-review-graph").exists()
+        )
+        if not has_repo_marker:
             raise ValueError(
                 f"Path does not look like a repository "
                 f"(no .git, .svn, or .code-review-graph): {resolved}"

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -560,6 +560,7 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 f" && code-review-graph update --skip-flows"
                                 f" --repo {repo_arg}"
@@ -577,6 +578,7 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 f" && code-review-graph status --repo {repo_arg}"
                                 " || echo 'Not a git repo, skipping'"
@@ -601,6 +603,7 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph update --skip-flows"
                                 " || true"
@@ -618,6 +621,7 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                         {
                             "type": "command",
                             "command": (
+                                "cat >/dev/null || true; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -61,19 +61,25 @@ _BUILTIN_CALL_NAMES: set[str] = {
 def _validate_repo_root(path: "Path | str") -> Path:
     """Validate that a path is a plausible project root.
 
-    Ensures the path is an existing directory that contains a ``.git``
-    or ``.code-review-graph`` directory, preventing arbitrary file-system
-    traversal via the ``repo_root`` parameter.
+    Ensures the path is an existing directory that contains a ``.git``,
+    ``.svn``, or ``.code-review-graph`` directory, preventing arbitrary
+    file-system traversal via the ``repo_root`` parameter.
     """
     resolved = Path(path).resolve()
     if not resolved.is_dir():
         raise ValueError(
             f"repo_root is not an existing directory: {resolved}"
         )
-    if not (resolved / ".git").exists() and not (resolved / ".code-review-graph").exists():
+    has_vcs = (
+        (resolved / ".git").exists()
+        or (resolved / ".svn").exists()
+        or (resolved / ".code-review-graph").exists()
+    )
+    if not has_vcs:
         raise ValueError(
-            f"repo_root does not look like a project root (no .git or "
-            f".code-review-graph directory found): {resolved}"
+            f"repo_root does not look like a project root "
+            f"(no .git, .svn, or .code-review-graph directory found): "
+            f"{resolved}"
         )
     return resolved
 

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -85,6 +85,52 @@ def _get_store(repo_root: str | None = None) -> tuple[GraphStore, Path]:
     return GraphStore(db_path), root
 
 
+def _resolve_graph_file_paths(
+    store: GraphStore, root: Path, file_paths: list[str],
+) -> list[str]:
+    """Resolve user-facing file paths to the paths stored in the graph.
+
+    Graphs may contain absolute paths, repo-relative paths, or cwd-relative
+    paths depending on how they were built. Tool inputs are usually relative to
+    repo root, so exact matching alone can miss existing graph nodes.
+    """
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        if path not in seen:
+            resolved.append(path)
+            seen.add(path)
+
+    for file_path in file_paths:
+        raw = file_path.replace("\\", "/")
+        candidates = [raw]
+        path = Path(file_path)
+        if path.is_absolute():
+            try:
+                candidates.append(str(path.resolve().relative_to(root)).replace("\\", "/"))
+            except ValueError:
+                pass
+        else:
+            candidates.append(str(root / path))
+
+        for candidate in candidates:
+            if store.get_nodes_by_file(candidate):
+                add(candidate)
+
+        suffixes = []
+        for candidate in candidates:
+            normalized = candidate.replace("\\", "/")
+            if normalized not in suffixes:
+                suffixes.append(normalized)
+
+        for suffix in suffixes:
+            for matched_path in store.get_files_matching(suffix):
+                add(matched_path)
+
+    return resolved
+
+
 def compact_response(
     summary: str,
     key_entities: list[str] | None = None,

--- a/code_review_graph/tools/community_tools.py
+++ b/code_review_graph/tools/community_tools.py
@@ -6,6 +6,7 @@ from collections import Counter
 from typing import Any
 
 from ..communities import get_architecture_overview, get_communities
+from ..context_savings import attach_context_savings
 from ..graph import node_to_dict
 from ..hints import generate_hints, get_session
 from ._common import _get_store
@@ -212,9 +213,10 @@ def get_architecture_overview_func(
     """
     store, root = _get_store(repo_root)
     try:
-        overview = get_architecture_overview(store)
+        full_overview = get_architecture_overview(store)
+        overview = full_overview
         if detail_level == "minimal":
-            overview = _minimal_overview(overview)
+            overview = _minimal_overview(full_overview)
         n_communities = len(overview["communities"])
         n_cross = len(overview["cross_community_edges"])
         n_warnings = len(overview["warnings"])
@@ -235,6 +237,8 @@ def get_architecture_overview_func(
         result["_hints"] = generate_hints(
             "get_architecture_overview", result, get_session()
         )
+        if detail_level == "minimal":
+            attach_context_savings(result, original_context=full_overview)
         return result
     except Exception as exc:
         return {"status": "error", "error": str(exc)}

--- a/code_review_graph/tools/community_tools.py
+++ b/code_review_graph/tools/community_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from ..communities import get_architecture_overview, get_communities
@@ -144,8 +145,52 @@ def get_community_func(
 # ---------------------------------------------------------------------------
 
 
+_MINIMAL_COMMUNITY_FIELDS = ("id", "name", "size", "cohesion", "dominant_language")
+
+
+def _minimal_overview(overview: dict[str, Any]) -> dict[str, Any]:
+    """Compress overview for ``detail_level="minimal"``.
+
+    The full overview can exceed 600KB on medium repos because it embeds
+    every community's member list and every individual cross-community
+    edge. Minimal mode drops member lists and aggregates the edge list
+    to one row per community pair with a count and the top edge kinds —
+    enough to spot coupling smells without exploding token budgets.
+    """
+    communities = [
+        {k: c[k] for k in _MINIMAL_COMMUNITY_FIELDS if k in c}
+        for c in overview.get("communities", [])
+    ]
+    id_to_name = {c["id"]: c["name"] for c in communities if "id" in c}
+
+    edge_pair_counts: Counter[tuple[int, int]] = Counter()
+    edge_pair_kinds: dict[tuple[int, int], Counter[str]] = {}
+    for e in overview.get("cross_community_edges", []):
+        # Use canonical (low, high) ordering so A↔B and B↔A aggregate together.
+        a, b = e["source_community"], e["target_community"]
+        pair = (a, b) if a <= b else (b, a)
+        edge_pair_counts[pair] += 1
+        edge_pair_kinds.setdefault(pair, Counter())[e["edge_kind"]] += 1
+
+    cross_pairs = [
+        {
+            "source_community": id_to_name.get(a, f"community-{a}"),
+            "target_community": id_to_name.get(b, f"community-{b}"),
+            "edge_count": count,
+            "top_kinds": [k for k, _ in edge_pair_kinds[(a, b)].most_common(3)],
+        }
+        for (a, b), count in edge_pair_counts.most_common()
+    ]
+    return {
+        "communities": communities,
+        "cross_community_edges": cross_pairs,
+        "warnings": overview.get("warnings", []),
+    }
+
+
 def get_architecture_overview_func(
     repo_root: str | None = None,
+    detail_level: str = "minimal",
 ) -> dict[str, Any]:
     """Generate an architecture overview based on community structure.
 
@@ -155,6 +200,11 @@ def get_architecture_overview_func(
 
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
+        detail_level: "minimal" (default) drops community member lists
+                      and aggregates edges to one row per community pair
+                      (typical reduction: 600KB -> <5KB);
+                      "standard" returns the full overview including
+                      per-edge cross-community detail.
 
     Returns:
         Architecture overview with communities, cross-community edges,
@@ -163,14 +213,21 @@ def get_architecture_overview_func(
     store, root = _get_store(repo_root)
     try:
         overview = get_architecture_overview(store)
+        if detail_level == "minimal":
+            overview = _minimal_overview(overview)
         n_communities = len(overview["communities"])
         n_cross = len(overview["cross_community_edges"])
         n_warnings = len(overview["warnings"])
+        cross_label = (
+            "community pairs"
+            if detail_level == "minimal"
+            else "cross-community edges"
+        )
         result = {
             "status": "ok",
             "summary": (
                 f"Architecture: {n_communities} communities, "
-                f"{n_cross} cross-community edges, "
+                f"{n_cross} {cross_label}, "
                 f"{n_warnings} warning(s)"
             ),
             **overview,

--- a/code_review_graph/tools/docs.py
+++ b/code_review_graph/tools/docs.py
@@ -109,15 +109,27 @@ def get_docs_section(
 
     search_roots: list[Path] = []
 
+    # Wheel install: docs are packaged inside code_review_graph/docs.
+    in_pkg_docs = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "LLM-OPTIMIZED-REFERENCE.md"
+    )
     if repo_root:
         try:
             search_roots.append(_validate_repo_root(Path(repo_root)))
         except ValueError:
             pass
-    else:
-        search_roots.append(find_project_root())
+    elif in_pkg_docs.exists():
+        in_pkg_root = in_pkg_docs.parent.parent
+        search_roots.append(in_pkg_root)
 
-    # Fallback: package directory (for uvx/pip installs)
+    if not repo_root:
+        project_root = find_project_root()
+        if project_root not in search_roots:
+            search_roots.append(project_root)
+
+    # Editable/source-tree fallback: docs live next to code_review_graph/.
     pkg_docs = (
         Path(__file__).parent.parent.parent
         / "docs"

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -216,29 +216,43 @@ def query_graph(
         qn = node.qualified_name if node else target
 
         if pattern == "callers_of":
+            seen_sources: set[str] = set()
             for e in store.get_edges_by_target(qn):
                 if e.kind == "CALLS":
-                    caller = store.get_node(e.source_qualified)
-                    if caller:
-                        results.append(node_to_dict(caller))
-                    edges_out.append(edge_to_dict(e))
+                    if e.source_qualified not in seen_sources:
+                        seen_sources.add(e.source_qualified)
+                        caller = store.get_node(e.source_qualified)
+                        if caller:
+                            results.append(node_to_dict(caller))
+                        edges_out.append(edge_to_dict(e))
             # Fallback: CALLS edges store unqualified target names
             # (e.g. "generateTestCode") while qn is fully qualified
             # (e.g. "file.ts::generateTestCode"). Search by plain name too.
-            if not results and node:
+            if node:
                 for e in store.search_edges_by_target_name(node.name):
-                    caller = store.get_node(e.source_qualified)
-                    if caller:
-                        results.append(node_to_dict(caller))
-                    edges_out.append(edge_to_dict(e))
+                    if e.source_qualified not in seen_sources:
+                        seen_sources.add(e.source_qualified)
+                        caller = store.get_node(e.source_qualified)
+                        if caller:
+                            results.append(node_to_dict(caller))
+                        edges_out.append(edge_to_dict(e))
 
         elif pattern == "callees_of":
+            seen_targets: set[str] = set()
             for e in store.get_edges_by_source(qn):
                 if e.kind == "CALLS":
-                    callee = store.get_node(e.target_qualified)
-                    if callee:
-                        results.append(node_to_dict(callee))
-                    edges_out.append(edge_to_dict(e))
+                    if e.target_qualified not in seen_targets:
+                        seen_targets.add(e.target_qualified)
+                        callee = store.get_node(e.target_qualified)
+                        if callee:
+                            results.append(node_to_dict(callee))
+                        elif "::" not in e.target_qualified:
+                            results.append({
+                                "kind": "Function",
+                                "name": e.target_qualified,
+                                "qualified_name": e.target_qualified,
+                            })
+                        edges_out.append(edge_to_dict(e))
 
         elif pattern == "imports_of":
             for e in store.get_edges_by_source(qn):

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..embeddings import EmbeddingStore
 from ..graph import _sanitize_name, edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
@@ -73,6 +74,7 @@ def get_impact_radius(
             }
 
         # Resolve user-facing paths to the file paths stored in the graph.
+        original_tokens = estimate_file_tokens(root, changed_files)
         abs_files = _resolve_graph_file_paths(store, root, changed_files)
         result = store.get_impact_radius(
             abs_files, max_depth=max_depth, max_nodes=max_results
@@ -107,7 +109,7 @@ def get_impact_radius(
             key_entities = [
                 n["name"] for n in impacted_dicts[:5]
             ]
-            return {
+            minimal_response = {
                 "status": "ok",
                 "summary": "\n".join(summary_parts),
                 "risk": risk,
@@ -115,8 +117,10 @@ def get_impact_radius(
                 "key_entities": key_entities,
                 "truncated": truncated,
             }
+            attach_context_savings(minimal_response, original_tokens=original_tokens)
+            return minimal_response
 
-        return {
+        response = {
             "status": "ok",
             "summary": "\n".join(summary_parts),
             "changed_files": changed_files,
@@ -127,6 +131,8 @@ def get_impact_radius(
             "truncated": truncated,
             "total_impacted": total_impacted,
         }
+        attach_context_savings(response, original_tokens=original_tokens)
+        return response
     finally:
         store.close()
 

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -11,7 +11,7 @@ from ..graph import _sanitize_name, edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_db_path, get_staged_and_unstaged
 from ..search import hybrid_search
-from ._common import _BUILTIN_CALL_NAMES, _get_store
+from ._common import _BUILTIN_CALL_NAMES, _get_store, _resolve_graph_file_paths
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +72,8 @@ def get_impact_radius(
                 "total_impacted": 0,
             }
 
-        # Convert to absolute paths for graph lookup
-        abs_files = [str(root / f) for f in changed_files]
+        # Resolve user-facing paths to the file paths stored in the graph.
+        abs_files = _resolve_graph_file_paths(store, root, changed_files)
         result = store.get_impact_radius(
             abs_files, max_depth=max_depth, max_nodes=max_results
         )
@@ -186,26 +186,29 @@ def query_graph(
                 "results": [], "edges": [],
             }
 
-        # Resolve target - try as-is, then as absolute path, then search
-        node = store.get_node(target)
-        if not node:
-            abs_target = str(root / target)
-            node = store.get_node(abs_target)
-        if not node:
-            # Search by name
-            candidates = store.search_nodes(target, limit=5)
-            if len(candidates) == 1:
-                node = candidates[0]
-                target = node.qualified_name
-            elif len(candidates) > 1:
-                return {
-                    "status": "ambiguous",
-                    "summary": (
-                        f"Multiple matches for '{target}'. "
-                        "Please use a qualified name."
-                    ),
-                    "candidates": [node_to_dict(c) for c in candidates],
-                }
+        # Resolve target - try as-is, then as absolute path, then search.
+        # file_summary targets are paths, so skip broad node search.
+        node = None
+        if pattern != "file_summary":
+            node = store.get_node(target)
+            if not node:
+                abs_target = str(root / target)
+                node = store.get_node(abs_target)
+            if not node:
+                # Search by name
+                candidates = store.search_nodes(target, limit=5)
+                if len(candidates) == 1:
+                    node = candidates[0]
+                    target = node.qualified_name
+                elif len(candidates) > 1:
+                    return {
+                        "status": "ambiguous",
+                        "summary": (
+                            f"Multiple matches for '{target}'. "
+                            "Please use a qualified name."
+                        ),
+                        "candidates": [node_to_dict(c) for c in candidates],
+                    }
 
         if not node and pattern != "file_summary":
             return {
@@ -317,10 +320,10 @@ def query_graph(
                         edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":
-            abs_path = str(root / target)
-            file_nodes = store.get_nodes_by_file(abs_path)
-            for n in file_nodes:
-                results.append(node_to_dict(n))
+            graph_paths = _resolve_graph_file_paths(store, root, [target])
+            for graph_path in graph_paths:
+                for n in store.get_nodes_by_file(graph_path):
+                    results.append(node_to_dict(n))
 
         summary = (
             f"Found {len(results)} result(s) "

--- a/code_review_graph/tools/refactor_tools.py
+++ b/code_review_graph/tools/refactor_tools.py
@@ -90,7 +90,7 @@ def refactor_func(
 
         elif mode == "dead_code":
             dead = find_dead_code(
-                store, kind=kind, file_pattern=file_pattern
+                store, kind=kind, file_pattern=file_pattern, root=root
             )
             result = {
                 "status": "ok",

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from ..changes import analyze_changes, parse_diff_ranges, parse_git_diff_ranges  # noqa: F401
+from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
@@ -66,6 +67,7 @@ def get_review_context(
             }
 
         graph_files = _resolve_graph_file_paths(store, root, changed_files)
+        original_tokens = estimate_file_tokens(root, changed_files)
         impact = store.get_impact_radius(graph_files, max_depth=max_depth)
 
         if detail_level == "minimal":
@@ -102,7 +104,7 @@ def get_review_context(
                 f" in {len(impact['impacted_files'])} files",
             ]
 
-            return {
+            result = {
                 "status": "ok",
                 "summary": "\n".join(summary_parts),
                 "risk": risk,
@@ -116,6 +118,8 @@ def get_review_context(
                     "get_impact_radius",
                 ],
             }
+            attach_context_savings(result, original_tokens=original_tokens)
+            return result
 
         # Build review context
         context: dict[str, Any] = {
@@ -173,11 +177,13 @@ def get_review_context(
             guidance,
         ]
 
-        return {
+        result = {
             "status": "ok",
             "summary": "\n".join(summary_parts),
             "context": context,
         }
+        attach_context_savings(result, original_tokens=original_tokens)
+        return result
     finally:
         store.close()
 
@@ -397,6 +403,8 @@ def detect_changes_func(
                 "review_priorities": [],
             }
 
+        original_tokens = estimate_file_tokens(root, changed_files)
+
         # Convert to absolute paths for graph lookup.
         abs_files = [str(root / f) for f in changed_files]
 
@@ -461,6 +469,7 @@ def detect_changes_func(
         result["_hints"] = generate_hints(
             "detect_changes", result, get_session()
         )
+        attach_context_savings(result, original_tokens=original_tokens)
         return result
     except Exception as exc:
         return {"status": "error", "error": str(exc)}

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -11,7 +11,7 @@ from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_staged_and_unstaged
-from ._common import _get_store
+from ._common import _get_store, _resolve_graph_file_paths
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +65,8 @@ def get_review_context(
                 "context": {},
             }
 
-        abs_files = [str(root / f) for f in changed_files]
-        impact = store.get_impact_radius(abs_files, max_depth=max_depth)
+        graph_files = _resolve_graph_file_paths(store, root, changed_files)
+        impact = store.get_impact_radius(graph_files, max_depth=max_depth)
 
         if detail_level == "minimal":
             impacted_count = len(impact["impacted_nodes"])

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,7 +19,7 @@ Review a PR or branch diff.
 - Full impact analysis across all PR commits
 - Structured output with risk assessment
 
-## MCP Tools (22 total)
+## MCP Tools
 
 ### Core Tools
 
@@ -37,6 +37,7 @@ max_depth: int = 2               # Hops in graph
 repo_root: str | None
 base: str = "HEAD~1"
 ```
+Relevant responses may include compact estimated `context_savings` metadata.
 
 #### `query_graph_tool`
 ```
@@ -55,6 +56,7 @@ max_lines_per_file: int = 200
 repo_root: str | None
 base: str = "HEAD~1"
 ```
+Relevant responses may include compact estimated `context_savings` metadata.
 
 #### `semantic_search_nodes_tool`
 ```
@@ -136,7 +138,9 @@ repo_root: str | None
 #### `get_architecture_overview_tool`
 ```
 repo_root: str | None
+detail_level: str = "minimal"    # "minimal" compact default, "standard" full detail
 ```
+Minimal responses may include compact estimated `context_savings` metadata.
 
 ### Change Analysis and Refactoring Tools
 
@@ -149,6 +153,7 @@ max_depth: int = 2
 repo_root: str | None
 ```
 Primary tool for code review. Maps git diffs to affected functions, flows, communities, and test coverage gaps. Returns risk scores and prioritized review items.
+Relevant responses may include compact estimated `context_savings` metadata.
 
 #### `refactor_tool`
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,19 +1,16 @@
 # Features
 
-## v2.2.1 (Current)
-- **24 MCP tools** (up from 22): Added `get_minimal_context` and `run_postprocess`.
-- **Parallel parsing**: `ProcessPoolExecutor` for 3-5x faster builds on large repos.
-- **Lazy post-processing**: `postprocess="full"|"minimal"|"none"` to skip expensive steps.
-- **SQLite-native BFS**: Recursive CTE replaces NetworkX for impact analysis (faster on large graphs).
-- **Token-efficient output**: `detail_level="minimal"` on 8 tools for 40-60% token reduction.
-- **`get_minimal_context`**: Ultra-compact entry point (~100 tokens) with task-based tool routing.
-- **Incremental flow/community updates**: Only re-trace affected flows, skip community re-detection when unaffected.
-- **Visualization aggregation**: Community/file/auto modes with drill-down for 5k+ node graphs.
-- **Token-efficiency benchmarks**: 5 workflow benchmarks in eval framework.
-- **Pre-computed summary tables**: DB schema v6 with `community_summaries`, `flow_snapshots`, `risk_index`.
-- **Configurable limits**: `CRG_MAX_IMPACT_NODES`, `CRG_MAX_IMPACT_DEPTH`, `CRG_DEPENDENT_HOPS`, etc.
-- **Multi-hop dependents**: N-hop dependent discovery (default 2) with 500-file cap.
-- **615 tests** across 22 test files.
+## v2.3.4 (Current)
+- **Estimated context savings**: Review, impact, detect-changes, and compact architecture responses include tiny `context_savings` metadata (`estimated`, `saved_tokens`, `saved_percent`) where a baseline can be estimated.
+- **Compact architecture overview by default**: `get_architecture_overview_tool` defaults to `detail_level="minimal"` to avoid huge member lists and per-edge payloads. Use `detail_level="standard"` for full detail.
+- **Bounded change analysis**: `CRG_MAX_CHANGED_FUNCS`, `CRG_MAX_TRANSITIVE_FRONTIER`, and `CRG_TOOL_TIMEOUT` help keep large MCP review calls responsive.
+- **Windows MCP reliability**: Local embedding models are pre-warmed on Windows before FastMCP starts worker dispatch to avoid semantic-search deadlocks.
+- **Parser correctness**: Rust `#[test]` and common async test attributes now produce `Test` nodes.
+- **Graph lookup correctness**: Review, impact, and file-summary tools resolve user-facing paths to stored graph paths; `callers_of` includes cross-file callers even when same-file callers exist.
+- **Install/runtime reliability**: Generated Codex/Claude hooks drain stdin, bundled docs are available from wheels, missing local embeddings report unavailable status, and `.svn` roots pass validation.
+- **CLI reliability**: `build --skip-postprocess` and `update --skip-flows` honor the requested post-processing level.
+- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Jupyter/Databricks notebooks, and Perl XS files.
+- **Local-first by design**: SQLite graph storage remains local, with no telemetry and no cloud-default behavior.
 
 ## v2.1.0
 - **22 MCP tools** (up from 9): 13 new tools for flows, communities, architecture, refactoring, wiki, multi-repo, and risk-scored change detection.

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -1,4 +1,4 @@
-# LLM-OPTIMIZED REFERENCE -- code-review-graph v2.2.1
+# LLM-OPTIMIZED REFERENCE -- code-review-graph v2.3.4
 
 Claude Code: Read ONLY the exact `<section>` you need. Never load the whole file.
 
@@ -9,6 +9,7 @@ First run: /code-review-graph:build-graph
 After that use only delta/pr commands.
 ALWAYS start with get_minimal_context_tool(task="your task") — returns ~100 tokens with risk, communities, flows, and suggested next tools.
 Use detail_level="minimal" on all subsequent calls unless you need more detail.
+When present, context_savings is an estimated compact hint, not exact tokenization.
 </section>
 
 <section name="review-delta">
@@ -24,11 +25,11 @@ Never include full files unless explicitly asked.
 </section>
 
 <section name="commands">
-MCP tools (24): get_minimal_context_tool, build_or_update_graph_tool, run_postprocess_tool, get_impact_radius_tool, query_graph_tool, get_review_context_tool, semantic_search_nodes_tool, embed_graph_tool, list_graph_stats_tool, get_docs_section_tool, find_large_functions_tool, list_flows_tool, get_flow_tool, get_affected_flows_tool, list_communities_tool, get_community_tool, get_architecture_overview_tool, detect_changes_tool, refactor_tool, apply_refactor_tool, generate_wiki_tool, get_wiki_page_tool, list_repos_tool, cross_repo_search_tool
+Core MCP tools: get_minimal_context_tool, detect_changes_tool, get_review_context_tool, get_impact_radius_tool, query_graph_tool, semantic_search_nodes_tool, get_architecture_overview_tool, get_affected_flows_tool, list_flows_tool, list_communities_tool, refactor_tool, build_or_update_graph_tool, run_postprocess_tool, embed_graph_tool, list_graph_stats_tool, get_docs_section_tool
 MCP prompts (5): review_changes, architecture_map, debug_issue, onboard_developer, pre_merge_check
 Skills: build-graph, review-delta, review-pr
 CLI: code-review-graph [install|init|build|update|status|watch|visualize|serve|wiki|detect-changes|postprocess|register|unregister|repos|eval]
-Token efficiency: All tools support detail_level="minimal" for compact output. Always call get_minimal_context_tool first.
+Token efficiency: Prefer detail_level="minimal" where available. Always call get_minimal_context_tool first. Some review/context tools return compact estimated context_savings metadata.
 </section>
 
 <section name="legal">
@@ -49,7 +50,7 @@ Configure via CRG_EMBEDDING_MODEL env var or model parameter.
 </section>
 
 <section name="languages">
-Supported (19): Python, TypeScript/TSX, JavaScript, Vue, Go, Rust, Java, Scala, C#, Ruby, Kotlin, Swift, PHP, Solidity, C/C++, Dart, R, Perl, Lua
+Supported: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Jupyter/Databricks notebooks, and Perl XS files.
 Parser: Tree-sitter via tree-sitter-language-pack
 </section>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["code_review_graph"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"docs/LLM-OPTIMIZED-REFERENCE.md" = "code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md"
+
 [tool.hatch.build.targets.sdist]
 include = [
     "code_review_graph/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.3.3"
+version = "2.3.4"
 description = "Persistent incremental knowledge graph for token-efficient, context-aware code reviews with Claude Code"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,4 +135,5 @@ norecursedirs = ["tests/fixtures"]
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "pytest-asyncio>=0.23,<1",
 ]

--- a/tests/fixtures/sample_rust.rs
+++ b/tests/fixtures/sample_rust.rs
@@ -44,3 +44,26 @@ pub fn create_user(repo: &mut impl Repository, name: &str, email: &str) -> User 
     repo.save(user.clone());
     user
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_repo_is_empty() {
+        let repo = InMemoryRepo::new();
+        assert!(repo.find_by_id(1).is_none());
+    }
+
+    #[test]
+    fn create_user_saves_to_repo() {
+        let mut repo = InMemoryRepo::new();
+        let user = create_user(&mut repo, "alice", "a@b.c");
+        assert_eq!(user.name, "alice");
+    }
+
+    #[tokio::test]
+    async fn async_test_is_detected() {
+        assert!(true);
+    }
+}

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -473,3 +473,45 @@ class TestChanges:
             assert "risk_score" in result
             assert "test_gaps" in result
             assert "review_priorities" in result
+
+
+class TestAnalyzeChangesFunctionCap:
+    """Regression tests for O(N) slowdown when PR touches many functions."""
+
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.store = GraphStore(self.tmp.name)
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _add_funcs(self, count: int, path: str = "app.py") -> None:
+        for i in range(count):
+            node = NodeInfo(
+                kind="Function", name=f"func_{i}", file_path=path,
+                line_start=i * 10 + 1, line_end=i * 10 + 9, language="python",
+            )
+            self.store.upsert_node(node, file_hash="abc")
+        self.store.commit()
+
+    def test_changed_funcs_capped(self, monkeypatch):
+        """analyze_changes processes at most CRG_MAX_CHANGED_FUNCS functions."""
+        monkeypatch.setenv("CRG_MAX_CHANGED_FUNCS", "10")
+        self._add_funcs(20)
+
+        result = analyze_changes(self.store, changed_files=["app.py"])
+
+        assert len(result["changed_functions"]) == 10
+        assert result["functions_truncated"] is True
+        assert "CRG_MAX_CHANGED_FUNCS" in result["summary"]
+
+    def test_no_truncation_below_cap(self, monkeypatch):
+        """analyze_changes processes all functions when count is below cap."""
+        monkeypatch.setenv("CRG_MAX_CHANGED_FUNCS", "50")
+        self._add_funcs(5)
+
+        result = analyze_changes(self.store, changed_files=["app.py"])
+
+        assert len(result["changed_functions"]) == 5
+        assert result["functions_truncated"] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,78 @@ class TestWatchInteraction:
                             assert False, "Expected SystemExit"
                         except SystemExit as exc:
                             assert exc.code == 1
+
+
+class TestBuildUpdateCommands:
+    def test_build_skip_postprocess_does_not_run_extra_cli_postprocess(self):
+        argv = [
+            "code-review-graph",
+            "build",
+            "--skip-postprocess",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_parsed": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "none",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ) as mock_postprocess:
+                            cli.main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=True,
+            repo_root="repo-root",
+            postprocess="none",
+        )
+        mock_postprocess.assert_not_called()
+
+    def test_update_skip_flows_does_not_run_extra_cli_postprocess(self):
+        argv = [
+            "code-review-graph",
+            "update",
+            "--skip-flows",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_updated": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "minimal",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ) as mock_postprocess:
+                            cli.main()
+
+        mock_build.assert_called_once_with(
+            full_rebuild=False,
+            repo_root="repo-root",
+            base="HEAD~1",
+            postprocess="minimal",
+        )
+        mock_postprocess.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI helpers and MCP serve command wiring."""
 
+import json
 import logging
 import sys
 from importlib.metadata import PackageNotFoundError
@@ -147,3 +148,71 @@ class TestBuildUpdateCommands:
             postprocess="minimal",
         )
         mock_postprocess.assert_not_called()
+
+
+class TestDetectChangesCommand:
+    def test_brief_output_includes_one_estimated_savings_line(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "app.py").write_text("x" * 2000, encoding="utf-8")
+        argv = [
+            "code-review-graph",
+            "detect-changes",
+            "--repo",
+            str(repo),
+            "--brief",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.incremental.get_changed_files",
+                        return_value=["app.py"],
+                    ):
+                        with patch(
+                            "code_review_graph.changes.analyze_changes",
+                            return_value={"summary": "summary only"},
+                        ):
+                            cli.main()
+
+        output = capsys.readouterr().out
+        assert "summary only" in output
+        assert output.count("Estimated context saved:") == 1
+
+    def test_json_output_includes_compact_savings_metadata(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "app.py").write_text("x" * 2000, encoding="utf-8")
+        argv = [
+            "code-review-graph",
+            "detect-changes",
+            "--repo",
+            str(repo),
+        ]
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.incremental.get_changed_files",
+                        return_value=["app.py"],
+                    ):
+                        with patch(
+                            "code_review_graph.changes.analyze_changes",
+                            return_value={"summary": "json summary"},
+                        ):
+                            cli.main()
+
+        result = json.loads(capsys.readouterr().out)
+        assert set(result["context_savings"]) == {
+            "estimated",
+            "saved_tokens",
+            "saved_percent",
+        }

--- a/tests/test_context_savings.py
+++ b/tests/test_context_savings.py
@@ -1,0 +1,64 @@
+"""Tests for compact estimated context savings metadata."""
+
+from __future__ import annotations
+
+import json
+
+from code_review_graph.context_savings import (
+    estimate_context_savings,
+    estimate_file_tokens,
+    estimate_tokens,
+    format_context_savings,
+)
+
+
+def test_estimate_tokens_uses_conservative_character_approximation():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens("abcde") == 2
+
+
+def test_estimate_context_savings_returns_tiny_metadata():
+    estimate = estimate_context_savings(
+        original_tokens=100,
+        returned_context="x" * 80,
+    )
+
+    assert estimate == {
+        "estimated": True,
+        "saved_tokens": 80,
+        "saved_percent": 80,
+    }
+    assert len(json.dumps(estimate, separators=(",", ":"))) < 64
+
+
+def test_estimate_context_savings_never_reports_negative_savings():
+    estimate = estimate_context_savings(
+        original_tokens=10,
+        returned_context="x" * 200,
+    )
+
+    assert estimate == {
+        "estimated": True,
+        "saved_tokens": 0,
+        "saved_percent": 0,
+    }
+
+
+def test_estimate_context_savings_unknown_original_returns_none():
+    assert estimate_context_savings(original_tokens=0, returned_context="x") is None
+
+
+def test_estimate_file_tokens_uses_file_sizes_without_reading_contents(tmp_path):
+    source = tmp_path / "source.py"
+    source.write_text("x" * 17, encoding="utf-8")
+
+    assert estimate_file_tokens(tmp_path, ["source.py", "missing.py"]) == 5
+
+
+def test_format_context_savings_is_one_short_line():
+    text = format_context_savings(
+        {"estimated": True, "saved_tokens": 1240, "saved_percent": 18}
+    )
+
+    assert text == "Estimated context saved: ~1,240 tokens (~18%)"

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -173,16 +173,33 @@ class TestGetProviderModel:
     """Tests for model parameter in get_provider()."""
 
     @patch("code_review_graph.embeddings.LocalEmbeddingProvider")
-    def test_local_passes_model(self, mock_cls):
+    @patch("code_review_graph.embeddings._check_available", return_value=True)
+    def test_local_passes_model(self, _mock_available, mock_cls):
         mock_cls.return_value = MagicMock()
         get_provider(provider=None, model="custom/model")
         mock_cls.assert_called_once_with(model_name="custom/model")
 
     @patch("code_review_graph.embeddings.LocalEmbeddingProvider")
-    def test_local_default_passes_none(self, mock_cls):
+    @patch("code_review_graph.embeddings._check_available", return_value=True)
+    def test_local_default_passes_none(self, _mock_available, mock_cls):
         mock_cls.return_value = MagicMock()
         get_provider(provider=None, model=None)
         mock_cls.assert_called_once_with(model_name=None)
+
+    @patch("code_review_graph.embeddings._check_available", return_value=False)
+    def test_local_unavailable_returns_none(self, _mock_available):
+        assert get_provider("local") is None
+
+    @patch("code_review_graph.embeddings._check_available", return_value=False)
+    def test_embedding_store_unavailable_without_local_dependency(
+        self, _mock_available, tmp_path,
+    ):
+        db = tmp_path / "embeddings.db"
+        store = EmbeddingStore(db, provider="local")
+        try:
+            assert store.available is False
+        finally:
+            store.close()
 
 
 class TestCloudProviderWarning:
@@ -237,8 +254,9 @@ class TestCloudProviderWarning:
         with patch(
             "code_review_graph.embeddings.LocalEmbeddingProvider",
         ) as mock_cls:
-            mock_cls.return_value = MagicMock()
-            get_provider(provider=None)
+            with patch("code_review_graph.embeddings._check_available", return_value=True):
+                mock_cls.return_value = MagicMock()
+                get_provider(provider=None)
         captured = capsys.readouterr()
         assert "cloud" not in captured.err.lower()
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -318,3 +318,77 @@ class TestImpactRadiusSql:
         assert result["changed_nodes"] == []
         assert result["impacted_nodes"] == []
         assert result["total_impacted"] == 0
+
+
+class TestGetTransitiveTestsFrontierCap:
+    """Regression tests for O(N*M) query explosion in get_transitive_tests."""
+
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.store = GraphStore(self.tmp.name)
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _add_func(self, name: str, path: str) -> str:
+        node = NodeInfo(
+            kind="Function", name=name, file_path=path,
+            line_start=1, line_end=5, language="python",
+        )
+        self.store.upsert_node(node)
+        return f"{path}::{name}"
+
+    def _add_calls_edge(self, source_qn: str, target_qn: str) -> None:
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source=source_qn, target=target_qn,
+            file_path=source_qn.split("::")[0], line=1,
+        ))
+
+    def test_frontier_capped_limits_sql_queries(self):
+        """Hub function with 200 callees must not issue 200 TESTED_BY queries."""
+        hub_qn = self._add_func("hub", "/t/hub.py")
+        for i in range(200):
+            callee_qn = self._add_func(f"callee_{i}", "/t/callee.py")
+            self._add_calls_edge(hub_qn, callee_qn)
+        self.store.commit()
+
+        query_count = 0
+
+        def _trace(stmt: str) -> None:
+            nonlocal query_count
+            query_count += 1
+
+        self.store._conn.set_trace_callback(_trace)
+        self.store.get_transitive_tests(hub_qn, max_frontier=50)
+        self.store._conn.set_trace_callback(None)
+
+        # Without cap: 200 callee TESTED_BY queries + overhead = ~204
+        # With cap of 50: ~54 queries max
+        assert query_count <= 60, (
+            f"Expected <=60 queries with frontier cap, got {query_count}"
+        )
+
+    def test_uncapped_small_frontier_unchanged(self):
+        """Small fan-out (< cap) returns same results regardless of cap."""
+        hub_qn = self._add_func("hub", "/t/hub.py")
+        test_qn = self._add_func("test_hub", "/t/test_hub.py")
+        for i in range(5):
+            callee_qn = self._add_func(f"callee_{i}", "/t/callee.py")
+            self._add_calls_edge(hub_qn, callee_qn)
+            # Only callee_2 has a test
+            if i == 2:
+                self.store.upsert_edge(EdgeInfo(
+                    kind="TESTED_BY", source=test_qn, target=callee_qn,
+                    file_path="/t/test_hub.py", line=1,
+                ))
+        self.store.commit()
+
+        results_default = self.store.get_transitive_tests(hub_qn)
+        results_capped = self.store.get_transitive_tests(hub_qn, max_frontier=50)
+
+        indirect_default = [r for r in results_default if r["indirect"]]
+        indirect_capped = [r for r in results_capped if r["indirect"]]
+        assert len(indirect_default) == 1
+        assert len(indirect_capped) == 1
+        assert indirect_default[0]["name"] == indirect_capped[0]["name"]

--- a/tests/test_integration_v2.py
+++ b/tests/test_integration_v2.py
@@ -326,8 +326,8 @@ class TestV2Integration:
         prompt_messages = review_changes_prompt(base="HEAD~1")
         assert isinstance(prompt_messages, list)
         assert len(prompt_messages) > 0
-        assert prompt_messages[0]["role"] == "user"
-        assert "detect_changes" in prompt_messages[0]["content"]
+        assert prompt_messages[0].role == "user"
+        assert "detect_changes" in prompt_messages[0].content.text
 
         # ---- Step 10: generate_wiki ----
         with tempfile.TemporaryDirectory() as wiki_dir:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,6 +168,26 @@ class TestLongRunningToolsAreAsync:
                 f"See #46, #136."
             )
 
+    @pytest.mark.asyncio
+    async def test_detect_changes_timeout_uses_error_response_shape(
+        self, monkeypatch
+    ):
+        async def fake_wait_for(coro, timeout):
+            coro.close()
+            raise asyncio.TimeoutError
+
+        monkeypatch.setenv("CRG_TOOL_TIMEOUT", "1")
+        monkeypatch.setattr(crg_main.asyncio, "wait_for", fake_wait_for)
+
+        tool = getattr(crg_main.detect_changes_tool, "fn", None)
+        underlying = tool or crg_main.detect_changes_tool
+
+        result = await underlying()
+
+        assert result["status"] == "error"
+        assert "timed out after 1s" in result["error"]
+        assert result["summary"] == result["error"]
+
     def test_regression_guard_does_not_depend_on_fastmcp_internals(self):
         """Regression guard for #239 bug 3: ensure the async guards above
         resolve heavy tools by module attribute lookup, NOT through a
@@ -307,4 +327,3 @@ class TestApplyToolFilter:
         crg_main._apply_tool_filter(" query_graph_tool , semantic_search_nodes_tool ")
         remaining = await self._tool_names()
         assert remaining == {"query_graph_tool", "semantic_search_nodes_tool"}
-

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -113,6 +113,26 @@ class TestRustParsing:
         calls = [e for e in self.edges if e.kind == "CALLS"]
         assert len(calls) >= 3
 
+    def test_detects_test_attribute(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        names = {t.name for t in tests}
+        assert "new_repo_is_empty" in names
+        assert "create_user_saves_to_repo" in names
+        assert all(t.is_test for t in tests)
+
+    def test_detects_tokio_test_attribute(self):
+        tests = {n.name for n in self.nodes if n.kind == "Test"}
+        assert "async_test_is_detected" in tests
+
+    def test_non_test_functions_not_misclassified(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "create_user" in funcs
+        assert "new" in funcs
+        # `create_user` carries no `#[test]` — must stay Function.
+        for n in self.nodes:
+            if n.name == "create_user":
+                assert not n.is_test
+
 
 class TestJavaParsing:
     def setup_method(self):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,5 +1,7 @@
 """Tests for MCP prompt templates."""
 
+from fastmcp.prompts.prompt import Message
+
 from code_review_graph.prompts import (
     architecture_map_prompt,
     debug_issue_prompt,
@@ -7,6 +9,11 @@ from code_review_graph.prompts import (
     pre_merge_check_prompt,
     review_changes_prompt,
 )
+
+
+def _text(msg: Message) -> str:
+    """Extract the text content from a fastmcp Message."""
+    return msg.content.text
 
 
 class TestReviewChangesPrompt:
@@ -18,29 +25,29 @@ class TestReviewChangesPrompt:
     def test_message_has_role_and_content(self):
         result = review_changes_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_default_base(self):
         result = review_changes_prompt()
-        assert "HEAD~1" in result[0]["content"]
+        assert "HEAD~1" in _text(result[0])
 
     def test_custom_base(self):
         result = review_changes_prompt(base="main")
-        assert "main" in result[0]["content"]
+        assert "main" in _text(result[0])
 
     def test_mentions_detect_changes(self):
         result = review_changes_prompt()
-        assert "detect_changes" in result[0]["content"]
+        assert "detect_changes" in _text(result[0])
 
     def test_mentions_affected_flows(self):
         result = review_changes_prompt()
-        assert "affected_flows" in result[0]["content"]
+        assert "affected_flows" in _text(result[0])
 
     def test_mentions_test_gaps(self):
         result = review_changes_prompt()
-        assert "test" in result[0]["content"].lower()
+        assert "test" in _text(result[0]).lower()
 
 
 class TestArchitectureMapPrompt:
@@ -52,17 +59,17 @@ class TestArchitectureMapPrompt:
     def test_message_has_role_and_content(self):
         result = architecture_map_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_mentions_communities(self):
         result = architecture_map_prompt()
-        assert "communities" in result[0]["content"].lower()
+        assert "communities" in _text(result[0]).lower()
 
     def test_mentions_mermaid(self):
         result = architecture_map_prompt()
-        assert "Mermaid" in result[0]["content"]
+        assert "Mermaid" in _text(result[0])
 
 
 class TestDebugIssuePrompt:
@@ -74,26 +81,26 @@ class TestDebugIssuePrompt:
     def test_message_has_role_and_content(self):
         result = debug_issue_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_includes_description(self):
         result = debug_issue_prompt(description="login fails with 500 error")
-        assert "login fails with 500 error" in result[0]["content"]
+        assert "login fails with 500 error" in _text(result[0])
 
     def test_empty_description(self):
         result = debug_issue_prompt()
-        content = result[0]["content"]
+        content = _text(result[0])
         assert "debug" in content.lower()
 
     def test_mentions_search(self):
         result = debug_issue_prompt(description="test issue")
-        assert "semantic_search_nodes" in result[0]["content"]
+        assert "semantic_search_nodes" in _text(result[0])
 
     def test_mentions_get_minimal_context(self):
         result = debug_issue_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
 
 class TestOnboardDeveloperPrompt:
@@ -105,21 +112,21 @@ class TestOnboardDeveloperPrompt:
     def test_message_has_role_and_content(self):
         result = onboard_developer_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_mentions_stats(self):
         result = onboard_developer_prompt()
-        assert "list_graph_stats" in result[0]["content"]
+        assert "list_graph_stats" in _text(result[0])
 
     def test_mentions_architecture(self):
         result = onboard_developer_prompt()
-        assert "architecture" in result[0]["content"].lower()
+        assert "architecture" in _text(result[0]).lower()
 
     def test_mentions_critical_flows(self):
         result = onboard_developer_prompt()
-        assert "critical" in result[0]["content"].lower()
+        assert "critical" in _text(result[0]).lower()
 
 
 class TestPreMergeCheckPrompt:
@@ -131,14 +138,14 @@ class TestPreMergeCheckPrompt:
     def test_message_has_role_and_content(self):
         result = pre_merge_check_prompt()
         for msg in result:
-            assert "role" in msg
-            assert "content" in msg
-            assert msg["role"] == "user"
+            assert isinstance(msg, Message)
+            assert msg.role == "user"
+            assert _text(msg)
 
     def test_default_base(self):
         result = pre_merge_check_prompt()
         # The pre-merge prompt is now generic (doesn't embed the base ref)
-        assert "pre-merge" in result[0]["content"].lower()
+        assert "pre-merge" in _text(result[0]).lower()
 
     def test_custom_base(self):
         # pre_merge_check_prompt still accepts base but the workflow
@@ -149,15 +156,15 @@ class TestPreMergeCheckPrompt:
 
     def test_mentions_risk_scoring(self):
         result = pre_merge_check_prompt()
-        assert "risk" in result[0]["content"].lower()
+        assert "risk" in _text(result[0]).lower()
 
     def test_mentions_test_gaps(self):
         result = pre_merge_check_prompt()
-        assert "tests_for" in result[0]["content"]
+        assert "tests_for" in _text(result[0])
 
     def test_mentions_dead_code(self):
         result = pre_merge_check_prompt()
-        assert "dead_code" in result[0]["content"]
+        assert "dead_code" in _text(result[0])
 
 
 class TestTokenEfficiencyPreamble:
@@ -165,21 +172,21 @@ class TestTokenEfficiencyPreamble:
 
     def test_review_has_preamble(self):
         result = review_changes_prompt()
-        assert "get_minimal_context" in result[0]["content"]
-        assert "detail_level" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
+        assert "detail_level" in _text(result[0])
 
     def test_architecture_has_preamble(self):
         result = architecture_map_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_debug_has_preamble(self):
         result = debug_issue_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_onboard_has_preamble(self):
         result = onboard_developer_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])
 
     def test_pre_merge_has_preamble(self):
         result = pre_merge_check_prompt()
-        assert "get_minimal_context" in result[0]["content"]
+        assert "get_minimal_context" in _text(result[0])

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -162,6 +162,22 @@ class TestFindDeadCode:
         dead_names = {d["name"] for d in dead}
         assert "dead_func" in dead_names
 
+    def test_find_dead_code_response_fields(self):
+        """dead_code entries include file_path, relative_path, and language."""
+        dead = find_dead_code(self.store, root="/repo")
+        entry = next(d for d in dead if d["name"] == "dead_func")
+        assert entry["file_path"] == "/repo/app.py"
+        assert entry["relative_path"] == "app.py"
+        assert entry["language"] == "python"
+        # backward compat: 'file' key still present
+        assert entry["file"] == "/repo/app.py"
+
+    def test_find_dead_code_relative_path_without_root(self):
+        """Without root, relative_path falls back to file_path."""
+        dead = find_dead_code(self.store)
+        entry = next(d for d in dead if d["name"] == "dead_func")
+        assert entry["relative_path"] == "/repo/app.py"
+
     def test_find_dead_code_excludes_called(self):
         """find_dead_code does NOT include functions with callers."""
         dead = find_dead_code(self.store)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import stat
 import sys
 from pathlib import Path
@@ -121,6 +122,7 @@ class TestGenerateHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "update" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert 0 < inner["timeout"] <= 600
 
     def test_has_session_start(self):
@@ -131,6 +133,7 @@ class TestGenerateHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "status" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert 0 < inner["timeout"] <= 600
 
     def test_does_not_emit_invalid_pre_commit_hook(self):
@@ -278,6 +281,7 @@ class TestGenerateCodexHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "update" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -288,7 +292,36 @@ class TestGenerateCodexHooksConfig:
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "status" in inner["command"]
+        assert inner["command"].startswith("cat >/dev/null || true; ")
         assert inner["statusMessage"] == "Checking code-review-graph status"
+
+
+    def test_post_tool_use_command_handles_large_stdin_payload(self, tmp_path):
+        config = generate_codex_hooks_config(tmp_path)
+        cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+
+        payload = ("x" * 1024 + "\n") * 20000
+        proc = subprocess.Popen(
+            ["bash", "-lc", cmd],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=tmp_path,
+        )
+
+        broken_pipe = None
+        try:
+            assert proc.stdin is not None
+            proc.stdin.write(payload)
+            proc.stdin.close()
+        except BrokenPipeError as exc:  # pragma: no cover - regression guard
+            broken_pipe = exc
+
+        proc.stdin = None
+        stdout, stderr = proc.communicate()
+        assert broken_pipe is None, f"hook command raised BrokenPipeError: {stderr}"
+        assert proc.returncode == 0, stderr
 
     def test_commands_do_not_pin_a_specific_repo_path(self, tmp_path):
         config = generate_codex_hooks_config(tmp_path / "repo with spaces")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import code_review_graph.tools.docs as docs_module
 from code_review_graph.graph import GraphStore, _sanitize_name, node_to_dict
 from code_review_graph.parser import EdgeInfo, NodeInfo
 from code_review_graph.tools import (
@@ -384,6 +385,37 @@ class TestGetDocsSection:
         assert result["status"] in ("ok", "not_found")
         if result["status"] == "ok":
             assert len(result["content"]) > 0
+
+    def test_source_tree_docs_lookup_from_outside_repo(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+
+        result = get_docs_section(section_name="usage")
+
+        assert result["status"] == "ok"
+        assert len(result["content"]) > 0
+
+    def test_packaged_docs_lookup_from_outside_repo(self, tmp_path, monkeypatch):
+        package_dir = tmp_path / "site-packages" / "code_review_graph"
+        tools_dir = package_dir / "tools"
+        docs_dir = package_dir / "docs"
+        tools_dir.mkdir(parents=True)
+        docs_dir.mkdir()
+        (docs_dir / "LLM-OPTIMIZED-REFERENCE.md").write_text(
+            '<section name="usage">packaged docs</section>\n',
+            encoding="utf-8",
+        )
+        work_dir = tmp_path / "elsewhere"
+        work_dir.mkdir()
+
+        monkeypatch.chdir(work_dir)
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+        monkeypatch.setattr(docs_module, "__file__", str(tools_dir / "docs.py"))
+
+        result = docs_module.get_docs_section("usage")
+
+        assert result["status"] == "ok"
+        assert result["content"] == "packaged docs"
 
 
 class TestFindLargeFunctions:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,6 +19,7 @@ from code_review_graph.tools import (
     list_communities_func,
     list_flows,
     query_graph,
+    _validate_repo_root,
 )
 
 
@@ -346,6 +347,17 @@ class TestGraphPathResolution:
         )
 
         assert any(n["name"] == "handle" for n in result["results"])
+
+
+class TestRepoRootValidation:
+    def test_validate_repo_root_accepts_svn_working_copy(self, tmp_path):
+        (tmp_path / ".svn").mkdir()
+
+        assert _validate_repo_root(tmp_path) == tmp_path.resolve()
+
+    def test_validate_repo_root_error_mentions_svn_marker(self, tmp_path):
+        with pytest.raises(ValueError, match=r"\.git, \.svn, or \.code-review-graph"):
+            _validate_repo_root(tmp_path)
 
 
 class TestGetDocsSection:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -297,7 +297,7 @@ class TestGraphPathResolution:
         (repo / ".git").mkdir()
         (repo / "src").mkdir()
         (repo / "src" / "app.py").write_text(
-            "def handle():\n    return 'ok'\n",
+            "def handle():\n    return 'ok'\n" + ("# padding\n" * 500),
             encoding="utf-8",
         )
         _seed_repo_relative_graph(repo)
@@ -310,6 +310,12 @@ class TestGraphPathResolution:
 
         changed = result["context"]["graph"]["changed_nodes"]
         assert any(n["name"] == "handle" for n in changed)
+        assert result["context_savings"]["estimated"] is True
+        assert set(result["context_savings"]) == {
+            "estimated",
+            "saved_tokens",
+            "saved_percent",
+        }
 
     def test_get_impact_radius_resolves_repo_relative_changed_file(self, tmp_path):
         repo = tmp_path / "fixtures" / "sample_repo"
@@ -950,6 +956,18 @@ class TestCommunityTools:
         assert "community pairs" in result["summary"]
         for c in result["communities"]:
             assert "members" not in c
+        assert result["context_savings"]["estimated"] is True
+        assert set(result["context_savings"]) == {
+            "estimated",
+            "saved_tokens",
+            "saved_percent",
+        }
+
+    def test_get_architecture_overview_standard_omits_savings_metadata(self):
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="standard"
+        )
+        assert "context_savings" not in result
 
     def test_get_architecture_overview_minimal_drops_members(self):
         result = get_architecture_overview_func(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,6 +15,7 @@ from code_review_graph.tools import (
     get_flow,
     list_communities_func,
     list_flows,
+    query_graph,
 )
 
 
@@ -149,6 +150,112 @@ class TestTools:
         edges = self.store.search_edges_by_target_name("helper")
         assert len(edges) == 1
         assert edges[0].source_qualified == "/repo/main.py::process"
+
+
+class TestQueryGraphCallTargetFallbacks:
+    """Regression tests for mixed qualified and bare CALLS targets."""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.root = Path(self.tmp_dir).resolve()
+        (self.root / ".git").mkdir()
+        (self.root / ".code-review-graph").mkdir()
+
+        self.target_file = str(self.root / "target.m")
+        self.cross_file = str(self.root / "cross.m")
+        self.dispatch_file = str(self.root / "dispatch.m")
+        self.db_path = str(self.root / ".code-review-graph" / "graph.db")
+        self._seed_data()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _seed_data(self):
+        with GraphStore(self.db_path) as store:
+            store.upsert_node(NodeInfo(
+                kind="Function", name="target_func", file_path=self.target_file,
+                line_start=10, line_end=12, language="objc",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function", name="same_file_caller", file_path=self.target_file,
+                line_start=20, line_end=24, language="objc",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function", name="cross_file_caller", file_path=self.cross_file,
+                line_start=5, line_end=9, language="objc",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{self.target_file}::same_file_caller",
+                target=f"{self.target_file}::target_func",
+                file_path=self.target_file,
+                line=22,
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{self.cross_file}::cross_file_caller",
+                target="target_func",
+                file_path=self.cross_file,
+                line=7,
+            ))
+
+            store.upsert_node(NodeInfo(
+                kind="Function", name="dispatcher", file_path=self.dispatch_file,
+                line_start=1, line_end=8, language="objc",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function", name="resolved_helper", file_path=self.dispatch_file,
+                line_start=12, line_end=14, language="objc",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{self.dispatch_file}::dispatcher",
+                target=f"{self.dispatch_file}::resolved_helper",
+                file_path=self.dispatch_file,
+                line=3,
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{self.dispatch_file}::dispatcher",
+                target="external_helper",
+                file_path=self.dispatch_file,
+                line=4,
+            ))
+            store.commit()
+
+    def test_callers_of_includes_qualified_and_bare_target_callers(self):
+        result = query_graph(
+            pattern="callers_of",
+            target=f"{self.target_file}::target_func",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        names = {r["name"] for r in result["results"]}
+        assert names == {"same_file_caller", "cross_file_caller"}
+        assert len(result["results"]) == 2
+
+        edge_targets = {e["target"] for e in result["edges"]}
+        assert edge_targets == {f"{self.target_file}::target_func", "target_func"}
+
+    def test_callees_of_includes_resolved_and_bare_target_callees(self):
+        result = query_graph(
+            pattern="callees_of",
+            target=f"{self.dispatch_file}::dispatcher",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        names = {r["name"] for r in result["results"]}
+        assert names == {"resolved_helper", "external_helper"}
+
+        edge_targets = {e["target"] for e in result["edges"]}
+        assert edge_targets == {
+            f"{self.dispatch_file}::resolved_helper",
+            "external_helper",
+        }
 
 
 class TestGetDocsSection:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,8 @@ from code_review_graph.tools import (
     get_community_func,
     get_docs_section,
     get_flow,
+    get_impact_radius,
+    get_review_context,
     list_communities_func,
     list_flows,
     query_graph,
@@ -256,6 +258,93 @@ class TestQueryGraphCallTargetFallbacks:
             f"{self.dispatch_file}::resolved_helper",
             "external_helper",
         }
+
+
+def _seed_repo_relative_graph(root: Path) -> None:
+    """Seed graph data with cwd-relative paths, as eval repos currently do."""
+    graph_dir = root / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    stored_path = "fixtures/sample_repo/src/app.py"
+    try:
+        store.upsert_node(NodeInfo(
+            kind="File",
+            name=stored_path,
+            file_path=stored_path,
+            line_start=1,
+            line_end=6,
+            language="python",
+        ))
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="handle",
+            file_path=stored_path,
+            line_start=1,
+            line_end=3,
+            language="python",
+        ))
+        store.commit()
+    finally:
+        store.close()
+
+
+class TestGraphPathResolution:
+    def test_get_review_context_resolves_repo_relative_changed_file(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = get_review_context(
+            changed_files=["src/app.py"],
+            repo_root=str(repo),
+            include_source=False,
+        )
+
+        changed = result["context"]["graph"]["changed_nodes"]
+        assert any(n["name"] == "handle" for n in changed)
+
+    def test_get_impact_radius_resolves_repo_relative_changed_file(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = get_impact_radius(
+            changed_files=["src/app.py"],
+            repo_root=str(repo),
+        )
+
+        assert any(n["name"] == "handle" for n in result["changed_nodes"])
+
+    def test_file_summary_resolves_repo_relative_target(self, tmp_path):
+        repo = tmp_path / "fixtures" / "sample_repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "app.py").write_text(
+            "def handle():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        _seed_repo_relative_graph(repo)
+
+        result = query_graph(
+            pattern="file_summary",
+            target="src/app.py",
+            repo_root=str(repo),
+        )
+
+        assert any(n["name"] == "handle" for n in result["results"])
 
 
 class TestGetDocsSection:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -698,10 +698,52 @@ class TestCommunityTools:
         assert "summary" in result
 
     def test_get_architecture_overview_summary_format(self):
-        result = get_architecture_overview_func(repo_root=str(self.root))
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="standard"
+        )
         assert "Architecture:" in result["summary"]
         assert "communities" in result["summary"]
         assert "cross-community edges" in result["summary"]
+
+    def test_get_architecture_overview_defaults_to_compact_output(self):
+        result = get_architecture_overview_func(repo_root=str(self.root))
+        assert "community pairs" in result["summary"]
+        for c in result["communities"]:
+            assert "members" not in c
+
+    def test_get_architecture_overview_minimal_drops_members(self):
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        assert result["status"] == "ok"
+        for c in result["communities"]:
+            assert "members" not in c
+            assert "name" in c and "size" in c and "cohesion" in c
+
+    def test_get_architecture_overview_minimal_aggregates_edges(self):
+        std = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="standard"
+        )
+        minimal = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        # Minimal edges are pair-aggregated, so count is <= standard's
+        # per-edge count.
+        assert len(minimal["cross_community_edges"]) <= len(
+            std["cross_community_edges"]
+        )
+        for pair in minimal["cross_community_edges"]:
+            assert "source_community" in pair
+            assert "target_community" in pair
+            assert "edge_count" in pair
+            assert pair["edge_count"] >= 1
+            assert isinstance(pair["top_kinds"], list)
+
+    def test_get_architecture_overview_minimal_summary_label(self):
+        result = get_architecture_overview_func(
+            repo_root=str(self.root), detail_level="minimal"
+        )
+        assert "community pairs" in result["summary"]
 
 
 class TestBuildPostprocess:

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.3.3"
+version = "2.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,7 @@ wiki = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -420,7 +421,10 @@ requires-dist = [
 provides-extras = ["embeddings", "google-embeddings", "communities", "eval", "wiki", "all", "enrichment", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4.2" }]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23,<1" },
+]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## Summary

Prepare a focused 2.3.4 release around local-first, token-efficient MCP/CLI code review.

## Included

- Integrates selected project-aligned bugfix PRs for Windows/FastMCP reliability, parser correctness, graph lookup correctness, CLI reliability, and MCP response correctness.
- Adds compact estimated context savings metadata for relevant MCP/CLI review paths.
- Makes architecture overview compact by default to mitigate huge output from #476.
- Updates Python package version to 2.3.4, release notes, README, FEATURES, LLM reference, COMMANDS, and VS Code changelog 0.2.2.

## Not included

- No release tag, publish, or marketplace release performed.
- No VS Code status bar implementation; VS Code remains a supporting surface for this release.
- No telemetry, cloud-default behavior, broad platform expansion, or exact-token claims.

## Verification

- uv run pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65
- uv run ruff check code_review_graph/
- uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
- uvx --from 'bandit[toml]' bandit -r code_review_graph/ -c pyproject.toml
- schema version sync check
- npm run compile (code-review-graph-vscode)
- npm run lint (code-review-graph-vscode)
