### PR TITLE
feat: add Terraform/HCL language support (#199)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -142,6 +142,8 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".v": "verilog",
     ".vh": "verilog",
     ".sql": "sql",
+    ".tf": "hcl",
+    ".hcl": "hcl",
 }
 
 # Shebang interpreter → language mapping for extension-less Unix scripts.
@@ -235,6 +237,9 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "gdscript": ["class_definition", "class_name_statement"],
     # SQL: CREATE TABLE / CREATE VIEW are handled via _parse_sql dispatch.
     "sql": [],
+    # HCL/Terraform: all constructs are blocks; dispatched via
+    # _extract_hcl_constructs.
+    "hcl": [],
 }
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
@@ -296,6 +301,8 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "gdscript": ["function_definition"],
     # SQL: CREATE FUNCTION / CREATE PROCEDURE handled via _parse_sql dispatch.
     "sql": [],
+    # HCL/Terraform: dispatched via _extract_hcl_constructs.
+    "hcl": [],
 }
 
 _IMPORT_TYPES: dict[str, list[str]] = {
@@ -348,6 +355,9 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "gdscript": ["extends_statement"],
     # SQL: table references extracted as IMPORTS_FROM via _parse_sql dispatch.
     "sql": [],
+    # HCL/Terraform: module source attributes become IMPORTS_FROM via
+    # _extract_hcl_constructs.
+    "hcl": [],
 }
 
 _CALL_TYPES: dict[str, list[str]] = {
@@ -406,6 +416,8 @@ _CALL_TYPES: dict[str, list[str]] = {
     "gdscript": ["call", "attribute_call"],
     # SQL: no call edges extracted (grammar too unreliable for procedure calls).
     "sql": [],
+    # HCL/Terraform: resource references dispatched via _extract_hcl_constructs.
+    "hcl": [],
 }
 
 # Patterns that indicate a test function
@@ -772,6 +784,156 @@ def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
+
+# ---------------------------------------------------------------------------
+# HCL / Terraform helpers (module-level; no self needed)
+# ---------------------------------------------------------------------------
+
+def _hcl_text(node) -> str:
+    """Decode tree-sitter node bytes to a string."""
+    return node.text.decode("utf-8", errors="replace")
+
+
+def _hcl_child(node, *types: str):
+    """Return the first direct child whose type is in *types*, or None."""
+    return next((c for c in node.children if c.type in types), None)
+
+
+def _hcl_block_name(prefix: str, labels: list[str], n_labels: int) -> Optional[str]:
+    """Build *prefix.label0[.label1]* from the first *n_labels* labels, or None."""
+    if len(labels) < n_labels:
+        return None
+    return ".".join([prefix] + labels[:n_labels])
+
+
+# Terraform reference-namespace prefixes (special roots, not resource types).
+# These roots are *not* resource type names, so they must never be mapped to
+# ``resource.<root>.*``.  The block-local iterators (each, count, self) and
+# built-in namespace objects (path, terraform) are also included so that
+# expressions like ``each.value.id`` or ``terraform.workspace`` do not
+# generate spurious REFERENCES edges.
+_HCL_REF_PREFIXES: frozenset[str] = frozenset({
+    "var", "module", "local", "data",
+    # block-local meta-argument iterators
+    "each", "count", "self",
+    # built-in namespace objects
+    "path", "terraform",
+})
+
+
+def _hcl_ref_target(root: str, attrs: list[str]) -> Optional[str]:
+    """Map a ``variable_expr.get_attr*`` chain to its canonical graph name."""
+    if root == "var" and attrs:
+        return f"var.{attrs[0]}"
+    if root == "module" and attrs:
+        return f"module.{attrs[0]}"
+    if root == "local" and attrs:
+        return f"local.{attrs[0]}"
+    if root == "data" and len(attrs) >= 2:
+        return f"data.{attrs[0]}.{attrs[1]}"
+    if root not in _HCL_REF_PREFIXES and attrs:
+        return f"resource.{root}.{attrs[0]}"
+    return None
+
+
+def _hcl_variable_refs(expr_node):
+    """Yield (root, attrs, line) for each ``variable_expr get_attr*`` chain
+    that is a direct child sequence inside *expr_node*."""
+    children = expr_node.children
+    i = 0
+    while i < len(children):
+        child = children[i]
+        if child.type != "variable_expr":
+            i += 1
+            continue
+        ident = _hcl_child(child, "identifier")
+        if ident is None:
+            i += 1
+            continue
+        j, attrs = i + 1, []
+        while j < len(children) and children[j].type == "get_attr":
+            id_node = _hcl_child(children[j], "identifier")
+            if id_node:
+                attrs.append(_hcl_text(id_node))
+            j += 1
+        yield _hcl_text(ident), attrs, child.start_point[0] + 1
+        i = j
+
+
+# Node types to recurse into when scanning for HCL variable references.
+# ``function_call`` / ``function_arguments`` ensure that variable references
+# inside calls like ``length(var.x)`` are extracted.
+# ``quoted_template`` / ``template_interpolation`` ensure that variable
+# references inside ``"${var.x}"`` template strings are extracted.
+_HCL_RECURSE_TYPES: frozenset[str] = frozenset({
+    "expression", "body", "block", "attribute", "tuple",
+    "object", "object_elem", "collection_value",
+    "template_expr", "for_expr", "conditional",
+    # variable refs inside function call arguments, e.g. length(var.x)
+    "function_call", "function_arguments",
+    # variable refs inside template string interpolations, e.g. "${var.x}"
+    "quoted_template", "template_interpolation",
+})
+
+def _hcl_dynamic_iterator_name(block_node) -> Optional[str]:
+    """Return the iterator symbol for a ``dynamic`` block, or ``None``.
+
+    Defaults to the dynamic block's string label (e.g. ``"setting"`` becomes
+    the symbol ``setting``).  Can be overridden by an
+    ``iterator = <ident>`` attribute inside the block body.  Returns ``None``
+    when *block_node* is not a ``dynamic`` block.
+
+    This is used by ``_walk_hcl_expressions`` to build a *local_names* scope
+    so that iterator references such as ``setting.value[...]`` or
+    ``origin_group.key`` do not produce spurious ``resource.*`` REFERENCES
+    edges.
+    """
+    id_node = _hcl_child(block_node, "identifier")
+    if id_node is None or _hcl_text(id_node) != "dynamic":
+        return None
+
+    # Default iterator name = the string label of the dynamic block.
+    # Block children: identifier("dynamic"), string_lit(label), body
+    default_name: Optional[str] = None
+    for child in block_node.children:
+        if child.type == "string_lit":
+            tmpl = _hcl_child(child, "template_literal")
+            default_name = _hcl_text(tmpl) if tmpl is not None else _hcl_text(child).strip('"')
+            break
+    if default_name is None:
+        return None
+
+    # Check for optional ``iterator = <ident>`` override inside the block body.
+    # The value is an unquoted identifier expression, e.g. ``iterator = srv``.
+    body_node = _hcl_child(block_node, "body")
+    if body_node is not None:
+        for attr in body_node.children:
+            if attr.type != "attribute":
+                continue
+            key = _hcl_child(attr, "identifier")
+            if key is None or _hcl_text(key) != "iterator":
+                continue
+            expr = _hcl_child(attr, "expression")
+            if expr is None:
+                continue
+            # Handles both bare identifier (``srv``) and quoted string (``"srv"``)
+            raw = _hcl_text(expr).strip().strip('"')
+            if raw and raw.isidentifier():
+                return raw
+
+    return default_name
+
+
+# Dispatch table: block_type → (graph_kind, name_prefix, n_labels, emit_refs)
+# "terraform" and unknown types are absent so they are silently skipped.
+_HCL_BLOCK_CFG: dict[str, tuple[str, str, int, bool]] = {
+    "resource": ("Class",    "resource", 2, True),
+    "data":     ("Class",    "data",     2, True),
+    "module":   ("Class",    "module",   1, True),
+    "variable": ("Function", "var",      1, False),
+    "output":   ("Function", "output",   1, True),
+    "provider": ("Function", "provider", 1, True),
+}
 
 # ---------------------------------------------------------------------------
 # Parser
@@ -2246,6 +2408,18 @@ class CodeParser:
                 ):
                     continue
 
+            # --- HCL/Terraform-specific constructs ---
+            # All Terraform top-level constructs are ``block`` nodes whose
+            # first identifier child labels the block type (resource, module,
+            # variable, data, output, locals, provider, terraform).  Dispatch
+            # via _extract_hcl_constructs to produce Class, Function, and
+            # IMPORTS_FROM/REFERENCES edges.  See issue #199.
+            if language == "hcl" and node_type == "block":
+                if self._extract_hcl_constructs(
+                    child, file_path, nodes, edges,
+                ):
+                    continue
+
             # --- Julia-specific constructs ---
             # Short-form functions (`f(x) = expr`) parse as ``assignment``,
             # ``include("file.jl")`` as a call_expression, exports as
@@ -2875,6 +3049,173 @@ class CodeParser:
             _depth=_depth + 1,
         )
         return True
+
+    # ------------------------------------------------------------------
+    # HCL / Terraform constructs
+    # ------------------------------------------------------------------
+
+    def _extract_hcl_constructs(
+        self,
+        node,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> bool:
+        """Handle an HCL ``block`` node and emit Class/Function/edge data.
+
+        Mapping (see ``_HCL_BLOCK_CFG`` for the dispatch table):
+        - ``resource/data``        → Class  ``resource.type.name`` / ``data.type.name``
+        - ``module``               → Class  ``module.name`` + IMPORTS_FROM (source attr)
+        - ``variable/output/provider`` → Function  ``var|output|provider.name``
+        - ``locals``               → Function ``local.<key>`` per attribute
+        - ``terraform`` / unknown  → skipped
+
+        Returns True unconditionally so the main walker skips the subtree.
+        """
+        children = node.children
+        if not children or children[0].type != "identifier":
+            return False
+
+        block_type = _hcl_text(children[0])
+        labels = [
+            _hcl_text(tmpl)
+            for child in children[1:]
+            if child.type == "string_lit"
+            if (tmpl := _hcl_child(child, "template_literal")) is not None
+        ]
+        body_node = _hcl_child(node, "body")
+        line_start = node.start_point[0] + 1
+
+        if block_type == "locals":
+            return self._emit_hcl_locals(body_node, file_path, nodes, edges)
+
+        cfg = _HCL_BLOCK_CFG.get(block_type)
+        if cfg is None:  # "terraform" and unknown blocks silently skipped
+            return True
+
+        kind, prefix, n_labels, emit_refs = cfg
+        name = _hcl_block_name(prefix, labels, n_labels)
+        if name is None:
+            return True
+
+        qualified = self._qualify(name, file_path, None)
+        nodes.append(NodeInfo(
+            kind=kind, name=name, file_path=file_path,
+            line_start=line_start, line_end=node.end_point[0] + 1,
+            language="hcl", extra={"hcl_type": block_type},
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS", source=file_path, target=qualified,
+            file_path=file_path, line=line_start,
+        ))
+
+        if body_node is None:
+            return True
+
+        if block_type == "module":
+            src = self._hcl_get_attribute_string(body_node, "source")
+            if src:
+                resolved = self._resolve_module_to_file(src, file_path, "hcl")
+                edges.append(EdgeInfo(
+                    kind="IMPORTS_FROM", source=file_path, target=resolved or src,
+                    file_path=file_path, line=line_start,
+                ))
+
+        if emit_refs:
+            self._walk_hcl_expressions(body_node, file_path, edges, name)
+
+        return True
+
+    def _emit_hcl_locals(
+        self,
+        body_node,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> bool:
+        """Emit one Function node per binding in a ``locals { ... }`` block."""
+        if body_node is None:
+            return True
+        for attr in body_node.children:
+            if attr.type != "attribute":
+                continue
+            key = _hcl_child(attr, "identifier")
+            if key is None:
+                continue
+            lname = f"local.{_hcl_text(key)}"
+            lline = attr.start_point[0] + 1
+            nodes.append(NodeInfo(
+                kind="Function", name=lname, file_path=file_path,
+                line_start=lline, line_end=attr.end_point[0] + 1,
+                language="hcl", extra={"hcl_type": "local"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS", source=file_path,
+                target=self._qualify(lname, file_path, None),
+                file_path=file_path, line=lline,
+            ))
+        return True
+
+    def _hcl_get_attribute_string(self, body_node, attr_name: str) -> Optional[str]:
+        """Return the string value of a named attribute in an HCL body, or None."""
+        for attr in body_node.children:
+            if attr.type != "attribute":
+                continue
+            key = _hcl_child(attr, "identifier")
+            expr = _hcl_child(attr, "expression")
+            if key is None or expr is None or _hcl_text(key) != attr_name:
+                continue
+            # Navigate: expression > literal_value > string_lit > template_literal
+            lit = _hcl_child(expr, "literal_value")
+            if lit is None:
+                continue
+            str_lit = _hcl_child(lit, "string_lit")
+            if str_lit is None:
+                continue
+            tmpl = _hcl_child(str_lit, "template_literal")
+            if tmpl is not None:
+                return _hcl_text(tmpl)
+        return None
+
+    def _walk_hcl_expressions(
+        self,
+        node,
+        file_path: str,
+        edges: list[EdgeInfo],
+        enclosing_name: str,
+        local_names: frozenset[str] = frozenset(),
+    ) -> None:
+        """Emit REFERENCES edges for every HCL variable reference under *node*.
+
+        *local_names* accumulates iterator symbols introduced by enclosing
+        ``dynamic`` blocks.  Any reference whose root matches a name in this
+        set is suppressed, preventing spurious ``resource.<iterator>.*``
+        edges from expressions like ``setting.value[...]`` or
+        ``origin_group.key``.
+        """
+        if node.type in ("expression", "body"):
+            for root, attrs, line in _hcl_variable_refs(node):
+                if root in local_names:
+                    continue
+                ref = _hcl_ref_target(root, attrs)
+                if ref:
+                    edges.append(EdgeInfo(
+                        kind="REFERENCES",
+                        source=self._qualify(enclosing_name, file_path, None),
+                        target=self._qualify(ref, file_path, None),
+                        file_path=file_path,
+                        line=line,
+                    ))
+        for child in node.children:
+            if child.type not in _HCL_RECURSE_TYPES:
+                continue
+            child_local_names = local_names
+            if child.type == "block":
+                iter_name = _hcl_dynamic_iterator_name(child)
+                if iter_name:
+                    child_local_names = local_names | {iter_name}
+            self._walk_hcl_expressions(child, file_path, edges, enclosing_name, child_local_names)
+
 
     def _extract_bash_source_command(
         self,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,7 +9,7 @@
 - **Graph lookup correctness**: Review, impact, and file-summary tools resolve user-facing paths to stored graph paths; `callers_of` includes cross-file callers even when same-file callers exist.
 - **Install/runtime reliability**: Generated Codex/Claude hooks drain stdin, bundled docs are available from wheels, missing local embeddings report unavailable status, and `.svn` roots pass validation.
 - **CLI reliability**: `build --skip-postprocess` and `update --skip-flows` honor the requested post-processing level.
-- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
+- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, HCL/Terraform, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
 - **Local-first by design**: SQLite graph storage remains local, with no telemetry and no cloud-default behavior.
 
 ## v2.0.0

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -50,7 +50,7 @@ Configure via provider/model parameters, CRG_EMBEDDING_MODEL for local, or CRG_O
 </section>
 
 <section name="languages">
-Supported: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
+Supported: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, HCL/Terraform, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
 Parser: Tree-sitter via tree-sitter-language-pack
 </section>
 

--- a/tests/fixtures/sample.tf
+++ b/tests/fixtures/sample.tf
@@ -1,0 +1,255 @@
+# Sample Terraform configuration exercising the HCL parser.
+#
+# Covers: resources, data sources, modules, variables, outputs, locals,
+# providers, the terraform block, cross-resource references, variable
+# references, local references, data source references, depends_on,
+# lifecycle blocks, template interpolations, function call arguments,
+# built-in namespace objects, and dynamic blocks.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t2.micro"
+}
+
+locals {
+  name_prefix = "myapp"
+  full_name   = "${local.name_prefix}-web"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = local.full_name
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.main.id
+
+  tags = {
+    Name = local.full_name
+  }
+
+  depends_on = [aws_vpc.main]
+}
+
+resource "aws_subnet" "main" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  owners = ["099720109477"]
+}
+
+module "security" {
+  source = "./modules/security"
+
+  vpc_id      = aws_vpc.main.id
+  environment = "production"
+}
+
+output "instance_ip" {
+  value       = aws_instance.web.public_ip
+  description = "The public IP of the web instance"
+}
+
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+# ---------------------------------------------------------------------------
+# Variable reference inside a function call argument (count = length(var.x))
+# and inside an index expression (var.x[count.index]).  count.index is a
+# block-local meta-argument and must not produce a REFERENCES edge.
+# ---------------------------------------------------------------------------
+variable "subnet_ids" {
+  type = list(string)
+}
+
+resource "aws_instance" "fleet" {
+  count         = length(var.subnet_ids)
+  subnet_id     = var.subnet_ids[count.index]
+  instance_type = var.instance_type
+
+  tags = {
+    Name = "fleet-${count.index}"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Resource-to-resource for_each chaining.  The 'each' iterator is block-local
+# and must not produce a REFERENCES edge.
+# ---------------------------------------------------------------------------
+resource "aws_internet_gateway" "gw" {
+  for_each = aws_vpc.main
+  vpc_id   = each.value.id
+}
+
+# ---------------------------------------------------------------------------
+# Variable reference inside a template string interpolation ("${var.x}").
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket" "static" {
+  bucket = "${var.region}-static-assets"
+}
+
+# ---------------------------------------------------------------------------
+# Terraform built-in namespace objects (path.module, terraform.workspace)
+# are not resource references and must not produce REFERENCES edges.
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "tfstate-${terraform.workspace}"
+
+  tags = {
+    Module = path.module
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Reference inside a lifecycle nested block (replace_triggered_by).
+# ---------------------------------------------------------------------------
+resource "aws_autoscaling_group" "web" {
+  min_size = 1
+  max_size = 3
+
+  lifecycle {
+    replace_triggered_by = [aws_launch_template.web.id]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Dynamic block with default iterator name ('ingress' = block label).
+# The for_each variable reference must be extracted; references to
+# ingress.value.* inside the content block must not produce edges.
+# ---------------------------------------------------------------------------
+variable "ingress_rules" {
+  type = list(object({
+    from_port = number
+    to_port   = number
+    protocol  = string
+  }))
+}
+
+resource "aws_security_group" "main" {
+  vpc_id = aws_vpc.main.id
+
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port = ingress.value.from_port
+      to_port   = ingress.value.to_port
+      protocol  = ingress.value.protocol
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Dynamic block with default iterator name ('setting' = block label).
+# References to setting.value[...] inside the content block must not
+# produce REFERENCES edges; var.settings and the resource reference on
+# 'application' must be extracted.
+# ---------------------------------------------------------------------------
+variable "settings" {
+  type = list(object({
+    namespace = string
+    name      = string
+    value     = string
+  }))
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name        = "tf-test-name"
+  application = aws_elastic_beanstalk_application.tftest.name
+
+  dynamic "setting" {
+    for_each = var.settings
+    content {
+      namespace = setting.value["namespace"]
+      name      = setting.value["name"]
+      value     = setting.value["value"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Dynamic block with a custom iterator name set via the 'iterator' argument
+# ('srv' overrides the default 'condition' label).  References to
+# srv.value[...] inside the content block must not produce REFERENCES edges;
+# var.server_list must be extracted.
+# ---------------------------------------------------------------------------
+variable "server_list" {
+  type = list(object({
+    port     = number
+    protocol = string
+  }))
+}
+
+resource "aws_lb_listener_rule" "hosts" {
+  dynamic "condition" {
+    for_each = var.server_list
+    iterator = srv
+    content {
+      host_header {
+        values = [srv.value["port"]]
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Multi-level nested dynamic blocks.  Each level introduces its own iterator
+# symbol (origin_group, origin).  Only var.load_balancer_origin_groups must
+# produce a REFERENCES edge; all iterator references (origin_group.key,
+# origin_group.value.origins, origin.value.hostname) must be suppressed.
+# ---------------------------------------------------------------------------
+variable "load_balancer_origin_groups" {
+  type = map(object({
+    origins = set(object({
+      hostname = string
+    }))
+  }))
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  dynamic "origin_group" {
+    for_each = var.load_balancer_origin_groups
+    content {
+      name = origin_group.key
+
+      dynamic "origin" {
+        for_each = origin_group.value.origins
+        content {
+          hostname = origin.value.hostname
+        }
+      }
+    }
+  }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2548,3 +2548,366 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+
+
+class TestHCLParsing:
+    """HCL / Terraform parser — closes #199."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.tf")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("main.tf")) == "hcl"
+        assert self.parser.detect_language(Path("config.hcl")) == "hcl"
+
+    def test_nodes_have_hcl_language(self):
+        for n in self.nodes:
+            assert n.language == "hcl"
+
+    def test_file_node(self):
+        file_nodes = [n for n in self.nodes if n.kind == "File"]
+        assert len(file_nodes) == 1
+        assert file_nodes[0].name.endswith("sample.tf")
+
+    def test_finds_resources(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "resource.aws_vpc.main" in classes
+        assert "resource.aws_instance.web" in classes
+        assert "resource.aws_subnet.main" in classes
+
+    def test_finds_data_sources(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "data.aws_ami.ubuntu" in classes
+
+    def test_finds_modules(self):
+        classes = {n.name for n in self.nodes if n.kind == "Class"}
+        assert "module.security" in classes
+
+    def test_finds_variables(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "var.region" in funcs
+        assert "var.instance_type" in funcs
+
+    def test_finds_outputs(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "output.instance_ip" in funcs
+        assert "output.vpc_id" in funcs
+
+    def test_finds_locals(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "local.name_prefix" in funcs
+        assert "local.full_name" in funcs
+
+    def test_finds_provider(self):
+        funcs = {n.name for n in self.nodes if n.kind == "Function"}
+        assert "provider.aws" in funcs
+
+    def test_hcl_type_extra_metadata(self):
+        by_name = {n.name: n for n in self.nodes if n.kind != "File"}
+        assert by_name["resource.aws_vpc.main"].extra["hcl_type"] == "resource"
+        assert by_name["data.aws_ami.ubuntu"].extra["hcl_type"] == "data"
+        assert by_name["module.security"].extra["hcl_type"] == "module"
+        assert by_name["var.region"].extra["hcl_type"] == "variable"
+        assert by_name["output.instance_ip"].extra["hcl_type"] == "output"
+        assert by_name["local.name_prefix"].extra["hcl_type"] == "local"
+        assert by_name["provider.aws"].extra["hcl_type"] == "provider"
+
+    def test_module_source_creates_import_edge(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = [e.target for e in imports]
+        assert any("modules/security" in t for t in targets)
+
+    def test_contains_edges(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target for e in contains}
+        # All non-File nodes should be contained by the file
+        for n in self.nodes:
+            if n.kind != "File":
+                qn = f"{n.file_path}::{n.name}"
+                assert qn in targets, f"missing CONTAINS for {n.name}"
+
+    def test_resource_references_variable(self):
+        """resource.aws_instance.web references var.instance_type."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_instance.web" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.instance_type" in t for t in targets)
+
+    def test_resource_references_other_resource(self):
+        """resource.aws_instance.web references resource.aws_subnet.main."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_instance.web" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_subnet.main" in t for t in targets)
+
+    def test_resource_references_data_source(self):
+        """resource.aws_instance.web references data.aws_ami.ubuntu."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_instance.web" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("data.aws_ami.ubuntu" in t for t in targets)
+
+    def test_output_references_resource(self):
+        """output.instance_ip references resource.aws_instance.web."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "output.instance_ip" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_instance.web" in t for t in targets)
+
+    def test_module_references_resource(self):
+        """module.security references resource.aws_vpc.main."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "module.security" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_vpc.main" in t for t in targets)
+
+    def test_provider_references_variable(self):
+        """provider.aws references var.region."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "provider.aws" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.region" in t for t in targets)
+
+    def test_terraform_block_skipped(self):
+        """terraform {} block should not produce any nodes."""
+        names = {n.name for n in self.nodes}
+        assert not any("terraform" in name for name in names if name != "File")
+
+    def test_resource_references_local(self):
+        """resource.aws_vpc.main references local.full_name."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_vpc.main" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("local.full_name" in t for t in targets)
+
+    # ------------------------------------------------------------------
+    # Variable references inside function call arguments
+    # ------------------------------------------------------------------
+
+    def test_count_with_function_extracts_var_ref(self):
+        """length(var.subnet_ids) in count — var.subnet_ids must be extracted."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_instance.fleet" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.subnet_ids" in t for t in targets), (
+            f"Expected var.subnet_ids in refs from fleet; got {targets}"
+        )
+
+    # ------------------------------------------------------------------
+    # Block-local meta-argument iterators must not produce REFERENCES edges
+    # ------------------------------------------------------------------
+
+    def test_each_value_produces_no_spurious_edge(self):
+        """each.value.id should not produce any REFERENCES edge."""
+        each_edges = [
+            e for e in self.edges
+            if e.kind == "REFERENCES" and "each" in e.target
+        ]
+        assert each_edges == [], (
+            f"Spurious 'each' REFERENCES edges: {[e.target for e in each_edges]}"
+        )
+
+    def test_count_index_produces_no_spurious_edge(self):
+        """count.index should not produce any REFERENCES edge."""
+        count_edges = [
+            e for e in self.edges
+            if e.kind == "REFERENCES" and "count" in e.target
+        ]
+        assert count_edges == [], (
+            f"Spurious 'count' REFERENCES edges: {[e.target for e in count_edges]}"
+        )
+
+    def test_path_module_produces_no_edge(self):
+        """path.module must not produce a REFERENCES edge."""
+        path_edges = [
+            e for e in self.edges
+            if e.kind == "REFERENCES" and "path" in e.target
+        ]
+        assert path_edges == [], (
+            f"Spurious 'path' REFERENCES edges: {[e.target for e in path_edges]}"
+        )
+
+    def test_terraform_workspace_produces_no_edge(self):
+        """terraform.workspace must not produce a REFERENCES edge."""
+        tf_edges = [
+            e for e in self.edges
+            if e.kind == "REFERENCES" and "terraform" in e.target
+        ]
+        assert tf_edges == [], (
+            f"Spurious 'terraform' REFERENCES edges: {[e.target for e in tf_edges]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Resource-to-resource for_each chaining
+    # ------------------------------------------------------------------
+
+    def test_for_each_resource_chaining(self):
+        """for_each = aws_vpc.main emits REFERENCES to resource.aws_vpc.main."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_internet_gateway.gw" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_vpc.main" in t for t in targets), (
+            f"Expected resource.aws_vpc.main in refs from gw; got {targets}"
+        )
+
+    # ------------------------------------------------------------------
+    # Variable references inside template string interpolations
+    # ------------------------------------------------------------------
+
+    def test_template_interpolation_extracts_var_ref(self):
+        """\"${var.region}-static-assets\" must produce a REFERENCES edge to var.region."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_s3_bucket.static" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.region" in t for t in targets), (
+            f"Expected var.region in refs from static bucket; got {targets}"
+        )
+
+    # ------------------------------------------------------------------
+    # Nested block and dynamic block references
+    # ------------------------------------------------------------------
+
+    def test_lifecycle_replace_triggered_by(self):
+        """lifecycle { replace_triggered_by = [...] } must emit REFERENCES edges."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_autoscaling_group.web" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_launch_template.web" in t for t in targets), (
+            f"Expected resource.aws_launch_template.web in refs from asg.web; got {targets}"
+        )
+
+    def test_dynamic_block_for_each_ref(self):
+        """dynamic block: for_each = var.ingress_rules must produce REFERENCES edge."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_security_group.main" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.ingress_rules" in t for t in targets), (
+            f"Expected var.ingress_rules in refs from sg.main; got {targets}"
+        )
+
+    # ------------------------------------------------------------------
+    # Dynamic block iterator scope
+    # ------------------------------------------------------------------
+
+    def test_dynamic_block_iterator_no_spurious_edge(self):
+        """Iterator variables from dynamic blocks must not produce REFERENCES edges.
+
+        Covers: ingress (existing fixture), setting (default iterator),
+        srv (custom iterator=), origin_group and origin (nested dynamic).
+        """
+        iterator_names = ("ingress", "setting", "srv", "origin_group", "origin")
+        spurious = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and any(f"resource.{name}." in e.target for name in iterator_names)
+        ]
+        assert spurious == [], (
+            f"Spurious iterator REFERENCES edges: {[e.target for e in spurious]}"
+        )
+
+    def test_dynamic_block_default_iterator_for_each_extracted(self):
+        """for_each = var.settings inside dynamic block must produce a REFERENCES edge."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_elastic_beanstalk_environment.tfenvtest" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.settings" in t for t in targets), (
+            f"Expected var.settings in refs from tfenvtest; got {targets}"
+        )
+
+    def test_dynamic_block_resource_ref_alongside_iterator(self):
+        """Non-iterator attribute refs must still be extracted from the same block.
+
+        aws_elastic_beanstalk_environment.tfenvtest references both
+        var.settings (via for_each) and aws_elastic_beanstalk_application.tftest
+        (via application = <resource>.name) while also containing a 'setting'
+        iterator.  Both real refs must survive.
+        """
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_elastic_beanstalk_environment.tfenvtest" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("resource.aws_elastic_beanstalk_application.tftest" in t for t in targets), (
+            f"Expected aws_elastic_beanstalk_application.tftest ref; got {targets}"
+        )
+
+    def test_dynamic_block_custom_iterator_for_each_extracted(self):
+        """for_each = var.server_list with iterator = srv must still extract var.server_list."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_lb_listener_rule.hosts" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.server_list" in t for t in targets), (
+            f"Expected var.server_list in refs from aws_lb_listener_rule.hosts; got {targets}"
+        )
+
+    def test_nested_dynamic_outer_for_each_extracted(self):
+        """Outer dynamic for_each = var.load_balancer_origin_groups must be extracted."""
+        refs = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.aws_cloudfront_distribution.cdn" in e.source
+        ]
+        targets = {e.target for e in refs}
+        assert any("var.load_balancer_origin_groups" in t for t in targets), (
+            f"Expected var.load_balancer_origin_groups in refs from cdn; got {targets}"
+        )
+
+    def test_nested_dynamic_inner_iterator_refs_suppressed(self):
+        """Inner dynamic for_each = origin_group.value.origins must produce NO edge.
+
+        origin_group is an iterator variable from the outer dynamic block;
+        treating it as a resource type would emit a spurious
+        resource.origin_group.value edge.
+        """
+        spurious = [
+            e for e in self.edges
+            if e.kind == "REFERENCES"
+            and "resource.origin_group." in e.target
+        ]
+        assert spurious == [], (
+            f"Spurious origin_group REFERENCES edges: {[e.target for e in spurious]}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
Adds full .tf / .hcl parsing to code-review-graph, addressing issue #199.

| Terraform construct        | Node kind | Name               |
|----------------------------|-----------|--------------------|
| resource "type" "name"     | Class     | resource.type.name |
| data "type" "name"         | Class     | data.type.name     |
| module "name"              | Class     | module.name        |
| variable "name"            | Function  | var.name           |
| output "name"              | Function  | output.name        |
| locals { key = ... }       | Function  | local.key          |
| provider "name"            | Function  | provider.name      |
| terraform { ... }          | (skipped) |                    |

Edge types emitted:
- CONTAINS    — file -> every node
- IMPORTS_FROM — file -> module source path (resolved when possible)
- REFERENCES  — cross-block value references via variable_expr+get_attr chains

_hcl_variable_refs / _hcl_ref_target resolve dotted expression chains:
- var.x, local.x, module.x, data.type.name -> named graph targets
- resource references (aws_vpc.main.id) -> resource.aws_vpc.main
- Built-in / block-local roots suppressed (no spurious edges): _HCL_REF_PREFIXES includes each, count, self, path, terraform

_HCL_RECURSE_TYPES covers function_call + function_arguments (so var refs inside length(var.x) are extracted) and quoted_template + template_interpolation (so "${var.x}" interpolations are extracted).

_hcl_dynamic_iterator_name() extracts the iterator symbol from any dynamic block (defaulting to the block label; respecting the optional iterator = <ident> override). _walk_hcl_expressions accepts a local_names: frozenset[str] scope that accumulates iterator symbols across nested dynamic blocks, suppressing spurious resource.<iter>.* edges from expressions like setting.value[...] or origin_group.key.

Covers all three cases from the Terraform dynamic-blocks documentation:
  - Default iterator (block label = iterator symbol)
  - Custom iterator via iterator = <ident>
  - Multi-level nested dynamic blocks

- code_review_graph/parser.py — extension map, type dicts, 10+ module-level helpers, 4 class methods, _walk_hcl_expressions scope-aware iterator tracking
- tests/fixtures/sample.tf — 243-line fixture covering resources, data sources, modules, variables, outputs, locals, providers, for_each chaining, function-call refs, template interpolations, lifecycle/replace_triggered_by, and all three dynamic block cases
- tests/test_multilang.py — TestHCLParsing: 36 tests, all passing
- docs/FEATURES.md — HCL/Terraform added to language list
- docs/LLM-OPTIMIZED-REFERENCE.md — HCL/Terraform added to <section name="languages">

Recognised and fully parsed: Terraform and OpenTofu (.tf, .hcl). OpenTofu is a direct fork of Terraform with identical block schemas.

The following tools also use .hcl files but with different top-level block schemas.  Their files will be detected as language="hcl" by extension, but their block types are absent from _HCL_BLOCK_CFG and will produce a File node only (no resources, variables, or edges):

  - Terragrunt  (terragrunt.hcl, terragrunt.stack.hcl) blocks: include, dependency, dependencies, remote_state, generate, inputs, unit, stack
  - Packer      (*.pkr.hcl)
    blocks: source, build, packer
  - Nomad       (*.hcl, *.nomad)
    blocks: job, group, task, service, network
  - Vault       (*.hcl policy files)
    blocks: path
  - Consul      (*.hcl config files)
    blocks: datacenter, acl, server, and others
  - Waypoint    (waypoint.hcl)
    blocks: app, build, deploy, release
  - Boundary    (*.hcl)
    blocks: controller, worker, listener