### PR TITLE
fix(graph): guard store_file_batch against open transactions (#489)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -260,14 +260,20 @@ class GraphStore:
         self._conn.execute("DELETE FROM edges WHERE file_path = ?", (file_path,))
         self._invalidate_cache()
 
-    def store_file_nodes_edges(
-        self, file_path: str, nodes: list[NodeInfo], edges: list[EdgeInfo], fhash: str = ""
-    ) -> None:
-        """Atomically replace all data for a file."""
+    def _begin_immediate(self) -> None:
+        """Start an IMMEDIATE transaction, rolling back any prior uncommitted
+        transaction first (regression guard for #135 / #489).
+        """
         if self._conn.in_transaction:
             logger.warning("Rolling back uncommitted transaction before BEGIN IMMEDIATE")
             self._conn.rollback()
         self._conn.execute("BEGIN IMMEDIATE")
+
+    def store_file_nodes_edges(
+        self, file_path: str, nodes: list[NodeInfo], edges: list[EdgeInfo], fhash: str = ""
+    ) -> None:
+        """Atomically replace all data for a file."""
+        self._begin_immediate()
         try:
             self.remove_file_data(file_path)
             for node in nodes:
@@ -284,7 +290,7 @@ class GraphStore:
         self, batch: list[tuple[str, list[NodeInfo], list[EdgeInfo], str]]
     ) -> None:
         """Atomically replace data for a batch of files in one transaction."""
-        self._conn.execute("BEGIN IMMEDIATE")
+        self._begin_immediate()
         try:
             for file_path, nodes, edges, fhash in batch:
                 self.remove_file_data(file_path)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -154,6 +154,28 @@ class TestGraphStore:
         assert self.store.get_node(new_path) is not None
         assert self.store.get_node("/test/file_0.py") is None
 
+    def test_store_with_open_transaction_no_error(self):
+        """Regression test for #489: store_file_nodes_edges and
+        store_file_batch must not raise 'cannot start a transaction
+        within a transaction' when the caller has an explicit BEGIN open.
+        """
+        node_a = self._make_file_node("/test/a.py")
+        node_b = self._make_file_node("/test/b.py")
+
+        # Force an open transaction on the shared connection.
+        self.store._conn.execute("BEGIN")
+        assert self.store._conn.in_transaction
+
+        # Must not raise sqlite3.OperationalError.
+        self.store.store_file_nodes_edges("/test/a.py", [node_a], [])
+        assert self.store.get_node("/test/a.py") is not None
+
+        # Re-open the transaction and verify the batch path is guarded too.
+        self.store._conn.execute("BEGIN")
+        assert self.store._conn.in_transaction
+        self.store.store_file_batch([("/test/b.py", [node_b], [], "")])
+        assert self.store.get_node("/test/b.py") is not None
+
     def test_search_nodes(self):
         self.store.upsert_node(self._make_func_node("authenticate"))
         self.store.upsert_node(self._make_func_node("authorize"))


### PR DESCRIPTION
store_file_nodes_edges already rolled back any uncommitted transaction before issuing BEGIN IMMEDIATE, but store_file_batch did not. When a caller had an explicit BEGIN open, store_file_batch raised sqlite3.OperationalError: cannot start a transaction within a transaction.

Extract a small _begin_immediate() helper and use it from both call sites so the guard stays consistent. Adds a regression test that exercises both methods with an explicit BEGIN already active.

Fixes #489