### PR TITLE
fix: use lowercase-hyphen skill names

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -396,7 +396,7 @@ def install_platform_configs(
 
 _SKILLS: dict[str, dict[str, str]] = {
     "explore-codebase.md": {
-        "name": "Explore Codebase",
+        "name": "explore-codebase",
         "description": "Navigate and understand codebase structure using the knowledge graph",
         "body": (
             "## Explore Codebase\n\n"
@@ -424,7 +424,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "review-changes.md": {
-        "name": "Review Changes",
+        "name": "review-changes",
         "description": "Perform a structured code review using change detection and impact",
         "body": (
             "## Review Changes\n\n"
@@ -452,7 +452,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "debug-issue.md": {
-        "name": "Debug Issue",
+        "name": "debug-issue",
         "description": "Systematically debug issues using graph-powered code navigation",
         "body": (
             "## Debug Issue\n\n"
@@ -478,7 +478,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "refactor-safely.md": {
-        "name": "Refactor Safely",
+        "name": "refactor-safely",
         "description": "Plan and execute safe refactoring using dependency analysis",
         "body": (
             "## Refactor Safely\n\n"

--- a/skills/debug-issue/SKILL.md
+++ b/skills/debug-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Debug Issue
+name: debug-issue
 description: Systematically debug issues using graph-powered code navigation
 ---
 

--- a/skills/explore-codebase/SKILL.md
+++ b/skills/explore-codebase/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Explore Codebase
+name: explore-codebase
 description: Navigate and understand codebase structure using the knowledge graph
 ---
 

--- a/skills/refactor-safely/SKILL.md
+++ b/skills/refactor-safely/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Refactor Safely
+name: refactor-safely
 description: Plan and execute safe refactoring using dependency analysis
 ---
 


### PR DESCRIPTION
## What

Set every skill `name:` frontmatter field to its kebab-case slug.

| skill | before | after |
|---|---|---|
| explore-codebase | `Explore Codebase` | `explore-codebase` |
| review-changes | `Review Changes` | `review-changes` |
| debug-issue | `Debug Issue` | `debug-issue` |
| refactor-safely | `Refactor Safely` | `refactor-safely` |

Changed in both `code_review_graph/skills.py` (`_SKILLS`) and the checked-in `skills/*/SKILL.md` files. `build-graph` was already `name: build-graph` and is left as-is.

## Why

The skill directory names — and therefore the invocation slugs (e.g. `/review-changes`) — are already kebab-case, but the `name:` field rendered as Title Case, so the picker label was inconsistent with the slug and with the repo's own newer `build-graph` skill. This aligns all skills with the lowercase-hyphen naming convention.

Cosmetic only: invocation already resolves on the directory slug, so no behavior changes.

## Test

- `git diff` shows only the 7 `name:` lines changed across 4 files; no body/description/logic edits.
- Generated skill files (`code-review-graph init`) now emit `name: review-changes` etc., matching their directory slug.

Closes #561
