### PR TITLE
Generate Claude-compatible skills

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -526,11 +526,11 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
     skills_dir.mkdir(parents=True, exist_ok=True)
 
     for filename, skill in _SKILLS.items():
-        # Claude Code expects skills at .claude/skills/<name>/skill.md
+        # Claude Code expects skills at .claude/skills/<name>/SKILL.md
         skill_name = filename.removesuffix(".md")
         skill_subdir = skills_dir / skill_name
         skill_subdir.mkdir(parents=True, exist_ok=True)
-        path = skill_subdir / "skill.md"
+        path = skill_subdir / "SKILL.md"
         content = (
             "---\n"
             f"name: {skill['name']}\n"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -60,12 +60,12 @@ class TestGenerateSkills:
             "review-changes",
         ]
         for d in skills_dir.iterdir():
-            assert (d / "skill.md").is_file()
+            assert (d / "SKILL.md").is_file()
 
     def test_skill_files_have_frontmatter(self, tmp_path):
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            path = subdir / "skill.md"
+            path = subdir / "SKILL.md"
             content = path.read_text()
             assert content.startswith("---\n")
             assert "name:" in content
@@ -87,7 +87,7 @@ class TestGenerateSkills:
         """Every skill template must reference get_minimal_context."""
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            content = (subdir / "skill.md").read_text()
+            content = (subdir / "SKILL.md").read_text()
             assert "get_minimal_context" in content, (
                 f"{subdir.name} missing get_minimal_context reference"
             )
@@ -96,7 +96,7 @@ class TestGenerateSkills:
         """Every skill template must reference detail_level."""
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            content = (subdir / "skill.md").read_text()
+            content = (subdir / "SKILL.md").read_text()
             assert "detail_level" in content, (
                 f"{subdir.name} missing detail_level reference"
             )


### PR DESCRIPTION
# Pull Request

## What & why

We currently generate Claude skills as a `skill.md` (lowercase) file in a sub-directory of `.claude/skills/`.

Unfortunately, Claude Code [expects](https://code.claude.com/docs/en/skills) skills as a `SKILL.md` file (uppercase!), thus it simply ignores the skills we generate :cry: 

## How it was tested

```bash
uvx pytest tests/test_skills.py --tb=short -q
uv run ruff check code_review_graph/
uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

> [!NOTE]
> I had to add `--with mypy` compared to the project instructions, because `mypy` is not declared as a dependency.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [ ] Docs updated where behavior changed (README, `docs/`, docstrings)
