### PR TITLE
fix(visualization): use #graph-svg selector instead of bare svg

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -856,7 +856,7 @@ function moveTooltip(ev) {
 }
 function hideTooltip() { tooltip.classList.remove("visible"); }
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()
@@ -1605,7 +1605,7 @@ _AGGREGATED_HTML_TEMPLATE = r"""<!DOCTYPE html>
 <div id="stats-bar" role="status" aria-label="Graph statistics"></div>
 <div id="tooltip"></div>
 <button id="btn-back" aria-label="Back to overview">&larr; Back to Overview</button>
-<svg role="img" aria-label="Interactive code knowledge graph visualization (aggregated view)."></svg>
+<svg id="graph-svg" role="img" aria-label="Interactive code knowledge graph visualization (aggregated view)."></svg>
 <script>
 "use strict";
 var graphData = __GRAPH_DATA__;
@@ -1756,7 +1756,7 @@ function hideTooltip() { tooltip.classList.remove("visible"); }
 
 /* --- SVG setup --- */
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -307,6 +307,42 @@ def test_generate_html_includes_loading_and_empty_state(store_with_data, tmp_pat
     assert "No nodes to display" in content
 
 
+def test_generate_html_uses_id_selector_for_svg(store_with_data, tmp_path):
+    """Regression test for #523: d3.select("svg") selects the legend icon, not the canvas.
+
+    The legend <nav> contains inline <svg> icons that appear before #graph-svg
+    in document order. d3.select("svg") returns the first match — a 16px legend
+    icon — causing the entire force graph to render inside it. The fix targets
+    #graph-svg by id.
+    """
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "graph.html"
+    generate_html(store_with_data, output_path)
+    content = output_path.read_text()
+    assert 'd3.select("#graph-svg")' in content, (
+        "HTML should use d3.select('#graph-svg') to target the main canvas, "
+        "not d3.select('svg') which selects the first inline legend icon"
+    )
+    assert 'd3.select("svg")' not in content, (
+        "No bare d3.select('svg') should remain — it selects legend icons"
+    )
+
+
+def test_community_mode_uses_id_selector_for_svg(large_store, tmp_path):
+    """Regression test for #523: community/aggregated template must also use #graph-svg."""
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "community.html"
+    generate_html(large_store, output_path, mode="community")
+    content = output_path.read_text()
+    assert 'd3.select("#graph-svg")' in content
+    assert 'd3.select("svg")' not in content
+    assert 'id="graph-svg"' in content, (
+        "Aggregated template's <svg> must have id='graph-svg' for the selector to work"
+    )
+
+
 def test_generate_html_includes_focus_visible(store_with_data, tmp_path):
     """Generated HTML should include :focus-visible styles."""
     from code_review_graph.visualization import generate_html


### PR DESCRIPTION
## Summary

- `d3.select("svg")` returns the first `<svg>` in document order, which is a 16px legend icon — not the main `#graph-svg` canvas. This caused the entire force graph to render inside the tiny legend swatch while the full-screen canvas stayed empty.
- Fix: target `#graph-svg` by id in both template copies (full mode + aggregated/community mode).
- Added `id="graph-svg"` to the aggregated-view template's `<svg>` element (it was missing).

## Root cause

In `visualization.py`, the legend `<nav>` is emitted *before* `#graph-svg` and its first child is an inline `<svg>` icon:

```html
<svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true">...</svg>
```

`d3.select("svg")` matches this 16px icon, so `gRoot` + all nodes/links get appended into it (viewBox `-8 -8 16 16`), producing a microscopic graph in the legend and an empty canvas.

## Fix

```js
// Before
var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);

// After
var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
```

Applied to both template copies. The aggregated-view template's `<svg>` also gets `id="graph-svg"` added (it was missing).

## Test plan

- [x] `test_generate_html_uses_id_selector_for_svg` — verifies full-mode HTML uses `d3.select("#graph-svg")` and contains no bare `d3.select("svg")`
- [x] `test_community_mode_uses_id_selector_for_svg` — verifies community-mode HTML uses `d3.select("#graph-svg")`, has no bare `d3.select("svg")`, and the `<svg>` has `id="graph-svg"`
- [x] All 22 existing visualization tests still pass
- [x] `ruff check` passes

Closes #523