### PR TITLE
Resolve Spring DI calls through constructor injection, @Qualifier and @Primary

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3874,6 +3874,43 @@ class CodeParser:
                             break
         return names
 
+    @staticmethod
+    def _first_java_string_literal(node) -> Optional[str]:
+        """Return the first string-literal value (quotes stripped) anywhere under node."""
+        stack = list(node.children)
+        while stack:
+            n = stack.pop(0)
+            if n.type == "string_literal":
+                return n.text.decode("utf-8", errors="replace").strip('"')
+            stack.extend(n.children)
+        return None
+
+    @staticmethod
+    def _get_java_annotation_string_args(modifier_owner) -> dict:
+        """Map annotation name -> first string-literal argument.
+
+        Captures Spring bean names and qualifiers, e.g.
+        ``@Service("kafkaLedger")`` -> {"Service": "kafkaLedger"} and
+        ``@Qualifier("kafkaLedger")`` -> {"Qualifier": "kafkaLedger"}.
+        Marker annotations with no arguments are omitted.
+        """
+        result: dict = {}
+        for child in modifier_owner.children:
+            if child.type != "modifiers":
+                continue
+            for mod in child.children:
+                if mod.type != "annotation":  # marker_annotation has no args
+                    continue
+                ann_name = None
+                for sub in mod.children:
+                    if sub.type == "identifier" and ann_name is None:
+                        ann_name = sub.text.decode("utf-8", errors="replace")
+                    elif sub.type == "annotation_argument_list":
+                        val = CodeParser._first_java_string_literal(sub)
+                        if ann_name and val is not None:
+                            result[ann_name] = val
+        return result
+
     def _emit_spring_injections(
         self,
         class_node,
@@ -3896,12 +3933,23 @@ class CodeParser:
         has_lombok_constructor = any(
             a in _LOMBOK_CONSTRUCTOR_ANNOTATIONS for a in class_annotations
         )
+        is_spring_bean = any(
+            a in _SPRING_STEREOTYPE_ANNOTATIONS for a in class_annotations
+        )
         qualified_source = self._qualify(class_name, file_path, None)
 
         # Find the class body
         for node in class_node.children:
             if node.type != "class_body":
                 continue
+            # Single-constructor implicit injection rule (Spring 4.3+):
+            # a stereotype bean with exactly one constructor is autowired
+            # even without an @Autowired annotation.
+            ctor_count = sum(
+                1 for m in node.children
+                if m.type == "constructor_declaration"
+            )
+            sole_constructor = ctor_count == 1
             for member in node.children:
                 if member.type == "field_declaration":
                     self._emit_spring_field_injection(
@@ -3911,6 +3959,8 @@ class CodeParser:
                 elif member.type == "constructor_declaration":
                     self._emit_spring_constructor_injection(
                         member, qualified_source, file_path, edges,
+                        is_spring_bean=is_spring_bean,
+                        sole_constructor=sole_constructor,
                     )
 
     def _emit_spring_field_injection(
@@ -3976,6 +4026,10 @@ class CodeParser:
         extra: dict = {"injection_type": injection_type}
         if field_name:
             extra["field_name"] = field_name
+        # @Qualifier("beanName") at the injection point disambiguates multi-impl
+        qualifier = self._get_java_annotation_string_args(field_node).get("Qualifier")
+        if qualifier:
+            extra["qualifier"] = qualifier
         edges.append(EdgeInfo(
             kind="INJECTS",
             source=qualified_source,
@@ -3991,11 +4045,23 @@ class CodeParser:
         qualified_source: str,
         file_path: str,
         edges: list[EdgeInfo],
+        is_spring_bean: bool = False,
+        sole_constructor: bool = False,
     ) -> None:
-        """Emit INJECTS edges for @Autowired constructor parameters."""
+        """Emit INJECTS edges for constructor parameters.
+
+        Two triggers:
+        - Explicit: constructor carries @Autowired / @Inject / @Resource.
+        - Implicit: class is a Spring stereotype bean with exactly one
+          constructor (Spring 4.3+ implicit constructor injection — no
+          annotation required). This is the recommended modern style.
+        """
         ctor_annotations = self._get_java_annotations(ctor_node)
-        if not any(a in _SPRING_INJECT_ANNOTATIONS for a in ctor_annotations):
+        has_inject = any(a in _SPRING_INJECT_ANNOTATIONS for a in ctor_annotations)
+        implicit = is_spring_bean and sole_constructor
+        if not has_inject and not implicit:
             return
+        resolved_injection_type = "constructor" if has_inject else "constructor_implicit"
 
         for child in ctor_node.children:
             if child.type != "formal_parameters":
@@ -4011,9 +4077,13 @@ class CodeParser:
                     elif sub.type == "identifier":
                         param_name = sub.text.decode("utf-8", errors="replace")
                 if param_type:
-                    extra: dict = {"injection_type": "constructor"}
+                    extra: dict = {"injection_type": resolved_injection_type}
                     if param_name:
                         extra["field_name"] = param_name
+                    # @Qualifier("bean") on the constructor parameter
+                    qualifier = self._get_java_annotation_string_args(param).get("Qualifier")
+                    if qualifier:
+                        extra["qualifier"] = qualifier
                     edges.append(EdgeInfo(
                         kind="INJECTS",
                         source=qualified_source,
@@ -4319,6 +4389,21 @@ class CodeParser:
 
         # Inheritance edges
         bases = self._get_bases(child, language, source)
+        # Spring bean identity for DI disambiguation (@Qualifier / @Primary).
+        # Carried on INHERITS so the post-build resolver can pick the right
+        # implementation when an interface has multiple implementors.
+        inherits_extra: dict = {}
+        if language == "java" and extra.get("spring_stereotype"):
+            ann_args = self._get_java_annotation_string_args(child)
+            bean_name = (
+                ann_args.get("Component") or ann_args.get("Service")
+                or ann_args.get("Repository") or ann_args.get("Controller")
+                or (name[0].lower() + name[1:] if name else None)
+            )
+            if bean_name:
+                inherits_extra["bean_name"] = bean_name
+            if "Primary" in class_annotations:
+                inherits_extra["primary"] = True
         for base in bases:
             edges.append(EdgeInfo(
                 kind="INHERITS",
@@ -4328,6 +4413,7 @@ class CodeParser:
                 target=base,
                 file_path=file_path,
                 line=child.start_point[0] + 1,
+                extra=dict(inherits_extra),
             ))
 
         # Spring DI: emit INJECTS edges for injected dependencies

--- a/code_review_graph/spring_resolver.py
+++ b/code_review_graph/spring_resolver.py
@@ -52,6 +52,8 @@ def resolve_spring_di_calls(store: GraphStore) -> dict:
     # from INJECTS edges that carry extra.field_name
     # -----------------------------------------------------------------------
     field_map: dict[tuple[str, str], str] = {}
+    # (class_qual, field_name) → @Qualifier bean name at the injection point
+    qualifier_map: dict[tuple[str, str], str] = {}
     injects_rows = conn.execute(
         "SELECT source_qualified, target_qualified, extra FROM edges WHERE kind = 'INJECTS'"
     ).fetchall()
@@ -66,6 +68,9 @@ def resolve_spring_di_calls(store: GraphStore) -> dict:
         # source_qualified is the full class qualified name
         class_qual = row["source_qualified"]
         field_map[(class_qual, fname)] = row["target_qualified"]
+        qualifier = extra.get("qualifier")
+        if qualifier:
+            qualifier_map[(class_qual, fname)] = qualifier
 
     if not field_map:
         logger.info("Spring resolver: no INJECTS edges with field_name found, skipping")
@@ -101,14 +106,21 @@ def resolve_spring_di_calls(store: GraphStore) -> dict:
     # Build implementors: bare interface name → list of implementing class quals
     # from INHERITS edges (Java uses INHERITS for both extends and implements)
     # -----------------------------------------------------------------------
-    implementors: dict[str, list[str]] = {}
+    # bare interface name → list of (impl_qual, bean_name, is_primary)
+    implementors: dict[str, list[tuple[str, str | None, bool]]] = {}
     for row in conn.execute(
-        "SELECT source_qualified, target_qualified FROM edges WHERE kind = 'INHERITS'"
+        "SELECT source_qualified, target_qualified, extra FROM edges WHERE kind = 'INHERITS'"
     ).fetchall():
         iface = row["target_qualified"]
         impl = row["source_qualified"]
+        try:
+            iextra = json.loads(row["extra"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            iextra = {}
         if any(impl.startswith(f) for f in java_files) or "::" in impl:
-            implementors.setdefault(iface, []).append(impl)
+            implementors.setdefault(iface, []).append(
+                (impl, iextra.get("bean_name"), bool(iextra.get("primary")))
+            )
 
     # -----------------------------------------------------------------------
     # Resolve CALLS edges
@@ -167,11 +179,30 @@ def resolve_spring_di_calls(store: GraphStore) -> dict:
         if not injected_type:
             continue
 
-        # Resolve to concrete implementation if unique
+        # Resolve to a concrete implementation.
+        #   1 impl            → that impl
+        #   N impls + @Qualifier("bean") at injection point → matching bean
+        #   N impls + exactly one @Primary impl             → the primary
+        #   otherwise         → leave at interface level (ambiguous)
         impls = implementors.get(injected_type, [])
+        chosen: str | None = None
         if len(impls) == 1:
-            concrete_class = impls[0].split("::")[-1]
-            fallback = f"{impls[0]}.{method_name}"
+            chosen = impls[0][0]
+        elif len(impls) > 1:
+            wanted = qualifier_map.get((enclosing_class_qual, receiver))
+            if wanted:
+                for impl_qual, bean_name, _primary in impls:
+                    if bean_name == wanted:
+                        chosen = impl_qual
+                        break
+            if chosen is None:
+                primaries = [i for i in impls if i[2]]
+                if len(primaries) == 1:
+                    chosen = primaries[0][0]
+
+        if chosen is not None:
+            concrete_class = chosen.split("::")[-1]
+            fallback = f"{chosen}.{method_name}"
             new_target = method_to_qual.get((concrete_class, method_name)) or fallback
         else:
             type_bare = injected_type.rsplit(".", 1)[-1]

--- a/tests/fixtures/SpringDIAdvanced.java
+++ b/tests/fixtures/SpringDIAdvanced.java
@@ -1,0 +1,83 @@
+package com.example.advanced;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+// ── Single-impl interface for implicit constructor injection ──
+interface Mailer {
+    void send(String to);
+}
+
+@Service
+class SmtpMailer implements Mailer {
+    public void send(String to) {}
+}
+
+// Implicit constructor injection (Spring 4.3+): one constructor, no @Autowired.
+@Service
+class WelcomeService {
+    private final Mailer mailer;
+
+    WelcomeService(Mailer mailer) {
+        this.mailer = mailer;
+    }
+
+    public void welcome(String to) {
+        mailer.send(to);
+    }
+}
+
+// ── Multi-impl interface for @Qualifier / @Primary disambiguation ──
+interface Gateway {
+    String pay(String id);
+}
+
+@Service("primaryGw")
+@Primary
+class PrimaryGateway implements Gateway {
+    public String pay(String id) { return "P:" + id; }
+}
+
+@Service("backupGw")
+class BackupGateway implements Gateway {
+    public String pay(String id) { return "B:" + id; }
+}
+
+// Field injection + @Qualifier → BackupGateway
+@Service
+class CheckoutService {
+    @Autowired
+    @Qualifier("backupGw")
+    private Gateway gateway;
+
+    public String checkout(String id) {
+        return gateway.pay(id);
+    }
+}
+
+// Constructor injection + @Qualifier on the parameter → PrimaryGateway
+@Service
+class RefundService {
+    private final Gateway gateway;
+
+    RefundService(@Qualifier("primaryGw") Gateway gateway) {
+        this.gateway = gateway;
+    }
+
+    public String refund(String id) {
+        return gateway.pay(id);
+    }
+}
+
+// Field injection, no qualifier, multi-impl → @Primary (PrimaryGateway) wins
+@Service
+class AuditService {
+    @Autowired
+    private Gateway gateway;
+
+    public String audit(String id) {
+        return gateway.pay(id);
+    }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2226,6 +2226,145 @@ class TestSpringDIResolver:
             )
 
 
+class TestSpringDIAdvancedParsing:
+    """Parser-level tests for implicit constructor injection, bean names,
+    @Primary and @Qualifier metadata used by the multi-impl resolver."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "SpringDIAdvanced.java"
+        )
+
+    def _injects(self):
+        return [e for e in self.edges if e.kind == "INJECTS"]
+
+    def test_implicit_constructor_injection_emitted(self):
+        """A stereotype bean with one unannotated constructor is injected."""
+        edges = [e for e in self._injects()
+                 if e.extra.get("injection_type") == "constructor_implicit"]
+        targets = {e.target for e in edges}
+        assert "Mailer" in targets  # WelcomeService(Mailer)
+        assert "Gateway" in targets  # RefundService(@Qualifier Gateway)
+
+    def test_field_qualifier_captured(self):
+        edges = [e for e in self._injects() if e.extra.get("field_name") == "gateway"]
+        quals = {e.extra.get("qualifier") for e in edges}
+        assert "backupGw" in quals  # CheckoutService field @Qualifier
+
+    def test_constructor_param_qualifier_captured(self):
+        edges = [e for e in self._injects()
+                 if e.extra.get("injection_type") == "constructor_implicit"
+                 and e.extra.get("qualifier")]
+        quals = {e.extra.get("qualifier") for e in edges}
+        assert "primaryGw" in quals  # RefundService ctor param @Qualifier
+
+    def test_inherits_carries_bean_name(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        beans = {e.extra.get("bean_name") for e in inherits}
+        assert "primaryGw" in beans
+        assert "backupGw" in beans
+
+    def test_inherits_marks_primary(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        primary_sources = {e.source for e in inherits if e.extra.get("primary")}
+        assert any("PrimaryGateway" in s for s in primary_sources)
+        assert not any("BackupGateway" in s for s in primary_sources)
+
+
+class TestSpringDIDisambiguation:
+    """Integration tests: resolver picks the right impl for multi-impl beans."""
+
+    def _build(self, tmp_path):
+        pkg = tmp_path / "src/main/java/com/example"
+        pkg.mkdir(parents=True)
+
+        (pkg / "Gateway.java").write_text(
+            "package com.example;\n"
+            "public interface Gateway { String pay(String id); }\n"
+        )
+        (pkg / "PrimaryGateway.java").write_text(
+            "package com.example;\n"
+            "import org.springframework.context.annotation.Primary;\n"
+            "import org.springframework.stereotype.Service;\n"
+            "@Service(\"primaryGw\")\n@Primary\n"
+            "public class PrimaryGateway implements Gateway {\n"
+            "    public String pay(String id) { return id; }\n}\n"
+        )
+        (pkg / "BackupGateway.java").write_text(
+            "package com.example;\n"
+            "import org.springframework.stereotype.Service;\n"
+            "@Service(\"backupGw\")\n"
+            "public class BackupGateway implements Gateway {\n"
+            "    public String pay(String id) { return id; }\n}\n"
+        )
+        (pkg / "CheckoutService.java").write_text(
+            "package com.example;\n"
+            "import org.springframework.beans.factory.annotation.Autowired;\n"
+            "import org.springframework.beans.factory.annotation.Qualifier;\n"
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\n"
+            "public class CheckoutService {\n"
+            "    @Autowired @Qualifier(\"backupGw\") private Gateway gateway;\n"
+            "    public String checkout(String id) { return gateway.pay(id); }\n}\n"
+        )
+        (pkg / "RefundService.java").write_text(
+            "package com.example;\n"
+            "import org.springframework.beans.factory.annotation.Qualifier;\n"
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\n"
+            "public class RefundService {\n"
+            "    private final Gateway gateway;\n"
+            "    public RefundService(@Qualifier(\"primaryGw\") Gateway gateway) "
+            "{ this.gateway = gateway; }\n"
+            "    public String refund(String id) { return gateway.pay(id); }\n}\n"
+        )
+        (pkg / "AuditService.java").write_text(
+            "package com.example;\n"
+            "import org.springframework.beans.factory.annotation.Autowired;\n"
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\n"
+            "public class AuditService {\n"
+            "    @Autowired private Gateway gateway;\n"
+            "    public String audit(String id) { return gateway.pay(id); }\n}\n"
+        )
+
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.incremental import full_build
+        from code_review_graph.postprocessing import run_post_processing
+
+        store = GraphStore(str(tmp_path / "graph.db"))
+        full_build(tmp_path, store)
+        run_post_processing(store)
+        return store
+
+    def _resolved_target(self, store, caller_method):
+        cur = store._conn.cursor()
+        rows = cur.execute(
+            "SELECT source_qualified, target_qualified FROM edges "
+            "WHERE kind='CALLS' AND extra LIKE '%spring_resolved%'"
+        ).fetchall()
+        for src, tgt in rows:
+            if src.endswith(caller_method):
+                return tgt
+        return None
+
+    def test_field_qualifier_resolves_to_backup(self, tmp_path):
+        store = self._build(tmp_path)
+        target = self._resolved_target(store, "CheckoutService.checkout")
+        assert target and "BackupGateway" in target
+
+    def test_constructor_qualifier_resolves_to_primary(self, tmp_path):
+        store = self._build(tmp_path)
+        target = self._resolved_target(store, "RefundService.refund")
+        assert target and "PrimaryGateway" in target
+
+    def test_primary_wins_without_qualifier(self, tmp_path):
+        store = self._build(tmp_path)
+        target = self._resolved_target(store, "AuditService.audit")
+        assert target and "PrimaryGateway" in target
+
+
 class TestTemporalParsing:
     """Tests for Temporal @WorkflowInterface / @ActivityInterface detection."""
 


### PR DESCRIPTION
# Resolve Spring DI calls through constructor injection, `@Qualifier` and `@Primary`

## Problem

The Spring DI post-build resolver only rewrote `CALLS` edges when the dependency was
**field-injected** *and* the interface had **exactly one** implementation. Three of the
most common Spring patterns were therefore left unresolved — calls fell back to the
interface or stayed as bare method names, which weakens blast-radius / caller analysis
on real Spring Boot codebases:

| Pattern | Before | After |
|---|---|---|
| Field injection, 1 impl | ✅ concrete | ✅ concrete |
| **Constructor injection (implicit, Spring 4.3+)** | ❌ no `INJECTS` emitted | ✅ concrete |
| **Multi-impl + `@Qualifier`** | ⚠️ interface only | ✅ matching bean |
| **Multi-impl + `@Primary`** | ⚠️ interface only | ✅ primary bean |
| **Constructor param + `@Qualifier`** | ❌ | ✅ matching bean |
| Multi-impl, ambiguous (no qualifier/primary) | interface | interface (unchanged) |

Root cause: `_get_java_annotations` only captured annotation **names**, so the bean name
in `@Service("x")` / `@Qualifier("x")` was discarded; and constructor injection only
emitted an `INJECTS` edge when the constructor carried `@Autowired`.

## Changes

**`parser.py`**
- Add `_get_java_annotation_string_args` / `_first_java_string_literal` to capture
  annotation string arguments (bean names, qualifiers).
- Emit `INJECTS` for **implicit single-constructor injection** on stereotype beans
  (`injection_type="constructor_implicit"`) — no `@Autowired` required.
- Carry `bean_name` + `primary` on `INHERITS` edges; carry `qualifier` on `INJECTS`
  edges (both field and constructor parameter).

**`spring_resolver.py`**
- When an interface has multiple implementors: pick by `@Qualifier` bean name → else the
  unique `@Primary` → else fall back to the interface (ambiguous case unchanged).

## Tests

- New fixture `tests/fixtures/SpringDIAdvanced.java`.
- `TestSpringDIAdvancedParsing` — parser metadata (implicit constructor injection,
  qualifier capture on field and constructor param, `bean_name`/`primary` on `INHERITS`).
- `TestSpringDIDisambiguation` — end-to-end: resolver picks the correct implementation
  for `@Qualifier` (field & constructor) and `@Primary` fallback.
- All existing Spring/parser tests pass; `ruff check` clean.

## Known follow-ups (not in this PR)

- `@Qualifier` aliased via a custom annotation (`@interface ... @Qualifier`).
- Param-name ≠ field-name in constructor bodies (resolution keys on the parameter name).
- Kafka / event-bus producer↔consumer linkage (separate concern — topic-name extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
