### PR TITLE
fix(flows): normalize changed_files to absolute paths for incremental flow detection

### DIFF
--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -459,6 +459,11 @@ def incremental_trace_flows(
     if not changed_files:
         return 0
 
+    # Normalize to absolute paths — git diff returns relative paths but
+    # the graph stores absolute file_path values (see #569).
+    import os
+    changed_files = [os.path.abspath(f) for f in changed_files]
+
     conn = store._conn
     changed_file_set = set(changed_files)
 


### PR DESCRIPTION
Fixes #569

## Problem

`incremental_trace_flows()` in `flows.py` filters re-detected entry points by comparing `ep.file_path` (absolute path from graph) against `changed_file_set` (relative paths from `git diff --name-only`). This format mismatch means `ep.file_path in changed_file_set` is always `False`, so new entry points are never found during incremental updates.

The same mismatch affects the SQL query on line 473: `WHERE n.file_path IN ({placeholders})` compares relative paths against absolute paths in the database.

## What changed

Added one line at the start of `incremental_trace_flows()` to normalize `changed_files` to absolute paths:

```python
changed_files = [os.path.abspath(f) for f in changed_files]
```

This fixes both:
1. The SQL query (line 473) — now compares absolute vs absolute
2. The set comparison (line 513) — `ep.file_path in changed_file_set` now matches

No existing comments modified. No behavior change when paths are already absolute.

## Validation

- The issue reporter confirmed that `run_postprocess_tool` (non-incremental path) works correctly — this is because it doesn't filter by `changed_files`
- After this fix, the incremental path uses the same absolute path format as the graph storage