### PR TITLE
fix: resolve PHP `use` imports to file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PHP `use` imports now resolve to files** (`importers_of`, impact radius,
+  call disambiguation): PHP `use` statements had no branch in the parser's
+  import extraction and fell through to the raw-text fallback, storing the whole
+  `use ...;` statement as the `IMPORTS_FROM` edge target (e.g.
+  `"use App\Domain\Entity\Job;"`). As a result `importers_of` / `tests_for` /
+  `inheritors_of` and the upstream side of `get_impact_radius` returned nothing
+  for PHP classes, and the unresolved targets also degraded cross-file `CALLS`
+  disambiguation in `resolve_bare_call_targets`. PHP imports are now recorded as
+  fully-qualified names (handling `as` aliases, grouped `use A\{B, C}`, and
+  `use function` / `use const`) and resolved to absolute `.php` paths by walking
+  up from the importing file, mirroring the existing Java resolver. Vendor/global
+  classes with no local file stay as the bare FQN.
+
 ## [2.3.6] - 2026-06-10
 
 **Community-response release.** Built from a full audit of every open PR,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5531,6 +5531,24 @@ class CodeParser:
                         break
                     current = current.parent
 
+        elif language == "php":
+            # ``use App\Domain\Entity\Job;`` — convert namespace separators to
+            # a relative path and walk up from the caller's directory to find
+            # the file, mirroring the Java resolver. PSR-4 layouts where a
+            # namespace segment maps to a real directory (e.g. ``App\Foo`` ->
+            # ``.../App/Foo``) resolve; vendor/global classes (``\Exception``)
+            # and ``use function`` / ``use const`` targets with no matching
+            # file stay unresolved and keep the bare FQN, like JDK imports.
+            rel_path = module.replace("\\", "/").lstrip("/") + ".php"
+            current = caller_dir
+            while True:
+                target = current / rel_path
+                if target.is_file():
+                    return str(target.resolve())
+                if current == current.parent:
+                    break
+                current = current.parent
+
         return None
 
     def _find_dart_pubspec_root(
@@ -6394,6 +6412,47 @@ class CodeParser:
                     txt = child.text.decode("utf-8", errors="replace")
                     if txt and txt != "extends":
                         imports.append(txt)
+        elif language == "php":
+            # ``namespace_use_declaration`` covers several shapes:
+            #   use A\B\C;            use A\B\C as D;
+            #   use function A\b;     use const A\B;
+            #   use A\B, C\D;         (comma-separated clauses)
+            #   use A\B\{C, D as E};  (grouped — clause names are relative to A\B)
+            # Record the fully-qualified name of each imported symbol, ignoring
+            # any ``as`` alias and stripping a leading ``\``, so IMPORTS_FROM
+            # targets are clean FQNs that _do_resolve_module can map to files.
+            # Without this branch PHP falls through to the raw-text fallback and
+            # stores the entire ``use ...;`` statement as the edge target.
+            def _php_clause_fqn(clause) -> Optional[str]:
+                for sub in clause.children:
+                    if sub.type in ("qualified_name", "name"):
+                        return sub.text.decode(
+                            "utf-8", errors="replace",
+                        ).lstrip("\\")
+                return None
+
+            group_node = None
+            prefix = ""
+            for child in node.children:
+                if child.type == "namespace_name":
+                    prefix = child.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip("\\")
+                elif child.type == "namespace_use_group":
+                    group_node = child
+
+            if group_node is not None:
+                for clause in group_node.children:
+                    if clause.type == "namespace_use_clause":
+                        rel = _php_clause_fqn(clause)
+                        if rel:
+                            imports.append(f"{prefix}\\{rel}" if prefix else rel)
+            else:
+                for clause in node.children:
+                    if clause.type == "namespace_use_clause":
+                        fqn = _php_clause_fqn(clause)
+                        if fqn:
+                            imports.append(fqn)
         elif language in self._custom_languages:
             # Custom languages (languages.toml): prefer the grammar's
             # module-ish field over the raw statement text (e.g. Erlang

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -455,6 +455,94 @@ class TestPHPParsing:
         assert "dirname" in target_names
 
 
+class TestPHPImportResolution:
+    """PHP ``use`` imports resolve to absolute file paths (PSR-4 layout)."""
+
+    def test_resolves_project_import(self, tmp_path):
+        """``use`` of a project class resolves to its .php file."""
+        entity = tmp_path / "src/App/Domain/Entity"
+        entity.mkdir(parents=True)
+        (entity / "Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\nclass Job {}\n"
+        )
+        svc = tmp_path / "src/App/Service"
+        svc.mkdir(parents=True)
+        (svc / "MatchService.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use App\\Domain\\Entity\\Job;\n"
+            "class MatchService {}\n"
+        )
+
+        parser = CodeParser()
+        _, edges = parser.parse_file(svc / "MatchService.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == str((entity / "Job.php").resolve())
+
+    def test_vendor_import_stays_unresolved(self, tmp_path):
+        """A class with no local file stays as the bare FQN, not a raw
+        ``use ...;`` statement and not a fake path."""
+        svc = tmp_path / "src/App/Service"
+        svc.mkdir(parents=True)
+        (svc / "Logger.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use Psr\\Log\\LoggerInterface;\n"
+            "class Logger {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(svc / "Logger.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == "Psr\\Log\\LoggerInterface"
+        assert not imports[0].target.endswith(".php")
+
+    def test_aliased_import_records_fqn_not_alias(self, tmp_path):
+        """``use A\\B\\C as D`` records the FQN A\\B\\C, ignoring the alias."""
+        contact = tmp_path / "src/App/Domain/Embedded"
+        contact.mkdir(parents=True)
+        (contact / "Contact.php").write_text(
+            "<?php\nnamespace App\\Domain\\Embedded;\nclass Contact {}\n"
+        )
+        job = tmp_path / "src/App/Domain/Entity"
+        job.mkdir(parents=True)
+        (job / "Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\n"
+            "use App\\Domain\\Embedded\\Contact as ContactEmbedded;\n"
+            "class Job {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(job / "Job.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == str((contact / "Contact.php").resolve())
+
+    def test_grouped_use_expands_to_multiple_imports(self, tmp_path):
+        """``use App\\Domain\\{Entity\\Job, Model\\Status}`` -> two imports,
+        each prefixed with the group namespace and resolved independently."""
+        base = tmp_path / "src/App/Domain"
+        (base / "Entity").mkdir(parents=True)
+        (base / "Model").mkdir(parents=True)
+        (base / "Entity/Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\nclass Job {}\n"
+        )
+        (base / "Model/Status.php").write_text(
+            "<?php\nnamespace App\\Domain\\Model;\nclass Status {}\n"
+        )
+        consumer = tmp_path / "src/App/Service"
+        consumer.mkdir(parents=True)
+        (consumer / "C.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use App\\Domain\\{Entity\\Job, Model\\Status};\n"
+            "class C {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(consumer / "C.php")
+        targets = {e.target for e in edges if e.kind == "IMPORTS_FROM"}
+        assert str((base / "Entity/Job.php").resolve()) in targets
+        assert str((base / "Model/Status.php").resolve()) in targets
+        assert len(targets) == 2
+
+
 class TestKotlinParsing:
     def setup_method(self):
         self.parser = CodeParser()


### PR DESCRIPTION
## Linked issue

Closes #574.

Found while using the graph on a Symfony/PHP codebase: `importers_of` (and the
upstream side of impact-radius) returned **0** for PHP classes that are imported
by hundreds of files.

## What & why

PHP `use` statements had no branch in the parser's `_extract_import`, so they
fell through to the raw-text fallback (`imports.append(text)`) and stored the
**entire statement** as the `IMPORTS_FROM` edge target. For example,
`"use App\Domain\Entity\Job;"` was stored instead of the FQN
`App\Domain\Entity\Job`.

Consequences:

- `importers_of`, `tests_for`, and `inheritors_of` returned nothing for PHP
  classes, because the query matches edge targets by resolved file path, which
  the raw `use ...;` text never matches.
- The upstream side of `get_impact_radius` saw no PHP importers.
- `resolve_bare_call_targets` uses `IMPORTS_FROM` targets to disambiguate
  cross-file `CALLS`, so the unparsed targets silently degraded PHP call
  resolution too.

Every other FQN-style language already has an import branch, and Java
additionally resolves `import a.b.C;` to the class's `.java` file in
`_do_resolve_module`. This PR brings PHP to parity:

- **`_extract_import`**: new `php` branch recording the fully-qualified name of
  each imported symbol, handling `as` aliases (records the FQN, not the alias),
  grouped `use A\B\{C, D as E}` (prefix-joined), `use function` / `use const`,
  and a leading `\`.
- **`_do_resolve_module`**: new `php` branch mirroring Java. It converts `\` to
  `/`, appends `.php`, and walks up from the importing file to the source root.
  Vendor/global classes with no local file (such as `\Exception`) stay as the
  bare FQN, exactly like JDK imports.

No new dependencies, no schema changes, and no post-build resolver. The fix
lives entirely in the existing per-language parser paths, consistent with Java.

### Impact

In the codebase where this surfaced, `importers_of` for a core entity returned
**0** despite **452** files doing `use App\Domain\Entity\Job;` (confirmed via
grep). With the fix those `use` statements resolve to the entity's file. The
behavior is covered by a self-contained test (`TestPHPImportResolution`) on a
mini PSR-4 project.

## How it was tested

```bash
uv run pytest tests/test_multilang.py::TestPHPImportResolution -q   # 4 passed (new)
uv run pytest tests/ --tb=short -q                                  # 1388 passed, 1 skipped, 2 xpassed
uv run ruff check code_review_graph/                                # All checks passed!
uv run mypy code_review_graph/parser.py --ignore-missing-imports --no-strict-optional  # Success
```

Also verified end to end by building a graph for a mini PSR-4 project with the
patched code and confirming `query_graph("importers_of", <Job.php>)` returns the
two importing files and excludes a non-importing file. It returned nothing
before the change.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (CHANGELOG)
