### PR TITLE
feat(java): detect @Scheduled methods and emit TRIGGERS edges

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -518,6 +518,9 @@ _KAFKA_PRODUCER_TYPES = frozenset({
     "KafkaSender",
 })
 
+# Spring scheduling annotation
+_SPRING_SCHEDULED_ANNOTATIONS = frozenset({"Scheduled"})
+
 
 # ---------------------------------------------------------------------------
 # ReScript regex patterns and helpers (no tree-sitter grammar bundled)
@@ -4111,6 +4114,71 @@ class CodeParser:
                                     topics.append(raw)
         return topics
 
+    def _emit_scheduled_edges_from_method(
+        self,
+        method_node,
+        method_name: str,
+        class_name: Optional[str],
+        file_path: str,
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Emit TRIGGERS edge from a virtual SCHEDULER node for @Scheduled methods."""
+        for child in method_node.children:
+            if child.type != "modifiers":
+                continue
+            for mod in child.children:
+                if mod.type not in ("annotation", "marker_annotation"):
+                    continue
+                ann_name: Optional[str] = None
+                for sub in mod.children:
+                    if sub.type == "identifier":
+                        ann_name = sub.text.decode("utf-8", errors="replace")
+                        break
+                if ann_name not in _SPRING_SCHEDULED_ANNOTATIONS:
+                    continue
+
+                schedule_extra: dict = {"annotation": "Scheduled"}
+                scheduler_id = "SCHEDULER::scheduled"
+
+                for arg_list in mod.children:
+                    if arg_list.type != "annotation_argument_list":
+                        continue
+                    for pair in arg_list.children:
+                        if pair.type != "element_value_pair":
+                            continue
+                        key_node = next(
+                            (c for c in pair.children if c.type == "identifier"), None
+                        )
+                        val_node = next(
+                            (c for c in pair.children
+                             if c.type in ("string_literal",
+                                           "decimal_integer_literal",
+                                           "hex_integer_literal",
+                                           "decimal_floating_point_literal")),
+                            None,
+                        )
+                        if not (key_node and val_node):
+                            continue
+                        key = key_node.text.decode("utf-8", errors="replace")
+                        val = val_node.text.decode("utf-8", errors="replace").strip('"')
+                        schedule_extra[key] = val
+                        if key == "cron":
+                            scheduler_id = "SCHEDULER::cron"
+                        elif key in ("fixedRate", "fixedRateString"):
+                            scheduler_id = "SCHEDULER::fixedRate"
+                        elif key in ("fixedDelay", "fixedDelayString"):
+                            scheduler_id = "SCHEDULER::fixedDelay"
+
+                qualified_target = self._qualify(method_name, file_path, class_name)
+                edges.append(EdgeInfo(
+                    kind="TRIGGERS",
+                    source=scheduler_id,
+                    target=qualified_target,
+                    file_path=file_path,
+                    line=method_node.start_point[0] + 1,
+                    extra=schedule_extra,
+                ))
+
     def _emit_kafka_edges_from_class(
         self,
         class_node,
@@ -4442,6 +4510,11 @@ class CodeParser:
             if any(a.split("(")[0] in _KAFKA_LISTENER_ANNOTATIONS for a in deco_list):
                 method_extra["kafka_listener"] = True
                 self._emit_kafka_edges_from_method(
+                    child, name, enclosing_class, file_path, edges,
+                )
+            if any(a.split("(")[0] in _SPRING_SCHEDULED_ANNOTATIONS for a in deco_list):
+                method_extra["scheduled"] = True
+                self._emit_scheduled_edges_from_method(
                     child, name, enclosing_class, file_path, edges,
                 )
 

--- a/tests/fixtures/ScheduledTasks.java
+++ b/tests/fixtures/ScheduledTasks.java
@@ -1,0 +1,29 @@
+package com.example.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReportScheduler {
+
+    // cron-based schedule
+    @Scheduled(cron = "0 0 8 * * MON-FRI")
+    public void generateDailyReport() {
+        // business logic
+    }
+
+    // fixed-rate schedule
+    @Scheduled(fixedRate = 60000)
+    public void syncInventory() {
+        // business logic
+    }
+
+    // fixed-delay schedule
+    @Scheduled(fixedDelay = 30000)
+    public void cleanupExpiredSessions() {
+        // business logic
+    }
+
+    // unscheduled helper — must NOT produce a TRIGGERS edge
+    public void helperMethod() {}
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2041,6 +2041,67 @@ class TestNixParsing:
             )
 
 
+class TestSpringScheduledParsing:
+    """Tests for @Scheduled annotation detection and TRIGGERS edge generation."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "ScheduledTasks.java"
+        )
+
+    def test_cron_scheduled_emits_triggers_edge(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"]
+        cron_edges = [e for e in triggers if e.source == "SCHEDULER::cron"]
+        assert cron_edges, "Expected TRIGGERS edge with source SCHEDULER::cron"
+        targets = {e.target for e in cron_edges}
+        assert any("generateDailyReport" in t for t in targets)
+
+    def test_fixed_rate_scheduled_emits_triggers_edge(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"]
+        fixed_edges = [e for e in triggers if e.source == "SCHEDULER::fixedRate"]
+        assert fixed_edges, "Expected TRIGGERS edge with source SCHEDULER::fixedRate"
+        targets = {e.target for e in fixed_edges}
+        assert any("syncInventory" in t for t in targets)
+
+    def test_fixed_delay_scheduled_emits_triggers_edge(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"]
+        delay_edges = [e for e in triggers if e.source == "SCHEDULER::fixedDelay"]
+        assert delay_edges
+        targets = {e.target for e in delay_edges}
+        assert any("cleanupExpiredSessions" in t for t in targets)
+
+    def test_cron_value_stored_in_extra(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"
+                    and e.source == "SCHEDULER::cron"]
+        assert triggers
+        assert triggers[0].extra.get("cron") == "0 0 8 * * MON-FRI"
+
+    def test_fixedrate_value_stored_in_extra(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"
+                    and e.source == "SCHEDULER::fixedRate"]
+        assert triggers
+        assert triggers[0].extra.get("fixedRate") == "60000"
+
+    def test_non_scheduled_method_no_triggers_edge(self):
+        """helperMethod has no @Scheduled — must not produce a TRIGGERS edge."""
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"]
+        targets = {e.target for e in triggers}
+        assert not any("helperMethod" in t for t in targets)
+
+    def test_total_triggers_edge_count(self):
+        triggers = [e for e in self.edges if e.kind == "TRIGGERS"]
+        # ReportScheduler has 3 @Scheduled methods
+        assert len(triggers) == 3
+
+    def test_scheduled_method_extra_flag(self):
+        """Function nodes for @Scheduled methods should carry extra.scheduled=True."""
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        assert funcs["generateDailyReport"].extra.get("scheduled") is True
+        assert funcs["syncInventory"].extra.get("scheduled") is True
+        assert "scheduled" not in funcs.get("helperMethod", type("", (), {"extra": {}})()).extra
+
+
 class TestSpringDIParsing:
     """Tests for Spring DI annotation detection and INJECTS edge generation."""
 


### PR DESCRIPTION
## Problem

Spring `@Scheduled` methods are scheduler entry points with no static caller in the codebase. CRG previously had no way to discover them via graph queries — users had to fall back to `rg "@Scheduled"`.

## Solution

Emit `TRIGGERS` edges from virtual scheduler source nodes to annotated methods at parse time. No post-build resolver needed — schedule parameters are statically present in the annotation.

| `@Scheduled` param | Source node |
|---|---|
| `cron = "..."` | `SCHEDULER::cron` |
| `fixedRate = N` | `SCHEDULER::fixedRate` |
| `fixedDelay = N` | `SCHEDULER::fixedDelay` |
| (none / unrecognised) | `SCHEDULER::scheduled` |

Schedule metadata (cron expression, rate value, etc.) is stored in edge `extra` for traceability.

## Usage after this change

```
# Find all methods the scheduler triggers
query_graph(callers_of="SCHEDULER::cron")
query_graph(callers_of="SCHEDULER::fixedRate")
```

## Changes

- `code_review_graph/parser.py` — `_SPRING_SCHEDULED_ANNOTATIONS` constant + `_emit_scheduled_edges_from_method()` + hook in `_extract_functions`
- `tests/fixtures/ScheduledTasks.java` — fixture with cron / fixedRate / fixedDelay / plain methods
- `tests/test_multilang.py` — `TestSpringScheduledParsing` (8 assertions)