### PR TITLE
fix: read TESTED_BY edges in the parser's direction everywhere

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -352,7 +352,7 @@ def analyze_changes(
     for node in changed_funcs:
         if node.is_test:
             continue
-        tested = store.get_edges_by_target(node.qualified_name)
+        tested = store.get_edges_by_source(node.qualified_name)
         if not any(e.kind == "TESTED_BY" for e in tested):
             test_gaps.append({
                 "name": _sanitize_name(node.name),

--- a/code_review_graph/communities.py
+++ b/code_review_graph/communities.py
@@ -830,8 +830,8 @@ def get_architecture_overview(store: GraphStore) -> dict[str, Any]:
     cross_counts: Counter[tuple[int, int]] = Counter()
 
     for e in all_edges:
-        # TESTED_BY edges are expected cross-community coupling (test → code),
-        # not an architectural smell.
+        # TESTED_BY edges are expected cross-community coupling (code and
+        # its tests), not an architectural smell.
         if e.kind == "TESTED_BY":
             continue
         src_comm = node_to_community.get(e.source_qualified)

--- a/code_review_graph/enrich.py
+++ b/code_review_graph/enrich.py
@@ -158,11 +158,11 @@ def _format_node_context(
     if flow_names:
         lines.append(f"  Flows: {', '.join(flow_names)}")
 
-    # Tests
+    # Tests (TESTED_BY edges point production -> test)
     tests: list[str] = []
-    for e in store.get_edges_by_target(qn):
+    for e in store.get_edges_by_source(qn):
         if e.kind == "TESTED_BY" and len(tests) < 3:
-            t = store.get_node(e.source_qualified)
+            t = store.get_node(e.target_qualified)
             if t:
                 tests.append(t.name)
     if tests:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -377,7 +377,7 @@ class GraphStore:
     ) -> list[dict]:
         """Find tests covering a node, including indirect (transitive) coverage.
 
-        1. Direct: TESTED_BY edges targeting this node (+ bare-name fallback).
+        1. Direct: TESTED_BY edges from this node to its tests (+ bare-name fallback).
         2. Indirect: follow outgoing CALLS edges up to *max_depth* hops,
            then collect TESTED_BY edges on each callee.
 
@@ -421,31 +421,32 @@ class GraphStore:
                 "indirect": indirect,
             }
 
-        # Direct TESTED_BY
+        # Direct TESTED_BY (edges point production -> test)
         for qn in input_qns:
             for row in conn.execute(
-                "SELECT source_qualified FROM edges "
-                "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+                "SELECT target_qualified FROM edges "
+                "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                 (qn,),
             ).fetchall():
-                src = row["source_qualified"]
-                if src not in seen:
-                    seen.add(src)
-                    d = _node_dict(src, indirect=False)
+                tst = row["target_qualified"]
+                if tst not in seen:
+                    seen.add(tst)
+                    d = _node_dict(tst, indirect=False)
                     if d:
                         results.append(d)
 
-        # Bare-name fallback for direct
+        # Bare-name fallback for direct: the edge source inherits the CALLS
+        # target, which can be a bare name when unresolved cross-file.
         bare = qualified_name.rsplit("::", 1)[-1] if "::" in qualified_name else qualified_name
         for row in conn.execute(
-            "SELECT source_qualified FROM edges "
-            "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+            "SELECT target_qualified FROM edges "
+            "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
             (bare,),
         ).fetchall():
-            src = row["source_qualified"]
-            if src not in seen:
-                seen.add(src)
-                d = _node_dict(src, indirect=False)
+            tst = row["target_qualified"]
+            if tst not in seen:
+                seen.add(tst)
+                d = _node_dict(tst, indirect=False)
                 if d:
                     results.append(d)
 
@@ -464,14 +465,14 @@ class GraphStore:
                 next_frontier = set(list(next_frontier)[:max_frontier])
             for callee in next_frontier:
                 for row in conn.execute(
-                    "SELECT source_qualified FROM edges "
-                    "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+                    "SELECT target_qualified FROM edges "
+                    "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                     (callee,),
                 ).fetchall():
-                    src = row["source_qualified"]
-                    if src not in seen:
-                        seen.add(src)
-                        d = _node_dict(src, indirect=True)
+                    tst = row["target_qualified"]
+                    if tst not in seen:
+                        seen.add(tst)
+                        d = _node_dict(tst, indirect=True)
                         if d:
                             results.append(d)
             frontier = next_frontier
@@ -1269,8 +1270,8 @@ class GraphStore:
             kind, src, tgt = row["kind"], row["source_qualified"], row["target_qualified"]
             if kind == "CALLS":
                 calls_out.setdefault(src, []).append(tgt)
-            else:  # TESTED_BY
-                has_tested_by.add(tgt)
+            else:  # TESTED_BY points production -> test; the SOURCE is tested
+                has_tested_by.add(src)
 
         return FlowAdjacency(
             calls_out=calls_out,

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -492,19 +492,29 @@ def find_dead_code(
                 if _is_plausible_caller(e.file_path, node.file_path, node.name)
             ]
             incoming = incoming + all_bare
-        if not any(e.kind == "TESTED_BY" for e in incoming):
-            bare_tb = store.search_edges_by_target_name(node.name, kind="TESTED_BY")
-            bare_tb = [
-                e for e in bare_tb
+        # TESTED_BY edges point production -> test, so a node's test
+        # references are its OUTGOING edges. The edge source inherits the
+        # CALLS target, which can be a bare name when unresolved cross-file.
+        test_refs = [
+            e for e in store.get_edges_by_source(node.qualified_name)
+            if e.kind == "TESTED_BY"
+        ]
+        if not test_refs:
+            bare_tb_rows = conn.execute(
+                "SELECT * FROM edges WHERE kind = 'TESTED_BY'"
+                " AND source_qualified = ?",
+                (node.name,),
+            ).fetchall()
+            test_refs = [
+                e for e in (store._row_to_edge(r) for r in bare_tb_rows)
                 if _is_plausible_caller(e.file_path, node.file_path, node.name)
             ]
-            incoming = incoming + bare_tb
         # Check INHERITS -- classes with subclasses are not dead.
         if node.kind == "Class" and not any(e.kind == "INHERITS" for e in incoming):
             bare_inh = store.search_edges_by_target_name(node.name, kind="INHERITS")
             incoming = incoming + bare_inh
         has_callers = any(e.kind == "CALLS" for e in incoming)
-        has_test_refs = any(e.kind == "TESTED_BY" for e in incoming)
+        has_test_refs = bool(test_refs)
         has_importers = any(e.kind == "IMPORTS_FROM" for e in incoming)
         has_references = any(e.kind == "REFERENCES" for e in incoming)
         has_subclasses = any(e.kind == "INHERITS" for e in incoming)

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -293,9 +293,10 @@ def query_graph(
                         results.append(node_to_dict(child))
 
         elif pattern == "tests_for":
-            for e in store.get_edges_by_target(qn):
+            # TESTED_BY edges point production -> test.
+            for e in store.get_edges_by_source(qn):
                 if e.kind == "TESTED_BY":
-                    test = store.get_node(e.source_qualified)
+                    test = store.get_node(e.target_qualified)
                     if test:
                         results.append(node_to_dict(test))
             # Also search by naming convention

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -64,10 +64,11 @@ class TestChanges:
         self.store.commit()
 
     def _add_tested_by(self, test_qn: str, target_qn: str, path: str = "app.py") -> None:
+        # The parser emits TESTED_BY as production (target_qn) -> test (test_qn).
         edge = EdgeInfo(
             kind="TESTED_BY",
-            source=test_qn,
-            target=target_qn,
+            source=target_qn,
+            target=test_qn,
             file_path=path,
             line=1,
         )

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -100,8 +100,8 @@ class TestEnrichSearch:
             ),
             EdgeInfo(
                 kind="TESTED_BY",
-                source=f"{self.tmpdir}/test_parser.py::test_parse_file",
-                target=f"{self.tmpdir}/parser.py::parse_file",
+                source=f"{self.tmpdir}/parser.py::parse_file",
+                target=f"{self.tmpdir}/test_parser.py::test_parse_file",
                 file_path=f"{self.tmpdir}/test_parser.py", line=1,
             ),
         ]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -401,7 +401,7 @@ class TestGetTransitiveTestsFrontierCap:
             # Only callee_2 has a test
             if i == 2:
                 self.store.upsert_edge(EdgeInfo(
-                    kind="TESTED_BY", source=test_qn, target=callee_qn,
+                    kind="TESTED_BY", source=callee_qn, target=test_qn,
                     file_path="/t/test_hub.py", line=1,
                 ))
         self.store.commit()

--- a/tests/test_integration_v2.py
+++ b/tests/test_integration_v2.py
@@ -180,8 +180,8 @@ class TestV2Integration:
 
         # --- Edges: tested_by ---
         s.upsert_edge(EdgeInfo(
-            kind="TESTED_BY", source="test_auth.py::test_login",
-            target="auth.py::login", file_path="test_auth.py", line=5,
+            kind="TESTED_BY", source="auth.py::login",
+            target="test_auth.py::test_login", file_path="test_auth.py", line=5,
         ))
 
         s.commit()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -357,6 +357,24 @@ class TestCodeParser:
         tested_by = [e for e in edges if e.kind == "TESTED_BY"]
         assert len(tested_by) >= 1
 
+    def test_tested_by_edges_point_from_production_to_test(self):
+        """TESTED_BY direction: source = production symbol, target = the test.
+
+        Consumers (tests_for, get_transitive_tests, test-gap detection,
+        flow criticality) query by source_qualified, so a flipped edge
+        silently breaks all of them.
+        """
+        nodes, edges = self.parser.parse_file(FIXTURES / "test_sample.py")
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert tested_by
+        for e in tested_by:
+            assert "::test_" in e.target, (
+                f"TESTED_BY target must be the test, got {e.target!r}"
+            )
+            assert "::test_" not in e.source, (
+                f"TESTED_BY source must be production code, got {e.source!r}"
+            )
+
     def test_recursion_depth_guard(self):
         """Parser should not crash on deeply nested code."""
         # Generate Python code with many nested functions (> _MAX_AST_DEPTH)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -265,6 +265,56 @@ class TestQueryGraphCallTargetFallbacks:
         }
 
 
+class TestQueryGraphTestsFor:
+    """Regression tests for tests_for reading TESTED_BY in the parser's
+    direction (production -> test)."""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.root = Path(self.tmp_dir).resolve()
+        (self.root / ".git").mkdir()
+        (self.root / ".code-review-graph").mkdir()
+
+        self.prod_file = str(self.root / "billing.py")
+        self.test_file = str(self.root / "test_billing.py")
+        self.db_path = str(self.root / ".code-review-graph" / "graph.db")
+        with GraphStore(self.db_path) as store:
+            store.upsert_node(NodeInfo(
+                kind="Function", name="compute_total", file_path=self.prod_file,
+                line_start=1, line_end=10, language="python",
+            ))
+            # Deliberately NOT named test_compute_total so the naming
+            # convention fallback cannot find it -- only the edge can.
+            store.upsert_node(NodeInfo(
+                kind="Test", name="test_sums_line_items", file_path=self.test_file,
+                line_start=1, line_end=8, language="python", is_test=True,
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="TESTED_BY",
+                source=f"{self.prod_file}::compute_total",
+                target=f"{self.test_file}::test_sums_line_items",
+                file_path=self.test_file,
+                line=3,
+            ))
+            store.commit()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_tests_for_follows_production_to_test_edges(self):
+        result = query_graph(
+            pattern="tests_for",
+            target=f"{self.prod_file}::compute_total",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        names = {r["name"] for r in result["results"]}
+        assert "test_sums_line_items" in names
+
+
 def _seed_repo_relative_graph(root: Path) -> None:
     """Seed graph data with cwd-relative paths, as eval repos currently do."""
     graph_dir = root / ".code-review-graph"
@@ -1216,8 +1266,8 @@ class TestComputeSummaries:
         Shape (auth.py community, community_id=1):
             login  ->  check_token   (CALLS, internal)
             logout ->  check_token   (CALLS, internal)
-            test_login -> login      (TESTED_BY)
-            test_login -> logout     (TESTED_BY)
+            login  -> test_login     (TESTED_BY, production -> test)
+            logout -> test_login     (TESTED_BY, production -> test)
             (login is called from db.py::query to force cross-community
              edges into caller_counts)
 
@@ -1276,7 +1326,8 @@ class TestComputeSummaries:
             target="auth.py::login", file_path="db.py", line=3,
         ))
 
-        # TESTED_BY edges from the Test node back to auth functions.
+        # TESTED_BY edges from the auth functions to their Test node
+        # (the parser emits production -> test).
         self.store.upsert_edge(EdgeInfo(
             kind="TESTED_BY", source="auth.py::login",
             target="tests/test_auth.py::test_login",


### PR DESCRIPTION
## Problem

The parser emits `TESTED_BY` edges as **production → test** (`source` = the code under test, `target` = the test function). Several consumers read the edge in the opposite direction, so they silently return nothing:

- `query_graph(pattern="tests_for")` looked for incoming edges on the production node and returned the wrong endpoint.
- `graph.get_transitive_tests` queried `target_qualified = ?` for the production node in all three lookup blocks (direct, bare-name fallback, transitive).
- `changes.py` counted "tested" nodes from incoming edges → `tests_for` context in change reviews was empty.
- `enrich.py`'s Tests block and `refactor.py`'s test-reference augmentation read the reverse direction as well.

Some call sites already read the correct direction (`build.py`, `analysis.py`, `review.py`, `communities.py`), which is how the inconsistency stayed invisible: half the features worked, half quietly returned empty results.

## Fix

Read `TESTED_BY` by `source_qualified` (production) and take `target_qualified` (test) everywhere, matching the parser. Test seeds that encoded the inverted direction were flipped to the parser's real output, and two end-to-end regression tests pin the direction:

- `test_tested_by_edges_point_from_production_to_test` (parser level)
- `TestQueryGraphTestsFor` (tool level, with a test name that deliberately defeats the name-matching fallback so only the edge lookup can find it)

## Notes

`resolve_bare_call_targets` upgrades bare `CALLS` targets to qualified names but does not touch `TESTED_BY` sources that inherited a bare name from an unresolved cross-file call. `refactor.py` keeps its plausibility-checked bare-name fallback for exactly that case. Two natural follow-up PRs if you want them: extending bare-name resolution to `TESTED_BY`, and a canonical `GraphStore.get_tests_of()` accessor so the direction knowledge lives in one place instead of each consumer's SQL.

## Testing

Full suite: 1412 passed / 0 failed on Windows 11; the new regression tests fail on main and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
