### PR TITLE
fix: split camelCase and truncate community slugs at word boundaries

### DIFF
--- a/code_review_graph/communities.py
+++ b/code_review_graph/communities.py
@@ -149,9 +149,28 @@ def _split_name(name: str) -> list[str]:
     return [p for p in re.split(r"[_\-.\s]+", s) if p]
 
 
+_SLUG_MAX_LEN = 30
+
+
 def _to_slug(s: str) -> str:
-    """Convert a string to a short lowercase slug."""
-    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:30]
+    """Convert a string to a short lowercase slug.
+
+    CamelCase and snake_case inputs are split into hyphenated words, and
+    truncation happens at a word boundary so a slug never ends mid-word:
+    ``TestBuildPreAnalysisPromptBlock`` becomes
+    ``test-build-pre-analysis-prompt`` rather than
+    ``testbuildpreanalysispromptbloc``.
+    """
+    normalized = re.sub(r"[^A-Za-z0-9]+", " ", s)
+    slug = "-".join(w.lower() for w in _split_name(normalized))
+    if len(slug) <= _SLUG_MAX_LEN:
+        return slug
+    cut = slug[:_SLUG_MAX_LEN]
+    if slug[_SLUG_MAX_LEN] != "-":
+        head, sep, _ = cut.rpartition("-")
+        if sep:
+            cut = head
+    return cut.rstrip("-")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -11,6 +11,7 @@ from code_review_graph.communities import (
     _compute_cohesion_batch,
     _detect_file_based,
     _generate_community_name,
+    _to_slug,
     detect_communities,
     get_architecture_overview,
     get_communities,
@@ -590,3 +591,46 @@ class TestCommunities:
         # Pass a file that IS part of existing communities
         result = incremental_detect_communities(self.store, ["auth.py"])
         assert result > 0
+
+
+class TestToSlug:
+    """Slug generation: word splitting and word-boundary truncation."""
+
+    def test_short_snake_case_unchanged(self):
+        assert _to_slug("rate_sheet") == "rate-sheet"
+
+    def test_camel_case_split_into_words(self):
+        assert _to_slug("AuthService") == "auth-service"
+
+    def test_long_camel_case_truncates_at_word_boundary(self):
+        # Lowercased raw form is 31+ chars; the old implementation produced
+        # the mid-word cut "testbuildpreanalysispromptbloc".
+        result = _to_slug("TestBuildPreAnalysisPromptBlock")
+        assert result == "test-build-pre-analysis-prompt"
+
+    def test_truncation_never_ends_mid_word(self):
+        result = _to_slug("normalize_service_level_values_for_carrier")
+        assert len(result) <= 30
+        # Every word in the slug must be a complete word of the input.
+        input_words = set("normalize_service_level_values_for_carrier".split("_"))
+        assert set(result.split("-")) <= input_words
+
+    def test_exact_boundary_cut_keeps_full_word(self):
+        # 30th char lands exactly on a hyphen: keep all complete words.
+        result = _to_slug("aaaaaaaaaa_bbbbbbbbbb_cccccccc_dd")
+        assert result == "aaaaaaaaaa-bbbbbbbbbb-cccccccc"
+
+    def test_mid_word_cut_drops_partial_word(self):
+        # The 30-char cut lands inside the third word: drop the fragment.
+        result = _to_slug("aaaaaaaaaa_bbbbbbbbbb_ccccccccc")
+        assert result == "aaaaaaaaaa-bbbbbbbbbb"
+
+    def test_single_overlong_word_falls_back_to_hard_cut(self):
+        result = _to_slug("a" * 40)
+        assert result == "a" * 30
+
+    def test_punctuation_becomes_word_separator(self):
+        assert _to_slug("foo/bar.baz") == "foo-bar-baz"
+
+    def test_empty_string_gives_empty_slug(self):
+        assert _to_slug("") == ""


### PR DESCRIPTION
## What

`_to_slug()` lowercases its input and hard-slices at 30 characters, so a camelCase class name produces an unreadable, mid-word community name. Observed on a real ~4.8k-node graph:

```
services-testbuildpreanalysispromptbloc   # from TestBuildPreAnalysisPromptBlock...
```

Two problems compound here: camelCase survives lowercasing as one giant "word" (the existing `[^a-z0-9]+` substitution never fires inside it), and the `[:30]` slice cuts wherever it lands.

## How

`_to_slug()` now:

1. normalizes punctuation to spaces,
2. splits camelCase/snake_case into words via the existing `_split_name()` helper,
3. joins with hyphens,
4. truncates at the **last complete word** within the 30-char budget.

A single word longer than the budget still falls back to a hard cut (best effort).

```
TestBuildPreAnalysisPromptBlock  ->  test-build-pre-analysis-prompt   (was: testbuildpreanalysispromptbloc)
AuthService                      ->  auth-service                     (was: authservice)
rate_sheet                       ->  rate-sheet                       (unchanged)
```

Community names derived from dominant classes become hyphenated and readable; names from file stems and already-split keywords are unchanged.

## Testing

- New `TestToSlug` class: 9 tests covering camelCase splitting, exact-boundary cuts, mid-word cuts, overlong single words, punctuation, and empty input.
- `tests/test_communities.py` passes (36 passed on Windows; the teardown errors are the pre-existing Windows unlink issue addressed separately in #596).

## Known trade-offs (kept out of scope)

- Word-boundary truncation can collide slightly more often than a hard cut when two long names share every complete word within the budget (`service_SupercalifragilisticAlpha` / `...Beta` both become `service-supercalifragilistic`). The hard cut already collided for shared 30-char prefixes; name-level dedup is handled in #603.
- `_split_name` does not split consecutive-uppercase acronyms (`HTTPServer` → `httpserver`, unchanged from current behavior for every existing caller). Improving that helper would also change keyword extraction, so it belongs in its own change if wanted.
