### PR TITLE
fix: pre-warm local embeddings on all platforms, not just Windows

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -1049,15 +1049,22 @@ def main(
 
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        # Pre-warm sentence-transformers on the main thread before fastmcp's
-        # event loop starts. Lazy-loading ``torch`` + tokenizers inside an
-        # executor worker thread deadlocks ``semantic_search_nodes_tool`` on
-        # Windows stdio MCP (DLL init / OpenMP thread-pool registration grabs
-        # locks the loop needs). #385 added ``asyncio.to_thread`` to peer
-        # tools but cannot fix this case — the dangerous initialization has
-        # to happen on the main thread before any worker thread is spawned.
-        from .embeddings import prewarm_local_embeddings
-        prewarm_local_embeddings()
+
+    # Pre-warm sentence-transformers on the main thread before fastmcp's
+    # event loop starts — on every platform. On Windows, lazy-loading
+    # ``torch`` + tokenizers inside an executor worker thread deadlocks
+    # ``semantic_search_nodes_tool`` on stdio MCP (DLL init / OpenMP
+    # thread-pool registration grabs locks the loop needs); #385 added
+    # ``asyncio.to_thread`` to peer tools but cannot fix this case. On
+    # macOS/Linux, MCP clients batch tool calls in parallel, so two worker
+    # threads can race the first ``import torch``; the loser sees a
+    # partially initialized module that stays poisoned in ``sys.modules``
+    # for the process lifetime, breaking stats/embed tools and silently
+    # degrading semantic search to keyword mode (#610). Either way the
+    # dangerous initialization has to happen on the main thread before any
+    # worker thread is spawned.
+    from .embeddings import prewarm_local_embeddings
+    prewarm_local_embeddings()
 
     try:
         if transport == "stdio":


### PR DESCRIPTION
Fixes #610

## Problem

`prewarm_local_embeddings()` only runs on Windows. On macOS/Linux, `torch` is lazy-imported inside `asyncio.to_thread` executor workers at first use. MCP clients (e.g. Claude Code) batch independent tool calls in parallel, so the first two torch-touching calls regularly arrive together: two executor threads race `import torch`, the loser sees a partially initialized module (`module 'torch' has no attribute 'library'`), and the half-initialized module stays poisoned in `sys.modules` for the process lifetime — `list_graph_stats_tool`/`embed_graph_tool` fail on every call and `semantic_search_nodes_tool` silently degrades to keyword mode. Full diagnosis in #610.

## Change

Hoist the `prewarm_local_embeddings()` call out of the `sys.platform == "win32"` guard so the dangerous initialization always happens on the main thread before any worker thread is spawned. The `WindowsSelectorEventLoopPolicy` line stays Windows-only. `prewarm_local_embeddings()` is already a no-op for cloud-provider setups without sentence-transformers, so non-embedding installs are unaffected.

Trade-off: server startup on macOS/Linux with local embeddings now pays the model-load cost (~7s for `paraphrase-multilingual-MiniLM-L12-v2` on an M-series Mac) up front instead of on first use — same behavior Windows already had.

## Verification

- `uv run pytest tests/ --tb=short -q` → **1384 passed, 1 skipped, 2 xpassed**
- `uvx ruff check code_review_graph/` → clean
- Manually verified on macOS arm64 / Python 3.13 / torch 2.12.1: running prewarm on the main thread before `serve` boots a healthy server (MCP initialize handshake OK, no torch errors), while the unpatched lazy path is reproducibly poisoned by concurrent first calls.