### PR TITLE
feat: CSS/SCSS/LESS support — stylesheets join the code graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ uv run code-review-graph eval               # Run evaluation benchmarks
 - `tests/test_tools.py` — MCP tool integration tests
 - `tests/test_visualization.py` — Export, HTML generation, C++ resolution
 - `tests/test_incremental.py` — Build, update, migration, git ops
-- `tests/test_multilang.py` — Broad language parsing tests, including SFCs, notebooks, SQL, Perl XS, and modern systems/web languages
+- `tests/test_multilang.py` — Broad language parsing tests, including SFCs, notebooks, SQL, CSS/SCSS/LESS, Perl XS, and modern systems/web languages
+- `tests/test_css_linking.py` — Cross-file CSS linking (STYLES edges, CSS Modules, POTENTIAL_CONFLICT detection)
 - `tests/test_custom_languages.py` — Config-driven custom languages (languages.toml loader + end-to-end Erlang parse)
 - `tests/test_embeddings.py` — Vector encode/decode, similarity, store
 - `tests/test_flows.py` — Execution flow detection and criticality

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Large monorepos are where token waste is most painful. The graph cuts through th
   <img src="diagrams/diagram9_language_coverage.png" alt="Language coverage organized by category: Web, Backend, Systems, Mobile, Scripting, Config, plus Jupyter and Databricks notebook support" width="90%" />
 </p>
 
-Parser support covers functions, classes, imports, call sites, inheritance, and test detection across the current parser surface, using Tree-sitter where available and targeted fallbacks where needed. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
+Parser support covers functions, classes, imports, call sites, inheritance, and test detection across the current parser surface, using Tree-sitter where available and targeted fallbacks where needed. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, CSS/SCSS/LESS stylesheets, Vue/Svelte SFCs (including `<style>` blocks), Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
 ### Add your own language (no fork needed)
 
@@ -252,7 +252,7 @@ The benchmark also runs an honest **co-change mode**: the predictor is seeded wi
 | Feature | Details |
 |---------|---------|
 | **Incremental updates** | Re-parses only changed files. Subsequent updates complete in under 2 seconds. |
-| **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
+| **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, CSS/SCSS/LESS, Vue/Svelte SFCs (including `<style>` blocks), Astro files parsed through the TypeScript parser, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
 | **Blast-radius analysis** | Shows which functions, classes, and files are likely affected by a change |
 | **Auto-update hooks** | Hooks and watch mode can update the graph on file saves and supported commit hooks |
 | **Semantic search** | Optional vector embeddings via sentence-transformers, Google Gemini, MiniMax, or any OpenAI-compatible endpoint (real OpenAI, Azure, new-api, LiteLLM, vLLM, LocalAI) |

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1,7 +1,8 @@
 """SQLite-backed knowledge graph storage and query engine.
 
 Stores code structure as nodes (File, Class, Function, Type, Test) and
-edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON, REFERENCES).
+edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON,
+REFERENCES, OVERRIDES, STYLES, POTENTIAL_CONFLICT).
 Supports impact-radius queries and subgraph extraction.
 """
 
@@ -1279,6 +1280,32 @@ class GraphStore:
             nodes_by_id=nodes_by_id,
         )
 
+    def delete_edges_by_kind(self, kind: str) -> int:
+        """Delete all edges of the given kind. Returns count of deleted rows."""
+        cur = self._conn.execute("DELETE FROM edges WHERE kind = ?", (kind,))
+        self._invalidate_cache()
+        return cur.rowcount
+
+    def get_nodes_by_extra_pattern(
+        self, pattern: str, kind: str | None = None,
+    ) -> list[GraphNode]:
+        """Find nodes where extra JSON matches a LIKE pattern.
+
+        Args:
+            pattern: SQL LIKE pattern, e.g. '%"css_kind":"selector"%'.
+            kind: Optional node kind filter (Class, Function, etc.).
+        """
+        if kind:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ? AND kind = ?",
+                (pattern, kind),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM nodes WHERE extra LIKE ?", (pattern,),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
     # --- Internal helpers ---
 
     def _build_networkx_graph(self) -> nx.DiGraph:
@@ -1352,6 +1379,21 @@ def _sanitize_name(s: str, max_len: int = 256) -> str:
     return cleaned[:max_len]
 
 
+def _sanitize_extra(extra: dict) -> dict:
+    """Sanitize string values in extra dict for safe display."""
+    if not extra:
+        return {}
+
+    def _sanitize_value(v):  # type: ignore[no-untyped-def]
+        if isinstance(v, str):
+            return _sanitize_name(v)
+        if isinstance(v, list):
+            return [_sanitize_value(item) for item in v]
+        return v
+
+    return {k: _sanitize_value(v) for k, v in extra.items()}
+
+
 def node_to_dict(n: GraphNode) -> dict:
     return {
         "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
@@ -1360,6 +1402,7 @@ def node_to_dict(n: GraphNode) -> dict:
         "language": n.language,
         "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
+        "extra": _sanitize_extra(n.extra),
     }
 
 
@@ -1370,4 +1413,5 @@ def edge_to_dict(e: GraphEdge) -> dict:
         "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
         "confidence": e.confidence, "confidence_tier": e.confidence_tier,
+        "extra": _sanitize_extra(e.extra),
     }

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -82,6 +82,30 @@ def _run_spring_resolver(store: GraphStore) -> Optional[dict]:
         return None
 
 
+def _run_css_resolver(store: GraphStore) -> Optional[dict]:
+    """Run cross-file CSS linking + conflict detection, swallowing any
+    failure so build never fails because of it. Returns stats or None.
+    """
+    try:
+        selectors = _get_css_selectors(store)
+        styles_count = link_css_styles(store, selectors)
+        conflicts_count = detect_cross_file_conflicts(store, selectors)
+        logger.info(
+            "CSS linking: %d STYLES edges, %d POTENTIAL_CONFLICT edges",
+            styles_count, conflicts_count,
+        )
+        return {"styles_edges": styles_count, "conflict_edges": conflicts_count}
+    except Exception as exc:  # noqa: BLE001 - best-effort post-pass
+        logger.warning("CSS resolver failed: %s", exc)
+        return None
+
+
+# File extensions whose changes can affect STYLES/POTENTIAL_CONFLICT edges.
+_CSS_RELEVANT_EXTENSIONS = (
+    ".css", ".scss", ".less", ".vue", ".svelte", ".tsx", ".jsx", ".ts", ".js",
+)
+
+
 def _run_temporal_resolver(store: GraphStore) -> Optional[dict]:
     """Run the Temporal workflow/activity call resolver, swallowing any failure so
     build never fails because of it. Returns stats or None on error.
@@ -819,12 +843,19 @@ def _parse_single_file(
         return (rel_path, [], [], str(e), "")
 
 
-def link_css_styles(store: GraphStore) -> int:
+def _get_css_selectors(store: GraphStore) -> list:
+    """Fetch all CSS selector nodes (css_kind == "selector")."""
+    return store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+
+
+def link_css_styles(store: GraphStore, selectors: list | None = None) -> int:
     """Create STYLES edges between class references and CSS selectors.
 
     Queries the graph for:
     1. All CSS selector nodes (css_kind == "selector")
-    2. All nodes with css_classes or vue_template_classes in extra
+    2. All nodes with css_classes in extra (JSX functions, Vue/Svelte files)
 
     Creates STYLES edges from the referencing component/function to
     the matching CSS selector node.
@@ -837,9 +868,8 @@ def link_css_styles(store: GraphStore) -> int:
     store.delete_edges_by_kind("STYLES")
 
     # Build selector index: bare class name → list of (qualified_name, file_path)
-    selectors = store.get_nodes_by_extra_pattern(
-        '%"css_kind":%"selector"%', kind="Class",
-    )
+    if selectors is None:
+        selectors = _get_css_selectors(store)
     selector_index: dict[str, list[tuple[str, str]]] = {}
     for sel in selectors:
         sel_name = sel.name.strip()
@@ -885,41 +915,19 @@ def link_css_styles(store: GraphStore) -> int:
                 ))
                 count += 1
 
-    # Link Vue template class references
-    vue_nodes = store.get_nodes_by_extra_pattern('%"vue_template_classes"%')
-    for node in vue_nodes:
-        classes = node.extra.get("vue_template_classes", [])
-        for cls_name in classes:
-            matches = selector_index.get(cls_name, [])
-            for sel_qn, sel_file in matches:
-                store.upsert_edge(EdgeInfo(
-                    kind="STYLES",
-                    source=node.qualified_name,
-                    target=sel_qn,
-                    file_path=node.file_path,
-                    line=node.line_start or 0,
-                    extra={
-                        "class_name": cls_name,
-                        "resolution": "static",
-                    },
-                ))
-                count += 1
-
     # Link CSS Module references
     module_nodes = store.get_nodes_by_extra_pattern('%"css_module_refs"%')
-    for node in module_nodes:
-        refs = node.extra.get("css_module_refs", [])
-        # Find the File node for CSS module imports
-        file_nodes = store.get_nodes_by_extra_pattern(
+    # Map of file_path → {import name: module path}, built once for all nodes
+    file_mod_imports: dict[str, dict[str, str]] = {}
+    if module_nodes:
+        for fn in store.get_nodes_by_extra_pattern(
             '%"css_module_imports"%', kind="File",
-        )
-        # Build a map of import names → module paths per file
-        file_mod_imports: dict[str, dict[str, str]] = {}
-        for fn in file_nodes:
+        ):
             file_mod_imports[fn.file_path] = fn.extra.get(
                 "css_module_imports", {},
             )
-
+    for node in module_nodes:
+        refs = node.extra.get("css_module_refs", [])
         mod_imports = file_mod_imports.get(node.file_path, {})
         for ref in refs:
             imp_name = ref.get("import", "")
@@ -952,7 +960,9 @@ def link_css_styles(store: GraphStore) -> int:
     return count
 
 
-def detect_cross_file_conflicts(store: GraphStore) -> int:
+def detect_cross_file_conflicts(
+    store: GraphStore, selectors: list | None = None,
+) -> int:
     """Detect potential CSS conflicts across files.
 
     Scans for CSS selectors across different files that target the same
@@ -964,9 +974,8 @@ def detect_cross_file_conflicts(store: GraphStore) -> int:
 
     store.delete_edges_by_kind("POTENTIAL_CONFLICT")
 
-    selectors = store.get_nodes_by_extra_pattern(
-        '%"css_kind":%"selector"%', kind="Class",
-    )
+    if selectors is None:
+        selectors = _get_css_selectors(store)
 
     # Group by bare class name
     by_class: dict[str, list[tuple[str, str, list]]] = {}
@@ -1101,19 +1110,12 @@ def full_build(
                 if i % 200 == 0 or i == file_count:
                     logger.info("Progress: %d/%d files parsed", i, file_count)
 
-    # Post-build: cross-file CSS linking and conflict detection
-    styles_count = link_css_styles(store)
-    conflicts_count = detect_cross_file_conflicts(store)
-    logger.info(
-        "CSS linking: %d STYLES edges, %d POTENTIAL_CONFLICT edges",
-        styles_count, conflicts_count,
-    )
-
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
+    css_stats = _run_css_resolver(store)
     rescript_stats = _run_rescript_resolver(store)
     spring_stats = _run_spring_resolver(store)
     temporal_stats = _run_temporal_resolver(store)
@@ -1122,8 +1124,8 @@ def full_build(
         "files_parsed": len(files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
-        "styles_edges": styles_count,
-        "conflict_edges": conflicts_count,
+        "styles_edges": (css_stats or {}).get("styles_edges"),
+        "conflict_edges": (css_stats or {}).get("conflict_edges"),
         "errors": errors,
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
@@ -1241,16 +1243,17 @@ def incremental_update(
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
-    # Post-build: cross-file CSS linking and conflict detection
-    styles_count = link_css_styles(store)
-    conflicts_count = detect_cross_file_conflicts(store)
-
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
     # Only re-run language-specific resolvers when the relevant files changed.
+    css_changed = any(
+        rp.endswith(_CSS_RELEVANT_EXTENSIONS) for rp in all_files
+    )
+    css_stats = _run_css_resolver(store) if css_changed else None
+
     rescript_changed = any(
         rp.endswith((".res", ".resi")) for rp in all_files
     )
@@ -1266,8 +1269,8 @@ def incremental_update(
         "files_updated": len(all_files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
-        "styles_edges": styles_count,
-        "conflict_edges": conflicts_count,
+        "styles_edges": (css_stats or {}).get("styles_edges"),
+        "conflict_edges": (css_stats or {}).get("conflict_edges"),
         "changed_files": list(changed_files),
         "dependent_files": list(dependent_files),
         "errors": errors,

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -728,7 +728,9 @@ def _single_hop_dependents(store: GraphStore, file_path: str) -> set[str]:
     nodes = store.get_nodes_by_file(file_path)
     for node in nodes:
         for e in store.get_edges_by_target(node.qualified_name):
-            if e.kind in ("CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"):
+            if e.kind in (
+                "CALLS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS", "STYLES",
+            ):
                 dependents.add(e.file_path)
 
     dependents.discard(file_path)
@@ -817,6 +819,209 @@ def _parse_single_file(
         return (rel_path, [], [], str(e), "")
 
 
+def link_css_styles(store: GraphStore) -> int:
+    """Create STYLES edges between class references and CSS selectors.
+
+    Queries the graph for:
+    1. All CSS selector nodes (css_kind == "selector")
+    2. All nodes with css_classes or vue_template_classes in extra
+
+    Creates STYLES edges from the referencing component/function to
+    the matching CSS selector node.
+
+    Returns count of STYLES edges created.
+    """
+    from .parser import CodeParser, EdgeInfo  # noqa: F811 (avoid circular)
+
+    # Clean up previous STYLES edges
+    store.delete_edges_by_kind("STYLES")
+
+    # Build selector index: bare class name → list of (qualified_name, file_path)
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+    selector_index: dict[str, list[tuple[str, str]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        # Only index class selectors (starting with .)
+        if sel_name.startswith("."):
+            bare = sel_name.lstrip(".")
+            selector_index.setdefault(bare, []).append(
+                (sel.qualified_name, sel.file_path),
+            )
+        # For compound selectors, also index by last class segment
+        parts = sel_name.split()
+        if len(parts) > 1:
+            last = parts[-1].strip()
+            if last.startswith("."):
+                bare = last.lstrip(".")
+                selector_index.setdefault(bare, []).append(
+                    (sel.qualified_name, sel.file_path),
+                )
+
+    if not selector_index:
+        store.commit()
+        return 0
+
+    count = 0
+
+    # Link static css_classes references
+    class_nodes = store.get_nodes_by_extra_pattern('%"css_classes"%')
+    for node in class_nodes:
+        classes = node.extra.get("css_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link Vue template class references
+    vue_nodes = store.get_nodes_by_extra_pattern('%"vue_template_classes"%')
+    for node in vue_nodes:
+        classes = node.extra.get("vue_template_classes", [])
+        for cls_name in classes:
+            matches = selector_index.get(cls_name, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": cls_name,
+                        "resolution": "static",
+                    },
+                ))
+                count += 1
+
+    # Link CSS Module references
+    module_nodes = store.get_nodes_by_extra_pattern('%"css_module_refs"%')
+    for node in module_nodes:
+        refs = node.extra.get("css_module_refs", [])
+        # Find the File node for CSS module imports
+        file_nodes = store.get_nodes_by_extra_pattern(
+            '%"css_module_imports"%', kind="File",
+        )
+        # Build a map of import names → module paths per file
+        file_mod_imports: dict[str, dict[str, str]] = {}
+        for fn in file_nodes:
+            file_mod_imports[fn.file_path] = fn.extra.get(
+                "css_module_imports", {},
+            )
+
+        mod_imports = file_mod_imports.get(node.file_path, {})
+        for ref in refs:
+            imp_name = ref.get("import", "")
+            prop_name = ref.get("property", "")
+            if not imp_name or not prop_name:
+                continue
+            # Find the module path
+            if imp_name not in mod_imports:
+                continue
+            # Convert camelCase to kebab-case for selector lookup
+            kebab = CodeParser._camel_to_kebab(prop_name)
+            matches = selector_index.get(kebab, [])
+            for sel_qn, sel_file in matches:
+                store.upsert_edge(EdgeInfo(
+                    kind="STYLES",
+                    source=node.qualified_name,
+                    target=sel_qn,
+                    file_path=node.file_path,
+                    line=node.line_start or 0,
+                    extra={
+                        "class_name": kebab,
+                        "resolution": "css_module",
+                        "import_name": imp_name,
+                        "property": prop_name,
+                    },
+                ))
+                count += 1
+
+    store.commit()
+    return count
+
+
+def detect_cross_file_conflicts(store: GraphStore) -> int:
+    """Detect potential CSS conflicts across files.
+
+    Scans for CSS selectors across different files that target the same
+    class name. Creates POTENTIAL_CONFLICT edges when found.
+
+    Returns count of conflict edges created.
+    """
+    from .parser import EdgeInfo  # noqa: F811
+
+    store.delete_edges_by_kind("POTENTIAL_CONFLICT")
+
+    selectors = store.get_nodes_by_extra_pattern(
+        '%"css_kind":%"selector"%', kind="Class",
+    )
+
+    # Group by bare class name
+    by_class: dict[str, list[tuple[str, str, list]]] = {}
+    for sel in selectors:
+        sel_name = sel.name.strip()
+        if not sel_name.startswith("."):
+            continue
+        bare = sel_name.lstrip(".")
+        specificity = sel.extra.get("specificity", [0, 0, 0])
+        by_class.setdefault(bare, []).append(
+            (sel.qualified_name, sel.file_path, specificity),
+        )
+
+    count = 0
+    max_pairs_per_class = 50
+
+    for bare, entries in by_class.items():
+        # Only flag if selectors appear in 2+ different files
+        files_seen = {fp for _, fp, _ in entries}
+        if len(files_seen) < 2:
+            continue
+
+        pairs = 0
+        for i, (src_qn, src_fp, src_spec) in enumerate(entries):
+            for tgt_qn, tgt_fp, tgt_spec in entries[i + 1:]:
+                if src_fp == tgt_fp:
+                    continue
+                if pairs >= max_pairs_per_class:
+                    break
+                # Conflict confidence label; keyed as conflict_confidence
+                # because extra["confidence"] is reserved for the numeric
+                # edge-confidence score read by GraphStore.upsert_edge.
+                conflict_confidence = "high"  # same bare class name
+                store.upsert_edge(EdgeInfo(
+                    kind="POTENTIAL_CONFLICT",
+                    source=src_qn,
+                    target=tgt_qn,
+                    file_path="<cross-file>",
+                    line=0,
+                    extra={
+                        "class_name": f".{bare}",
+                        "source_specificity": src_spec,
+                        "target_specificity": tgt_spec,
+                        "conflict_confidence": conflict_confidence,
+                    },
+                ))
+                count += 1
+                pairs += 1
+            if pairs >= max_pairs_per_class:
+                break
+
+    store.commit()
+    return count
+
+
 def full_build(
     repo_root: Path,
     store: GraphStore,
@@ -896,6 +1101,14 @@ def full_build(
                 if i % 200 == 0 or i == file_count:
                     logger.info("Progress: %d/%d files parsed", i, file_count)
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+    logger.info(
+        "CSS linking: %d STYLES edges, %d POTENTIAL_CONFLICT edges",
+        styles_count, conflicts_count,
+    )
+
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
     _store_vcs_metadata(repo_root, store)
@@ -909,6 +1122,8 @@ def full_build(
         "files_parsed": len(files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
         "errors": errors,
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
@@ -1026,6 +1241,10 @@ def incremental_update(
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
+    # Post-build: cross-file CSS linking and conflict detection
+    styles_count = link_css_styles(store)
+    conflicts_count = detect_cross_file_conflicts(store)
+
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")
     _store_vcs_metadata(repo_root, store)
@@ -1047,6 +1266,8 @@ def incremental_update(
         "files_updated": len(all_files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
+        "styles_edges": styles_count,
+        "conflict_edges": conflicts_count,
         "changed_files": list(changed_files),
         "dependent_files": list(dependent_files),
         "errors": errors,

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -229,6 +229,11 @@ def query_graph_tool(
     - children_of: Find nodes contained in a file or class
     - tests_for: Find tests for the target
     - inheritors_of: Find classes inheriting from the target
+    - overrides_of: Find CSS selectors that the target overrides
+    - overridden_by: Find CSS selectors that override the target
+    - styles_of: Find CSS selectors that style a component or function
+    - styled_by: Find components/functions using a given CSS selector
+    - conflicts_of: Find potential cross-file CSS conflicts for a selector
     - file_summary: Get all nodes in a file
 
     Args:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2007,6 +2007,35 @@ class CodeParser:
 
         return static_classes, module_refs
 
+    @staticmethod
+    def _attr_name_value(attr_node) -> tuple[Optional[str], Optional[str]]:
+        """Decode an SFC ``attribute`` AST node into (name, value).
+
+        Value comes from a quoted_attribute_value child; bare/boolean and
+        expression-valued attributes yield value=None.
+        """
+        attr_name = None
+        attr_value = None
+        for child in attr_node.children:
+            if child.type == "attribute_name":
+                attr_name = child.text.decode("utf-8", errors="replace")
+            elif child.type == "quoted_attribute_value":
+                for v in child.children:
+                    if v.type == "attribute_value":
+                        attr_value = v.text.decode("utf-8", errors="replace")
+        return attr_name, attr_value
+
+    @classmethod
+    def _tag_attrs(cls, start_tag) -> dict[str, str]:
+        """Decode all quoted attributes of an SFC start_tag into {name: value}."""
+        attrs: dict[str, str] = {}
+        for attr in start_tag.children:
+            if attr.type == "attribute":
+                name, value = cls._attr_name_value(attr)
+                if name is not None and value is not None:
+                    attrs[name] = value
+        return attrs
+
     def _extract_vue_template_classes(self, node) -> list[str]:
         """Recursively walk Vue template AST, extract class='...' values.
 
@@ -2017,19 +2046,7 @@ class CodeParser:
         while stack:
             n = stack.pop()
             if n.type == "attribute":
-                attr_name = None
-                attr_value = None
-                for child in n.children:
-                    if child.type == "attribute_name":
-                        attr_name = child.text.decode(
-                            "utf-8", errors="replace",
-                        )
-                    elif child.type == "quoted_attribute_value":
-                        for v in child.children:
-                            if v.type == "attribute_value":
-                                attr_value = v.text.decode(
-                                    "utf-8", errors="replace",
-                                )
+                attr_name, attr_value = self._attr_name_value(n)
                 if attr_name == "class" and attr_value:
                     classes.extend(attr_value.split())
             # Skip directive_attribute (:class bindings)
@@ -2077,22 +2094,10 @@ class CodeParser:
                 elif sub.type == "raw_text":
                     raw_text_node = sub
 
-            if start_tag:
-                for attr in start_tag.children:
-                    if attr.type == "attribute":
-                        attr_name = None
-                        attr_value = None
-                        for a in attr.children:
-                            if a.type == "attribute_name":
-                                attr_name = a.text.decode("utf-8", errors="replace")
-                            elif a.type == "quoted_attribute_value":
-                                for v in a.children:
-                                    if v.type == "attribute_value":
-                                        attr_value = v.text.decode(
-                                            "utf-8", errors="replace",
-                                        )
-                        if attr_name == "lang" and attr_value in ("ts", "typescript"):
-                            script_lang = "typescript"
+            if start_tag and self._tag_attrs(start_tag).get("lang") in (
+                "ts", "typescript",
+            ):
+                script_lang = "typescript"
 
             if not raw_text_node:
                 continue
@@ -2143,7 +2148,7 @@ class CodeParser:
             if child.type == "template_element":
                 template_classes = self._extract_vue_template_classes(child)
                 if template_classes:
-                    all_nodes[0].extra["vue_template_classes"] = sorted(
+                    all_nodes[0].extra["css_classes"] = sorted(
                         set(template_classes),
                     )
                 break  # Only one <template> per SFC
@@ -2189,22 +2194,10 @@ class CodeParser:
                 elif sub.type == "raw_text":
                     raw_text_node = sub
 
-            if start_tag:
-                for attr in start_tag.children:
-                    if attr.type == "attribute":
-                        attr_name = None
-                        attr_value = None
-                        for a in attr.children:
-                            if a.type == "attribute_name":
-                                attr_name = a.text.decode("utf-8", errors="replace")
-                            elif a.type == "quoted_attribute_value":
-                                for v in a.children:
-                                    if v.type == "attribute_value":
-                                        attr_value = v.text.decode(
-                                            "utf-8", errors="replace",
-                                        )
-                        if attr_name == "lang" and attr_value in ("scss", "sass"):
-                            style_lang = "scss"
+            if start_tag and self._tag_attrs(start_tag).get("lang") in (
+                "scss", "sass",
+            ):
+                style_lang = "scss"
 
             if not raw_text_node:
                 continue
@@ -2274,29 +2267,10 @@ class CodeParser:
                 elif sub.type == "raw_text":
                     raw_text_node = sub
 
-            if start_tag:
-                for attr in start_tag.children:
-                    if attr.type == "attribute":
-                        attr_name = None
-                        attr_value = None
-                        for a in attr.children:
-                            if a.type == "attribute_name":
-                                attr_name = a.text.decode(
-                                    "utf-8", errors="replace",
-                                )
-                            elif a.type == "quoted_attribute_value":
-                                for v in a.children:
-                                    if v.type == "attribute_value":
-                                        attr_value = v.text.decode(
-                                            "utf-8",
-                                            errors="replace",
-                                        )
-                        if (
-                            attr_name == "lang"
-                            and attr_value
-                            in ("ts", "typescript")
-                        ):
-                            script_lang = "typescript"
+            if start_tag and self._tag_attrs(start_tag).get("lang") in (
+                "ts", "typescript",
+            ):
+                script_lang = "typescript"
 
             if not raw_text_node:
                 continue

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2132,7 +2132,51 @@ class CodeParser:
             all_edges.extend(edges)
 
         # Extract <style> blocks and delegate to CSS/SCSS parser
+        style_nodes, style_edges = self._extract_style_blocks(
+            tree.root_node, path, "vue",
+        )
+        all_nodes.extend(style_nodes)
+        all_edges.extend(style_edges)
+
+        # Extract static class names from <template> elements
         for child in tree.root_node.children:
+            if child.type == "template_element":
+                template_classes = self._extract_vue_template_classes(child)
+                if template_classes:
+                    all_nodes[0].extra["vue_template_classes"] = sorted(
+                        set(template_classes),
+                    )
+                break  # Only one <template> per SFC
+
+        # Generate TESTED_BY edges
+        if test_file:
+            test_qnames = set()
+            for n in all_nodes:
+                if n.is_test:
+                    qn = self._qualify(n.name, n.file_path, n.parent_name)
+                    test_qnames.add(qn)
+            for edge in list(all_edges):
+                if edge.kind == "CALLS" and edge.source in test_qnames:
+                    all_edges.append(EdgeInfo(
+                        kind="TESTED_BY",
+                        source=edge.target,
+                        target=edge.source,
+                        file_path=edge.file_path,
+                        line=edge.line,
+                    ))
+
+        return all_nodes, all_edges
+
+    def _extract_style_blocks(
+        self, root, path: Path, container_language: str,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Extract <style> blocks from an SFC AST (Vue/Svelte) and delegate
+        each to the CSS/SCSS parser. Returns nodes/edges with line numbers
+        offset to the enclosing file and language set to the container's."""
+        all_nodes: list[NodeInfo] = []
+        all_edges: list[EdgeInfo] = []
+
+        for child in root.children:
             if child.type != "style_element":
                 continue
 
@@ -2175,37 +2219,10 @@ class CodeParser:
             # Remove the File node that _parse_css creates (we already have one)
             style_nodes = [n for n in style_nodes if n.kind != "File"]
             for sn in style_nodes:
-                sn.language = "vue"
+                sn.language = container_language
 
             all_nodes.extend(style_nodes)
             all_edges.extend(style_edges)
-
-        # Extract static class names from <template> elements
-        for child in tree.root_node.children:
-            if child.type == "template_element":
-                template_classes = self._extract_vue_template_classes(child)
-                if template_classes:
-                    all_nodes[0].extra["vue_template_classes"] = sorted(
-                        set(template_classes),
-                    )
-                break  # Only one <template> per SFC
-
-        # Generate TESTED_BY edges
-        if test_file:
-            test_qnames = set()
-            for n in all_nodes:
-                if n.is_test:
-                    qn = self._qualify(n.name, n.file_path, n.parent_name)
-                    test_qnames.add(qn)
-            for edge in list(all_edges):
-                if edge.kind == "CALLS" and edge.source in test_qnames:
-                    all_edges.append(EdgeInfo(
-                        kind="TESTED_BY",
-                        source=edge.target,
-                        target=edge.source,
-                        file_path=edge.file_path,
-                        line=edge.line,
-                    ))
 
         return all_nodes, all_edges
 
@@ -2314,6 +2331,26 @@ class CodeParser:
 
             all_nodes.extend(nodes)
             all_edges.extend(edges)
+
+        # Extract <style> blocks and delegate to CSS/SCSS parser
+        style_nodes, style_edges = self._extract_style_blocks(
+            tree.root_node, path, "svelte",
+        )
+        all_nodes.extend(style_nodes)
+        all_edges.extend(style_edges)
+
+        # Extract static class names from markup elements. Svelte markup
+        # lives at the document root (no <template> wrapper), so walk every
+        # top-level element. class:foo directives parse as attributes named
+        # "class:foo" and are skipped by the walker's exact "class" match.
+        markup_classes: list[str] = []
+        for child in tree.root_node.children:
+            if child.type == "element":
+                markup_classes.extend(
+                    self._extract_vue_template_classes(child),
+                )
+        if markup_classes:
+            all_nodes[0].extra["css_classes"] = sorted(set(markup_classes))
 
         # Generate TESTED_BY edges
         if test_file:
@@ -6520,7 +6557,7 @@ class CodeParser:
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue", ".css", ".scss"]
+                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue", ".css", ".scss", ".less"]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
@@ -6541,10 +6578,10 @@ class CodeParser:
                 if resolved:
                     return resolved
 
-        elif language in ("css", "scss"):
+        elif language in ("css", "scss", "less"):
             if module.startswith(".") or module.startswith("/"):
                 base = caller_dir / module
-                extensions = [".css", ".scss"]
+                extensions = [".css", ".scss", ".less"]
                 if base.is_file():
                     return str(base.resolve())
                 for ext in extensions:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -68,7 +68,7 @@ class NodeInfo:
 @dataclass
 class EdgeInfo:
     # CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS,
-    # TESTED_BY, DEPENDS_ON, REFERENCES
+    # TESTED_BY, DEPENDS_ON, REFERENCES, OVERRIDES, STYLES, POTENTIAL_CONFLICT
     kind: str
     source: str  # qualified name or path
     target: str  # qualified name or path
@@ -143,6 +143,9 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".v": "verilog",
     ".vh": "verilog",
     ".sql": "sql",
+    ".css": "css",
+    ".scss": "scss",
+    ".less": "less",
 }
 
 # Shebang interpreter → language mapping for extension-less Unix scripts.
@@ -807,6 +810,10 @@ class CodeParser:
         self._tsconfig_resolver = TsconfigResolver()
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
+        # Per-parse JSX className collector; set by parse_bytes, read back
+        # after the walk. One CodeParser instance parses one file at a time
+        # (worker processes create their own instance), so this is safe.
+        self._jsx_class_collector: Optional[dict[str, dict]] = None
         # Config-driven custom languages (.code-review-graph/languages.toml).
         # The built-in tables stay shared module-level constants; only when a
         # repo defines custom languages does this parser switch to merged
@@ -989,6 +996,14 @@ class CodeParser:
         if language == "sql":
             return self._parse_sql(path, source)
 
+        # CSS/SCSS: dedicated parser for stylesheet languages
+        if language in ("css", "scss"):
+            return self._parse_css(path, source, language)
+
+        # LESS: regex-based fallback (no tree-sitter grammar available)
+        if language == "less":
+            return self._parse_less(path, source)
+
         parser = self._get_parser(language)
         if not parser:
             return [], []
@@ -1015,11 +1030,42 @@ class CodeParser:
             tree.root_node, language, source,
         )
 
-        # Walk the tree
+        # Walk the tree (with JSX class collection for JSX-capable languages)
+        self._jsx_class_collector = {}
         self._extract_from_tree(
             tree.root_node, source, language, file_path_str, nodes, edges,
             import_map=import_map, defined_names=defined_names,
         )
+        jsx_class_collector = self._jsx_class_collector
+        self._jsx_class_collector = None
+
+        # Attach collected JSX class refs to their enclosing function nodes
+        if jsx_class_collector:
+            node_by_qn: dict[str, NodeInfo] = {}
+            for n in nodes:
+                qn = self._qualify(n.name, n.file_path, n.parent_name)
+                node_by_qn[qn] = n
+            for func_qn, refs in jsx_class_collector.items():
+                target_node = node_by_qn.get(func_qn)
+                if target_node:
+                    if refs.get("classes"):
+                        target_node.extra["css_classes"] = sorted(
+                            set(refs["classes"]),
+                        )
+                    if refs.get("module_refs"):
+                        target_node.extra["css_module_refs"] = [
+                            {"import": imp, "property": prop}
+                            for imp, prop in refs["module_refs"]
+                        ]
+
+        # Detect CSS Module imports and store on File node
+        if import_map:
+            css_mod_imports = {
+                name: mod for name, mod in import_map.items()
+                if ".module.css" in mod or ".module.scss" in mod
+            }
+            if css_mod_imports:
+                nodes[0].extra["css_module_imports"] = css_mod_imports
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -1043,6 +1089,955 @@ class CodeParser:
                     ))
 
         return nodes, edges
+
+    # -------------------------------------------------------------------
+    # CSS / SCSS parsing
+    # -------------------------------------------------------------------
+
+    @dataclass
+    class _SelectorRecord:
+        """Ephemeral record for CSS override detection within a single file."""
+
+        selector_text: str
+        qualified_name: str
+        specificity: tuple[int, int, int]
+        properties: dict[str, int]          # property_name -> line
+        has_important: dict[str, bool]      # property_name -> has !important
+        line_start: int
+        line_end: int
+        source_order: int
+
+    def _parse_css(
+        self,
+        path: Path,
+        source: bytes,
+        language: str = "css",
+        line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a CSS/SCSS file and extract selectors, custom properties,
+        mixins, variables, @import, var() usage, and override relationships."""
+        css_parser = self._get_parser(language)
+        if not css_parser:
+            return [], []
+
+        tree = css_parser.parse(source)
+        file_path_str = str(path)
+
+        nodes: list[NodeInfo] = [NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=source.count(b"\n") + 1 + line_offset,
+            language=language,
+        )]
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        self._walk_css(
+            tree.root_node, source, language, file_path_str,
+            nodes, edges, selector_records,
+            enclosing_context=None, line_offset=line_offset,
+        )
+
+        # Override detection (post-processing after all selectors collected)
+        override_edges = self._detect_css_overrides(selector_records, file_path_str)
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    def _walk_css(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str] = None,
+        line_offset: int = 0,
+        _depth: int = 0,
+    ) -> None:
+        """Recursively walk CSS/SCSS AST extracting nodes and edges."""
+        if _depth > self._MAX_AST_DEPTH:
+            return
+
+        for child in node.children:
+            node_type = child.type
+
+            # --- @import / @use ---
+            if node_type in ("import_statement", "use_statement"):
+                target = self._extract_css_import(child)
+                if target:
+                    edges.append(EdgeInfo(
+                        kind="IMPORTS_FROM",
+                        source=file_path,
+                        target=target,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- rule_set (selector + block) ---
+            if node_type == "rule_set":
+                self._handle_css_ruleset(
+                    child, source, language, file_path,
+                    nodes, edges, selector_records,
+                    enclosing_context, line_offset, _depth,
+                )
+                continue
+
+            # --- @media ---
+            if node_type == "media_statement":
+                media_text = self._get_css_media_text(child)
+                media_name = f"@media({media_text})"
+                qualified = self._qualify(media_name, file_path, None)
+
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=media_name,
+                    file_path=file_path,
+                    line_start=child.start_point[0] + 1 + line_offset,
+                    line_end=child.end_point[0] + 1 + line_offset,
+                    language=language,
+                    extra={"css_kind": "media_query"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path,
+                    target=qualified,
+                    file_path=file_path,
+                    line=child.start_point[0] + 1 + line_offset,
+                ))
+
+                for sub in child.children:
+                    if sub.type == "block":
+                        self._walk_css(
+                            sub, source, language, file_path,
+                            nodes, edges, selector_records,
+                            enclosing_context=media_name,
+                            line_offset=line_offset,
+                            _depth=_depth + 1,
+                        )
+                continue
+
+            # --- @keyframes ---
+            if node_type == "keyframes_statement":
+                kf_name = None
+                for sub in child.children:
+                    if sub.type == "keyframes_name":
+                        kf_name = sub.text.decode("utf-8", errors="replace")
+                if kf_name:
+                    name = f"@keyframes({kf_name})"
+                    nodes.append(NodeInfo(
+                        kind="Class",
+                        name=name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "keyframes"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: top-level $variable declarations ---
+            if language == "scss" and node_type == "declaration":
+                prop_name = self._get_css_property_name(child)
+                if prop_name and prop_name.startswith("$"):
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=prop_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "scss_variable"},
+                    ))
+                    container = (
+                        self._qualify(enclosing_context, file_path, None)
+                        if enclosing_context
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=self._qualify(prop_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- SCSS: @mixin ---
+            if language == "scss" and node_type == "mixin_statement":
+                mixin_name = None
+                for sub in child.children:
+                    if sub.type == "identifier":
+                        mixin_name = sub.text.decode("utf-8", errors="replace")
+                        break
+                if mixin_name:
+                    nodes.append(NodeInfo(
+                        kind="Function",
+                        name=mixin_name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1 + line_offset,
+                        line_end=child.end_point[0] + 1 + line_offset,
+                        language=language,
+                        extra={"css_kind": "mixin"},
+                    ))
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=file_path,
+                        target=self._qualify(mixin_name, file_path, None),
+                        file_path=file_path,
+                        line=child.start_point[0] + 1 + line_offset,
+                    ))
+                continue
+
+            # --- Recurse into other nodes ---
+            self._walk_css(
+                child, source, language, file_path,
+                nodes, edges, selector_records,
+                enclosing_context=enclosing_context,
+                line_offset=line_offset,
+                _depth=_depth + 1,
+            )
+
+    def _handle_css_ruleset(
+        self,
+        node,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        selector_records: list[_SelectorRecord],
+        enclosing_context: Optional[str],
+        line_offset: int,
+        _depth: int,
+    ) -> None:
+        """Process a CSS rule_set: extract selectors, properties, var() refs."""
+        selectors_node = None
+        block_node = None
+        for sub in node.children:
+            if sub.type == "selectors":
+                selectors_node = sub
+            elif sub.type == "block":
+                block_node = sub
+
+        if not selectors_node:
+            return
+
+        # Extract properties and var() refs from the block
+        properties: dict[str, int] = {}
+        has_important: dict[str, bool] = {}
+        var_refs: list[tuple[str, int]] = []   # (var_name, line)
+        include_refs: list[tuple[str, int]] = []  # (mixin_name, line)
+        custom_prop_defs: list[tuple[str, int, int]] = []  # (name, line_start, line_end)
+
+        if block_node:
+            for decl in block_node.children:
+                if decl.type == "declaration":
+                    prop = self._get_css_property_name(decl)
+                    if prop:
+                        line = decl.start_point[0] + 1 + line_offset
+                        if prop.startswith("--"):
+                            # Custom property definition
+                            custom_prop_defs.append((
+                                prop, line, decl.end_point[0] + 1 + line_offset,
+                            ))
+                        else:
+                            properties[prop] = line
+                            has_important[prop] = self._has_important(decl)
+                        # Check for var() references in value
+                        for var_name in self._find_var_refs(decl):
+                            var_refs.append((var_name, line))
+                elif decl.type == "include_statement" and language == "scss":
+                    # @include mixin_name
+                    for sub in decl.children:
+                        if sub.type == "identifier":
+                            include_refs.append((
+                                sub.text.decode("utf-8", errors="replace"),
+                                decl.start_point[0] + 1 + line_offset,
+                            ))
+                            break
+
+        # Split comma-separated selectors into individual nodes
+        individual_selectors = self._split_css_selectors(selectors_node)
+
+        # Create custom property nodes once (not per selector in comma groups)
+        seen_custom_props: set[str] = set()
+        first_qualified: Optional[str] = None
+
+        for sel_text, sel_node in individual_selectors:
+            # Resolve SCSS nesting selector (&)
+            if language == "scss" and enclosing_context and "&" in sel_text:
+                # For BEM: &-primary → .btn-primary (parent is .btn)
+                parent_sel = enclosing_context
+                if parent_sel.startswith("@"):
+                    parent_sel = ""  # Don't resolve & against @media
+                sel_text = sel_text.replace("&", parent_sel)
+
+            specificity = self._compute_specificity(sel_node)
+            qualified = self._qualify(sel_text, file_path, enclosing_context)
+            if first_qualified is None:
+                first_qualified = qualified
+
+            nodes.append(NodeInfo(
+                kind="Class",
+                name=sel_text,
+                file_path=file_path,
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                language=language,
+                parent_name=enclosing_context,
+                extra={"css_kind": "selector", "specificity": list(specificity)},
+            ))
+
+            # CONTAINS edge
+            container = (
+                self._qualify(enclosing_context, file_path, None)
+                if enclosing_context
+                else file_path
+            )
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=container,
+                target=qualified,
+                file_path=file_path,
+                line=node.start_point[0] + 1 + line_offset,
+            ))
+
+            # Custom property definitions — only create once, parent to first selector
+            for cp_name, cp_start, cp_end in custom_prop_defs:
+                if cp_name in seen_custom_props:
+                    continue
+                seen_custom_props.add(cp_name)
+                cp_qualified = self._qualify(cp_name, file_path, None)
+                nodes.append(NodeInfo(
+                    kind="Function",
+                    name=cp_name,
+                    file_path=file_path,
+                    line_start=cp_start,
+                    line_end=cp_end,
+                    language=language,
+                    parent_name=sel_text,
+                    extra={"css_kind": "custom_property"},
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=first_qualified,
+                    target=cp_qualified,
+                    file_path=file_path,
+                    line=cp_start,
+                ))
+
+            # var() references → CALLS edges
+            for var_name, var_line in var_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=var_name,
+                    file_path=file_path,
+                    line=var_line,
+                ))
+
+            # SCSS @include → CALLS edges
+            for mixin_name, inc_line in include_refs:
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=qualified,
+                    target=mixin_name,
+                    file_path=file_path,
+                    line=inc_line,
+                ))
+
+            # Record for override detection
+            selector_records.append(CodeParser._SelectorRecord(
+                selector_text=sel_text,
+                qualified_name=qualified,
+                specificity=specificity,
+                properties=dict(properties),
+                has_important=dict(has_important),
+                line_start=node.start_point[0] + 1 + line_offset,
+                line_end=node.end_point[0] + 1 + line_offset,
+                source_order=len(selector_records),
+            ))
+
+        # Recurse into nested rule_sets (SCSS nesting / CSS nesting)
+        if block_node:
+            for sub in block_node.children:
+                if sub.type == "rule_set":
+                    # Use the first selector as enclosing context for nesting
+                    ctx = individual_selectors[0][0] if individual_selectors else enclosing_context
+                    self._handle_css_ruleset(
+                        sub, source, language, file_path,
+                        nodes, edges, selector_records,
+                        enclosing_context=ctx,
+                        line_offset=line_offset,
+                        _depth=_depth + 1,
+                    )
+
+    def _compute_specificity(self, selector_node) -> tuple[int, int, int]:
+        """Compute CSS specificity (a, b, c) from a selector AST node.
+
+        a = ID selectors, b = class/pseudo-class/attribute, c = type/pseudo-element.
+        """
+        a = b = c = 0
+        stack = [selector_node]
+        while stack:
+            n = stack.pop()
+            t = n.type
+            if t == "id_selector":
+                a += 1
+            elif t in ("class_selector", "pseudo_class_selector", "attribute_selector"):
+                b += 1
+            elif t == "pseudo_element_selector":
+                c += 1
+            elif t == "tag_name":
+                # Don't count tag_name inside pseudo_element_selector (already counted)
+                if not (n.parent and n.parent.type == "pseudo_element_selector"):
+                    c += 1
+            for child in n.children:
+                stack.append(child)
+        return (a, b, c)
+
+    def _detect_css_overrides(
+        self,
+        records: list[_SelectorRecord],
+        file_path: str,
+    ) -> list[EdgeInfo]:
+        """Detect CSS override relationships between selectors in a file."""
+        if len(records) < 2:
+            return []
+
+        # Build property → record indices
+        prop_index: dict[str, list[int]] = {}
+        for i, rec in enumerate(records):
+            for prop in rec.properties:
+                prop_index.setdefault(prop, []).append(i)
+
+        seen_pairs: set[tuple[str, str, str]] = set()
+        raw_edges: list[EdgeInfo] = []
+
+        max_override_candidates = 50  # Cap pairwise comparisons per property
+
+        for prop, rec_indices in prop_index.items():
+            if len(rec_indices) < 2:
+                continue
+            # Cap to avoid O(n²) blow-up on large files with common properties
+            candidates = rec_indices[:max_override_candidates]
+            for i in range(len(candidates)):
+                for j in range(i + 1, len(candidates)):
+                    ri = records[rec_indices[i]]
+                    rj = records[rec_indices[j]]
+                    result = self._check_override(ri, rj, prop)
+                    if result is None:
+                        continue
+                    winner, loser, mechanism = result
+                    pair_key = (winner.qualified_name, loser.qualified_name, prop)
+                    if pair_key in seen_pairs:
+                        continue
+                    seen_pairs.add(pair_key)
+                    raw_edges.append(EdgeInfo(
+                        kind="OVERRIDES",
+                        source=winner.qualified_name,
+                        target=loser.qualified_name,
+                        file_path=file_path,
+                        line=winner.line_start,
+                        extra={
+                            "properties": [prop],
+                            "source_specificity": list(winner.specificity),
+                            "target_specificity": list(loser.specificity),
+                            "mechanism": mechanism,
+                        },
+                    ))
+
+        # Consolidate: merge edges between same (source, target) pair
+        consolidated: dict[tuple[str, str], EdgeInfo] = {}
+        for edge in raw_edges:
+            key = (edge.source, edge.target)
+            if key in consolidated:
+                consolidated[key].extra["properties"].extend(edge.extra["properties"])
+            else:
+                consolidated[key] = edge
+
+        return list(consolidated.values())
+
+    def _check_override(
+        self,
+        a: _SelectorRecord,
+        b: _SelectorRecord,
+        prop: str,
+    ) -> Optional[tuple[_SelectorRecord, _SelectorRecord, str]]:
+        """Check if two selectors override each other for a property.
+
+        Returns (winner, loser, mechanism) or None.
+        """
+        a_imp = a.has_important.get(prop, False)
+        b_imp = b.has_important.get(prop, False)
+        if a_imp and not b_imp:
+            return (a, b, "important")
+        if b_imp and not a_imp:
+            return (b, a, "important")
+
+        # BEM refinement
+        if self._is_bem_refinement(a.selector_text, b.selector_text):
+            return (a, b, "bem_refinement")
+        if self._is_bem_refinement(b.selector_text, a.selector_text):
+            return (b, a, "bem_refinement")
+
+        # Same selector, source order
+        if a.selector_text == b.selector_text:
+            if a.source_order > b.source_order:
+                return (a, b, "source_order")
+            return (b, a, "source_order")
+
+        # Key selector match with different specificity
+        key_a = self._extract_key_selector(a.selector_text)
+        key_b = self._extract_key_selector(b.selector_text)
+        if key_a and key_b and key_a == key_b:
+            if a.specificity > b.specificity:
+                return (a, b, "specificity")
+            elif b.specificity > a.specificity:
+                return (b, a, "specificity")
+
+        return None
+
+    @staticmethod
+    def _is_bem_refinement(candidate: str, base: str) -> bool:
+        """Check if candidate is a BEM refinement of base.
+
+        Only applies to simple class selectors (e.g. .btn → .btn-primary).
+        """
+        candidate = candidate.strip()
+        base = base.strip()
+        if not base or not candidate or len(candidate) <= len(base):
+            return False
+        # Only match simple class selectors (no spaces, combinators, etc.)
+        if " " in base or ">" in base or "+" in base or "~" in base:
+            return False
+        if candidate.startswith(base):
+            next_char = candidate[len(base)]
+            return next_char in ("-", "_", ".")
+        return False
+
+    @staticmethod
+    def _extract_key_selector(selector_text: str) -> Optional[str]:
+        """Extract the rightmost simple selector (key selector)."""
+        parts = re.split(r"\s*[>+~]\s*|\s+", selector_text.strip())
+        return parts[-1] if parts else None
+
+    def _split_css_selectors(
+        self, selectors_node,
+    ) -> list[tuple[str, object]]:
+        """Split comma-separated selectors into (text, AST node) tuples."""
+        result: list[tuple[str, object]] = []
+        current_parts: list = []
+        for child in selectors_node.children:
+            if child.type == ",":
+                if current_parts:
+                    sel_text = self._normalize_selector_text(current_parts)
+                    result.append((sel_text, current_parts[-1]))
+                    current_parts = []
+            else:
+                current_parts.append(child)
+        if current_parts:
+            sel_text = self._normalize_selector_text(current_parts)
+            result.append((sel_text, current_parts[-1]))
+        return result
+
+    @staticmethod
+    def _normalize_selector_text(parts: list) -> str:
+        """Build normalized selector text from AST node parts."""
+        texts = []
+        for part in parts:
+            raw = part.text.decode("utf-8", errors="replace").strip()
+            raw = re.sub(r"\s+", " ", raw)
+            texts.append(raw)
+        return " ".join(texts)
+
+    @staticmethod
+    def _extract_css_import(node) -> Optional[str]:
+        """Extract the import target from a CSS @import statement."""
+        for child in node.children:
+            if child.type == "string_value":
+                raw = child.text.decode("utf-8", errors="replace")
+                return raw.strip("'\"")
+            if child.type == "call_expression":
+                # url('path')
+                for sub in child.children:
+                    if sub.type == "arguments":
+                        for arg in sub.children:
+                            if arg.type == "string_value":
+                                raw = arg.text.decode("utf-8", errors="replace")
+                                return raw.strip("'\"")
+        return None
+
+    @staticmethod
+    def _get_css_media_text(node) -> str:
+        """Extract normalized media query text from a media_statement node."""
+        parts = []
+        for child in node.children:
+            if child.type in ("feature_query", "keyword_query", "binary_query"):
+                raw = child.text.decode("utf-8", errors="replace")
+                parts.append(re.sub(r"\s+", "", raw))
+        return ",".join(parts) if parts else "unknown"
+
+    @staticmethod
+    def _get_css_property_name(decl_node) -> Optional[str]:
+        """Extract property name from a CSS declaration node."""
+        for child in decl_node.children:
+            if child.type == "property_name":
+                return child.text.decode("utf-8", errors="replace")
+            if child.type == "variable_name":
+                return child.text.decode("utf-8", errors="replace")
+        return None
+
+    @staticmethod
+    def _find_var_refs(decl_node) -> list[str]:
+        """Find all var(--name) references in a declaration value."""
+        refs: list[str] = []
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "call_expression":
+                fn_name = None
+                for child in n.children:
+                    if child.type == "function_name":
+                        fn_name = child.text.decode("utf-8", errors="replace")
+                    elif child.type == "arguments" and fn_name == "var":
+                        for arg in child.children:
+                            if arg.type in ("plain_value", "identifier"):
+                                val = arg.text.decode("utf-8", errors="replace")
+                                if val.startswith("--"):
+                                    refs.append(val)
+            for child in n.children:
+                stack.append(child)
+        return refs
+
+    @staticmethod
+    def _has_important(decl_node) -> bool:
+        """Check if a CSS declaration has !important."""
+        stack = list(decl_node.children)
+        while stack:
+            n = stack.pop()
+            if n.type == "important":
+                return True
+            for child in n.children:
+                stack.append(child)
+        return False
+
+    # --- LESS regex-based parser (v2) ---
+
+    # Regex patterns for LESS parsing (no tree-sitter grammar available)
+    _LESS_SELECTOR_RE = re.compile(
+        r"^([.#\w][\w\-\s>+~,.:[\]=*^$|\"'()]*?)\s*\{", re.MULTILINE,
+    )
+    _LESS_VARIABLE_RE = re.compile(r"^(@[\w-]+)\s*:\s*(.+?);", re.MULTILINE)
+    _LESS_IMPORT_RE = re.compile(
+        r'@import\s+(?:\([^)]+\)\s+)?["\']([^"\']+)["\']', re.MULTILINE,
+    )
+    _LESS_MIXIN_DEF_RE = re.compile(
+        r"^([.#][\w-]+)\s*\(([^)]*)\)\s*\{", re.MULTILINE,
+    )
+    _LESS_MIXIN_CALL_RE = re.compile(
+        r"^\s*([.#][\w-]+)\s*\(([^)]*)\)\s*;", re.MULTILINE,
+    )
+
+    @staticmethod
+    def _less_specificity(selector_text: str) -> tuple[int, int, int]:
+        """Compute CSS specificity from selector text using regex.
+
+        Returns (a, b, c) where a=IDs, b=classes/attrs/pseudo-classes,
+        c=type selectors/pseudo-elements.
+        """
+        # Strip pseudo-elements first (::before, ::after, etc.)
+        stripped = re.sub(r"::[a-zA-Z-]+", "", selector_text)
+        a = len(re.findall(r"#[\w-]+", stripped))
+        b = len(re.findall(r"\.[\w-]+", stripped))
+        b += len(re.findall(r"\[[\w-]+", stripped))
+        b += len(re.findall(r":[\w-]+", stripped))
+        # Type selectors: standalone word not preceded by . # : [
+        c = len(re.findall(r"(?<![.#:\[])(?:^|[\s>+~])([a-zA-Z][\w]*)", stripped))
+        return (a, b, c)
+
+    def _parse_less(
+        self, path: Path, source: bytes, line_offset: int = 0,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse a LESS file using regex-based extraction.
+
+        Creates same NodeInfo/EdgeInfo structures as _parse_css().
+        Supports selectors, @variables, @import, mixins, and mixin calls.
+        Note: nesting is not fully resolved (top-level selectors only).
+        """
+        file_path_str = str(path)
+        text = source.decode("utf-8", errors="replace")
+        nodes: list[NodeInfo] = []
+        edges: list[EdgeInfo] = []
+        selector_records: list[CodeParser._SelectorRecord] = []
+
+        # File node
+        nodes.append(NodeInfo(
+            kind="File",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1 + line_offset,
+            line_end=text.count("\n") + 1 + line_offset,
+            language="less",
+        ))
+
+        source_order = 0
+
+        # Extract @import statements
+        for m in self._LESS_IMPORT_RE.finditer(text):
+            target = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="IMPORTS_FROM",
+                source=file_path_str,
+                target=target,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract @variable declarations
+        for m in self._LESS_VARIABLE_RE.finditer(text):
+            var_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            qualified = self._qualify(var_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=var_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                extra={"css_kind": "less_variable"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract mixin definitions (before selectors to avoid double-matching)
+        mixin_names: set[str] = set()
+        for m in self._LESS_MIXIN_DEF_RE.finditer(text):
+            mixin_name = m.group(1)
+            params = m.group(2).strip()
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            mixin_names.add(mixin_name)
+            qualified = self._qualify(mixin_name, file_path_str, None)
+            nodes.append(NodeInfo(
+                kind="Function",
+                name=mixin_name,
+                file_path=file_path_str,
+                line_start=line,
+                line_end=line,
+                language="less",
+                params=params if params else None,
+                extra={"css_kind": "mixin"},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=file_path_str,
+                target=qualified,
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Extract selectors (skip lines that are mixin definitions)
+        for m in self._LESS_SELECTOR_RE.finditer(text):
+            sel_text = m.group(1).strip()
+            if not sel_text:
+                continue
+            # Skip if this is a mixin definition (has parens)
+            full_line = text[m.start():m.end()]
+            if re.search(r"\(", full_line.split("{")[0]):
+                continue
+            # Skip @-rules
+            if sel_text.startswith("@"):
+                continue
+
+            line_start = text[:m.start()].count("\n") + 1 + line_offset
+            # Split comma-separated selectors
+            for individual in sel_text.split(","):
+                individual = individual.strip()
+                if not individual:
+                    continue
+                specificity = self._less_specificity(individual)
+                qualified = self._qualify(individual, file_path_str, None)
+                nodes.append(NodeInfo(
+                    kind="Class",
+                    name=individual,
+                    file_path=file_path_str,
+                    line_start=line_start,
+                    line_end=line_start,
+                    language="less",
+                    extra={
+                        "css_kind": "selector",
+                        "specificity": list(specificity),
+                    },
+                ))
+                edges.append(EdgeInfo(
+                    kind="CONTAINS",
+                    source=file_path_str,
+                    target=qualified,
+                    file_path=file_path_str,
+                    line=line_start,
+                ))
+                # Collect for override detection
+                selector_records.append(self._SelectorRecord(
+                    selector_text=individual,
+                    qualified_name=qualified,
+                    specificity=specificity,
+                    properties={},
+                    has_important={},
+                    line_start=line_start,
+                    line_end=line_start,
+                    source_order=source_order,
+                ))
+                source_order += 1
+
+        # Extract mixin calls
+        for m in self._LESS_MIXIN_CALL_RE.finditer(text):
+            call_name = m.group(1)
+            line = text[:m.start()].count("\n") + 1 + line_offset
+            edges.append(EdgeInfo(
+                kind="CALLS",
+                source=file_path_str,
+                target=self._qualify(call_name, file_path_str, None),
+                file_path=file_path_str,
+                line=line,
+            ))
+
+        # Detect overrides among selectors
+        override_edges = self._detect_css_overrides(
+            selector_records, file_path_str,
+        )
+        edges.extend(override_edges)
+
+        return nodes, edges
+
+    # --- JSX / Vue template class extraction (v2) ---
+
+    @staticmethod
+    def _camel_to_kebab(name: str) -> str:
+        """Convert camelCase to kebab-case for CSS Modules resolution.
+
+        Examples: btnPrimary → btn-primary, navItem → nav-item
+        """
+        return re.sub(r"(?<=[a-z0-9])([A-Z])", r"-\1", name).lower()
+
+    def _extract_jsx_class_refs(
+        self, attr_node, source: bytes,
+    ) -> tuple[list[str], list[tuple[str, str]]]:
+        """Extract class names from a jsx_attribute node.
+
+        Returns (static_classes, module_refs) where module_refs are
+        (import_name, property_name) tuples for CSS Modules.
+        """
+        static_classes: list[str] = []
+        module_refs: list[tuple[str, str]] = []
+
+        # Check this is a className or class attribute
+        attr_name = None
+        value_node = None
+        for child in attr_node.children:
+            if child.type == "property_identifier":
+                attr_name = child.text.decode("utf-8", errors="replace")
+            elif child.type == "string":
+                value_node = child
+            elif child.type == "jsx_expression":
+                value_node = child
+
+        if attr_name not in ("className", "class"):
+            return static_classes, module_refs
+
+        if value_node is None:
+            return static_classes, module_refs
+
+        if value_node.type == "string":
+            # className="btn btn-primary"
+            text = value_node.text.decode("utf-8", errors="replace")
+            text = text.strip("'\"")
+            static_classes.extend(text.split())
+        elif value_node.type == "jsx_expression":
+            # Look inside the expression
+            for expr_child in value_node.children:
+                if expr_child.type == "string":
+                    # className={"btn btn-primary"}
+                    text = expr_child.text.decode("utf-8", errors="replace")
+                    text = text.strip("'\"")
+                    static_classes.extend(text.split())
+                elif expr_child.type == "template_string":
+                    # className={`btn ${...}`} — extract literal parts
+                    for frag in expr_child.children:
+                        if frag.type == "string_fragment":
+                            for part in frag.text.decode(
+                                "utf-8", errors="replace",
+                            ).split():
+                                if part and not part.startswith("$"):
+                                    static_classes.append(part)
+                elif expr_child.type == "member_expression":
+                    # className={styles.btnPrimary}
+                    obj_name = None
+                    prop_name = None
+                    for me_child in expr_child.children:
+                        if me_child.type == "identifier":
+                            obj_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                        elif me_child.type == "property_identifier":
+                            prop_name = me_child.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                    if obj_name and prop_name:
+                        module_refs.append((obj_name, prop_name))
+
+        return static_classes, module_refs
+
+    def _extract_vue_template_classes(self, node) -> list[str]:
+        """Recursively walk Vue template AST, extract class='...' values.
+
+        Only extracts static class attributes, skips :class dynamic bindings.
+        """
+        classes: list[str] = []
+        stack = [node]
+        while stack:
+            n = stack.pop()
+            if n.type == "attribute":
+                attr_name = None
+                attr_value = None
+                for child in n.children:
+                    if child.type == "attribute_name":
+                        attr_name = child.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                    elif child.type == "quoted_attribute_value":
+                        for v in child.children:
+                            if v.type == "attribute_value":
+                                attr_value = v.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                if attr_name == "class" and attr_value:
+                    classes.extend(attr_value.split())
+            # Skip directive_attribute (:class bindings)
+            elif n.type == "directive_attribute":
+                continue
+            for child in n.children:
+                stack.append(child)
+        return classes
 
     def _parse_vue(
         self, path: Path, source: bytes,
@@ -1135,6 +2130,65 @@ class CodeParser:
 
             all_nodes.extend(nodes)
             all_edges.extend(edges)
+
+        # Extract <style> blocks and delegate to CSS/SCSS parser
+        for child in tree.root_node.children:
+            if child.type != "style_element":
+                continue
+
+            style_lang = "css"
+            raw_text_node = None
+            start_tag = None
+            for sub in child.children:
+                if sub.type == "start_tag":
+                    start_tag = sub
+                elif sub.type == "raw_text":
+                    raw_text_node = sub
+
+            if start_tag:
+                for attr in start_tag.children:
+                    if attr.type == "attribute":
+                        attr_name = None
+                        attr_value = None
+                        for a in attr.children:
+                            if a.type == "attribute_name":
+                                attr_name = a.text.decode("utf-8", errors="replace")
+                            elif a.type == "quoted_attribute_value":
+                                for v in a.children:
+                                    if v.type == "attribute_value":
+                                        attr_value = v.text.decode(
+                                            "utf-8", errors="replace",
+                                        )
+                        if attr_name == "lang" and attr_value in ("scss", "sass"):
+                            style_lang = "scss"
+
+            if not raw_text_node:
+                continue
+
+            style_source = raw_text_node.text
+            style_line_offset = raw_text_node.start_point[0]
+
+            style_nodes, style_edges = self._parse_css(
+                path, style_source, style_lang, line_offset=style_line_offset,
+            )
+
+            # Remove the File node that _parse_css creates (we already have one)
+            style_nodes = [n for n in style_nodes if n.kind != "File"]
+            for sn in style_nodes:
+                sn.language = "vue"
+
+            all_nodes.extend(style_nodes)
+            all_edges.extend(style_edges)
+
+        # Extract static class names from <template> elements
+        for child in tree.root_node.children:
+            if child.type == "template_element":
+                template_classes = self._extract_vue_template_classes(child)
+                if template_classes:
+                    all_nodes[0].extra["vue_template_classes"] = sorted(
+                        set(template_classes),
+                    )
+                break  # Only one <template> per SFC
 
         # Generate TESTED_BY edges
         if test_file:
@@ -2387,6 +3441,25 @@ class CodeParser:
                     enclosing_class, enclosing_func,
                     import_map, defined_names,
                 )
+
+            # --- JSX className extraction (for cross-language STYLES edges) ---
+            if (
+                node_type == "jsx_attribute"
+                and language in ("javascript", "typescript", "tsx")
+                and self._jsx_class_collector is not None
+            ):
+                static_cls, mod_refs = self._extract_jsx_class_refs(
+                    child, source,
+                )
+                if static_cls or mod_refs:
+                    func_key = self._qualify(
+                        enclosing_func or "<module>", file_path, enclosing_class,
+                    )
+                    entry = self._jsx_class_collector.setdefault(
+                        func_key, {"classes": [], "module_refs": []},
+                    )
+                    entry["classes"].extend(static_cls)
+                    entry["module_refs"].extend(mod_refs)
 
             # --- Value references (function-as-value in maps, arrays, args) ---
             self._extract_value_references(
@@ -5447,7 +6520,7 @@ class CodeParser:
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue"]
+                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue", ".css", ".scss"]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
@@ -5467,6 +6540,23 @@ class CodeParser:
                 resolved = self._tsconfig_resolver.resolve_alias(module, file_path)
                 if resolved:
                     return resolved
+
+        elif language in ("css", "scss"):
+            if module.startswith(".") or module.startswith("/"):
+                base = caller_dir / module
+                extensions = [".css", ".scss"]
+                if base.is_file():
+                    return str(base.resolve())
+                for ext in extensions:
+                    target = base.with_suffix(ext)
+                    if target.is_file():
+                        return str(target.resolve())
+                # SCSS partial: _filename.scss
+                base_name = base.name
+                for ext in extensions:
+                    partial = base.parent / f"_{base_name}{ext}"
+                    if partial.is_file():
+                        return str(partial.resolve())
 
         elif language == "dart":
             if module.startswith("."):

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -36,6 +36,16 @@ _QUERY_PATTERNS = {
     "file_summary": "Get a summary of all nodes in a file",
 }
 
+# CSS patterns that are a pure (edge kind, direction) walk: follow edges of
+# `kind` in each listed direction and return the node at the far endpoint.
+_EDGE_WALK_PATTERNS = {
+    "overrides_of": ("OVERRIDES", ("source",)),
+    "overridden_by": ("OVERRIDES", ("target",)),
+    "styles_of": ("STYLES", ("source",)),
+    "styled_by": ("STYLES", ("target",)),
+    "conflicts_of": ("POTENTIAL_CONFLICT", ("source", "target")),
+}
+
 
 def get_impact_radius(
     changed_files: list[str] | None = None,
@@ -332,50 +342,23 @@ def query_graph(
                             results.append(node_to_dict(child))
                         edges_out.append(edge_to_dict(e))
 
-        elif pattern == "overrides_of":
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "OVERRIDES":
-                    overridden = store.get_node(e.target_qualified)
-                    if overridden:
-                        results.append(node_to_dict(overridden))
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "overridden_by":
-            for e in store.get_edges_by_target(qn):
-                if e.kind == "OVERRIDES":
-                    overrider = store.get_node(e.source_qualified)
-                    if overrider:
-                        results.append(node_to_dict(overrider))
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "styles_of":
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "STYLES":
-                    styled = store.get_node(e.target_qualified)
-                    if styled:
-                        results.append(node_to_dict(styled))
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "styled_by":
-            for e in store.get_edges_by_target(qn):
-                if e.kind == "STYLES":
-                    styler = store.get_node(e.source_qualified)
-                    if styler:
-                        results.append(node_to_dict(styler))
-                    edges_out.append(edge_to_dict(e))
-
-        elif pattern == "conflicts_of":
-            for e in store.get_edges_by_source(qn):
-                if e.kind == "POTENTIAL_CONFLICT":
-                    conflict = store.get_node(e.target_qualified)
-                    if conflict:
-                        results.append(node_to_dict(conflict))
-                    edges_out.append(edge_to_dict(e))
-            for e in store.get_edges_by_target(qn):
-                if e.kind == "POTENTIAL_CONFLICT":
-                    conflict = store.get_node(e.source_qualified)
-                    if conflict:
-                        results.append(node_to_dict(conflict))
+        elif pattern in _EDGE_WALK_PATTERNS:
+            kind, directions = _EDGE_WALK_PATTERNS[pattern]
+            for direction in directions:
+                if direction == "source":
+                    edges_iter = store.get_edges_by_source(qn)
+                else:
+                    edges_iter = store.get_edges_by_target(qn)
+                for e in edges_iter:
+                    if e.kind != kind:
+                        continue
+                    far_qn = (
+                        e.target_qualified if direction == "source"
+                        else e.source_qualified
+                    )
+                    far_node = store.get_node(far_qn)
+                    if far_node:
+                        results.append(node_to_dict(far_node))
                     edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -28,6 +28,11 @@ _QUERY_PATTERNS = {
     "children_of": "Find all nodes contained in a file or class",
     "tests_for": "Find all tests for a given function or class",
     "inheritors_of": "Find all classes that inherit from a given class",
+    "overrides_of": "Find all CSS selectors that a given selector overrides",
+    "overridden_by": "Find all CSS selectors that override a given selector",
+    "styles_of": "Find CSS selectors that style a component or function",
+    "styled_by": "Find components/functions that use a given CSS selector",
+    "conflicts_of": "Find potential cross-file CSS conflicts for a selector",
     "file_summary": "Get a summary of all nodes in a file",
 }
 
@@ -152,7 +157,9 @@ def query_graph(
 
     Args:
         pattern: Query pattern. One of: callers_of, callees_of, imports_of,
-                 importers_of, children_of, tests_for, inheritors_of, file_summary.
+                 importers_of, children_of, tests_for, inheritors_of,
+                 overrides_of, overridden_by, styles_of, styled_by,
+                 conflicts_of, file_summary.
         target: The node name, qualified name, or file path to query about.
         repo_root: Repository root path. Auto-detected if omitted.
         detail_level: "standard" (full output) or "minimal" (summary only).
@@ -324,6 +331,52 @@ def query_graph(
                         if child:
                             results.append(node_to_dict(child))
                         edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overrides_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "OVERRIDES":
+                    overridden = store.get_node(e.target_qualified)
+                    if overridden:
+                        results.append(node_to_dict(overridden))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "overridden_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "OVERRIDES":
+                    overrider = store.get_node(e.source_qualified)
+                    if overrider:
+                        results.append(node_to_dict(overrider))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styles_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "STYLES":
+                    styled = store.get_node(e.target_qualified)
+                    if styled:
+                        results.append(node_to_dict(styled))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "styled_by":
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "STYLES":
+                    styler = store.get_node(e.source_qualified)
+                    if styler:
+                        results.append(node_to_dict(styler))
+                    edges_out.append(edge_to_dict(e))
+
+        elif pattern == "conflicts_of":
+            for e in store.get_edges_by_source(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.target_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
+                    edges_out.append(edge_to_dict(e))
+            for e in store.get_edges_by_target(qn):
+                if e.kind == "POTENTIAL_CONFLICT":
+                    conflict = store.get_node(e.source_qualified)
+                    if conflict:
+                        results.append(node_to_dict(conflict))
+                    edges_out.append(edge_to_dict(e))
 
         elif pattern == "file_summary":
             graph_paths = _resolve_graph_file_paths(store, root, [target])

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -267,6 +267,14 @@ def _generate_review_guidance(
             "Check for Liskov substitution violations."
         )
 
+    # Check for CSS override changes
+    override_edges = [e for e in impact["edges"] if e.kind == "OVERRIDES"]
+    if override_edges:
+        guidance_parts.append(
+            f"- {len(override_edges)} CSS override relationship(s) affected. "
+            "Check for specificity conflicts and unintended style changes."
+        )
+
     # Check for cross-file impact
     impacted_file_count = len(impact["impacted_files"])
     if impacted_file_count > 3:

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -746,7 +746,7 @@ var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#
 var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5 };
 var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79 };
 var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross };
-var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387" };
+var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387", OVERRIDES:"#f778ba", STYLES:"#79c0ff", POTENTIAL_CONFLICT:"#f85149" };
 var communityColorScale = d3.scaleOrdinal(d3.schemeTableau10);
 var communityColoringOn = false;
 function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;").replace(/`/g,"&#96;"); }
@@ -867,7 +867,7 @@ var defs = svg.append("defs");
 var glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"}].forEach(function(mk) {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"},{id:"arrow-overrides",color:"#f778ba"},{id:"arrow-styles",color:"#79c0ff"},{id:"arrow-conflict",color:"#f85149"}].forEach(function(mk) {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")
@@ -894,6 +894,9 @@ var EDGE_CFG = {
   IMPLEMENTS:   { dash:"4,3", width:1.5, opacity:0.65, marker:"url(#arrow-implements)" },
   TESTED_BY:    { dash:"2,4", width:1.5, opacity:0.6, marker:"url(#arrow-tested_by)" },
   DEPENDS_ON:   { dash:"8,4", width:1, opacity:0.6, marker:"url(#arrow-depends_on)" },
+  OVERRIDES:    { dash:"2,4", width:1.5, opacity:0.65, marker:"url(#arrow-overrides)" },
+  STYLES:       { dash:"4,4", width:1.5, opacity:0.6, marker:"url(#arrow-styles)" },
+  POTENTIAL_CONFLICT: { dash:"2,2", width:2, opacity:0.8, marker:"url(#arrow-conflict)" },
 };
 function eStyle(d) { return EDGE_CFG[d.kind] || {dash:null,width:1,opacity:0.3,marker:""}; }
 function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }
@@ -1468,6 +1471,9 @@ _AGGREGATED_HTML_TEMPLATE = r"""<!DOCTYPE html>
   .l-imports { border-top: 2px dashed #f0883e; }
   .l-inherits { border-top: 2.5px dotted #d2a8ff; }
   .l-contains { border-top: 1.5px solid rgba(139,148,158,0.3); }
+  .l-overrides { border-top: 2px dotted #f778ba; }
+  .l-styles { border-top: 2px dashed #79c0ff; }
+  .l-conflict { border-top: 2px dotted #f85149; }
   #stats-bar {
     position: absolute; bottom: 0; left: 0; right: 0;
     background: rgba(13,17,23,0.95); border-top: 1px solid #21262d;
@@ -1622,7 +1628,8 @@ var KIND_COLOR = {
 var EDGE_COLOR = {
   CROSS_COMMUNITY: "#58a6ff", DEPENDS_ON: "#f0883e",
   CALLS: "#3fb950", IMPORTS_FROM: "#f0883e",
-  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)"
+  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)",
+  OVERRIDES: "#f778ba", STYLES: "#79c0ff", POTENTIAL_CONFLICT: "#f85149"
 };
 var EDGE_CFG = {
   CROSS_COMMUNITY: { dash: null, width: 2, opacity: 0.6, marker: "" },
@@ -1631,6 +1638,9 @@ var EDGE_CFG = {
   CALLS:           { dash: null, width: 1.5, opacity: 0.7, marker: "url(#arrow-calls)" },
   IMPORTS_FROM:    { dash: "6,3", width: 1.5, opacity: 0.65, marker: "url(#arrow-imports)" },
   INHERITS:        { dash: "3,4", width: 2, opacity: 0.7, marker: "url(#arrow-inherits)" },
+  OVERRIDES:       { dash: "2,4", width: 1.5, opacity: 0.65, marker: "url(#arrow-overrides)" },
+  STYLES:          { dash: "4,4", width: 1.5, opacity: 0.6, marker: "url(#arrow-styles)" },
+  POTENTIAL_CONFLICT: { dash: "2,2", width: 2, opacity: 0.8, marker: "url(#arrow-conflict)" },
 };
 function eStyle(d) { return EDGE_CFG[d.kind] || { dash: null, width: 1, opacity: 0.3, marker: "" }; }
 function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }
@@ -1654,7 +1664,7 @@ function buildLegend(nodeKinds, edgeKinds) {
   edgeKinds.forEach(function(k) {
     var div = document.createElement("div");
     div.className = "legend-item";
-    var cls = k === "CROSS_COMMUNITY" ? "l-cross" : k === "DEPENDS_ON" ? "l-dep" : k === "CALLS" ? "l-calls" : k === "IMPORTS_FROM" ? "l-imports" : k === "INHERITS" ? "l-inherits" : "l-contains";
+    var cls = k === "CROSS_COMMUNITY" ? "l-cross" : k === "DEPENDS_ON" ? "l-dep" : k === "CALLS" ? "l-calls" : k === "IMPORTS_FROM" ? "l-imports" : k === "INHERITS" ? "l-inherits" : k === "OVERRIDES" ? "l-overrides" : k === "STYLES" ? "l-styles" : k === "POTENTIAL_CONFLICT" ? "l-conflict" : "l-contains";
     var line = document.createElement("span");
     line.className = "legend-line " + cls;
     div.appendChild(line);
@@ -1712,7 +1722,8 @@ function showTooltip(ev, d) {
   kindSpan.className = "tt-kind";
   kindSpan.style.background = bg;
   kindSpan.style.color = "#0d1117";
-  kindSpan.textContent = d.kind;
+  var ex = d.extra || {};
+  kindSpan.textContent = ex.css_kind ? ("CSS " + ex.css_kind) : d.kind;
   tooltip.appendChild(kindSpan);
   function addRow(label, value) {
     var row = document.createElement("div");
@@ -1741,6 +1752,10 @@ function showTooltip(ev, d) {
   if (d.params) addRow("Params", d.params);
   if (d.return_type) addRow("Returns", d.return_type);
   if (d.weight != null) addRow("Weight", d.weight);
+  if (ex.specificity) {
+    var sp = ex.specificity;
+    addRow("Specificity", "(" + (Array.isArray(sp) ? sp.join(",") : sp) + ")");
+  }
   tooltip.classList.add("visible");
   moveTooltip(ev);
 }
@@ -1767,7 +1782,7 @@ var defs = svg.append("defs");
 var glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"}].forEach(function(mk) {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-overrides",color:"#f778ba"},{id:"arrow-styles",color:"#79c0ff"},{id:"arrow-conflict",color:"#f85149"}].forEach(function(mk) {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")
@@ -1882,8 +1897,9 @@ function renderGraph(nodesData, edgesData, drillDown) {
   enter.append("circle").attr("class", "node-circle")
     .attr("r", function(d) { return nodeRadius(d); })
     .attr("fill", function(d) { return nodeColor(d); })
-    .attr("stroke", "rgba(255,255,255,0.15)")
+    .attr("stroke", function(d) { return (d.extra||{}).css_kind ? "#f778ba" : "rgba(255,255,255,0.15)"; })
     .attr("stroke-width", 2)
+    .attr("stroke-dasharray", function(d) { return (d.extra||{}).css_kind ? "3,2" : null; })
     .attr("cursor", "pointer");
   enter
     .on("mouseover", function(ev, d) { highlightConnected(d, true); showTooltip(ev, d); })

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -1648,6 +1648,11 @@ function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }
 /* --- Legend setup --- */
 var legendNodes = document.getElementById("legend-nodes");
 var legendEdges = document.getElementById("legend-edges");
+var LEGEND_CLASS = {
+  CROSS_COMMUNITY: "l-cross", DEPENDS_ON: "l-dep", CALLS: "l-calls",
+  IMPORTS_FROM: "l-imports", INHERITS: "l-inherits",
+  OVERRIDES: "l-overrides", STYLES: "l-styles", POTENTIAL_CONFLICT: "l-conflict"
+};
 function buildLegend(nodeKinds, edgeKinds) {
   legendNodes.textContent = "";
   legendEdges.textContent = "";
@@ -1664,7 +1669,7 @@ function buildLegend(nodeKinds, edgeKinds) {
   edgeKinds.forEach(function(k) {
     var div = document.createElement("div");
     div.className = "legend-item";
-    var cls = k === "CROSS_COMMUNITY" ? "l-cross" : k === "DEPENDS_ON" ? "l-dep" : k === "CALLS" ? "l-calls" : k === "IMPORTS_FROM" ? "l-imports" : k === "INHERITS" ? "l-inherits" : k === "OVERRIDES" ? "l-overrides" : k === "STYLES" ? "l-styles" : k === "POTENTIAL_CONFLICT" ? "l-conflict" : "l-contains";
+    var cls = LEGEND_CLASS[k] || "l-contains";
     var line = document.createElement("span");
     line.className = "legend-line " + cls;
     div.appendChild(line);

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -63,7 +63,9 @@ Relevant responses may include compact estimated `context_savings` metadata.
 #### `query_graph_tool`
 ```
 pattern: str    # callers_of, callees_of, imports_of, importers_of,
-                # children_of, tests_for, inheritors_of, file_summary
+                # children_of, tests_for, inheritors_of, overrides_of,
+                # overridden_by, styles_of, styled_by, conflicts_of,
+                # file_summary
 target: str     # Node name, qualified name, or file path
 repo_root: str | None
 detail_level: str = "standard"   # "standard" or "minimal"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,7 +36,7 @@
 - **Graph lookup correctness**: Review, impact, and file-summary tools resolve user-facing paths to stored graph paths; `callers_of` includes cross-file callers even when same-file callers exist.
 - **Install/runtime reliability**: Generated Codex/Claude hooks drain stdin, bundled docs are available from wheels, missing local embeddings report unavailable status, and `.svn` roots pass validation.
 - **CLI reliability**: `build --skip-postprocess` and `update --skip-flows` honor the requested post-processing level.
-- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
+- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, CSS/SCSS/LESS stylesheets, Vue/Svelte SFCs (including `<style>` blocks), Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
 - **Local-first by design**: SQLite graph storage remains local, with no telemetry and no cloud-default behavior.
 
 ## v2.0.0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -116,7 +116,7 @@ Since v2.3.4, review and impact tools include compact `context_savings` metadata
 
 ## Supported Languages
 
-The parser currently covers Python, JavaScript, TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte single-file components, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
+The parser currently covers Python, JavaScript, TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, CSS/SCSS/LESS stylesheets, Vue/Svelte single-file components (including `<style>` blocks), Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
 Extension-less scripts are detected by shebang for common bash/sh/zsh/ksh/dash/ash, Python, Node, Ruby, Perl, Lua, Rscript, and PHP interpreters.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -123,6 +123,33 @@ A value-level reference to another symbol, often used for function-as-value patt
 ### INJECTS
 A dependency-injection relationship, currently used by Java/Spring enrichment for injected fields and constructor parameters.
 
+### OVERRIDES
+A CSS selector overrides another selector's properties within the same file (higher specificity, later source order, or `!important`).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| source | string | Overriding selector qualified name |
+| target | string | Overridden selector qualified name |
+| extra | json | Overridden properties and specificity details |
+
+### STYLES
+A component or function references a CSS class that a selector defines. Sources are JSX functions (`className`), Vue/Svelte files (static template classes), or CSS Modules references.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| source | string | Referencing component/function/file qualified name |
+| target | string | CSS selector qualified name |
+| extra | json | `class_name` and `resolution` ("static" or "css_module") |
+
+### POTENTIAL_CONFLICT
+Two selectors in different files target the same class name and may conflict.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| source | string | First selector qualified name |
+| target | string | Second selector qualified name |
+| extra | json | `class_name`, both specificities, `conflict_confidence` |
+
 ### CONSUMES / PRODUCES
 Data or event flow relationships emitted by specialised parsers when a source consumes or produces a named resource.
 

--- a/tests/fixtures/button.module.css
+++ b/tests/fixtures/button.module.css
@@ -1,0 +1,9 @@
+.btn-outline {
+  border: 1px solid #333;
+  background: transparent;
+}
+
+.btn-filled {
+  background: #333;
+  color: white;
+}

--- a/tests/fixtures/conflict_a.css
+++ b/tests/fixtures/conflict_a.css
@@ -1,0 +1,8 @@
+.btn {
+  color: red;
+  padding: 10px;
+}
+
+.card {
+  border: 1px solid #ccc;
+}

--- a/tests/fixtures/conflict_b.css
+++ b/tests/fixtures/conflict_b.css
@@ -1,0 +1,8 @@
+.btn {
+  color: blue;
+  padding: 15px;
+}
+
+.sidebar {
+  width: 250px;
+}

--- a/tests/fixtures/sample.css
+++ b/tests/fixtures/sample.css
@@ -1,0 +1,60 @@
+@import "reset.css";
+@import url("components.css");
+
+:root {
+  --primary-color: #3498db;
+  --font-size: 16px;
+  --spacing-md: 1rem;
+}
+
+body {
+  font-size: var(--font-size);
+  color: var(--primary-color);
+}
+
+.btn {
+  padding: 10px 20px;
+  border-radius: 4px;
+  color: blue;
+}
+
+.btn-primary {
+  background: blue;
+  color: white;
+}
+
+#main-header {
+  display: flex;
+  align-items: center;
+}
+
+h1, h2 {
+  font-weight: bold;
+  color: var(--primary-color);
+}
+
+.nav .nav-item {
+  padding: var(--spacing-md);
+}
+
+@media (max-width: 768px) {
+  .btn {
+    padding: 5px 10px;
+  }
+  .sidebar {
+    display: none;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.card {
+  animation: fadeIn 0.3s;
+}
+
+.important-thing {
+  color: red !important;
+}

--- a/tests/fixtures/sample.less
+++ b/tests/fixtures/sample.less
@@ -1,0 +1,29 @@
+@import 'variables';
+
+@primary-color: #3498db;
+@font-size: 16px;
+
+.mixin-flex() {
+  display: flex;
+  align-items: center;
+}
+
+.btn {
+  padding: 10px;
+  font-size: @font-size;
+  color: @primary-color;
+  .mixin-flex();
+
+  &-primary {
+    background: @primary-color;
+    color: white;
+  }
+}
+
+.card {
+  border: 1px solid #ccc;
+
+  .card-title {
+    font-weight: bold;
+  }
+}

--- a/tests/fixtures/sample.scss
+++ b/tests/fixtures/sample.scss
@@ -1,0 +1,46 @@
+@import 'variables';
+@import 'mixins';
+
+$primary-color: #3498db;
+$font-size: 16px;
+$spacing: 1rem;
+
+@mixin flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@mixin responsive($breakpoint) {
+  @media (max-width: $breakpoint) {
+    @content;
+  }
+}
+
+.btn {
+  padding: $spacing;
+  font-size: $font-size;
+  @include flex-center;
+  color: $primary-color;
+
+  &-primary {
+    background: $primary-color;
+    color: white;
+  }
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.card {
+  border: 1px solid #ccc;
+
+  .card-title {
+    font-weight: bold;
+  }
+
+  .card-body {
+    padding: $spacing;
+  }
+}

--- a/tests/fixtures/sample_button.tsx
+++ b/tests/fixtures/sample_button.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from './button.module.css';
+
+function Button({ label }: { label: string }) {
+  return (
+    <button className="btn btn-primary" onClick={() => {}}>
+      {label}
+    </button>
+  );
+}
+
+function StyledButton({ label }: { label: string }) {
+  return (
+    <button className={styles.btnOutline}>
+      {label}
+    </button>
+  );
+}
+
+function DynamicButton({ active }: { active: boolean }) {
+  return (
+    <button className={active ? "active" : "inactive"}>
+      Toggle
+    </button>
+  );
+}
+
+export { Button, StyledButton, DynamicButton };

--- a/tests/fixtures/sample_vue_classes.vue
+++ b/tests/fixtures/sample_vue_classes.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="container main-layout">
+    <h1 class="title">{{ heading }}</h1>
+    <span :class="{active: isActive}">Dynamic</span>
+    <p class="description">Some text</p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const heading = ref('Hello')
+const isActive = ref(true)
+</script>
+
+<style>
+.container { max-width: 1200px; }
+.title { font-size: 2rem; }
+.description { color: #666; }
+</style>

--- a/tests/fixtures/sample_widget.svelte
+++ b/tests/fixtures/sample_widget.svelte
@@ -1,0 +1,21 @@
+<script>
+  let count = 0;
+  function increment() {
+    count += 1;
+  }
+</script>
+
+<button class="btn btn--primary" on:click={increment}>+</button>
+<div class:active={count > 0} class="counter">{count}</div>
+
+<style lang="scss">
+  .btn {
+    color: red;
+  }
+  .btn--primary {
+    font-weight: bold;
+  }
+  .counter {
+    padding: 4px;
+  }
+</style>

--- a/tests/test_css_linking.py
+++ b/tests/test_css_linking.py
@@ -1,0 +1,173 @@
+"""Tests for cross-file CSS linking and conflict detection."""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import (
+    full_build,
+)
+from code_review_graph.parser import CodeParser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _build_graph_from_files(tmp_dir: Path, files: dict[str, bytes]) -> GraphStore:
+    """Write files to tmp_dir, build a graph, and return the store."""
+    for rel_path, content in files.items():
+        p = tmp_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(content)
+    db_path = tmp_dir / ".code-review-graph" / "graph.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = GraphStore(str(db_path))
+    full_build(tmp_dir, store)
+    return store
+
+
+class TestCamelToKebab:
+    def test_simple(self):
+        assert CodeParser._camel_to_kebab("btnPrimary") == "btn-primary"
+
+    def test_multiple_words(self):
+        assert CodeParser._camel_to_kebab("navItemActive") == "nav-item-active"
+
+    def test_already_kebab(self):
+        assert CodeParser._camel_to_kebab("btn-primary") == "btn-primary"
+
+    def test_single_word(self):
+        assert CodeParser._camel_to_kebab("btn") == "btn"
+
+
+class TestCSSStylesLinking:
+    def test_static_styles_edge(self):
+        """TSX className should create STYLES edge to matching CSS selector."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="btn">Click</div>;
+}
+''',
+                "styles.css": b'.btn { color: blue; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    "btn" in e.extra.get("class_name", "")
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_vue_same_file_styles_edge(self):
+        """Vue template class + inline <style> should create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.vue": b'''<template>
+  <div class="container">Hello</div>
+</template>
+<style>
+.container { max-width: 1200px; }
+</style>
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    e.extra.get("class_name") == "container"
+                    for e in styles
+                )
+            finally:
+                store.close()
+
+    def test_no_styles_edge_for_missing_selector(self):
+        """className with no matching CSS should NOT create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "App.tsx": b'''
+function App() {
+  return <div className="nonexistent">Hello</div>;
+}
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) == 0
+            finally:
+                store.close()
+
+
+class TestCrossFileConflicts:
+    def test_detects_same_selector_conflict(self):
+        """Same .btn selector in two files should create POTENTIAL_CONFLICT."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                assert any(
+                    ".btn" in e.extra.get("class_name", "")
+                    for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_no_conflict_unique_selectors(self):
+        """Unique selectors (.card, .sidebar) should NOT conflict."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "base.css": FIXTURES.joinpath("conflict_a.css").read_bytes(),
+                "theme.css": FIXTURES.joinpath("conflict_b.css").read_bytes(),
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                # .card only in conflict_a, .sidebar only in conflict_b
+                assert not any(
+                    e.extra.get("class_name") == ".card" for e in conflicts
+                )
+                assert not any(
+                    e.extra.get("class_name") == ".sidebar" for e in conflicts
+                )
+            finally:
+                store.close()
+
+    def test_conflict_has_metadata(self):
+        """Conflict edges should have specificity and confidence metadata."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "a.css": b'.alert { color: red; }',
+                "b.css": b'.alert { color: green; }',
+            })
+            try:
+                edges = store.get_all_edges()
+                conflicts = [
+                    e for e in edges if e.kind == "POTENTIAL_CONFLICT"
+                ]
+                assert len(conflicts) >= 1
+                c = conflicts[0]
+                assert "conflict_confidence" in c.extra
+                assert "source_specificity" in c.extra
+                assert "target_specificity" in c.extra
+            finally:
+                store.close()

--- a/tests/test_css_linking.py
+++ b/tests/test_css_linking.py
@@ -87,6 +87,31 @@ function App() {
             finally:
                 store.close()
 
+    def test_svelte_same_file_styles_edge(self):
+        """Svelte markup class + inline <style> should create STYLES edge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            store = _build_graph_from_files(tmp_dir, {
+                "Widget.svelte": b'''<script>
+  let count = 0;
+</script>
+<div class="counter">{count}</div>
+<style>
+.counter { padding: 4px; }
+</style>
+''',
+            })
+            try:
+                edges = store.get_all_edges()
+                styles = [e for e in edges if e.kind == "STYLES"]
+                assert len(styles) >= 1
+                assert any(
+                    e.extra.get("class_name") == "counter"
+                    for e in styles
+                )
+            finally:
+                store.close()
+
     def test_no_styles_edge_for_missing_selector(self):
         """className with no matching CSS should NOT create STYLES edge."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2788,7 +2788,7 @@ class TestVueTemplateClassExtraction:
 
     def test_extracts_static_classes(self):
         file_node = [n for n in self.nodes if n.kind == "File"][0]
-        classes = file_node.extra.get("vue_template_classes", [])
+        classes = file_node.extra.get("css_classes", [])
         assert "container" in classes
         assert "main-layout" in classes
         assert "title" in classes
@@ -2797,7 +2797,7 @@ class TestVueTemplateClassExtraction:
     def test_skips_dynamic_class(self):
         """Dynamic :class bindings should not appear in static class list."""
         file_node = [n for n in self.nodes if n.kind == "File"][0]
-        classes = file_node.extra.get("vue_template_classes", [])
+        classes = file_node.extra.get("css_classes", [])
         assert "active" not in classes
 
     def test_vue_has_style_selectors(self):

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2857,3 +2857,46 @@ class TestLESSParsing:
     def test_nodes_have_less_language(self):
         for node in self.nodes:
             assert node.language == "less"
+
+
+class TestSvelteStyleParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_widget.svelte",
+        )
+
+    def test_finds_script_functions(self):
+        funcs = [n for n in self.nodes if n.kind == "Function"]
+        names = {f.name for f in funcs}
+        assert "increment" in names
+
+    def test_finds_style_selectors(self):
+        selectors = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {s.name for s in selectors}
+        assert ".btn" in names
+        assert ".btn--primary" in names
+        assert ".counter" in names
+
+    def test_style_nodes_have_svelte_language(self):
+        selectors = [
+            n for n in self.nodes if n.extra.get("css_kind") == "selector"
+        ]
+        for sel in selectors:
+            assert sel.language == "svelte"
+
+    def test_markup_classes_on_file_node(self):
+        file_node = next(n for n in self.nodes if n.kind == "File")
+        classes = file_node.extra.get("css_classes", [])
+        assert "btn" in classes
+        assert "btn--primary" in classes
+        assert "counter" in classes
+
+    def test_class_directive_not_collected_as_static(self):
+        file_node = next(n for n in self.nodes if n.kind == "File")
+        classes = file_node.extra.get("css_classes", [])
+        # class:active={...} is a dynamic directive, not a static class
+        assert "active" not in classes

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -826,6 +826,27 @@ class TestVueParsing:
         calls = [e for e in self.edges if e.kind == "CALLS"]
         assert len(calls) >= 1
 
+    def test_vue_style_block_parsing(self):
+        parser = CodeParser()
+        vue_with_style = b"""<template><div>Hello</div></template>
+<script setup>
+const x = 1;
+</script>
+<style scoped>
+.app { color: red; }
+.app .btn { padding: 10px; }
+</style>
+"""
+        nodes, edges = parser.parse_bytes(
+            Path("/tmp/test_style.vue"), vue_with_style,
+        )
+        css_selectors = [
+            n for n in nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        assert len(css_selectors) >= 2
+        for sel in css_selectors:
+            assert sel.language == "vue"
 
 class TestRParsing:
     def setup_method(self):
@@ -2548,3 +2569,291 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+
+
+class TestCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.css")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.css")) == "css"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".btn-primary" in names
+        assert "#main-header" in names
+        assert "body" in names
+
+    def test_comma_separated_selectors_split(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert "h1" in names
+        assert "h2" in names
+
+    def test_finds_custom_properties(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "custom_property"
+        ]
+        names = {f.name for f in funcs}
+        assert "--primary-color" in names
+        assert "--font-size" in names
+        assert "--spacing-md" in names
+
+    def test_finds_media_queries(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "media_query"
+        ]
+        assert len(classes) >= 1
+
+    def test_finds_keyframes(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "keyframes"
+        ]
+        names = {c.name for c in classes}
+        assert "@keyframes(fadeIn)" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "reset.css" in targets
+        assert "components.css" in targets
+
+    def test_finds_var_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        # body calls --font-size and --primary-color
+        assert len(calls) >= 2
+
+    def test_finds_contains(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        assert len(contains) >= 5
+
+    def test_specificity_computed(self):
+        classes = {
+            n.name: n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+            and n.parent_name is None  # top-level only
+        }
+        assert classes[".btn"].extra["specificity"] == [0, 1, 0]
+        assert classes["#main-header"].extra["specificity"] == [1, 0, 0]
+        assert classes["body"].extra["specificity"] == [0, 0, 1]
+
+    def test_override_edges_exist(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        assert len(overrides) >= 1
+
+    def test_bem_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        bem = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "bem_refinement"
+        ]
+        assert len(bem) >= 1
+        # .btn-primary overrides .btn
+        targets = {e.target.split("::")[-1] for e in bem}
+        assert ".btn" in targets
+
+    def test_important_override(self):
+        overrides = [e for e in self.edges if e.kind == "OVERRIDES"]
+        important = [
+            e for e in overrides
+            if e.extra.get("mechanism") == "important"
+        ]
+        assert len(important) >= 1
+
+    def test_nodes_have_css_language(self):
+        for node in self.nodes:
+            assert node.language == "css"
+
+
+class TestSCSSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(FIXTURES / "sample.scss")
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.scss")) == "scss"
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert "flex-center" in names
+        assert "responsive" in names
+
+    def test_finds_scss_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "scss_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "$primary-color" in names
+        assert "$font-size" in names
+        assert "$spacing" in names
+
+    def test_finds_include_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        targets = {e.target for e in calls}
+        assert any("flex-center" in t for t in targets)
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+        assert "mixins" in targets
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_nodes_have_scss_language(self):
+        for node in self.nodes:
+            assert node.language == "scss"
+
+
+class TestJSXClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_button.tsx",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("Component.tsx")) == "tsx"
+
+    def test_extracts_static_classname(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        button = funcs.get("Button")
+        assert button is not None
+        classes = button.extra.get("css_classes", [])
+        assert "btn" in classes
+        assert "btn-primary" in classes
+
+    def test_extracts_css_module_refs(self):
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        styled = funcs.get("StyledButton")
+        assert styled is not None
+        refs = styled.extra.get("css_module_refs", [])
+        assert len(refs) >= 1
+        assert any(
+            r["import"] == "styles" and r["property"] == "btnOutline"
+            for r in refs
+        )
+
+    def test_skips_dynamic_classname(self):
+        """Ternary expressions should not produce css_classes."""
+        funcs = {n.name: n for n in self.nodes if n.kind == "Function"}
+        dynamic = funcs.get("DynamicButton")
+        assert dynamic is not None
+        # Dynamic ternary should not be in css_classes
+        classes = dynamic.extra.get("css_classes", [])
+        assert "active" not in classes or "inactive" not in classes
+
+    def test_classname_on_correct_function(self):
+        """Classes should attach to the enclosing function, not file."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        assert "css_classes" not in file_node.extra
+
+    def test_css_module_imports_on_file_node(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        mod_imports = file_node.extra.get("css_module_imports", {})
+        assert "styles" in mod_imports
+        assert "button.module.css" in mod_imports["styles"]
+
+
+class TestVueTemplateClassExtraction:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample_vue_classes.vue",
+        )
+
+    def test_extracts_static_classes(self):
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "container" in classes
+        assert "main-layout" in classes
+        assert "title" in classes
+        assert "description" in classes
+
+    def test_skips_dynamic_class(self):
+        """Dynamic :class bindings should not appear in static class list."""
+        file_node = [n for n in self.nodes if n.kind == "File"][0]
+        classes = file_node.extra.get("vue_template_classes", [])
+        assert "active" not in classes
+
+    def test_vue_has_style_selectors(self):
+        """Both template classes and style selectors should be extracted."""
+        selectors = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {s.name for s in selectors}
+        assert ".container" in names
+        assert ".title" in names
+        assert ".description" in names
+
+
+class TestLESSParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_file(
+            FIXTURES / "sample.less",
+        )
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("styles.less")) == "less"
+
+    def test_finds_selectors(self):
+        classes = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("css_kind") == "selector"
+        ]
+        names = {c.name for c in classes}
+        assert ".btn" in names
+        assert ".card" in names
+
+    def test_finds_variables(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function"
+            and n.extra.get("css_kind") == "less_variable"
+        ]
+        names = {f.name for f in funcs}
+        assert "@primary-color" in names
+        assert "@font-size" in names
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        assert "variables" in targets
+
+    def test_finds_mixins(self):
+        funcs = [
+            n for n in self.nodes
+            if n.kind == "Function" and n.extra.get("css_kind") == "mixin"
+        ]
+        names = {f.name for f in funcs}
+        assert ".mixin-flex" in names
+
+    def test_nodes_have_less_language(self):
+        for node in self.nodes:
+            assert node.language == "less"


### PR DESCRIPTION
Hi! This PR teaches the graph to understand stylesheets, so reviews can see the relationship between components and the CSS that styles them.

### What's new

**Parsing**
- 🧩 `.css` and `.scss` files parse via tree-sitter: selectors, custom properties, `@media`, `@keyframes`, mixins, and SCSS variables all become graph nodes
- 🍃 `.less` support via a regex fallback (no tree-sitter grammar exists for LESS)
- 🖼️ Vue **and** Svelte `<style>` / `<style lang="scss">` blocks are parsed in place, with correct line offsets back into the SFC
- 📦 `@import` chains resolve to real files, including SCSS partials (`_variables.scss`)

**Cross-language edges**
- 🔗 **STYLES** — JSX `className`, Vue/Svelte static template classes, and CSS Modules references (`styles.btnPrimary` → `.btn-primary`, camelCase→kebab handled) link components to the selectors that style them
- ⚔️ **OVERRIDES** — same-file specificity conflicts, source-order overrides, and `!important` wins are tracked per property
- 🚨 **POTENTIAL_CONFLICT** — selectors in *different* files targeting the same class get flagged with both specificities

**Tooling**
- 🔍 Five new `query_graph` patterns: `styles_of`, `styled_by`, `overrides_of`, `overridden_by`, `conflicts_of`
- 📝 Review guidance now warns when a change touches CSS override relationships
- 🎨 Visualization renders the new edge kinds with their own colors, dashes, and legend entries; CSS nodes get a dashed ring

### Design notes
- Cross-file linking runs as a best-effort post-pass alongside the existing resolvers (ReScript/Spring/Temporal), so it can never fail a build and is skipped on incremental updates when no style-relevant file changed
- Query patterns are table-driven — a future edge kind is one dict entry, not a new branch
- Docs updated across README, USAGE, FEATURES, COMMANDS, and the edge-type schema

### Testing
- ✅ 68 new tests (parser fixtures for CSS/SCSS/LESS/TSX/Vue/Svelte + end-to-end linking through `full_build`)
- ✅ Full suite green on top of current `main`: 1437 passed, 1 skipped
- ✅ ruff clean

Happy to adjust anything — naming, edge semantics, or scope. Thanks for the great project!
