### PR TITLE
fix: preserve literal paths in Git change discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Incremental Git change discovery now preserves literal non-ASCII and
+  arrow-containing paths instead of returning quoted or truncated filenames.
+
 ## [2.3.6] - 2026-06-10
 
 **Community-response release.** Built from a full audit of every open PR,

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -473,6 +473,11 @@ _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
 _SAFE_SVN_REV = re.compile(r"^r?\d+(:r?\d+|:HEAD|:BASE|:COMMITTED)?$", re.IGNORECASE)
 
 
+def _decode_nul_paths(output: bytes) -> list[str]:
+    """Decode Git's NUL-delimited path output without quote mangling."""
+    return [os.fsdecode(path) for path in output.split(b"\0") if path]
+
+
 def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
     """Persist VCS branch/revision info into the graph metadata table."""
     vcs = detect_vcs(repo_root)
@@ -506,23 +511,22 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         return []
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", base, "--"],
+            ["git", "diff", "--name-only", "-z", base, "--"],
             capture_output=True,
-            text=True, encoding='utf-8',            cwd=str(repo_root),
+            cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
             result = subprocess.run(
-                ["git", "diff", "--name-only", "--cached"],
+                ["git", "diff", "--name-only", "-z", "--cached"],
                 capture_output=True,
-                text=True, encoding='utf-8',                cwd=str(repo_root),
+                cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
                 stdin=subprocess.DEVNULL,
             )
-        files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
-        return files
+        return _decode_nul_paths(result.stdout)
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 
@@ -580,20 +584,25 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
         return _get_svn_changed_files(repo_root)
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain=v1", "-z"],
             capture_output=True,
-            text=True, encoding='utf-8',            cwd=str(repo_root),
+            cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
         )
         files = []
-        for line in result.stdout.splitlines():
-            if len(line) > 3:
-                entry = line[3:].strip()
-                # Handle renamed files: "R  old -> new"
-                if " -> " in entry:
-                    entry = entry.split(" -> ", 1)[1]
-                files.append(entry)
+        records = result.stdout.split(b"\0")
+        index = 0
+        while index < len(records):
+            record = records[index]
+            if len(record) > 3:
+                status = record[:2]
+                files.append(os.fsdecode(record[3:]))
+                # Under porcelain -z, renames and copies store the destination
+                # in this record and the source path in the following record.
+                if b"R" in status or b"C" in status:
+                    index += 1
+            index += 1
         return files
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -454,7 +454,7 @@ class TestGitOperations:
     def test_get_changed_files(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="src/a.py\nsrc/b.py\n",
+            stdout=b"src/a.py\0src/b.py\0",
         )
         result = get_changed_files(tmp_path)
         assert result == ["src/a.py", "src/b.py"]
@@ -467,8 +467,8 @@ class TestGitOperations:
     def test_get_changed_files_fallback(self, mock_run, tmp_path):
         # First call fails, second succeeds
         mock_run.side_effect = [
-            MagicMock(returncode=1, stdout=""),
-            MagicMock(returncode=0, stdout="staged.py\n"),
+            MagicMock(returncode=1, stdout=b""),
+            MagicMock(returncode=0, stdout=b"staged.py\0"),
         ]
         result = get_changed_files(tmp_path)
         assert result == ["staged.py"]
@@ -484,14 +484,23 @@ class TestGitOperations:
     def test_get_staged_and_unstaged(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=" M src/a.py\n?? new.py\nR  old.py -> new_name.py\n",
+            stdout=(
+                b" M src/a.py\0"
+                b"?? new.py\0"
+                b"R  new_name.py\0old.py\0"
+                b"C  copied.py\0source.py\0"
+                b" M path -> literal.py\0"
+            ),
         )
         result = get_staged_and_unstaged(tmp_path)
         assert "src/a.py" in result
         assert "new.py" in result
         assert "new_name.py" in result
-        # old.py should NOT be in results (renamed away)
+        assert "copied.py" in result
+        assert "path -> literal.py" in result
+        # Rename/copy sources should NOT be in results (destination-only).
         assert "old.py" not in result
+        assert "source.py" not in result
 
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_all_tracked_files(self, mock_run, tmp_path):

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -23,6 +23,7 @@ from code_review_graph.incremental import (
     full_build,
     get_all_tracked_files,
     get_changed_files,
+    get_staged_and_unstaged,
     incremental_update,
 )
 from code_review_graph.wiki import get_wiki_page
@@ -79,6 +80,44 @@ def test_get_changed_files_real_git(git_repo: Path) -> None:
     """get_changed_files should list hello.py as changed between HEAD~1..HEAD."""
     changed = get_changed_files(git_repo, base="HEAD~1")
     assert "hello.py" in changed
+
+
+@pytest.fixture()
+def git_repo_with_unicode_path(tmp_path: Path) -> Path:
+    """Create a Git repo containing a committed non-ASCII Python path."""
+    repo = tmp_path / "unicode-repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "café.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "--", "café.py")
+    _git(repo, "commit", "-m", "add unicode path")
+    return repo
+
+
+def test_get_changed_files_preserves_unicode_path(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """Committed changes should use the literal path, not Git's quoted form."""
+    source = git_repo_with_unicode_path / "café.py"
+    source.write_text("value = 2\n", encoding="utf-8")
+    _git(git_repo_with_unicode_path, "add", "--", "café.py")
+    _git(git_repo_with_unicode_path, "commit", "-m", "modify unicode path")
+
+    assert get_changed_files(git_repo_with_unicode_path, base="HEAD~1") == [
+        "café.py"
+    ]
+
+
+def test_get_staged_and_unstaged_preserves_unicode_path(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """Working-tree changes should use the literal non-ASCII path."""
+    source = git_repo_with_unicode_path / "café.py"
+    source.write_text("value = 2\n", encoding="utf-8")
+
+    assert get_staged_and_unstaged(git_repo_with_unicode_path) == ["café.py"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue

No exact issue exists for these Git discovery functions; the defect was found with Ordeal while auditing the current Python Trending surface. #497 is related Unicode-path work, but it concerns generated host configuration rather than incremental Git output. PR #566 overlaps these subprocess blocks while addressing decode crashes, but its replacement decoding does not preserve Git's quoted paths.

## What & why

code-review-graph keeps a map of a repository so its review tools know which files changed and what those changes may affect. When someone edited a valid source file such as `café.py`, Git sometimes reported the name in an encoded form. The updater then searched for that encoded text instead of the real filename, so it could silently miss the changed file. This patch reads Git's unambiguous machine format, allowing the updater to find the real file while preserving its existing rename and copy behavior.

Before this change, both the working-tree and commit-diff paths produced:

```python
['"caf\\303\\251.py"']
```

instead of:

```python
["café.py"]
```

Downstream incremental parsing then looked up a filename that did not exist and could silently miss the changed source file. The line-based status parser also treated a literal ` -> ` inside a filename as a rename delimiter and truncated that path.

Git quotes unusual paths in its newline-delimited human-readable output. This change requests NUL-delimited output from `git diff --name-only -z` and `git status --porcelain=v1 -z`, keeps the subprocess output as bytes, and decodes each complete path with `os.fsdecode`. Rename and copy records retain the existing destination-only behavior by skipping the following source-path record.

The changelog now records both corrected behaviors. Ordinary ASCII paths and the existing rename behavior remain unchanged; no schema or migration change is required.

## Ordeal evidence

A contract-specific Ordeal `fuzz` property generated valid non-ASCII Python filenames and required each Git discovery API to return the literal path.

- `get_staged_and_unstaged`: 12 examples, minimized failure `{"filename": "café.py"}`.
- `get_changed_files`: 12 examples, minimized failure `{"filename": "café.py"}`.
- Direct reproduction outside the discovery harness returned `['"caf\\303\\251.py"']` from both APIs.
- The exact target-native regressions failed before the production change and passed afterward.
- Both Ordeal properties passed all 12 examples after the fix.

The semantic-delta check also covers simple paths, destination-only rename and copy records, and a literal `path -> literal.py` filename.

## How it was tested

```bash
uv lock --check
uv run pytest tests/test_integration_git.py -k unicode_path -q
uv run pytest tests/test_incremental.py::TestGitOperations -q
uv run pytest tests/ --tb=short -q
uv run pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65
uv run ruff check code_review_graph/
uv run ruff check tests/test_integration_git.py
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
uv run bandit -r code_review_graph/ -c pyproject.toml
git diff --check
```

Results:

- Full suite: 1,386 passed, 1 skipped, 2 xpassed.
- Coverage suite: 73.50%, above the required 65% threshold.
- Ruff, mypy, Bandit, lockfile, and diff checks passed.
- A self-hosted `code-review-graph build` parsed all 179 files, and `detect-changes --base origin/main --brief` analyzed the intended four-file patch.

The local run used macOS and Python 3.13. Repository CI will provide the configured Python 3.10-3.13 matrix. The coverage run emitted existing SQLite `ResourceWarning`s in unrelated parser, visualization, and wiki tests; they did not fail the suite.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (`CHANGELOG.md`)
