### PR TITLE
Fix Codex hooks on Windows

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -609,6 +609,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph update --skip-flows"
+                                ' || exit /b 0"'
+                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -626,6 +632,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
+                            ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph status"
+                                ' || echo Not a git repo, skipping"'
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -377,6 +377,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "update" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph update --skip-flows" in inner["commandWindows"]
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -388,6 +390,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "status" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
 


### PR DESCRIPTION
## Summary

- generate `commandWindows` overrides for Codex `PostToolUse` and `SessionStart` hooks
- consume hook stdin and preserve the existing non-repository no-op behavior with native `cmd.exe` commands
- add regression assertions for both Windows hook commands

## Why

`code-review-graph install --platform codex` currently writes only POSIX shell commands. On Windows, the generated hook exits with code 1 after Codex tool calls.

Closes #620.

## Validation

- `python -m pytest tests/test_skills.py::TestGenerateCodexHooksConfig -q` - 5 passed
- `ruff check code_review_graph/skills.py` - passed
- exercised the generated Windows wrapper with a large stdin payload - exit code 0

The broader Windows test file run had 137 passes and 5 unrelated existing failures around `HOME` resolution and executable bits.
