### PR TITLE
maint: reconcile verified local and community fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
   TESTED_BY edges for test blocks embedded in ordinary source files (PR #393).
 - Hardened generated skills/configuration: uppercase `SKILL.md` (PR #563),
   string-safe JSONC plus top-level and nested-container data-preservation guards
-  (#553, PR #354), portable PATH-aware hooks (PR #565), and Windows Codex hook
-  commands (#620/PR #621).
+  (#553, PR #354), and portable PATH-aware hooks (PR #565).
 - Packaged documentation remains reachable through the MCP wrapper (#613),
   Action comments render repository-relative paths, and both visualization
   templates select the graph SVG specifically (PR #564).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PHP `use` imports now resolve to files** (`importers_of`, impact radius,
+  call disambiguation): PHP `use` statements had no branch in the parser's
+  import extraction and fell through to the raw-text fallback, storing the whole
+  `use ...;` statement as the `IMPORTS_FROM` edge target (e.g.
+  `"use App\Domain\Entity\Job;"`). As a result `importers_of` / `tests_for` /
+  `inheritors_of` and the upstream side of `get_impact_radius` returned nothing
+  for PHP classes, and the unresolved targets also degraded cross-file `CALLS`
+  disambiguation in `resolve_bare_call_targets`. PHP imports are now recorded as
+  fully-qualified names (handling `as` aliases, grouped `use A\{B, C}`, and
+  `use function` / `use const`) and resolved to absolute `.php` paths by walking
+  up from the importing file, mirroring the existing Java resolver. Vendor/global
+  classes with no local file stay as the bare FQN.
+
 ## [2.3.6] - 2026-06-10
 
 **Community-response release.** Built from a full audit of every open PR,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- Corrected TESTED_BY edge direction across graph, refactor, and transitive-test
+  consumers, with a parser-to-store-to-query regression (#527/#559/#598 class).
+- C# receiver calls now capture bare, chained, member, and null-conditional
+  invocations with caller attribution (#612); Kotlin/C# annotations and C#
+  namespace importer resolution—including nested namespaces—are also preserved
+  (#295/#310, PR #353).
+- Restored advertised Zig structure, calls, imports, and test nodes, including
+  TESTED_BY edges for test blocks embedded in ordinary source files (PR #393).
+- Hardened generated skills/configuration: uppercase `SKILL.md` (PR #563),
+  string-safe JSONC plus top-level and nested-container data-preservation guards
+  (#553, PR #354), portable PATH-aware hooks (PR #565), and Windows Codex hook
+  commands (#620/PR #621).
+- Packaged documentation remains reachable through the MCP wrapper (#613),
+  Action comments render repository-relative paths, and both visualization
+  templates select the graph SVG specifically (PR #564).
 - **PHP `use` imports now resolve to files** (`importers_of`, impact radius,
   call disambiguation): PHP `use` statements had no branch in the parser's
   import extraction and fell through to the raw-text fallback, storing the whole

--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -352,7 +352,10 @@ def analyze_changes(
     for node in changed_funcs:
         if node.is_test:
             continue
-        tested = store.get_edges_by_target(node.qualified_name)
+        # TESTED_BY edges are stored as source=production, target=test by the
+        # parser, so a changed production function finds its tests by source.
+        # See: #515
+        tested = store.get_edges_by_source(node.qualified_name)
         if not any(e.kind == "TESTED_BY" for e in tested):
             test_gaps.append({
                 "name": _sanitize_name(node.name),

--- a/code_review_graph/enrich.py
+++ b/code_review_graph/enrich.py
@@ -159,10 +159,12 @@ def _format_node_context(
         lines.append(f"  Flows: {', '.join(flow_names)}")
 
     # Tests
+    # TESTED_BY edges are stored as source=production, target=test by the
+    # parser, so look them up by source. See: #515
     tests: list[str] = []
-    for e in store.get_edges_by_target(qn):
+    for e in store.get_edges_by_source(qn):
         if e.kind == "TESTED_BY" and len(tests) < 3:
-            t = store.get_node(e.source_qualified)
+            t = store.get_node(e.target_qualified)
             if t:
                 tests.append(t.name)
     if tests:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -377,7 +377,10 @@ class GraphStore:
     ) -> list[dict]:
         """Find tests covering a node, including indirect (transitive) coverage.
 
-        1. Direct: TESTED_BY edges targeting this node (+ bare-name fallback).
+        TESTED_BY edges are stored as source=production, target=test by
+        the parser, so look them up by source_qualified. See: #515
+
+        1. Direct: TESTED_BY edges originating at this node (+ bare-name fallback).
         2. Indirect: follow outgoing CALLS edges up to *max_depth* hops,
            then collect TESTED_BY edges on each callee.
 
@@ -421,31 +424,31 @@ class GraphStore:
                 "indirect": indirect,
             }
 
-        # Direct TESTED_BY
+        # Direct TESTED_BY (source=production, target=test). See: #515
         for qn in input_qns:
             for row in conn.execute(
-                "SELECT source_qualified FROM edges "
-                "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+                "SELECT target_qualified FROM edges "
+                "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                 (qn,),
             ).fetchall():
-                src = row["source_qualified"]
-                if src not in seen:
-                    seen.add(src)
-                    d = _node_dict(src, indirect=False)
+                tgt = row["target_qualified"]
+                if tgt not in seen:
+                    seen.add(tgt)
+                    d = _node_dict(tgt, indirect=False)
                     if d:
                         results.append(d)
 
         # Bare-name fallback for direct
         bare = qualified_name.rsplit("::", 1)[-1] if "::" in qualified_name else qualified_name
         for row in conn.execute(
-            "SELECT source_qualified FROM edges "
-            "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+            "SELECT target_qualified FROM edges "
+            "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
             (bare,),
         ).fetchall():
-            src = row["source_qualified"]
-            if src not in seen:
-                seen.add(src)
-                d = _node_dict(src, indirect=False)
+            tgt = row["target_qualified"]
+            if tgt not in seen:
+                seen.add(tgt)
+                d = _node_dict(tgt, indirect=False)
                 if d:
                     results.append(d)
 
@@ -464,14 +467,14 @@ class GraphStore:
                 next_frontier = set(list(next_frontier)[:max_frontier])
             for callee in next_frontier:
                 for row in conn.execute(
-                    "SELECT source_qualified FROM edges "
-                    "WHERE target_qualified = ? AND kind = 'TESTED_BY'",
+                    "SELECT target_qualified FROM edges "
+                    "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                     (callee,),
                 ).fetchall():
-                    src = row["source_qualified"]
-                    if src not in seen:
-                        seen.add(src)
-                        d = _node_dict(src, indirect=True)
+                    tgt = row["target_qualified"]
+                    if tgt not in seen:
+                        seen.add(tgt)
+                        d = _node_dict(tgt, indirect=True)
                         if d:
                             results.append(d)
             frontier = next_frontier
@@ -1269,8 +1272,8 @@ class GraphStore:
             kind, src, tgt = row["kind"], row["source_qualified"], row["target_qualified"]
             if kind == "CALLS":
                 calls_out.setdefault(src, []).append(tgt)
-            else:  # TESTED_BY
-                has_tested_by.add(tgt)
+            else:  # TESTED_BY: source is the production node being tested. See: #515
+                has_tested_by.add(src)
 
         return FlowAdjacency(
             calls_out=calls_out,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -845,7 +845,8 @@ def _csharp_namespaces(root_node) -> list[str]:
     """
     namespaces: list[str] = []
 
-    def _walk(node) -> None:
+    def _walk(node, parent_namespace: Optional[str] = None) -> None:
+        current_namespace = parent_namespace
         if node.type in (
             "namespace_declaration", "file_scoped_namespace_declaration",
         ):
@@ -853,10 +854,15 @@ def _csharp_namespaces(root_node) -> list[str]:
                 if c.type in ("qualified_name", "identifier"):
                     text = c.text.decode("utf-8", errors="replace").strip()
                     if text:
-                        namespaces.append(text)
+                        current_namespace = (
+                            f"{parent_namespace}.{text}"
+                            if parent_namespace
+                            else text
+                        )
+                        namespaces.append(current_namespace)
                     break
         for c in node.children:
-            _walk(c)
+            _walk(c, current_namespace)
 
     _walk(root_node)
     return namespaces
@@ -1112,12 +1118,12 @@ class CodeParser:
 
         # Generate TESTED_BY edges: when a test function calls a production
         # function, create an edge from the production function back to the test.
-        if test_file:
-            test_qnames = set()
-            for n in nodes:
-                if n.is_test:
-                    qn = self._qualify(n.name, n.file_path, n.parent_name)
-                    test_qnames.add(qn)
+        test_qnames = set()
+        for n in nodes:
+            if n.is_test:
+                qn = self._qualify(n.name, n.file_path, n.parent_name)
+                test_qnames.add(qn)
+        if test_qnames:
             for edge in list(edges):
                 if edge.kind == "CALLS" and edge.source in test_qnames:
                     edges.append(EdgeInfo(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -844,8 +844,10 @@ def _csharp_namespaces(root_node) -> list[str]:
     See: #310
     """
     namespaces: list[str] = []
+    stack = [(root_node, None)]
 
-    def _walk(node, parent_namespace: Optional[str] = None) -> None:
+    while stack:
+        node, parent_namespace = stack.pop()
         current_namespace = parent_namespace
         if node.type in (
             "namespace_declaration", "file_scoped_namespace_declaration",
@@ -861,10 +863,10 @@ def _csharp_namespaces(root_node) -> list[str]:
                         )
                         namespaces.append(current_namespace)
                     break
-        for c in node.children:
-            _walk(c, current_namespace)
-
-    _walk(root_node)
+        stack.extend(
+            (child, current_namespace)
+            for child in reversed(node.children)
+        )
     return namespaces
 
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -6605,7 +6605,8 @@ class CodeParser:
         member_types = (
             "attribute", "member_expression",
             "field_expression", "selector_expression",
-            "navigation_expression",
+            "navigation_expression", "member_access_expression",
+            "conditional_access_expression",
         )
         if first.type in member_types:
             # Get the rightmost identifier (the method name)
@@ -6619,6 +6620,10 @@ class CodeParser:
                 if child.type == "navigation_suffix":
                     for sub in child.children:
                         if sub.type == "simple_identifier":
+                            return sub.text.decode("utf-8", errors="replace")
+                if child.type == "member_binding_expression":
+                    for sub in child.children:
+                        if sub.type == "identifier":
                             return sub.text.decode("utf-8", errors="replace")
             return first.text.decode("utf-8", errors="replace")
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -785,6 +785,72 @@ def _is_test_function(
     return False
 
 
+def _modifier_annotation_names(node) -> list[str]:
+    """Return annotation names from a ``modifiers`` child of *node*.
+
+    Covers Java/Kotlin/C# where annotations live inside a ``modifiers``
+    node as ``annotation`` / ``marker_annotation`` children. The leading
+    ``@`` is stripped. See: #295
+    """
+    names: list[str] = []
+    for sub in node.children:
+        if sub.type == "modifiers":
+            for mod in sub.children:
+                if mod.type in ("annotation", "marker_annotation"):
+                    text = mod.text.decode("utf-8", errors="replace")
+                    names.append(text.lstrip("@").strip())
+    return names
+
+
+def _csharp_attribute_names(node) -> list[str]:
+    """Return C# attribute names from ``attribute_list`` children of *node*.
+
+    C# attributes (``[HttpGet]``, ``[Authorize]``, ``[ApiController]``) are
+    ``attribute_list`` nodes, each wrapping one or more ``attribute`` nodes
+    whose first ``identifier`` is the attribute name. The bracket wrapper
+    and any argument list are dropped. See: #295
+    """
+    names: list[str] = []
+    for sub in node.children:
+        if sub.type != "attribute_list":
+            continue
+        for attr in sub.children:
+            if attr.type != "attribute":
+                continue
+            for ident in attr.children:
+                if ident.type in ("identifier", "qualified_name"):
+                    names.append(ident.text.decode("utf-8", errors="replace").strip())
+                    break
+    return names
+
+
+def _csharp_namespaces(root_node) -> list[str]:
+    """Return all namespaces declared in a C# compilation unit.
+
+    Handles both the block form (``namespace_declaration``) and the C# 10+
+    file-scoped form (``file_scoped_namespace_declaration``). A single file
+    may declare multiple namespaces; all are returned in source order.
+    See: #310
+    """
+    namespaces: list[str] = []
+
+    def _walk(node) -> None:
+        if node.type in (
+            "namespace_declaration", "file_scoped_namespace_declaration",
+        ):
+            for c in node.children:
+                if c.type in ("qualified_name", "identifier"):
+                    text = c.text.decode("utf-8", errors="replace").strip()
+                    if text:
+                        namespaces.append(text)
+                    break
+        for c in node.children:
+            _walk(c)
+
+    _walk(root_node)
+    return namespaces
+
+
 def file_hash(path: Path) -> str:
     """SHA-256 hash of file contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
@@ -1000,6 +1066,14 @@ class CodeParser:
 
         # File node
         test_file = _is_test_file(file_path_str)
+        file_extra: dict = {}
+        # C#: record the namespace(s) this file declares so query-time
+        # fallbacks can resolve namespace-form IMPORTS_FROM targets (from
+        # `using X.Y;` directives) back to the declaring file. See: #310
+        if language == "csharp":
+            ns_list = _csharp_namespaces(tree.root_node)
+            if ns_list:
+                file_extra["csharp_namespaces"] = ns_list
         nodes.append(NodeInfo(
             kind="File",
             name=file_path_str,
@@ -1008,6 +1082,7 @@ class CodeParser:
             line_end=source.count(b"\n") + 1,
             language=language,
             is_test=test_file,
+            extra=file_extra,
         ))
 
         # Pre-scan for import mappings and defined names
@@ -4296,6 +4371,23 @@ class CodeParser:
                 role = "workflow_interface" if is_wf else "activity_interface"
                 extra["temporal_role"] = role
 
+        # Class-level annotation persistence for all annotation-bearing
+        # languages.  Kotlin (@HiltViewModel, @AndroidEntryPoint) and C#
+        # ([ApiController], [Route]) lost this metadata entirely; Java reuses
+        # the list already gathered above.  Stored in ``modifiers`` (string)
+        # and ``extra["decorators"]`` (list).  See: #295
+        if language == "java":
+            class_decorators = list(class_annotations)
+        else:
+            class_decorators = _modifier_annotation_names(child)
+            if language == "csharp":
+                class_decorators.extend(_csharp_attribute_names(child))
+        class_modifiers: Optional[str] = (
+            ",".join(class_decorators) if class_decorators else None
+        )
+        if class_decorators and "decorators" not in extra:
+            extra["decorators"] = class_decorators
+
         node = NodeInfo(
             kind="Class",
             name=name,
@@ -4304,6 +4396,7 @@ class CodeParser:
             line_end=child.end_point[0] + 1,
             language=language,
             parent_name=enclosing_class,
+            modifiers=class_modifiers,
             extra=extra,
         )
         nodes.append(node)
@@ -4412,6 +4505,12 @@ class CodeParser:
                     inner = inner[:-1]
                 deco_list.append(inner.strip())
                 sib = sib.prev_sibling
+        # C#: attributes use `attribute_list` child nodes ([HttpGet],
+        # [Authorize]) rather than `modifiers > annotation`. Capture the
+        # attribute name from each `attribute_list > attribute > identifier`.
+        # See: #295
+        if language == "csharp":
+            deco_list.extend(_csharp_attribute_names(child))
         if deco_list:
             decorators = tuple(deco_list)
 
@@ -4445,6 +4544,15 @@ class CodeParser:
                     child, name, enclosing_class, file_path, edges,
                 )
 
+        # Persist annotations/decorators so consumers can filter on them
+        # (e.g. "show me all @Composable functions").  Stored in BOTH
+        # ``modifiers`` (comma-joined string) and ``extra["decorators"]``
+        # (list) — merged into the existing method_extra dict rather than a
+        # separate one.  See: #295
+        modifiers_str: Optional[str] = ",".join(deco_list) if deco_list else None
+        if deco_list:
+            method_extra["decorators"] = list(deco_list)
+
         node = NodeInfo(
             kind=kind,
             name=name,
@@ -4455,6 +4563,7 @@ class CodeParser:
             parent_name=parent_name,
             params=params,
             return_type=ret_type,
+            modifiers=modifiers_str,
             is_test=is_test,
             extra=method_extra,
         )

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5531,6 +5531,24 @@ class CodeParser:
                         break
                     current = current.parent
 
+        elif language == "php":
+            # ``use App\Domain\Entity\Job;`` — convert namespace separators to
+            # a relative path and walk up from the caller's directory to find
+            # the file, mirroring the Java resolver. PSR-4 layouts where a
+            # namespace segment maps to a real directory (e.g. ``App\Foo`` ->
+            # ``.../App/Foo``) resolve; vendor/global classes (``\Exception``)
+            # and ``use function`` / ``use const`` targets with no matching
+            # file stay unresolved and keep the bare FQN, like JDK imports.
+            rel_path = module.replace("\\", "/").lstrip("/") + ".php"
+            current = caller_dir
+            while True:
+                target = current / rel_path
+                if target.is_file():
+                    return str(target.resolve())
+                if current == current.parent:
+                    break
+                current = current.parent
+
         return None
 
     def _find_dart_pubspec_root(
@@ -6394,6 +6412,47 @@ class CodeParser:
                     txt = child.text.decode("utf-8", errors="replace")
                     if txt and txt != "extends":
                         imports.append(txt)
+        elif language == "php":
+            # ``namespace_use_declaration`` covers several shapes:
+            #   use A\B\C;            use A\B\C as D;
+            #   use function A\b;     use const A\B;
+            #   use A\B, C\D;         (comma-separated clauses)
+            #   use A\B\{C, D as E};  (grouped — clause names are relative to A\B)
+            # Record the fully-qualified name of each imported symbol, ignoring
+            # any ``as`` alias and stripping a leading ``\``, so IMPORTS_FROM
+            # targets are clean FQNs that _do_resolve_module can map to files.
+            # Without this branch PHP falls through to the raw-text fallback and
+            # stores the entire ``use ...;`` statement as the edge target.
+            def _php_clause_fqn(clause) -> Optional[str]:
+                for sub in clause.children:
+                    if sub.type in ("qualified_name", "name"):
+                        return sub.text.decode(
+                            "utf-8", errors="replace",
+                        ).lstrip("\\")
+                return None
+
+            group_node = None
+            prefix = ""
+            for child in node.children:
+                if child.type == "namespace_name":
+                    prefix = child.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip("\\")
+                elif child.type == "namespace_use_group":
+                    group_node = child
+
+            if group_node is not None:
+                for clause in group_node.children:
+                    if clause.type == "namespace_use_clause":
+                        rel = _php_clause_fqn(clause)
+                        if rel:
+                            imports.append(f"{prefix}\\{rel}" if prefix else rel)
+            else:
+                for clause in node.children:
+                    if clause.type == "namespace_use_clause":
+                        fqn = _php_clause_fqn(clause)
+                        if fqn:
+                            imports.append(fqn)
         elif language in self._custom_languages:
             # Custom languages (languages.toml): prefer the grammar's
             # module-ish field over the raw statement text (e.g. Erlang

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -225,7 +225,10 @@ _CLASS_TYPES: dict[str, list[str]] = {
     # Nix: attrset bindings aren't "classes"; dispatched via
     # _extract_nix_constructs.
     "nix": [],
-    "zig": ["container_declaration"],
+    # Zig has no single class node; struct/union/enum/opaque are VarDecl
+    # whose RHS is a SuffixExpr > ContainerDecl. Dispatched via
+    # _extract_zig_constructs.
+    "zig": [],
     "powershell": ["class_statement"],
     "julia": [
         "struct_definition", "abstract_definition", "module_definition",
@@ -283,7 +286,10 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     # Nix: `attrpath = expr;` bindings become Function nodes —
     # handled in _extract_nix_constructs.
     "nix": [],
-    "zig": ["fn_proto", "fn_decl"],
+    # Zig: FnProto+Block pairs sit inside a Decl node; the standard generic
+    # walker can't bridge the FnProto signature to its sibling Block body,
+    # so the whole thing is dispatched via _extract_zig_constructs.
+    "zig": [],
     "powershell": ["function_statement"],
     # Julia: short-form functions `f(x) = expr` parse as `assignment` nodes
     # (not a dedicated definition node) and are handled in
@@ -335,8 +341,9 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     # `inputs.*.url` strings become IMPORTS_FROM edges —
     # handled in _extract_nix_constructs.
     "nix": [],
-    # Zig: @import("...") is a builtin_call_expr — handled
-    # generically via call types below.
+    # Zig: @import("path") is a SuffixExpr containing a BUILTINIDENTIFIER
+    # "@import" + FnCallArguments holding a STRINGLITERALSINGLE. Handled in
+    # _extract_zig_constructs as part of VarDecl processing.
     "zig": [],
     "powershell": [],
     # Julia: import/using are import_statement nodes.
@@ -392,7 +399,11 @@ _CALL_TYPES: dict[str, list[str]] = {
     # Nix: function application is ubiquitous; only import/callPackage
     # produce edges, in _extract_nix_constructs.
     "nix": [],
-    "zig": ["call_expression", "builtin_call_expr"],
+    # Zig calls are SuffixExpr/FieldOrFnCall nodes containing FnCallArguments.
+    # Mapping SuffixExpr here would over-match (every expression is a
+    # SuffixExpr); calls are walked explicitly in
+    # _extract_zig_calls_in_subtree from inside function bodies.
+    "zig": [],
     "powershell": ["command_expression"],
     "julia": [
         "call_expression",
@@ -2332,6 +2343,19 @@ class CodeParser:
             ):
                 continue
 
+            # --- Zig-specific constructs ---
+            # Zig's grammar emits PascalCase Decl/VarDecl/FnProto/SuffixExpr
+            # nodes that don't fit the generic class/function/import/call
+            # dispatch. _extract_zig_constructs handles top-level Decl and
+            # TestDecl nodes (functions, structs/unions/enums, @import,
+            # test blocks) and walks call sites itself.
+            if language == "zig" and self._extract_zig_constructs(
+                child, node_type, source, language, file_path,
+                nodes, edges, enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            ):
+                continue
+
             # --- Bash-specific constructs ---
             # ``source ./foo.sh`` and ``. ./foo.sh`` are commands in
             # tree-sitter-bash; re-interpret them as IMPORTS_FROM edges so
@@ -3774,6 +3798,379 @@ class CodeParser:
                         raw = arg.text.decode("utf-8", errors="replace")
                         return raw.strip("'\"")
         return None
+
+    # ------------------------------------------------------------------
+    # Zig-specific helpers
+    # ------------------------------------------------------------------
+
+    _ZIG_CONTAINER_KINDS = frozenset({"struct", "union", "enum", "opaque"})
+
+    def _extract_zig_constructs(
+        self,
+        child,
+        node_type: str,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle Zig's PascalCase AST shapes.
+
+        Top-level forms recognised:
+          - ``Decl > FnProto + Block``         -> Function/Test node
+          - ``Decl > VarDecl`` with ``@import`` -> IMPORTS_FROM edge
+          - ``Decl > VarDecl`` with ``ContainerDecl`` (struct/union/enum/
+            opaque) -> Class node, recurse for nested methods
+          - ``TestDecl``                        -> Test node
+
+        Returns True if the construct was fully handled and the main loop
+        should skip generic recursion. Returns False to let generic
+        recursion continue (e.g. unknown / line_comment children).
+        """
+        if node_type == "TestDecl":
+            return self._handle_zig_test_decl(
+                child, source, language, file_path, nodes, edges,
+                enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            )
+
+        if node_type != "Decl":
+            return False
+
+        fn_proto = None
+        body_block = None
+        var_decl = None
+        for sub in child.children:
+            t = sub.type
+            if t == "FnProto" and fn_proto is None:
+                fn_proto = sub
+            elif t == "Block" and fn_proto is not None and body_block is None:
+                body_block = sub
+            elif t == "VarDecl" and var_decl is None:
+                var_decl = sub
+
+        if fn_proto is not None:
+            return self._handle_zig_fn_decl(
+                child, fn_proto, body_block, source, language, file_path,
+                nodes, edges, enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            )
+
+        if var_decl is not None:
+            return self._handle_zig_var_decl(
+                child, var_decl, source, language, file_path,
+                nodes, edges, enclosing_class, enclosing_func,
+                import_map, defined_names, _depth,
+            )
+
+        return False
+
+    def _handle_zig_fn_decl(
+        self,
+        decl,
+        fn_proto,
+        body_block,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Emit a Function/Test node for ``fn name(...) ReturnType { body }``."""
+        name: Optional[str] = None
+        for sub in fn_proto.children:
+            if sub.type == "IDENTIFIER":
+                name = sub.text.decode("utf-8", errors="replace")
+                break
+        if not name:
+            return False
+
+        is_test = _is_test_function(name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(name, file_path, enclosing_class)
+
+        nodes.append(NodeInfo(
+            kind=kind,
+            name=name,
+            file_path=file_path,
+            line_start=decl.start_point[0] + 1,
+            line_end=decl.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            is_test=is_test,
+        ))
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class
+            else file_path
+        )
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=decl.start_point[0] + 1,
+        ))
+
+        if body_block is not None:
+            self._extract_zig_calls_in_subtree(
+                body_block, file_path, edges, enclosing_class, name,
+            )
+        return True
+
+    def _handle_zig_var_decl(
+        self,
+        decl,
+        var_decl,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle ``const Name = <expr>;`` decls.
+
+        Recognises @import (-> IMPORTS_FROM) and struct/union/enum/opaque
+        ContainerDecl (-> Class node + recurse). For other expressions,
+        scans the RHS for nested call sites so call edges aren't lost.
+        """
+        var_name: Optional[str] = None
+        rhs_suffix = None
+        for sub in var_decl.children:
+            t = sub.type
+            if t == "IDENTIFIER" and var_name is None:
+                var_name = sub.text.decode("utf-8", errors="replace")
+            elif t == "ErrorUnionExpr" and rhs_suffix is None:
+                for inner in sub.children:
+                    if inner.type == "SuffixExpr":
+                        rhs_suffix = inner
+                        break
+
+        if not var_name or rhs_suffix is None:
+            return False
+
+        suffix_children = list(rhs_suffix.children)
+
+        # @import("path") -> IMPORTS_FROM edge
+        if (
+            len(suffix_children) >= 2
+            and suffix_children[0].type == "BUILTINIDENTIFIER"
+            and suffix_children[0].text == b"@import"
+            and suffix_children[1].type == "FnCallArguments"
+        ):
+            target = self._zig_extract_import_target(suffix_children[1])
+            if target is not None:
+                resolved = self._resolve_module_to_file(
+                    target, file_path, language,
+                )
+                edges.append(EdgeInfo(
+                    kind="IMPORTS_FROM",
+                    source=file_path,
+                    target=resolved if resolved else target,
+                    file_path=file_path,
+                    line=decl.start_point[0] + 1,
+                ))
+                return True
+
+        # struct / union / enum / opaque -> Class node
+        container_decl = None
+        for inner in suffix_children:
+            if inner.type == "ContainerDecl":
+                container_decl = inner
+                break
+
+        if container_decl is not None:
+            kind_label = "struct"
+            for cd in container_decl.children:
+                if cd.type == "ContainerDeclType":
+                    for kw in cd.children:
+                        txt = kw.text.decode("utf-8", errors="replace")
+                        if txt in self._ZIG_CONTAINER_KINDS:
+                            kind_label = txt
+                            break
+                    break
+
+            nodes.append(NodeInfo(
+                kind="Class",
+                name=var_name,
+                file_path=file_path,
+                line_start=decl.start_point[0] + 1,
+                line_end=decl.end_point[0] + 1,
+                language=language,
+                parent_name=enclosing_class,
+                extra={"zig_kind": kind_label},
+            ))
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=(
+                    self._qualify(enclosing_class, file_path, None)
+                    if enclosing_class
+                    else file_path
+                ),
+                target=self._qualify(var_name, file_path, enclosing_class),
+                file_path=file_path,
+                line=decl.start_point[0] + 1,
+            ))
+            self._extract_from_tree(
+                container_decl, source, language, file_path, nodes, edges,
+                enclosing_class=var_name,
+                enclosing_func=enclosing_func,
+                import_map=import_map,
+                defined_names=defined_names,
+                _depth=_depth + 1,
+            )
+            return True
+
+        # Plain ``const x = expr;`` — still scan RHS for call sites so
+        # call edges aren't lost when calls appear at module scope.
+        self._extract_zig_calls_in_subtree(
+            rhs_suffix, file_path, edges,
+            enclosing_class, enclosing_func,
+        )
+        return True
+
+    def _handle_zig_test_decl(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle ``test "label" { ... }`` blocks."""
+        label: Optional[str] = None
+        body_block = None
+        for sub in child.children:
+            if sub.type == "STRINGLITERALSINGLE":
+                raw = sub.text.decode("utf-8", errors="replace")
+                stripped = raw.strip().strip('"').strip("'")
+                if stripped:
+                    label = stripped
+            elif sub.type == "Block":
+                body_block = sub
+
+        line_no = child.start_point[0] + 1
+        base = f"test:{label}" if label else "test"
+        synthetic = f"{base}@L{line_no}"
+        qualified = self._qualify(synthetic, file_path, enclosing_class)
+
+        nodes.append(NodeInfo(
+            kind="Test",
+            name=synthetic,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            is_test=True,
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=(
+                self._qualify(enclosing_class, file_path, None)
+                if enclosing_class
+                else file_path
+            ),
+            target=qualified,
+            file_path=file_path,
+            line=line_no,
+        ))
+
+        if body_block is not None:
+            self._extract_zig_calls_in_subtree(
+                body_block, file_path, edges, enclosing_class, synthetic,
+            )
+        return True
+
+    @staticmethod
+    def _zig_extract_import_target(args_node) -> Optional[str]:
+        """Pull the string argument out of ``@import("path")``.
+
+        Walks FnCallArguments > ErrorUnionExpr > SuffixExpr >
+        STRINGLITERALSINGLE. Returns the unquoted contents or None.
+        """
+        for arg in args_node.children:
+            if arg.type != "ErrorUnionExpr":
+                continue
+            for sub in arg.children:
+                if sub.type != "SuffixExpr":
+                    continue
+                for s in sub.children:
+                    if s.type == "STRINGLITERALSINGLE":
+                        raw = s.text.decode("utf-8", errors="replace")
+                        return raw.strip().strip('"').strip("'")
+        return None
+
+    def _extract_zig_calls_in_subtree(
+        self,
+        root,
+        file_path: str,
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+    ) -> None:
+        """Walk a subtree and emit a CALLS edge for each call site.
+
+        A call site is a ``SuffixExpr`` or ``FieldOrFnCall`` node whose
+        direct children include a ``FnCallArguments``; the callee is the
+        IDENTIFIER (or BUILTINIDENTIFIER) immediately preceding it. The
+        builtin ``@import`` is skipped here because it's already modelled
+        as IMPORTS_FROM by _handle_zig_var_decl.
+        """
+        src_qn = (
+            self._qualify(enclosing_func, file_path, enclosing_class)
+            if enclosing_func
+            else file_path
+        )
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type in ("SuffixExpr", "FieldOrFnCall"):
+                children = node.children
+                for i, ch in enumerate(children):
+                    if ch.type != "FnCallArguments" or i == 0:
+                        continue
+                    prev = children[i - 1]
+                    callee: Optional[str] = None
+                    if prev.type == "IDENTIFIER":
+                        callee = prev.text.decode("utf-8", errors="replace")
+                    elif prev.type == "BUILTINIDENTIFIER":
+                        txt = prev.text.decode("utf-8", errors="replace")
+                        if txt != "@import":
+                            callee = txt
+                    if callee:
+                        edges.append(EdgeInfo(
+                            kind="CALLS",
+                            source=src_qn,
+                            target=callee,
+                            file_path=file_path,
+                            line=node.start_point[0] + 1,
+                        ))
+                    break
+            for ch in node.children:
+                stack.append(ch)
 
     # ------------------------------------------------------------------
     # JS/TS: variable-assigned functions  (const foo = () => {})
@@ -5536,6 +5933,20 @@ class CodeParser:
                     return str(target)
             except (OSError, ValueError):
                 pass
+            return None
+
+        if language == "zig":
+            # Zig: only relative ``@import("./foo.zig")`` paths are
+            # resolvable here. ``@import("std")`` and other package-style
+            # imports stay unresolved (the caller falls back to the raw
+            # module string as the edge target).
+            if module.endswith(".zig"):
+                try:
+                    target = (caller_dir / module).resolve()
+                    if target.is_file():
+                        return str(target)
+                except (OSError, ValueError):
+                    pass
             return None
 
         if language == "python":

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -492,19 +492,38 @@ def find_dead_code(
                 if _is_plausible_caller(e.file_path, node.file_path, node.name)
             ]
             incoming = incoming + all_bare
-        if not any(e.kind == "TESTED_BY" for e in incoming):
-            bare_tb = store.search_edges_by_target_name(node.name, kind="TESTED_BY")
-            bare_tb = [
-                e for e in bare_tb
+        # TESTED_BY edges are stored as source=production, target=test by the
+        # parser, so a tested production node is the *source* of its TESTED_BY
+        # edge -- look outgoing, not incoming. See: #515
+        outgoing_tb = [
+            e for e in store.get_edges_by_source(node.qualified_name)
+            if e.kind == "TESTED_BY"
+        ]
+        if not outgoing_tb and node.parent_name:
+            # Class-qualified source (e.g. "ClassName::method") which lacks the
+            # file-path prefix used in node.qualified_name.
+            class_qn = f"{node.parent_name}::{node.name}"
+            outgoing_tb += [
+                e for e in store.get_edges_by_source(class_qn)
+                if e.kind == "TESTED_BY"
+            ]
+        if not outgoing_tb:
+            # Bare-name source fallback: unresolved TESTED_BY edges may store the
+            # production function by its plain name (e.g. "authenticate").
+            bare_rows = conn.execute(
+                "SELECT * FROM edges WHERE kind = 'TESTED_BY' AND source_qualified = ?",
+                (node.name,),
+            ).fetchall()
+            outgoing_tb += [
+                e for e in (store._row_to_edge(r) for r in bare_rows)
                 if _is_plausible_caller(e.file_path, node.file_path, node.name)
             ]
-            incoming = incoming + bare_tb
         # Check INHERITS -- classes with subclasses are not dead.
         if node.kind == "Class" and not any(e.kind == "INHERITS" for e in incoming):
             bare_inh = store.search_edges_by_target_name(node.name, kind="INHERITS")
             incoming = incoming + bare_inh
         has_callers = any(e.kind == "CALLS" for e in incoming)
-        has_test_refs = any(e.kind == "TESTED_BY" for e in incoming)
+        has_test_refs = bool(outgoing_tb)
         has_importers = any(e.kind == "IMPORTS_FROM" for e in incoming)
         has_references = any(e.kind == "REFERENCES" for e in incoming)
         has_subclasses = any(e.kind == "INHERITS" for e in incoming)

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -693,6 +693,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph update --skip-flows"
+                                ' || exit /b 0"'
+                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -710,6 +716,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
+                            ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph status"
+                                ' || echo Not a git repo, skipping"'
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -12,7 +12,6 @@ import json
 import logging
 import os
 import platform
-import re
 import shutil
 import stat
 import subprocess
@@ -290,6 +289,83 @@ def _merge_toml_mcp_server(
     return True
 
 
+def _strip_jsonc(text: str) -> str:
+    """Strip JSONC comments and trailing commas without corrupting string values.
+
+    Editors like Zed accept non-standard JSON (``//`` and ``/* */`` comments,
+    trailing commas). To merge such a config we must reduce it to strict JSON
+    first. A naive regex pass cannot tell structure from data: it would delete a
+    comma inside ``"foo, bar"`` or truncate a ``"https://..."`` URL at the
+    ``//``. This walks the text character by character, tracking whether we are
+    inside a double-quoted string (respecting ``\\`` escapes), and only removes
+    comments and trailing commas that appear in structural position. Content
+    inside string values is preserved verbatim. (GH #553)
+    """
+
+    def _skip_comment(s: str, idx: int) -> int | None:
+        """If a comment starts at ``idx``, return the index just past it."""
+        if s[idx] != "/" or idx + 1 >= len(s):
+            return None
+        nxt = s[idx + 1]
+        if nxt == "/":
+            idx += 2
+            while idx < len(s) and s[idx] != "\n":
+                idx += 1
+            return idx
+        if nxt == "*":
+            idx += 2
+            while idx + 1 < len(s) and not (s[idx] == "*" and s[idx + 1] == "/"):
+                idx += 1
+            return idx + 2  # consume the closing */ (or run off the end if unterminated)
+        return None
+
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])  # escaped char is data, never a delimiter
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        # Outside a string.
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        past = _skip_comment(text, i)
+        if past is not None:
+            i = past
+            continue
+        if ch == ",":
+            # Trailing comma if the next significant char (skipping whitespace
+            # and comments) closes an object or array.
+            j = i + 1
+            while j < n:
+                if text[j] in " \t\r\n":
+                    j += 1
+                    continue
+                past = _skip_comment(text, j)
+                if past is not None:
+                    j = past
+                    continue
+                break
+            if j < n and text[j] in "}]":
+                i += 1  # drop the trailing comma
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def install_platform_configs(
     repo_root: Path,
     target: str = "all",
@@ -345,10 +421,9 @@ def install_platform_configs(
         existing: dict[str, Any] = {}
         if config_path.exists():
             raw = config_path.read_text(encoding="utf-8", errors="replace")
-            # Strip single-line comments and trailing commas (JSONC compat
-            # for editors like Zed that allow non-standard JSON).
-            stripped = re.sub(r'//.*?$', '', raw, flags=re.MULTILINE)
-            stripped = re.sub(r',(\s*[}\]])', r'\1', stripped)
+            # Strip comments and trailing commas (JSONC compat for editors like
+            # Zed that allow non-standard JSON) without corrupting string values.
+            stripped = _strip_jsonc(raw)
             try:
                 existing = json.loads(stripped)
             except (json.JSONDecodeError, OSError):

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -424,13 +424,30 @@ def install_platform_configs(
             # Strip comments and trailing commas (JSONC compat for editors like
             # Zed that allow non-standard JSON) without corrupting string values.
             stripped = _strip_jsonc(raw)
-            try:
-                existing = json.loads(stripped)
-            except (json.JSONDecodeError, OSError):
-                print(f"  {plat['name']}: {config_path} contains "
-                      f"unparseable JSON — skipping to avoid data loss. "
-                      f"Please add the MCP config manually.")
-                continue
+            if not stripped.strip():
+                # An empty (or comment-only) file is a valid empty config,
+                # not a parse failure — proceed and write a fresh one rather
+                # than mis-flagging it "unparseable" and skipping. See #344.
+                existing = {}
+            else:
+                try:
+                    parsed = json.loads(stripped)
+                except (json.JSONDecodeError, OSError):
+                    print(f"  {plat['name']}: {config_path} contains "
+                          f"unparseable JSON — skipping to avoid data loss. "
+                          f"Please add the MCP config manually.")
+                    continue
+                if not isinstance(parsed, dict):
+                    # Valid JSON, but the top level is a list/scalar rather
+                    # than an object. Writing our server object would clobber
+                    # the user's data, and the ``.get()`` calls below would
+                    # raise AttributeError. Refuse and skip. See #344.
+                    print(f"  {plat['name']}: {config_path} is valid JSON but "
+                          f"not a top-level object "
+                          f"({type(parsed).__name__}) — skipping to avoid "
+                          f"data loss. Please add the MCP config manually.")
+                    continue
+                existing = parsed
 
         if plat["format"] == "array":
             arr = existing.get(server_key, [])

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -601,11 +601,11 @@ def generate_skills(repo_root: Path, skills_dir: Path | None = None) -> Path:
     skills_dir.mkdir(parents=True, exist_ok=True)
 
     for filename, skill in _SKILLS.items():
-        # Claude Code expects skills at .claude/skills/<name>/skill.md
+        # Claude Code expects skills at .claude/skills/<name>/SKILL.md
         skill_name = filename.removesuffix(".md")
         skill_subdir = skills_dir / skill_name
         skill_subdir.mkdir(parents=True, exist_ok=True)
-        path = skill_subdir / "skill.md"
+        path = skill_subdir / "SKILL.md"
         content = (
             "---\n"
             f"name: {skill['name']}\n"

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -449,10 +449,22 @@ def install_platform_configs(
                     continue
                 existing = parsed
 
+        expected_container = list if plat["format"] == "array" else dict
+        if server_key in existing and not isinstance(
+            existing[server_key], expected_container
+        ):
+            expected_name = "array" if expected_container is list else "object"
+            actual_name = type(existing[server_key]).__name__
+            print(
+                f"  {plat['name']}: {config_path} setting {server_key!r} "
+                f"is {actual_name}; expected a JSON {expected_name} — "
+                f"skipping to avoid data loss. Please repair that setting "
+                f"or add the MCP config manually."
+            )
+            continue
+
         if plat["format"] == "array":
             arr = existing.get(server_key, [])
-            if not isinstance(arr, list):
-                arr = []
             # Check if already present
             if any(isinstance(s, dict) and s.get("name") == "code-review-graph" for s in arr):
                 print(f"  {plat['name']}: already configured in {config_path}")
@@ -463,8 +475,6 @@ def install_platform_configs(
             existing[server_key] = arr
         else:
             servers = existing.get(server_key, {})
-            if not isinstance(servers, dict):
-                servers = {}
             if "code-review-graph" in servers:
                 print(f"  {plat['name']}: already configured in {config_path}")
                 configured.append(plat["name"])

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -550,21 +550,28 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
     Hooks use the v1.x+ schema: each entry needs a ``matcher`` and a nested
     ``hooks`` array. Timeouts are in seconds. ``PreCommit`` is not a valid
     Claude Code event — pre-commit checks are handled by ``install_git_hook``.
+
+    The ``repo_root`` parameter is retained for backward compatibility but is
+    not embedded in hook commands. Instead, the repo root is resolved at
+    runtime via ``git rev-parse --show-toplevel`` so that ``settings.json``
+    is shareable across collaborators with different checkout paths.
+    A PATH guard ensures the hook exits silently when the binary is not on
+    ``$PATH`` (e.g. installed in a project venv).
     """
-    repo_arg = json.dumps(repo_root.resolve().as_posix())
     return {
         "hooks": {
             "PostToolUse": [
                 {
-                    "matcher": "Edit|Write|Bash",
+                    "matcher": "Edit|Write",
                     "hooks": [
                         {
                             "type": "command",
                             "command": (
                                 "cat >/dev/null || true; "
+                                "command -v code-review-graph >/dev/null 2>&1 || exit 0; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
-                                f" && code-review-graph update --skip-flows"
-                                f" --repo {repo_arg}"
+                                " && code-review-graph update --skip-flows"
+                                " --repo \"$(git rev-parse --show-toplevel 2>/dev/null)\""
                                 " || true"
                             ),
                             "timeout": 30,
@@ -580,8 +587,10 @@ def generate_hooks_config(repo_root: Path) -> dict[str, Any]:
                             "type": "command",
                             "command": (
                                 "cat >/dev/null || true; "
+                                "command -v code-review-graph >/dev/null 2>&1 || exit 0; "
                                 "git rev-parse --git-dir >/dev/null 2>&1"
-                                f" && code-review-graph status --repo {repo_arg}"
+                                " && code-review-graph status"
+                                " --repo \"$(git rev-parse --show-toplevel 2>/dev/null)\""
                                 " || echo 'Not a git repo, skipping'"
                             ),
                             "timeout": 10,

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -720,12 +720,6 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
-                            "commandWindows": (
-                                'cmd.exe /d /s /c "more >nul & '
-                                "git rev-parse --git-dir >nul 2>&1"
-                                " && code-review-graph update --skip-flows"
-                                ' || exit /b 0"'
-                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -743,12 +737,6 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
-                            ),
-                            "commandWindows": (
-                                'cmd.exe /d /s /c "more >nul & '
-                                "git rev-parse --git-dir >nul 2>&1"
-                                " && code-review-graph status"
-                                ' || echo Not a git repo, skipping"'
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/code_review_graph/tools/docs.py
+++ b/code_review_graph/tools/docs.py
@@ -131,9 +131,10 @@ def get_docs_section(
             search_roots.append(_validate_repo_root(Path(repo_root)))
         except ValueError:
             pass
-    elif in_pkg_docs.exists():
+    if in_pkg_docs.exists():
         in_pkg_root = in_pkg_docs.parent.parent
-        search_roots.append(in_pkg_root)
+        if in_pkg_root not in search_roots:
+            search_roots.append(in_pkg_root)
 
     if not repo_root:
         project_root = find_project_root()

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -284,6 +284,32 @@ def query_graph(
                         "file": e.file_path,
                     })
                     edges_out.append(edge_to_dict(e))
+            # C# fallback: `using X.Y;` directives produce IMPORTS_FROM edges
+            # whose target is the raw namespace string, not a file path, so
+            # the path lookup above misses them. Resolve the target file's
+            # declared namespace(s) and also search edges by namespace.
+            # See: #310
+            if node is not None and node.language == "csharp":
+                declared_ns: list[str] = []
+                for n in store.get_nodes_by_file(node.file_path):
+                    if n.kind == "File":
+                        declared_ns = list(
+                            n.extra.get("csharp_namespaces", []) or []
+                        )
+                        break
+                seen_sources = {r.get("importer") for r in results}
+                for ns in declared_ns:
+                    for e in store.get_edges_by_target(ns):
+                        if e.kind != "IMPORTS_FROM":
+                            continue
+                        if e.source_qualified in seen_sources:
+                            continue
+                        results.append({
+                            "importer": e.source_qualified,
+                            "file": e.file_path,
+                        })
+                        edges_out.append(edge_to_dict(e))
+                        seen_sources.add(e.source_qualified)
 
         elif pattern == "children_of":
             for e in store.get_edges_by_source(qn):

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -293,9 +293,11 @@ def query_graph(
                         results.append(node_to_dict(child))
 
         elif pattern == "tests_for":
-            for e in store.get_edges_by_target(qn):
+            # TESTED_BY edges are stored as source=production, target=test
+            # by the parser, so look them up by source. See: #515
+            for e in store.get_edges_by_source(qn):
                 if e.kind == "TESTED_BY":
-                    test = store.get_node(e.source_qualified)
+                    test = store.get_node(e.target_qualified)
                     if test:
                         results.append(node_to_dict(test))
             # Also search by naming convention

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -856,7 +856,7 @@ function moveTooltip(ev) {
 }
 function hideTooltip() { tooltip.classList.remove("visible"); }
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()
@@ -1605,7 +1605,7 @@ _AGGREGATED_HTML_TEMPLATE = r"""<!DOCTYPE html>
 <div id="stats-bar" role="status" aria-label="Graph statistics"></div>
 <div id="tooltip"></div>
 <button id="btn-back" aria-label="Back to overview">&larr; Back to Overview</button>
-<svg role="img" aria-label="Interactive code knowledge graph visualization (aggregated view)."></svg>
+<svg id="graph-svg" role="img" aria-label="Interactive code knowledge graph visualization (aggregated view)."></svg>
 <script>
 "use strict";
 var graphData = __GRAPH_DATA__;
@@ -1756,7 +1756,7 @@ function hideTooltip() { tooltip.classList.remove("visible"); }
 
 /* --- SVG setup --- */
 var W = innerWidth, H = innerHeight;
-var svg = d3.select("svg").attr("viewBox", [0, 0, W, H]);
+var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
 var zoomBehavior = d3.zoom()

--- a/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
+++ b/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
@@ -77,7 +77,6 @@ Important local-branch conclusions:
 | `771307e` | issue #612 | Capture bare, member, chained, and null-conditional C# receiver calls with correct caller attribution; implemented red/green with focused tests. |
 | `eeef686` | issue #613 | Keep packaged documentation fallback available through the real MCP wrapper; implemented red/green with an installed-layout regression. |
 | `571f665` | content-equivalent/rebased port of PR #578 | Replace regex JSONC stripping with a string-aware scanner so URLs and comment-like string contents survive; import-neighborhood context differs from the source patch. |
-| `9ef6641` | PR #621 / issue #620 | Add `commandWindows` hook forms that drain stdin and fail open; exact contributor commit. Local Codex schema inspection confirms the field, but Windows execution still requires CI. |
 | `df87b60`, `e5f563b` | PR #563 | Generate the uppercase `SKILL.md` filename required by the [Claude Code skills documentation](https://code.claude.com/docs/en/skills) and update regressions. This does not adopt PR #562's unnecessary lowercasing of the display name. |
 | `90408c9` | PR #354 | Refuse and preserve valid top-level arrays/scalars, while treating empty/comment-only configs as fresh objects. Conflict resolution retained PR #578's stronger string-aware JSONC parser. Production fixes for #312/#350 were intentionally omitted because they are already on `main`; their regressions remain. |
 | `0abd789` | PR #353 | Persist Kotlin/C# annotations using the established metadata shape and resolve C# namespace importers. This does not claim to solve the remaining impact-radius design in #310. |
@@ -131,6 +130,11 @@ The routing groups are not blanket approvals. Material non-selection decisions:
 - Draft PR #618 is stronger than #566 for Git paths because it uses NUL-delimited
   bytes and `os.fsdecode`; it remains separate until its draft/CI state and
   overlap with branch/tracked-output behavior are resolved.
+- PR #621 is the focused Windows Codex-hook candidate, but target-native command
+  execution was not covered by this branch's Linux CI. Its contributor-authored
+  patch was removed from this integration and moved to dedicated
+  [draft PR #626](https://github.com/tirth8205/code-review-graph/pull/626) for
+  Windows testing.
 - PRs #595, #597, and #596 form a promising Windows daemon sequence, but they
   require genuine Windows execution and should not be hidden inside this
   cross-platform reconciliation.
@@ -181,7 +185,7 @@ All 84 open issues were read and classified exactly once:
 
 Selected patches address or materially advance #523 (visualization), #549 and
 #558 (portable hooks), #574 (PHP imports), #515 (TESTED_BY via the #559 subset),
-#553 (JSONC), #612, #613, #620, and #295. PR #353 advances only the namespace
+#553 (JSONC), #612, #613, and #295. PR #353 advances only the namespace
 importer portion of #310; its impact-radius/detect-changes BFS remains open.
 Issues #561 and #567 remain unaddressed because PRs #562 and #568 are absent.
 Issue #622's collision/overload problem is intentionally deferred because the
@@ -204,8 +208,9 @@ and #405:
   current cap implementation.
 - #318 and #410 support trustworthy status/doctor UX, while strengthening the
   requirement that diagnostics be non-mutating and fail honestly.
-- #501 supports portable PowerShell/Codex hooks and informed the selection of
-  PR #621; #405 shows the hook contract still needs clearer documentation.
+- #501 supports portable PowerShell/Codex hooks and informed the dedicated
+  validation path for PR #621; #405 shows the hook contract still needs clearer
+  documentation.
 - #464 and #137 reinforce worktree/monorepo-safe path and registry behavior.
 - #376 and #355 reinforce explicit inclusion/exclusion semantics; they do not
   justify hiding source paths with broad ignore patterns.
@@ -279,7 +284,8 @@ Package inspection also found pre-existing maintainer-only `.beads` hooks in the
 sdist; `crg-8u4` tracks the manifest policy fix. Neither is hidden as a passing
 claim.
 
-Windows hook command execution cannot be claimed from this macOS host or the
-current Linux-only GitHub matrix. The PR should remain a draft pending
-Windows-specific verification and maintainer review; source PRs/issues should
-not be closed before merge.
+The Windows hook patch from PR #621 is intentionally absent from this
+integration. It remains in
+[draft PR #626](https://github.com/tirth8205/code-review-graph/pull/626) until
+target-native CI and maintainer review verify command execution, stdin draining,
+failure behavior, and upgrades from existing Unix-only hook entries.

--- a/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
+++ b/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
@@ -1,6 +1,6 @@
 # Maintainer reconciliation — 2026-07-17
 
-Status: local validation complete; ready for draft review and remote CI.
+Status: local and remote CI validation complete; ready for maintainer review.
 
 Base: `main` at `b72413c`  
 Integration branch: `codex/reconcile-open-contributions-2026-07-17`  
@@ -259,6 +259,8 @@ Completed on the assembled branch:
 - graph review: 25 changed files, risk score `0.65`, 26 affected flows; the
   parser breadth is the main blast radius and received two independent review
   passes plus focused language regressions; and
+- draft PR #624: lint, mypy, Bandit, schema sync, PR Review, GitGuardian, and
+  the Python 3.10, 3.11, 3.12, and 3.13 test jobs all passed; and
 - `git diff --check`: clean.
 
 The independent reviews first found five P1/P2 gaps: the two #569 lifecycle
@@ -277,6 +279,7 @@ Package inspection also found pre-existing maintainer-only `.beads` hooks in the
 sdist; `crg-8u4` tracks the manifest policy fix. Neither is hidden as a passing
 claim.
 
-Windows hook command execution cannot be claimed from this macOS host. The PR
-must remain a draft until GitHub's Python 3.10–3.13 matrix and Windows-relevant
-checks run; source PRs/issues should not be closed before merge.
+Windows hook command execution cannot be claimed from this macOS host or the
+current Linux-only GitHub matrix. The PR should remain a draft pending
+Windows-specific verification and maintainer review; source PRs/issues should
+not be closed before merge.

--- a/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
+++ b/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
@@ -1,0 +1,256 @@
+# Maintainer reconciliation — 2026-07-17
+
+Status: draft integration; final repository-wide validation is in progress.
+
+Base: `main` at `b72413c`  
+Integration branch: `codex/reconcile-open-contributions-2026-07-17`  
+Tracking issue: `crg-nqi`
+
+## Outcome
+
+This branch is a deliberately narrow reconciliation of independently useful,
+evidence-backed fixes. It is not a release branch and it does not merge any
+large contribution wholesale. Contributor commits were retained where the
+patch was already the strongest implementation; conflict resolutions preserve
+current `main` behavior and are called out below.
+
+The audit snapshot covered:
+
+- every local branch, worktree, stash, tracked change, and untracked path;
+- all 104 open pull requests, using paginated live data rather than a
+  single-page search result;
+- all 84 open issues, excluding pull requests;
+- all 29 repository discussions; and
+- the repository knowledge graph, affected flows, tests, release notes, and
+  current CI/review evidence.
+
+No remote issue or source pull request is closed by this branch. Those actions
+should happen only after this integration passes review and is merged.
+
+## Preservation and safety record
+
+The primary checkout remains on `main` at `b72413c`, equal to `origin/main`.
+Its 31 untracked paths were not moved, cleaned, staged, or rewritten:
+
+- 26 iCloud-suffixed `* 2.*` copies are byte-identical to tracked files; and
+- five unique local artifacts remain private to the checkout: `.codex/`, a
+  local transcript, `OC3_TECHNICAL_CONTRIBUTION.md`, its PDF, and
+  `PRESENTATION_BRIEF.md`.
+
+All three stashes were preserved:
+
+- `stash@{0}` — CI lint/test fixes from merged PRs;
+- `stash@{1}` — local `uv.lock` bump; and
+- `stash@{2}` — scaling/token-efficiency mypy fixes.
+
+All pre-existing worktrees and branches were preserved, including
+`claude/hungry-morse`, `fix/incremental-flow-path-mismatch`,
+`release/v2.3.7`, `release/v2.4.0`, `review/local-fixes`, the old workflow
+branches, and their untracked worktree files. The reconciliation was performed
+only in `.claude/worktrees/codex-reconciliation`.
+
+Important local-branch conclusions:
+
+- `review/local-fixes` is a preservation source, not a merge candidate. Its
+  useful path and TESTED_BY work was extracted, while unsafe PID cleanup,
+  over-broad ignore rules, raw C++ header sniffing, and scoped-call false
+  positives remain excluded.
+- `release/v2.4.0` is the head of PR #559. Its token-budget, doctor, eval, and
+  installer surfaces remain coupled and have correctness/supply-chain
+  blockers. Four patch-equivalent commits were selected: the three-commit
+  TESTED_BY series and the independent Action path-rendering fix.
+- `release/v2.3.7` is PR #559 plus a version downgrade and must not be merged or
+  pushed as a release candidate.
+- `issue-194-specific-exception-logging` is patch-equivalent to work already on
+  `main`; the multi-word search branches are superseded or need decomposition.
+
+## Selected integration
+
+| Branch commit(s) | Source | Decision and evidence |
+| --- | --- | --- |
+| `34c5d00` | PR #564 | Use `#graph-svg` instead of a page-wide `svg` selector in both templates; carries focused regressions. |
+| `d8e5453` | PR #565 | Remove machine-specific hook paths, add a PATH guard, and avoid applying Bash hooks to unrelated tools. |
+| `326786e` | PR #573 | Resolve PHP `use`, grouped imports, aliases, functions, and constants to local files; preserves contributor attribution. |
+| `3e3cfc1`, `42e3f47`, `4339f09` | exact patch-equivalents of PR #559 commits `278e400`, `03e319e`, `a11dc04` | Correct TESTED_BY direction at every selected consumer, update dead-code analysis, and add a parser-to-store-to-query regression. This incorporates the #527 work and supersedes overlapping PR #598. |
+| `c809c9f` | PR #559 commit | Render repository-relative paths in Action comments without taking the rest of the release branch. |
+| `0365f74` | issue #612 | Capture bare, member, chained, and null-conditional C# receiver calls with correct caller attribution; implemented red/green with focused tests. |
+| `d4f8307` | issue #613 | Keep packaged documentation fallback available through the real MCP wrapper; implemented red/green with an installed-layout regression. |
+| `2abe90f` | content-equivalent/rebased port of PR #578 | Replace regex JSONC stripping with a string-aware scanner so URLs and comment-like string contents survive; import-neighborhood context differs from the source patch. |
+| `8c86437` | PR #621 / issue #620 | Add `commandWindows` hook forms that drain stdin and fail open; exact contributor commit. Local Codex schema inspection confirms the field, but Windows execution still requires CI. |
+| `4f7fba0`, `cd3f1b1` | PR #563 | Generate the required uppercase `SKILL.md` filename and update regressions. This does not adopt PR #562's unnecessary lowercasing of the display name. |
+| `fce147e` | PR #354 | Refuse and preserve valid top-level arrays/scalars, while treating empty/comment-only configs as fresh objects. Conflict resolution retained PR #578's stronger string-aware JSONC parser. Production fixes for #312/#350 were intentionally omitted because they are already on `main`; their regressions remain. |
+| `b2cd68a` | PR #353 | Persist Kotlin/C# annotations using the established metadata shape and resolve C# namespace importers. This does not claim to solve the remaining impact-radius design in #310. |
+| `3177954` | PR #393 | Repair advertised Zig parsing and add structure/call/import/test fixtures. Conflict resolution retained the newer Nix implementation on `main`. |
+| `a42b964` | reconciliation review fix | Preserve an existing platform config byte-for-byte when its nested server collection has the wrong array/object type; red/green coverage exercises both schemas. |
+| `d31c7ab` | reconciliation review fix | Generate TESTED_BY for in-source Zig tests regardless of filename and carry effective parent names through nested C# namespaces; both gaps were reproduced before implementation. |
+
+The final diff size and repository-wide validation results are recorded below.
+
+## Pull-request inventory and dispositions
+
+Live pagination returned 104 open PRs: 100 on page 1 and four on page 2. All
+target `main`; 102 are non-draft, while #582 and #618 are drafts. Each open PR
+appears exactly once in the routing inventory below.
+
+- Selected-area or directly overlapping work (24): #621, #618, #611, #601,
+  #598, #586, #583, #582, #578, #573, #572, #568, #566, #565, #564, #562,
+  #559, #538, #530, #527, #477, #354, #353, #92.
+- Parser/language work (29): #614, #602, #591, #590, #589, #580, #577, #560,
+  #539, #526, #522, #517, #516, #514, #462, #459, #393, #415, #339, #338,
+  #337, #333, #332, #331, #330, #329, #328, #252, #95.
+- Graph/search/performance/product work (25): #615, #606, #605, #604, #603,
+  #600, #599, #581, #555, #552, #536, #509, #468, #460, #458, #457, #452,
+  #394, #341, #340, #336, #335, #334, #327, #326.
+- Platform/install/CI/dependency/docs work (26): #617, #597, #596, #595, #584,
+  #563, #557, #556, #554, #548, #547, #546, #545, #544, #543, #542, #540,
+  #531, #505, #495, #491, #453, #449, #373, #347, #129.
+
+The routing groups are not blanket approvals. Material non-selection decisions:
+
+- PR #559 is not safe to merge wholesale. Its advertised hard token cap only
+  constrains snippets: a 44-file run with source disabled and a nominal 6,000
+  token limit still returned roughly 1.67 million characters. The lean default
+  hides tools that its own prompts and recovery text require. Eval can reuse
+  stale results after ignored failures; doctor can report false health and
+  mutate the database; installers execute floating network content. Separate
+  Beads issues `crg-1nx` and `crg-4ys` track the redesign.
+- PR #601's bare endpoint resolver is complementary to the TESTED_BY direction
+  fix, but it activates global unique-name resolution without import evidence
+  and materially changes graph communities. It needs precision and performance
+  evaluation before adoption.
+- PR #568 and the related local scoped resolver can manufacture global
+  `Class.method` edges from uniqueness alone and add full-scan work. They remain
+  excluded pending scoped identity semantics.
+- PR #586 prevents row loss but still binds ambiguous overload calls to the
+  first definition. Stable symbol identity is tracked in `crg-lw5`.
+- PR #611 plausibly avoids an embedding import race but adds about seven seconds
+  of eager startup latency. It needs concurrency coverage and an explicit
+  latency decision.
+- Draft PR #618 is stronger than #566 for Git paths because it uses NUL-delimited
+  bytes and `os.fsdecode`; it remains separate until its draft/CI state and
+  overlap with branch/tracked-output behavior are resolved.
+- PRs #595, #597, and #596 form a promising Windows daemon sequence, but they
+  require genuine Windows execution and should not be hidden inside this
+  cross-platform reconciliation.
+- PR #615 contains a credible small inherited-file-descriptor fix but no
+  regression. Reproduce the zombie-process failure and add one first.
+- PR #477 contains useful second-template visualization work but emits a literal
+  escaped quote in generated JavaScript. PR #564 is the safe subset; remaining
+  behavior needs browser/`node --check` coverage.
+- PRs #457 and #552 have the same head and an under-specified three-second cache
+  key. PRs #458 and #460 are stale/unmergeable token alternatives; #604 adds a
+  broad provenance surface; #536 adds a large optional DSL. These need isolated
+  product/API review.
+- PRs #326–#341 are a cumulative stale stack whose tip includes large obsolete
+  deletions. Broad parser/framework PRs, platform integrations, dependencies,
+  translations, and product features remain independent review units rather
+  than being bundled here.
+- PRs #556/#557 address fork-PR comments but need a clean port, explicit
+  `actions: read` and `issues: write` permissions, actionlint, and fork security
+  verification; #557's raw head also contains unrelated parser/package-lock
+  changes.
+- PR #491's uninstall design can delete user-owned Cursor scripts, misses Gemini
+  MCP state, parses JSONC unsafely, and duplicates platform inventories.
+- PR #459 may spawn a parser-probe subprocess per file. PR #394 is optional
+  defense in depth because the supported FastMCP version already threadpools
+  synchronous handlers.
+
+CI evidence is sparse: only PR #559 had both successful CI and PR Review runs at
+the audit snapshot. Many fork workflows show `action_required`, which is neither
+a pass nor a failure. Contributor-reported results were treated as supporting
+evidence, never as a substitute for validation of this combined branch.
+
+## Open-issue inventory
+
+All 84 open issues were read and classified exactly once:
+
+- Confirmed/actionable (21): #623, #622, #620, #619, #616, #613, #612, #610,
+  #609, #585, #579, #576, #500, #475, #473, #461, #343, #310, #291, #173,
+  #63.
+- Local/release partial or fixed (18): #574, #569, #567, #561, #558, #553,
+  #551, #550, #549, #537, #534, #523, #515, #497, #463, #450, #419, #295.
+- Already solved on `main` or release-pending (10): #524, #471, #243, #218,
+  #212, #190, #132, #91, #87, #83.
+- Support/retest (5): #474, #314, #262, #209, #189.
+- Feature backlog (25): #607, #593, #592, #588, #587, #521, #518, #504,
+  #482, #478, #436, #434, #430, #429, #369, #348, #346, #320, #311, #305,
+  #269, #265, #232, #210, #199.
+- Insufficient evidence/discussion (5): #535, #532, #506, #492, #426.
+
+Selected patches address or materially advance #523 (visualization), #549 and
+#558 (portable hooks), #574 (PHP imports), #515 (TESTED_BY via the #559 subset),
+#553 (JSONC), #612, #613, #620, and #295. PR #353 advances only the namespace
+importer portion of #310; its impact-radius/detect-changes BFS remains open.
+Issues #561 and #567 remain unaddressed because PRs #562 and #568 are absent.
+Issue #622's collision/overload problem is intentionally deferred because the
+open patch is not a complete identity model. Issues #619, #616, and #610 need
+separate API, platform-discovery, and startup-latency decisions respectively.
+
+Issue #569 remains open. The audited local/PR #572 variants normalize paths
+after incremental reparsing has already replaced node IDs; existing flow and
+community memberships therefore reference deleted nodes and modified files can
+still be skipped. A lifecycle-aware fix needs a regression that changes graph
+topology, not only a path-format fixture.
+
+## Discussion inventory
+
+All 29 discussions were enumerated and read. The threads with direct engineering
+implications are #501, #464, #137, #376, #355, #414, #410, #318, #467, #479,
+and #405:
+
+- #467 is real evidence for a lean tool surface, but does not validate PR #559's
+  current cap implementation.
+- #318 and #410 support trustworthy status/doctor UX, while strengthening the
+  requirement that diagnostics be non-mutating and fail honestly.
+- #501 supports portable PowerShell/Codex hooks and informed the selection of
+  PR #621; #405 shows the hook contract still needs clearer documentation.
+- #464 and #137 reinforce worktree/monorepo-safe path and registry behavior.
+- #376 and #355 reinforce explicit inclusion/exclusion semantics; they do not
+  justify hiding source paths with broad ignore patterns.
+- #414 informs scalability claims, and #479 supports fixing both visualization
+  templates rather than only the first page shape.
+
+The remaining support, setup, product, or announcement discussions were #525,
+#411, #105, #375, #109, #254, #206, #111, #131, #89, #186, #178, #134, #113,
+#101, #96, #85, and #84. They provide documentation/backlog context but no
+additional change was safe to couple into this branch.
+
+## Follow-up tracking and merge sequence
+
+The audit created focused Beads issues rather than hiding unresolved work in a
+large branch:
+
+- `crg-1nx` — redesign v2.4 token budgeting and the lean tool surface;
+- `crg-4ys` — split/harden doctor, eval, and installers;
+- `crg-ys0` — remove unsafe blockers from `review/local-fixes`;
+- `crg-lw5` — design stable symbol identity for collisions/overloads; and
+- `crg-o1d` — repair #569 across incremental node-ID replacement; and
+- existing platform/performance issues remain the owners for Windows daemon,
+  HOME isolation, and daemon-stop behavior.
+
+Recommended review order:
+
+1. path/edge semantics and their end-to-end tests;
+2. parser changes by language (PHP, C#, Kotlin, Zig);
+3. skills/config/hook compatibility and Windows CI;
+4. visualization, Action rendering, and packaged docs;
+5. release-note accuracy and potential source-PR/issue closure only after merge.
+
+## Validation record
+
+Completed on the assembled branch:
+
+- touched test modules excluding the known native WatchDaemon failure:
+  `966 passed`;
+- focused combined Nix/Zig conflict-resolution suite: `18 passed`; and
+- `git diff --check`: clean.
+
+The macOS Python 3.13 baseline has a native watchdog/FSEvents `SIGBUS` in
+`TestWatchDaemon` on both `main` and the integration branch. It is tracked in
+`crg-229` and is excluded from broad comparison runs; it must not be represented
+as a regression introduced here.
+
+Before this document changes from draft to ready, record fresh results for the
+full non-WatchDaemon suite, ruff, mypy, bandit, package build, schema sync,
+knowledge-graph rebuild/impact checks, and remote CI. Windows hook command
+execution cannot be claimed from this macOS host.

--- a/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
+++ b/docs/MAINTAINER_RECONCILIATION_2026-07-17.md
@@ -1,6 +1,6 @@
 # Maintainer reconciliation — 2026-07-17
 
-Status: draft integration; final repository-wide validation is in progress.
+Status: local validation complete; ready for draft review and remote CI.
 
 Base: `main` at `b72413c`  
 Integration branch: `codex/reconcile-open-contributions-2026-07-17`  
@@ -52,9 +52,10 @@ only in `.claude/worktrees/codex-reconciliation`.
 Important local-branch conclusions:
 
 - `review/local-fixes` is a preservation source, not a merge candidate. Its
-  useful path and TESTED_BY work was extracted, while unsafe PID cleanup,
-  over-broad ignore rules, raw C++ header sniffing, and scoped-call false
-  positives remain excluded.
+  useful TESTED_BY work was extracted. Its incremental path work was disproven
+  under the real node-replacement lifecycle; unsafe PID cleanup, over-broad
+  ignore rules, raw C++ header sniffing, and scoped-call false positives also
+  remain excluded.
 - `release/v2.4.0` is the head of PR #559. Its token-budget, doctor, eval, and
   installer surfaces remain coupled and have correctness/supply-chain
   blockers. Four patch-equivalent commits were selected: the three-commit
@@ -70,19 +71,20 @@ Important local-branch conclusions:
 | --- | --- | --- |
 | `34c5d00` | PR #564 | Use `#graph-svg` instead of a page-wide `svg` selector in both templates; carries focused regressions. |
 | `d8e5453` | PR #565 | Remove machine-specific hook paths, add a PATH guard, and avoid applying Bash hooks to unrelated tools. |
-| `326786e` | PR #573 | Resolve PHP `use`, grouped imports, aliases, functions, and constants to local files; preserves contributor attribution. |
-| `3e3cfc1`, `42e3f47`, `4339f09` | exact patch-equivalents of PR #559 commits `278e400`, `03e319e`, `a11dc04` | Correct TESTED_BY direction at every selected consumer, update dead-code analysis, and add a parser-to-store-to-query regression. This incorporates the #527 work and supersedes overlapping PR #598. |
-| `c809c9f` | PR #559 commit | Render repository-relative paths in Action comments without taking the rest of the release branch. |
-| `0365f74` | issue #612 | Capture bare, member, chained, and null-conditional C# receiver calls with correct caller attribution; implemented red/green with focused tests. |
-| `d4f8307` | issue #613 | Keep packaged documentation fallback available through the real MCP wrapper; implemented red/green with an installed-layout regression. |
-| `2abe90f` | content-equivalent/rebased port of PR #578 | Replace regex JSONC stripping with a string-aware scanner so URLs and comment-like string contents survive; import-neighborhood context differs from the source patch. |
-| `8c86437` | PR #621 / issue #620 | Add `commandWindows` hook forms that drain stdin and fail open; exact contributor commit. Local Codex schema inspection confirms the field, but Windows execution still requires CI. |
-| `4f7fba0`, `cd3f1b1` | PR #563 | Generate the required uppercase `SKILL.md` filename and update regressions. This does not adopt PR #562's unnecessary lowercasing of the display name. |
-| `fce147e` | PR #354 | Refuse and preserve valid top-level arrays/scalars, while treating empty/comment-only configs as fresh objects. Conflict resolution retained PR #578's stronger string-aware JSONC parser. Production fixes for #312/#350 were intentionally omitted because they are already on `main`; their regressions remain. |
-| `b2cd68a` | PR #353 | Persist Kotlin/C# annotations using the established metadata shape and resolve C# namespace importers. This does not claim to solve the remaining impact-radius design in #310. |
-| `3177954` | PR #393 | Repair advertised Zig parsing and add structure/call/import/test fixtures. Conflict resolution retained the newer Nix implementation on `main`. |
-| `a42b964` | reconciliation review fix | Preserve an existing platform config byte-for-byte when its nested server collection has the wrong array/object type; red/green coverage exercises both schemas. |
-| `d31c7ab` | reconciliation review fix | Generate TESTED_BY for in-source Zig tests regardless of filename and carry effective parent names through nested C# namespaces; both gaps were reproduced before implementation. |
+| `cbf9355` | PR #573 | Resolve PHP `use`, grouped imports, aliases, functions, and constants to local files; preserves contributor attribution. |
+| `ddc8544`, `918ef13`, `580205d` | exact patch-equivalents of PR #559 commits `278e400`, `03e319e`, `a11dc04` | Correct TESTED_BY direction at every selected consumer, update dead-code analysis, and add a parser-to-store-to-query regression. This incorporates the #527 work and supersedes overlapping PR #598. |
+| `6ece151` | PR #559 commit | Render repository-relative paths in Action comments without taking the rest of the release branch. |
+| `771307e` | issue #612 | Capture bare, member, chained, and null-conditional C# receiver calls with correct caller attribution; implemented red/green with focused tests. |
+| `eeef686` | issue #613 | Keep packaged documentation fallback available through the real MCP wrapper; implemented red/green with an installed-layout regression. |
+| `571f665` | content-equivalent/rebased port of PR #578 | Replace regex JSONC stripping with a string-aware scanner so URLs and comment-like string contents survive; import-neighborhood context differs from the source patch. |
+| `9ef6641` | PR #621 / issue #620 | Add `commandWindows` hook forms that drain stdin and fail open; exact contributor commit. Local Codex schema inspection confirms the field, but Windows execution still requires CI. |
+| `df87b60`, `e5f563b` | PR #563 | Generate the uppercase `SKILL.md` filename required by the [Claude Code skills documentation](https://code.claude.com/docs/en/skills) and update regressions. This does not adopt PR #562's unnecessary lowercasing of the display name. |
+| `90408c9` | PR #354 | Refuse and preserve valid top-level arrays/scalars, while treating empty/comment-only configs as fresh objects. Conflict resolution retained PR #578's stronger string-aware JSONC parser. Production fixes for #312/#350 were intentionally omitted because they are already on `main`; their regressions remain. |
+| `0abd789` | PR #353 | Persist Kotlin/C# annotations using the established metadata shape and resolve C# namespace importers. This does not claim to solve the remaining impact-radius design in #310. |
+| `b9ec19d` | PR #393 | Repair advertised Zig parsing and add structure/call/import/test fixtures. Conflict resolution retained the newer Nix implementation on `main`. |
+| `fc549ae` | reconciliation review fix | Preserve an existing platform config byte-for-byte when its nested server collection has the wrong array/object type; red/green coverage exercises both schemas. |
+| `d611a2d` | reconciliation review fix | Generate TESTED_BY for in-source Zig tests regardless of filename and carry effective parent names through nested C# namespaces; both gaps were reproduced before implementation. |
+| `c7d7211` | reconciliation review fix | Replace recursive C# namespace discovery with an explicit stack; a 1,200-level AST regression failed before the change and now passes without truncating namespace metadata. |
 
 The final diff size and repository-wide validation results are recorded below.
 
@@ -223,8 +225,10 @@ large branch:
 - `crg-1nx` — redesign v2.4 token budgeting and the lean tool surface;
 - `crg-4ys` — split/harden doctor, eval, and installers;
 - `crg-ys0` — remove unsafe blockers from `review/local-fixes`;
-- `crg-lw5` — design stable symbol identity for collisions/overloads; and
-- `crg-o1d` — repair #569 across incremental node-ID replacement; and
+- `crg-lw5` — design stable symbol identity for collisions/overloads;
+- `crg-o1d` — repair #569 across incremental node-ID replacement;
+- `crg-dtv` — close SQLite connections exposed by coverage warnings;
+- `crg-8u4` — exclude maintainer-only `.beads` hooks from the sdist; and
 - existing platform/performance issues remain the owners for Windows daemon,
   HOME isolation, and daemon-stop behavior.
 
@@ -240,17 +244,39 @@ Recommended review order:
 
 Completed on the assembled branch:
 
-- touched test modules excluding the known native WatchDaemon failure:
-  `966 passed`;
-- focused combined Nix/Zig conflict-resolution suite: `18 passed`; and
+- final Python 3.13 suite excluding the known native WatchDaemon failure:
+  `1,447 passed`, `13 deselected`, `2 xpassed`;
+- isolated CI-equivalent coverage run: `1,446 passed`, `1 skipped`,
+  `13 deselected`, `2 xpassed`; coverage `72.95%` against a `65%` threshold;
+- combined skills/multilingual regression run: `501 passed`, plus the final
+  C# namespace regression class: `6 passed`;
+- ruff: clean; mypy: no issues in 62 source files; Bandit: no issues;
+- Python and VS Code schema versions both `9`;
+- wheel and sdist built successfully, and both contain the packaged
+  `LLM-OPTIMIZED-REFERENCE.md` required by the docs fallback;
+- full knowledge-graph rebuild: 181 parsed files, 3,415 nodes, 24,940 edges,
+  200 flows, 16 communities, and no build errors;
+- graph review: 25 changed files, risk score `0.65`, 26 affected flows; the
+  parser breadth is the main blast radius and received two independent review
+  passes plus focused language regressions; and
 - `git diff --check`: clean.
+
+The independent reviews first found five P1/P2 gaps: the two #569 lifecycle
+defects were removed, while the nested-config, Zig TESTED_BY, and nested-C#
+cases were fixed red/green. A second pass found the deep C# recursion failure;
+that too was fixed red/green. No other P1/P2 finding remained.
 
 The macOS Python 3.13 baseline has a native watchdog/FSEvents `SIGBUS` in
 `TestWatchDaemon` on both `main` and the integration branch. It is tracked in
 `crg-229` and is excluded from broad comparison runs; it must not be represented
 as a regression introduced here.
 
-Before this document changes from draft to ready, record fresh results for the
-full non-WatchDaemon suite, ruff, mypy, bandit, package build, schema sync,
-knowledge-graph rebuild/impact checks, and remote CI. Windows hook command
-execution cannot be claimed from this macOS host.
+The isolated coverage run emits 29 `ResourceWarning`s for unclosed SQLite
+connections; `crg-dtv` tracks turning those warnings into deterministic closes.
+Package inspection also found pre-existing maintainer-only `.beads` hooks in the
+sdist; `crg-8u4` tracks the manifest policy fix. Neither is hidden as a passing
+claim.
+
+Windows hook command execution cannot be claimed from this macOS host. The PR
+must remain a draft until GitHub's Python 3.10–3.13 matrix and Windows-relevant
+checks run; source PRs/issues should not be closed before merge.

--- a/scripts/render_pr_comment.py
+++ b/scripts/render_pr_comment.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -54,6 +55,57 @@ def risk_level(score: float) -> str:
     return "low"
 
 
+def relativize_path(value: Any) -> str:
+    """Strip CI-runner absolute prefixes so paths render repo-relative.
+
+    detect-changes emits paths exactly as the graph stored them; in CI the
+    repo is checked out under an absolute prefix
+    (``/home/runner/work/<repo>/<repo>/...``), which is ugly in a PR comment
+    and leaks the runner layout. We strip that prefix so the reader sees
+    ``code_review_graph/embeddings.py`` instead.
+
+    Handles both bare paths and ``path::symbol`` qualified names (the
+    ``::symbol`` suffix is preserved). Already-relative paths and non-path
+    tokens (``?``) are returned unchanged.
+
+    Strategy, in order:
+      1. ``GITHUB_WORKSPACE`` prefix (set by Actions ``checkout``).
+      2. The ``<repo>/<repo>/`` doubled-segment that Actions uses under
+         ``/work/`` (derived from ``GITHUB_REPOSITORY`` when present).
+      3. Otherwise return the input untouched — never guess-mangle a path.
+    """
+    text = str(value)
+    path_part, sep, symbol = text.partition("::")
+    # Only touch absolute, POSIX-style runner paths; leave everything else.
+    if not path_part.startswith("/"):
+        return text
+
+    rel = _strip_workspace_prefix(path_part)
+    if rel is None:
+        return text
+    return f"{rel}{sep}{symbol}" if sep else rel
+
+
+def _strip_workspace_prefix(path_part: str) -> str | None:
+    """Return ``path_part`` made repo-relative, or None when nothing matches."""
+    workspace = os.environ.get("GITHUB_WORKSPACE", "").strip()
+    if workspace:
+        prefix = workspace.rstrip("/") + "/"
+        if path_part.startswith(prefix):
+            return path_part[len(prefix):]
+
+    # Fallback: Actions checks repos out at /work/<name>/<name>/<files...>.
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    name = repo.split("/")[-1] if "/" in repo else ""
+    if name:
+        marker = f"/{name}/{name}/"
+        idx = path_part.find(marker)
+        if idx != -1:
+            return path_part[idx + len(marker):]
+
+    return None
+
+
 def md_escape(value: Any, limit: int = _MAX_CELL) -> str:
     """Escape a value for safe inclusion in markdown tables and lists.
 
@@ -74,8 +126,11 @@ def md_escape(value: Any, limit: int = _MAX_CELL) -> str:
 
 
 def _location(entry: dict[str, Any]) -> str:
-    """Format ``file:line`` for a node-ish dict (file_path/file + line_start)."""
-    file_path = entry.get("file_path") or entry.get("file") or "?"
+    """Format ``file:line`` for a node-ish dict (file_path/file + line_start).
+
+    Paths are relativized first so CI-runner absolute prefixes don't leak.
+    """
+    file_path = relativize_path(entry.get("file_path") or entry.get("file") or "?")
     line_start = entry.get("line_start")
     if line_start:
         return f"{md_escape(file_path)}:{line_start}"
@@ -103,7 +158,7 @@ def _functions_table(
         else:
             tested = "yes"
         lines.append(
-            f"| {score:.2f} | {risk_level(score)} | {md_escape(name)} "
+            f"| {score:.2f} | {risk_level(score)} | {md_escape(relativize_path(name))} "
             f"| {_location(entry)} | {tested} |"
         )
     if len(priorities) > max_functions:
@@ -146,7 +201,7 @@ def _gaps_section(gaps: list[dict[str, Any]], max_gaps: int = 5) -> list[str]:
             break
     for gap in shown:
         name = gap.get("qualified_name") or gap.get("name") or "?"
-        lines.append(f"- {md_escape(name)} ({_location(gap)})")
+        lines.append(f"- {md_escape(relativize_path(name))} ({_location(gap)})")
     remaining = len(gaps) - len(shown)
     if remaining > 0:
         lines.append(f"- ...and {remaining} more without direct tests")

--- a/tests/fixtures/sample_zig.zig
+++ b/tests/fixtures/sample_zig.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const util = @import("./sample_zig_util.zig");
+
+pub fn main() !void {
+    std.debug.print("hello\n", .{});
+    const x = helper(2);
+    _ = x;
+    util.noop();
+}
+
+fn helper(x: i32) i32 {
+    return x + 1;
+}
+
+pub const Point = struct {
+    x: i32,
+    y: i32,
+
+    pub fn init(x: i32, y: i32) Point {
+        return .{ .x = x, .y = y };
+    }
+
+    pub fn distance(self: Point, other: Point) f32 {
+        _ = other;
+        return @intCast(helper(self.x));
+    }
+};
+
+const Color = enum { red, green, blue };
+
+pub const Shape = union(enum) {
+    circle: f32,
+    square: f32,
+};
+
+test "helper increments" {
+    try expect(helper(1) == 2);
+}

--- a/tests/fixtures/sample_zig_util.zig
+++ b/tests/fixtures/sample_zig_util.zig
@@ -1,0 +1,1 @@
+pub fn noop() void {}

--- a/tests/test_action_render.py
+++ b/tests/test_action_render.py
@@ -67,6 +67,91 @@ def test_md_escape_caps_length():
 
 
 # ---------------------------------------------------------------------------
+# relativize_path (strip CI-runner absolute prefixes)
+# ---------------------------------------------------------------------------
+
+
+def test_relativize_strips_github_workspace(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
+    out = render.relativize_path(
+        "/home/runner/work/repo/repo/code_review_graph/embeddings.py"
+    )
+    assert out == "code_review_graph/embeddings.py"
+
+
+def test_relativize_keeps_symbol_suffix(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
+    out = render.relativize_path(
+        "/home/runner/work/repo/repo/code_review_graph/embeddings.py::get_provider"
+    )
+    assert out == "code_review_graph/embeddings.py::get_provider"
+
+
+def test_relativize_handles_workspace_with_trailing_slash(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo/")
+    out = render.relativize_path(
+        "/home/runner/work/repo/repo/pkg/mod.py::fn"
+    )
+    assert out == "pkg/mod.py::fn"
+
+
+def test_relativize_leaves_already_relative_paths(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
+    assert render.relativize_path("auth/session.py::rotate_token") == (
+        "auth/session.py::rotate_token"
+    )
+    assert render.relativize_path("auth/session.py") == "auth/session.py"
+
+
+def test_relativize_falls_back_to_repo_segment_without_env(monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/code-review-graph")
+    out = render.relativize_path(
+        "/home/runner/work/code-review-graph/code-review-graph/"
+        "scripts/render_pr_comment.py::main"
+    )
+    assert out == "scripts/render_pr_comment.py::main"
+
+
+def test_relativize_no_env_no_match_returns_input(monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    # Nothing to strip against; render the path as-is rather than mangling it.
+    weird = "/opt/build/some/place/file.py::fn"
+    assert render.relativize_path(weird) == weird
+
+
+def test_relativize_handles_none_and_question_mark(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
+    assert render.relativize_path("?") == "?"
+
+
+def test_render_markdown_relativizes_absolute_paths(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
+    ws = "/home/runner/work/repo/repo"
+    abs_report = {
+        "risk_score": 0.72,
+        "review_priorities": [
+            {
+                "qualified_name": f"{ws}/code_review_graph/embeddings.py::get_provider",
+                "file_path": f"{ws}/code_review_graph/embeddings.py",
+                "line_start": 42,
+                "risk_score": 0.72,
+                "is_test": False,
+            }
+        ],
+        "affected_flows": [],
+        "test_gaps": [],
+    }
+    body = render.render_markdown(abs_report)
+    # Absolute CI-runner prefix must not leak into the rendered comment.
+    assert "/home/runner/work" not in body
+    assert render.md_escape("code_review_graph/embeddings.py::get_provider") in body
+    # Location column path is markdown-escaped (underscores) like every cell.
+    assert f"{render.md_escape('code_review_graph/embeddings.py')}:42" in body
+
+
+# ---------------------------------------------------------------------------
 # render_markdown
 # ---------------------------------------------------------------------------
 

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -63,11 +63,13 @@ class TestChanges:
         self.store.upsert_edge(edge)
         self.store.commit()
 
-    def _add_tested_by(self, test_qn: str, target_qn: str, path: str = "app.py") -> None:
+    def _add_tested_by(self, production_qn: str, test_qn: str, path: str = "app.py") -> None:
+        # TESTED_BY edges are stored as source=production, target=test
+        # by the parser. See: #515
         edge = EdgeInfo(
             kind="TESTED_BY",
-            source=test_qn,
-            target=target_qn,
+            source=production_qn,
+            target=test_qn,
             file_path=path,
             line=1,
         )
@@ -225,7 +227,7 @@ class TestChanges:
         self._add_func("untested_func", path="a.py", line_start=1, line_end=10)
         self._add_func("tested_func", path="b.py", line_start=1, line_end=10)
         self._add_func("test_tested_func", path="test_b.py", is_test=True)
-        self._add_tested_by("test_b.py::test_tested_func", "b.py::tested_func", "test_b.py")
+        self._add_tested_by("b.py::tested_func", "test_b.py::test_tested_func", "test_b.py")
 
         untested = self.store.get_node("a.py::untested_func")
         tested = self.store.get_node("b.py::tested_func")
@@ -367,7 +369,7 @@ class TestChanges:
 
         # Only tested_c has a test.
         self._add_func("test_c", path="test_app.py", is_test=True)
-        self._add_tested_by("test_app.py::test_c", "app.py::tested_c", "test_app.py")
+        self._add_tested_by("app.py::tested_c", "test_app.py::test_c", "test_app.py")
 
         result = analyze_changes(
             self.store,

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -99,9 +99,11 @@ class TestEnrichSearch:
                 file_path=f"{self.tmpdir}/build.py", line=15,
             ),
             EdgeInfo(
+                # TESTED_BY edges are stored as source=production, target=test
+                # by the parser. See: #515
                 kind="TESTED_BY",
-                source=f"{self.tmpdir}/test_parser.py::test_parse_file",
-                target=f"{self.tmpdir}/parser.py::parse_file",
+                source=f"{self.tmpdir}/parser.py::parse_file",
+                target=f"{self.tmpdir}/test_parser.py::test_parse_file",
                 file_path=f"{self.tmpdir}/test_parser.py", line=1,
             ),
         ]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -248,6 +248,66 @@ class TestGraphStore:
         assert self.store.get_metadata("test_key") == "test_value"
         assert self.store.get_metadata("nonexistent") is None
 
+    def test_get_transitive_tests_follows_direct_tested_by_edge(self):
+        """Regression test for #515: get_transitive_tests must follow
+        TESTED_BY edges by source_qualified (production) since the parser
+        stores source=production, target=test. The test function uses an
+        unconventional name so the bare-name fallback cannot mask the bug.
+        """
+        self.store.upsert_node(self._make_file_node("/src/calc.py"))
+        self.store.upsert_node(self._make_func_node("add", "/src/calc.py"))
+        self.store.upsert_node(self._make_file_node("/tests/check.py"))
+        self.store.upsert_node(self._make_func_node(
+            "verify_addition", "/tests/check.py", is_test=True,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="TESTED_BY",
+            source="/src/calc.py::add",
+            target="/tests/check.py::verify_addition",
+            file_path="/tests/check.py", line=1,
+        ))
+        self.store.commit()
+
+        results = self.store.get_transitive_tests("/src/calc.py::add")
+        qns = {r["qualified_name"] for r in results}
+        assert "/tests/check.py::verify_addition" in qns
+        assert all(not r["indirect"] for r in results)
+
+    def test_get_transitive_tests_follows_calls_then_tested_by(self):
+        """Transitive coverage: caller -> CALLS -> callee -> TESTED_BY -> test.
+        Uses an unconventional test name so the bare-name fallback cannot
+        match. See: #515.
+        """
+        self.store.upsert_node(self._make_file_node("/src/svc.py"))
+        self.store.upsert_node(self._make_func_node("orchestrate", "/src/svc.py"))
+        self.store.upsert_node(self._make_func_node("compute", "/src/svc.py"))
+        self.store.upsert_node(self._make_file_node("/tests/check.py"))
+        self.store.upsert_node(self._make_func_node(
+            "verify_compute", "/tests/check.py", is_test=True,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/src/svc.py::orchestrate",
+            target="/src/svc.py::compute", file_path="/src/svc.py", line=2,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="TESTED_BY",
+            source="/src/svc.py::compute",
+            target="/tests/check.py::verify_compute",
+            file_path="/tests/check.py", line=1,
+        ))
+        self.store.commit()
+
+        results = self.store.get_transitive_tests(
+            "/src/svc.py::orchestrate", max_depth=2,
+        )
+        qns = {r["qualified_name"] for r in results}
+        assert "/tests/check.py::verify_compute" in qns
+        match = next(
+            r for r in results
+            if r["qualified_name"] == "/tests/check.py::verify_compute"
+        )
+        assert match["indirect"] is True
+
     def test_get_all_community_ids_logs_when_column_missing(self, caplog):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row
@@ -401,7 +461,7 @@ class TestGetTransitiveTestsFrontierCap:
             # Only callee_2 has a test
             if i == 2:
                 self.store.upsert_edge(EdgeInfo(
-                    kind="TESTED_BY", source=test_qn, target=callee_qn,
+                    kind="TESTED_BY", source=callee_qn, target=test_qn,
                     file_path="/t/test_hub.py", line=1,
                 ))
         self.store.commit()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -308,6 +308,59 @@ class TestGraphStore:
         )
         assert match["indirect"] is True
 
+    def test_parse_store_get_transitive_tests_end_to_end(self):
+        """End-to-end producer->store->consumer guard for #515.
+
+        Parse a real fixture pair (production + test) through the parser,
+        persist the emitted nodes/edges, and confirm get_transitive_tests
+        surfaces the test as covering the production code. This couples the
+        parser's canonical TESTED_BY direction (source=production,
+        target=test) to the consumer query, so a future parser flip would
+        break this test even if every hand-seeded fixture test still passed.
+        """
+        from code_review_graph.parser import CodeParser
+
+        fixtures = Path(__file__).parent / "fixtures"
+        parser = CodeParser()
+        all_nodes: list[NodeInfo] = []
+        all_edges: list[EdgeInfo] = []
+        for fixture in ("sample_python.py", "test_sample.py"):
+            nodes, edges = parser.parse_file(fixtures / fixture)
+            all_nodes.extend(nodes)
+            all_edges.extend(edges)
+
+        for n in all_nodes:
+            self.store.upsert_node(n)
+        for e in all_edges:
+            self.store.upsert_edge(e)
+        self.store.commit()
+
+        tested_by = [e for e in all_edges if e.kind == "TESTED_BY"]
+        assert tested_by, "fixture pair should yield at least one TESTED_BY edge"
+
+        # Producer direction guard: every TESTED_BY target must be a stored
+        # Test node, and querying the consumer (get_transitive_tests) by the
+        # edge's *source* (production) must surface that test target. If a
+        # future parser flip swapped the direction, the target would point at
+        # production code and this end-to-end assertion would fail.
+        checked = 0
+        for edge in tested_by:
+            target = self.store.get_node(edge.target)
+            assert target is not None, f"missing test node {edge.target}"
+            assert target.is_test, (
+                f"TESTED_BY target {edge.target!r} should be a test node; "
+                f"a flipped parser would put production code here"
+            )
+
+            results = self.store.get_transitive_tests(edge.source)
+            qns = {r["qualified_name"] for r in results}
+            assert edge.target in qns, (
+                f"get_transitive_tests({edge.source!r}) should surface test "
+                f"{edge.target!r}; got {sorted(qns)}"
+            )
+            checked += 1
+        assert checked >= 1
+
     def test_get_all_community_ids_logs_when_column_missing(self, caplog):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ import inspect
 
 import pytest
 
+import code_review_graph.tools.docs as docs_module
 from code_review_graph import main as crg_main
 
 
@@ -57,6 +58,33 @@ class TestResolveRepoRoot:
     def test_client_arg_used_when_no_flag(self):
         crg_main._default_repo_root = None
         assert crg_main._resolve_repo_root("/explicit") == "/explicit"
+
+
+def test_docs_wrapper_falls_back_to_packaged_docs_with_resolved_repo(
+    tmp_path, monkeypatch,
+):
+    """The server's resolved repo must not hide wheel-packaged docs."""
+    package_dir = tmp_path / "site-packages" / "code_review_graph"
+    tools_dir = package_dir / "tools"
+    docs_dir = package_dir / "docs"
+    tools_dir.mkdir(parents=True)
+    docs_dir.mkdir()
+    (docs_dir / "LLM-OPTIMIZED-REFERENCE.md").write_text(
+        '<section name="usage">packaged docs</section>\n',
+        encoding="utf-8",
+    )
+
+    repo_root = tmp_path / "repo"
+    (repo_root / ".code-review-graph").mkdir(parents=True)
+    monkeypatch.setattr(docs_module, "__file__", str(tools_dir / "docs.py"))
+    monkeypatch.setattr(crg_main, "_default_repo_root", str(repo_root))
+    tool = getattr(crg_main.get_docs_section_tool, "fn", None)
+    get_docs = tool or crg_main.get_docs_section_tool
+
+    result = get_docs(section_name="usage")
+
+    assert result["status"] == "ok"
+    assert result["content"] == "packaged docs"
 
 
 class TestServeMainTransport:

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -578,6 +578,34 @@ class TestCSharpNamespaceResolution:
         importers = {r["file"] for r in result.get("results", [])}
         assert str(app) in importers
 
+    def test_deep_ast_preserves_nested_namespace_metadata(self, tmp_path):
+        """Namespace discovery must not recurse through the whole C# AST."""
+        source_file = tmp_path / "Deep.cs"
+        deep_expression = "(" * 1200 + "1" + ")" * 1200
+        self._write(
+            source_file,
+            "namespace Acme {\n"
+            "    namespace Core {\n"
+            "        public class Calculator {\n"
+            "            public int Value() {\n"
+            f"                return {deep_expression};\n"
+            "            }\n"
+            "        }\n"
+            "    }\n"
+            "}\n",
+        )
+
+        try:
+            nodes, _ = CodeParser().parse_file(source_file)
+        except RecursionError:
+            pytest.fail("C# namespace discovery overflowed on a deep expression AST")
+
+        file_node = next(node for node in nodes if node.kind == "File")
+        assert file_node.extra.get("csharp_namespaces") == [
+            "Acme",
+            "Acme.Core",
+        ]
+
 
 class TestRubyParsing:
     def setup_method(self):

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -539,6 +539,45 @@ class TestCSharpNamespaceResolution:
         assert str(app) in importers
         assert str(unrelated) not in importers
 
+    def test_importers_of_resolves_nested_block_namespace(self, tmp_path):
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.tools.query import query_graph
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".code-review-graph").mkdir()
+        core = tmp_path / "Core.cs"
+        self._write(
+            core,
+            "namespace Acme {\n"
+            "    namespace Core {\n"
+            "        public class TaskBoard {}\n"
+            "    }\n"
+            "}\n",
+        )
+        app = tmp_path / "App.cs"
+        self._write(
+            app,
+            "using Acme.Core;\n"
+            "namespace Acme.App;\n"
+            "public class App {}\n",
+        )
+
+        store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+        parser = CodeParser()
+        for path in (core, app):
+            nodes, edges = parser.parse_file(path)
+            for node in nodes:
+                store.upsert_node(node)
+            for edge in edges:
+                store.upsert_edge(edge)
+        store.commit()
+        store.close()
+
+        result = query_graph("importers_of", str(core), repo_root=str(tmp_path))
+        assert result.get("status") == "ok"
+        importers = {r["file"] for r in result.get("results", [])}
+        assert str(app) in importers
+
 
 class TestRubyParsing:
     def setup_method(self):
@@ -2908,6 +2947,40 @@ class TestZigParsing:
         assert len(tests) == 1
         assert tests[0].name.startswith("test:helper increments@L")
         assert tests[0].is_test is True
+
+    def test_in_source_test_emits_tested_by_outside_test_path(self):
+        path = Path("src/math.zig")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"fn increment(x: i32) i32 { return x + 1; }\n"
+            b'test "increment" { try expect(increment(1) == 2); }\n',
+        )
+
+        file_node = next(n for n in nodes if n.kind == "File")
+        test_node = next(n for n in nodes if n.kind == "Test")
+        function_node = next(
+            n for n in nodes if n.kind == "Function" and n.name == "increment"
+        )
+        test_qname = self.parser._qualify(
+            test_node.name, test_node.file_path, test_node.parent_name,
+        )
+        function_qname = self.parser._qualify(
+            function_node.name, function_node.file_path, function_node.parent_name,
+        )
+
+        assert file_node.is_test is False
+        assert any(
+            edge.kind == "CALLS"
+            and edge.source == test_qname
+            and edge.target == function_qname
+            for edge in edges
+        )
+        assert any(
+            edge.kind == "TESTED_BY"
+            and edge.source == function_qname
+            and edge.target == test_qname
+            for edge in edges
+        )
 
     def test_calls_inside_methods_have_qualified_source(self):
         # Point.distance calls helper(...) — the source should be the

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -389,6 +389,43 @@ class TestCSharpParsing:
         names = {f.name for f in funcs}
         assert "FindById" in names or "Save" in names
 
+    @pytest.mark.parametrize(
+        ("statement", "expected_targets"),
+        [
+            ("Ping();", {"Ping"}),
+            ("service.Send();", {"Send"}),
+            ("service.GetClient().Fetch();", {"GetClient", "Fetch"}),
+            ("service?.Notify();", {"Notify"}),
+        ],
+        ids=("bare", "member", "chained", "null-conditional"),
+    )
+    def test_finds_calls_and_attributes_them_to_enclosing_method(
+        self, tmp_path, statement, expected_targets,
+    ):
+        source_file = tmp_path / "Calls.cs"
+        source_file.write_text(
+            "class Caller\n"
+            "{\n"
+            "    void Run()\n"
+            "    {\n"
+            f"        {statement}\n"
+            "    }\n"
+            "}\n"
+        )
+
+        _, edges = self.parser.parse_file(source_file)
+        calls = [edge for edge in edges if edge.kind == "CALLS"]
+        call_targets = {
+            edge.target.split("::")[-1].split(".")[-1]: edge
+            for edge in calls
+        }
+
+        assert expected_targets <= call_targets.keys()
+        assert all(
+            call_targets[target].source.endswith("::Caller.Run")
+            for target in expected_targets
+        )
+
 
 class TestRubyParsing:
     def setup_method(self):

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2838,3 +2838,86 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+class TestZigParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.fixture = FIXTURES / "sample_zig.zig"
+        self.nodes, self.edges = self.parser.parse_file(self.fixture)
+
+    def test_detects_language(self):
+        assert self.parser.detect_language(Path("main.zig")) == "zig"
+
+    def test_finds_top_level_functions(self):
+        funcs = {
+            n.name for n in self.nodes
+            if n.kind == "Function" and n.parent_name is None
+        }
+        assert {"main", "helper"} <= funcs
+
+    def test_finds_struct_methods(self):
+        methods = {
+            n.name for n in self.nodes
+            if n.kind == "Function" and n.parent_name == "Point"
+        }
+        assert {"init", "distance"} <= methods
+
+    def test_finds_struct_enum_union_classes(self):
+        classes = {
+            n.name: n.extra.get("zig_kind") for n in self.nodes
+            if n.kind == "Class"
+        }
+        assert classes.get("Point") == "struct"
+        assert classes.get("Color") == "enum"
+        assert classes.get("Shape") == "union"
+
+    def test_finds_imports(self):
+        imports = [e for e in self.edges if e.kind == "IMPORTS_FROM"]
+        targets = {e.target for e in imports}
+        # std stays unresolved (no relative .zig path); util resolves to
+        # the absolute fixture path.
+        assert "std" in targets
+        assert any(
+            t.endswith("sample_zig_util.zig") and t != "./sample_zig_util.zig"
+            for t in targets
+        )
+
+    def test_finds_calls(self):
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        # Bare callees (std.debug.print, expect, util.noop) keep their final
+        # identifier as the target; same-file helper resolves to the
+        # qualified name via _resolve_call_targets.
+        bare_targets = {e.target.split("::")[-1] for e in calls}
+        assert "print" in bare_targets
+        assert "expect" in bare_targets
+        assert "helper" in bare_targets
+
+    def test_builtin_calls_emitted(self):
+        # @intCast inside Point.distance should produce a CALLS edge
+        # whose target is the builtin name (with the leading @).
+        targets = {e.target for e in self.edges if e.kind == "CALLS"}
+        assert "@intCast" in targets
+
+    def test_at_import_is_not_a_call(self):
+        # @import is modelled as IMPORTS_FROM only — never as CALLS, so
+        # it doesn't pollute the call graph.
+        targets = {e.target for e in self.edges if e.kind == "CALLS"}
+        assert "@import" not in targets
+
+    def test_test_block_creates_test_node(self):
+        tests = [n for n in self.nodes if n.kind == "Test"]
+        assert len(tests) == 1
+        assert tests[0].name.startswith("test:helper increments@L")
+        assert tests[0].is_test is True
+
+    def test_calls_inside_methods_have_qualified_source(self):
+        # Point.distance calls helper(...) — the source should be the
+        # qualified Point.distance name, not the bare file path.
+        sources = {
+            e.source.split("::")[-1] for e in self.edges
+            if e.kind == "CALLS"
+        }
+        assert "Point.distance" in sources
+
+    def test_nodes_have_zig_language(self):
+        for node in self.nodes:
+            assert node.language == "zig"

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -455,6 +455,94 @@ class TestPHPParsing:
         assert "dirname" in target_names
 
 
+class TestPHPImportResolution:
+    """PHP ``use`` imports resolve to absolute file paths (PSR-4 layout)."""
+
+    def test_resolves_project_import(self, tmp_path):
+        """``use`` of a project class resolves to its .php file."""
+        entity = tmp_path / "src/App/Domain/Entity"
+        entity.mkdir(parents=True)
+        (entity / "Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\nclass Job {}\n"
+        )
+        svc = tmp_path / "src/App/Service"
+        svc.mkdir(parents=True)
+        (svc / "MatchService.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use App\\Domain\\Entity\\Job;\n"
+            "class MatchService {}\n"
+        )
+
+        parser = CodeParser()
+        _, edges = parser.parse_file(svc / "MatchService.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == str((entity / "Job.php").resolve())
+
+    def test_vendor_import_stays_unresolved(self, tmp_path):
+        """A class with no local file stays as the bare FQN, not a raw
+        ``use ...;`` statement and not a fake path."""
+        svc = tmp_path / "src/App/Service"
+        svc.mkdir(parents=True)
+        (svc / "Logger.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use Psr\\Log\\LoggerInterface;\n"
+            "class Logger {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(svc / "Logger.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == "Psr\\Log\\LoggerInterface"
+        assert not imports[0].target.endswith(".php")
+
+    def test_aliased_import_records_fqn_not_alias(self, tmp_path):
+        """``use A\\B\\C as D`` records the FQN A\\B\\C, ignoring the alias."""
+        contact = tmp_path / "src/App/Domain/Embedded"
+        contact.mkdir(parents=True)
+        (contact / "Contact.php").write_text(
+            "<?php\nnamespace App\\Domain\\Embedded;\nclass Contact {}\n"
+        )
+        job = tmp_path / "src/App/Domain/Entity"
+        job.mkdir(parents=True)
+        (job / "Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\n"
+            "use App\\Domain\\Embedded\\Contact as ContactEmbedded;\n"
+            "class Job {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(job / "Job.php")
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert len(imports) == 1
+        assert imports[0].target == str((contact / "Contact.php").resolve())
+
+    def test_grouped_use_expands_to_multiple_imports(self, tmp_path):
+        """``use App\\Domain\\{Entity\\Job, Model\\Status}`` -> two imports,
+        each prefixed with the group namespace and resolved independently."""
+        base = tmp_path / "src/App/Domain"
+        (base / "Entity").mkdir(parents=True)
+        (base / "Model").mkdir(parents=True)
+        (base / "Entity/Job.php").write_text(
+            "<?php\nnamespace App\\Domain\\Entity;\nclass Job {}\n"
+        )
+        (base / "Model/Status.php").write_text(
+            "<?php\nnamespace App\\Domain\\Model;\nclass Status {}\n"
+        )
+        consumer = tmp_path / "src/App/Service"
+        consumer.mkdir(parents=True)
+        (consumer / "C.php").write_text(
+            "<?php\nnamespace App\\Service;\n"
+            "use App\\Domain\\{Entity\\Job, Model\\Status};\n"
+            "class C {}\n"
+        )
+        parser = CodeParser()
+        _, edges = parser.parse_file(consumer / "C.php")
+        targets = {e.target for e in edges if e.kind == "IMPORTS_FROM"}
+        assert str((base / "Entity/Job.php").resolve()) in targets
+        assert str((base / "Model/Status.php").resolve()) in targets
+        assert len(targets) == 2
+
+
 class TestKotlinParsing:
     def setup_method(self):
         self.parser = CodeParser()

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -427,6 +427,119 @@ class TestCSharpParsing:
         )
 
 
+@pytest.mark.skipif(
+    not _has_csharp_parser(), reason="csharp tree-sitter grammar not installed",
+)
+class TestCSharpAttributes:
+    """Regression tests for #295 (C# half): C# attributes use
+    ``attribute_list`` nodes, not ``modifiers > annotation``, so they need
+    a dedicated capture path. Persisted in ``modifiers`` + ``extra['decorators']``.
+    """
+
+    def _parse(self, source: str, tmp_path):
+        p = tmp_path / "x.cs"
+        p.write_text(source, encoding="utf-8")
+        return CodeParser().parse_file(p)
+
+    def test_method_attributes_captured(self, tmp_path):
+        nodes, _ = self._parse(
+            "namespace Api;\npublic class Ctrl {\n"
+            "    [HttpGet(\"/x\")]\n    [Authorize]\n"
+            "    public void Get() {}\n}\n",
+            tmp_path,
+        )
+        get = next(n for n in nodes if n.kind == "Function" and n.name == "Get")
+        assert get.extra.get("decorators") == ["HttpGet", "Authorize"]
+        assert get.modifiers == "HttpGet,Authorize"
+
+    def test_class_attribute_captured(self, tmp_path):
+        nodes, _ = self._parse(
+            "namespace Api;\n[ApiController]\npublic class Ctrl {\n"
+            "    public void Get() {}\n}\n",
+            tmp_path,
+        )
+        ctrl = next(n for n in nodes if n.kind == "Class" and n.name == "Ctrl")
+        assert ctrl.extra.get("decorators") == ["ApiController"]
+        assert ctrl.modifiers == "ApiController"
+
+    def test_unattributed_method_has_none_modifiers(self, tmp_path):
+        nodes, _ = self._parse(
+            "namespace Api;\npublic class C {\n    public void Plain() {}\n}\n",
+            tmp_path,
+        )
+        plain = next(n for n in nodes if n.kind == "Function" and n.name == "Plain")
+        assert plain.modifiers is None
+        assert "decorators" not in plain.extra
+
+
+@pytest.mark.skipif(
+    not _has_csharp_parser(), reason="csharp tree-sitter grammar not installed",
+)
+class TestCSharpNamespaceResolution:
+    """Regression tests for #310: C# ``using X.Y;`` directives carry a
+    namespace string as their ``IMPORTS_FROM.target`` (not a file path), so
+    ``importers_of`` returned [] for every .cs file. The fix tags File
+    nodes with their declared namespaces and adds a namespace fallback.
+    """
+
+    def _write(self, path: Path, source: str) -> None:
+        path.write_text(source, encoding="utf-8")
+
+    def test_file_scoped_namespace_tagged(self, tmp_path):
+        f = tmp_path / "Core.cs"
+        self._write(f, "namespace ACME.Core;\npublic class TaskBoard {}\n")
+        nodes, _ = CodeParser().parse_file(f)
+        file_node = next(n for n in nodes if n.kind == "File")
+        assert file_node.extra.get("csharp_namespaces") == ["ACME.Core"]
+
+    def test_block_namespace_tagged(self, tmp_path):
+        f = tmp_path / "Core.cs"
+        self._write(f, "namespace ACME.Core {\n    public class T {}\n}\n")
+        nodes, _ = CodeParser().parse_file(f)
+        file_node = next(n for n in nodes if n.kind == "File")
+        assert file_node.extra.get("csharp_namespaces") == ["ACME.Core"]
+
+    def test_non_csharp_file_has_no_namespace_tag(self, tmp_path):
+        f = tmp_path / "mod.py"
+        self._write(f, "def foo():\n    pass\n")
+        nodes, _ = CodeParser().parse_file(f)
+        file_node = next(n for n in nodes if n.kind == "File")
+        assert "csharp_namespaces" not in file_node.extra
+
+    def test_importers_of_resolves_namespace_to_file(self, tmp_path):
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.tools.query import query_graph
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".code-review-graph").mkdir()
+        core = tmp_path / "Core.cs"
+        self._write(core, "namespace ACME.Core;\npublic class TaskBoard {}\n")
+        app = tmp_path / "App.cs"
+        self._write(app, "using ACME.Core;\nnamespace ACME.App;\npublic class App {}\n")
+        unrelated = tmp_path / "Unrelated.cs"
+        self._write(
+            unrelated,
+            "using System.Linq;\nnamespace ACME.Other;\npublic class Other {}\n",
+        )
+
+        store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+        parser = CodeParser()
+        for path in (core, app, unrelated):
+            nodes, edges = parser.parse_file(path)
+            for n in nodes:
+                store.upsert_node(n)
+            for e in edges:
+                store.upsert_edge(e)
+        store.commit()
+        store.close()
+
+        result = query_graph("importers_of", str(core), repo_root=str(tmp_path))
+        assert result.get("status") == "ok"
+        importers = {r["file"] for r in result.get("results", [])}
+        assert str(app) in importers
+        assert str(unrelated) not in importers
+
+
 class TestRubyParsing:
     def setup_method(self):
         self.parser = CodeParser()
@@ -605,6 +718,58 @@ class TestKotlinParsing:
         assert "println" in targets
         # Method call: repo.save(user)
         assert any("save" in t for t in targets)
+
+
+class TestKotlinAnnotations:
+    """Regression tests for #295: Kotlin nodes must persist annotation
+    metadata in both ``modifiers`` (comma-joined string) and
+    ``extra['decorators']`` (list) so consumers can filter queries like
+    "show me all @Composable functions" or "find @HiltViewModel classes".
+    """
+
+    def _parse(self, source: str, tmp_path):
+        p = tmp_path / "x.kt"
+        p.write_text(source, encoding="utf-8")
+        return CodeParser().parse_file(p)
+
+    def test_hilt_viewmodel_annotation_on_class(self, tmp_path):
+        nodes, _ = self._parse(
+            "package com.example\n@HiltViewModel\nclass MyVM {\n    fun noop() {}\n}\n",
+            tmp_path,
+        )
+        vm = next(n for n in nodes if n.kind == "Class" and n.name == "MyVM")
+        assert vm.modifiers == "HiltViewModel"
+        assert vm.extra.get("decorators") == ["HiltViewModel"]
+
+    def test_composable_annotation_on_function(self, tmp_path):
+        nodes, _ = self._parse(
+            "package com.example\n@Composable\nfun Greeting(n: String) {\n"
+            "    println(n)\n}\n",
+            tmp_path,
+        )
+        fn = next(n for n in nodes if n.kind == "Function" and n.name == "Greeting")
+        assert fn.modifiers == "Composable"
+        assert fn.extra.get("decorators") == ["Composable"]
+
+    def test_unannotated_function_has_none_modifiers(self, tmp_path):
+        """Guard: adding annotation support must not leak an empty string
+        or empty list onto unannotated nodes."""
+        nodes, _ = self._parse(
+            "package com.example\nfun bare() { println(1) }\n", tmp_path,
+        )
+        fn = next(n for n in nodes if n.kind == "Function" and n.name == "bare")
+        assert fn.modifiers is None
+        assert "decorators" not in fn.extra
+
+    def test_test_annotation_still_triggers_test_kind(self, tmp_path):
+        """Guard: annotation persistence must not break the pre-existing
+        @Test -> Test-kind promotion."""
+        nodes, _ = self._parse(
+            "package com.example\nclass T {\n    @Test\n    fun testX() { println(1) }\n}\n",
+            tmp_path,
+        )
+        t = next(n for n in nodes if n.kind == "Test" and n.name == "testX")
+        assert t.extra.get("decorators") == ["Test"]
 
 
 class TestSwiftParsing:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -357,6 +357,39 @@ class TestCodeParser:
         tested_by = [e for e in edges if e.kind == "TESTED_BY"]
         assert len(tested_by) >= 1
 
+    def test_tested_by_edge_direction(self):
+        """Regression for #515: TESTED_BY must point production -> test.
+
+        Producer-side guard. Reads naturally as "X is tested by Y":
+        source = production code, target = the test that covers it.
+        Consumer-side queries (tests_for, get_transitive_tests,
+        test-gap detection, flow criticality, dead-code) were fixed in
+        #515 to match this canonical direction. Without this assertion the
+        parser could silently flip the direction and every consumer
+        test would still pass against the inverted edges.
+        """
+        nodes, edges = self.parser.parse_file(FIXTURES / "test_sample.py")
+        tested_by = [e for e in edges if e.kind == "TESTED_BY"]
+        assert len(tested_by) >= 1, "fixture should yield at least one TESTED_BY edge"
+
+        test_file = str(FIXTURES / "test_sample.py")
+        test_qualified = {
+            f"{test_file}::{n.name}" for n in nodes if n.kind == "Test"
+        }
+        assert test_qualified, "fixture should yield at least one Test node"
+
+        for edge in tested_by:
+            assert edge.target in test_qualified, (
+                f"TESTED_BY edge has wrong direction: target={edge.target!r} "
+                f"is not a Test node from {test_file}. "
+                f"Expected target in {sorted(test_qualified)}. "
+                f"Edge: kind={edge.kind} source={edge.source} target={edge.target}"
+            )
+            assert edge.source not in test_qualified, (
+                f"TESTED_BY edge points test -> test: "
+                f"{edge.source} -> {edge.target}"
+            )
+
     def test_recursion_depth_guard(self):
         """Parser should not crash on deeply nested code."""
         # Generate Python code with many nested functions (> _MAX_AST_DEPTH)

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -797,6 +797,75 @@ class TestFindDeadCodeWithReferences:
         assert "handleCreate" not in dead_names
 
 
+class TestFindDeadCodeWithTestedBy:
+    """Regression for #515: dead-code detection must read TESTED_BY edges
+    in the canonical direction (source=production, target=test).
+
+    A production function whose only reference is its test must NOT be
+    flagged as dead. Before the fix, find_dead_code looked for TESTED_BY
+    edges where the production node was the *target*, but the parser writes
+    the production node as the *source*, so tested-but-uncalled functions
+    were wrongly reported as dead.
+    """
+
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.store = GraphStore(self.tmp.name)
+        self._seed()
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _seed(self):
+        # Production file with a function that is tested but never called.
+        self.store.upsert_node(NodeInfo(
+            kind="File", name="/repo/calc.py", file_path="/repo/calc.py",
+            line_start=1, line_end=100, language="python",
+        ))
+        # Unconventional name so no naming-convention heuristic rescues it.
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="combine", file_path="/repo/calc.py",
+            line_start=10, line_end=20, language="python",
+        ))
+        # A truly dead function (no edges at all).
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="orphan", file_path="/repo/calc.py",
+            line_start=30, line_end=40, language="python",
+        ))
+        # Test file + test.
+        self.store.upsert_node(NodeInfo(
+            kind="File", name="/repo/spec.py", file_path="/repo/spec.py",
+            line_start=1, line_end=50, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Test", name="verify_combine_behaviour",
+            file_path="/repo/spec.py", line_start=5, line_end=10,
+            language="python", is_test=True,
+        ))
+        # Canonical TESTED_BY: source=production, target=test.
+        self.store.upsert_edge(EdgeInfo(
+            kind="TESTED_BY",
+            source="/repo/calc.py::combine",
+            target="/repo/spec.py::verify_combine_behaviour",
+            file_path="/repo/spec.py", line=6,
+        ))
+        self.store.commit()
+
+    def test_tested_function_not_dead(self):
+        """A function whose only reference is a canonical TESTED_BY edge
+        (source=production) must not be flagged as dead."""
+        dead = find_dead_code(self.store)
+        dead_names = {d["name"] for d in dead}
+        assert "combine" not in dead_names
+
+    def test_orphan_function_still_dead(self):
+        """A function with no edges at all is still reported as dead."""
+        dead = find_dead_code(self.store)
+        dead_names = {d["name"] for d in dead}
+        assert "orphan" in dead_names
+
+
 class TestTransitiveImportResolution:
     """Tests for 2-hop transitive import resolution in plausible caller."""
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -477,6 +477,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "update" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph update --skip-flows" in inner["commandWindows"]
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -488,6 +490,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "status" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -19,6 +19,7 @@ from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
     _cursor_hook_scripts,
+    _strip_jsonc,
     _detect_serve_command,
     _in_poetry_project,
     _in_uv_project,
@@ -42,6 +43,71 @@ from code_review_graph.skills import (
 _needs_tomllib = pytest.mark.skipif(
     tomllib is None, reason="tomllib requires Python 3.11+",
 )
+
+
+class TestStripJsonc:
+    """JSONC sanitizer must not corrupt string values (GH #553)."""
+
+    def test_comma_inside_string_preserved(self):
+        # The original #553 repro: a comma inside a string, immediately before a
+        # line whose first non-space char is `}`. A naive regex deleted it.
+        src = (
+            '{\n'
+            '  "mcp": {\n'
+            '    "my-server": {\n'
+            '      "command": ["x"],\n'
+            '      "description": "foo, bar"\n'
+            '    }\n'
+            '  }\n'
+            '}\n'
+        )
+        parsed = json.loads(_strip_jsonc(src))
+        assert parsed["mcp"]["my-server"]["description"] == "foo, bar"
+
+    def test_url_with_double_slash_preserved(self):
+        # The `//` comment stripper must not truncate `https://...` inside a string.
+        src = '{"url": "https://mcp.example.com/path", "n": 1}'
+        parsed = json.loads(_strip_jsonc(src))
+        assert parsed["url"] == "https://mcp.example.com/path"
+        assert parsed["n"] == 1
+
+    def test_real_trailing_comma_before_brace_removed(self):
+        src = '{"a": 1, "b": 2,}'
+        assert json.loads(_strip_jsonc(src)) == {"a": 1, "b": 2}
+
+    def test_real_trailing_comma_before_bracket_removed(self):
+        src = '{"list": [1, 2, 3,]}'
+        assert json.loads(_strip_jsonc(src)) == {"list": [1, 2, 3]}
+
+    def test_line_comment_removed(self):
+        src = '{\n  "a": 1 // inline comment\n}'
+        assert json.loads(_strip_jsonc(src)) == {"a": 1}
+
+    def test_block_comment_removed(self):
+        src = '{\n  /* leading */ "a": 1\n}'
+        assert json.loads(_strip_jsonc(src)) == {"a": 1}
+
+    def test_comment_markers_inside_string_preserved(self):
+        src = '{"a": "x // y", "b": "p /* q */ r"}'
+        parsed = json.loads(_strip_jsonc(src))
+        assert parsed["a"] == "x // y"
+        assert parsed["b"] == "p /* q */ r"
+
+    def test_escaped_quote_does_not_break_string_tracking(self):
+        # The escaped quote must not end the string early; the comma after it is
+        # data, and the `}` that follows is structural.
+        src = '{"a": "he said \\"hi, there\\"", "b": 2,}'
+        parsed = json.loads(_strip_jsonc(src))
+        assert parsed["a"] == 'he said "hi, there"'
+        assert parsed["b"] == 2
+
+    def test_trailing_comma_then_comment_then_close(self):
+        src = '{\n  "a": 1, // trailing then comment\n}'
+        assert json.loads(_strip_jsonc(src)) == {"a": 1}
+
+    def test_strict_json_unchanged(self):
+        src = '{"a": [1, 2], "b": {"c": "d, e"}}'
+        assert json.loads(_strip_jsonc(src)) == json.loads(src)
 
 
 class TestGenerateSkills:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1751,3 +1751,154 @@ class TestInstallOpenCodePlugin:
         # Should be readable as UTF-8 without errors
         content = result.read_text(encoding="utf-8")
         assert len(content) > 0
+
+
+class TestInstallConfigDataLoss:
+    """Regression tests for #344: ``install_platform_configs`` must never
+    destroy a user's existing platform config. Two residual bugs remained
+    on main even after the JSONC-stripping fix:
+
+    * a top-level JSON *array* hit ``existing.get(...)`` and crashed with
+      AttributeError before writing;
+    * an *empty* settings file was mis-flagged "unparseable" and skipped,
+      so a fresh install on an empty file silently did nothing.
+    """
+
+    def _run_zed(self, settings_path: Path, root: Path):
+        with patch.dict(
+            PLATFORMS,
+            {
+                "zed": {
+                    **PLATFORMS["zed"],
+                    "config_path": lambda r: settings_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            return install_platform_configs(root, target="zed")
+
+    def test_malformed_json_is_preserved_not_overwritten(self, tmp_path, capsys):
+        settings = tmp_path / "zed" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        original = "{ this is not valid json }\n"
+        settings.write_text(original, encoding="utf-8")
+
+        configured = self._run_zed(settings, tmp_path)
+
+        assert "Zed" not in configured
+        assert settings.read_text(encoding="utf-8") == original
+        assert "unparseable" in capsys.readouterr().out
+
+    def test_top_level_array_does_not_crash_and_is_preserved(self, tmp_path, capsys):
+        """The actual residual bug: a top-level array crashed install with
+        ``AttributeError: 'list' object has no attribute 'get'``."""
+        settings = tmp_path / "zed" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        original = '["not", "an", "object"]'
+        settings.write_text(original, encoding="utf-8")
+
+        # Must not raise.
+        configured = self._run_zed(settings, tmp_path)
+
+        assert "Zed" not in configured
+        assert settings.read_text(encoding="utf-8") == original
+        out = capsys.readouterr().out
+        assert "not a top-level object" in out
+
+    def test_empty_file_is_treated_as_fresh_config(self, tmp_path):
+        """An empty settings.json is a valid empty config, not a parse
+        failure — install should write a fresh config rather than skip."""
+        settings = tmp_path / "zed" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("", encoding="utf-8")
+
+        configured = self._run_zed(settings, tmp_path)
+
+        assert "Zed" in configured
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        assert "code-review-graph" in data["context_servers"]
+
+    def test_jsonc_comments_still_supported(self, tmp_path):
+        """Guard: the empty-file / array checks must not regress main's
+        JSONC support — a comment-bearing Zed config must still merge."""
+        settings = tmp_path / "zed" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(
+            "{\n"
+            '  // user theme preference\n'
+            '  "theme": "One Dark",\n'
+            "}\n",
+            encoding="utf-8",
+        )
+
+        configured = self._run_zed(settings, tmp_path)
+
+        assert "Zed" in configured
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        # User's existing setting preserved AND our server added.
+        assert data["theme"] == "One Dark"
+        assert "code-review-graph" in data["context_servers"]
+
+
+class TestGeneratedHooksGuardGitRepo:
+    """Regression coverage for #312: generated Claude Code hooks must guard
+    the ``update`` / ``status`` commands behind a git-repo check so that, in
+    a monorepo whose workspace root has no ``.git``, the PostToolUse hook
+    no-ops silently instead of erroring on every tool call.
+    """
+
+    def test_post_tool_use_command_guarded_by_git_check(self):
+        config = generate_hooks_config(Path("/repo"))
+        cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+        # Must short-circuit on the git check before calling update.
+        assert "git rev-parse --git-dir" in cmd
+        idx_guard = cmd.index("git rev-parse --git-dir")
+        idx_update = cmd.index("code-review-graph update")
+        assert idx_guard < idx_update, "git guard must precede the update call"
+
+    def test_session_start_command_guarded_by_git_check(self):
+        config = generate_hooks_config(Path("/repo"))
+        cmd = config["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        assert "git rev-parse --git-dir" in cmd
+        idx_guard = cmd.index("git rev-parse --git-dir")
+        idx_status = cmd.index("code-review-graph status")
+        assert idx_guard < idx_status
+
+
+class TestInstallSkillsRespectTargetPlatform:
+    """Regression coverage for #350: ``install --platform cursor`` must NOT
+    generate Claude Code skills under ``.claude/skills/`` — that directory
+    is only read by Claude Code, and creating it for other platforms
+    confused users into thinking the tool wrote Claude config unprompted.
+    """
+
+    def _run_install(self, tmp_path, platform: str) -> bool:
+        import argparse
+
+        from code_review_graph import cli as crg_cli
+
+        args = argparse.Namespace(
+            command="install",
+            repo=str(tmp_path),
+            platform=platform,
+            yes=True,
+            dry_run=False,
+            no_skills=False,
+            no_hooks=True,
+            no_instructions=True,
+        )
+        with patch("builtins.input", return_value="n"):
+            crg_cli._handle_init(args)
+        return (tmp_path / ".claude" / "skills").is_dir()
+
+    def test_cursor_install_does_not_create_claude_skills(self, tmp_path):
+        assert self._run_install(tmp_path, "cursor") is False
+
+    def test_windsurf_install_does_not_create_claude_skills(self, tmp_path):
+        assert self._run_install(tmp_path, "windsurf") is False
+
+    def test_claude_install_creates_skills(self, tmp_path):
+        assert self._run_install(tmp_path, "claude") is True
+
+    def test_all_target_creates_skills(self, tmp_path):
+        assert self._run_install(tmp_path, "all") is True

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1777,6 +1777,19 @@ class TestInstallConfigDataLoss:
         ):
             return install_platform_configs(root, target="zed")
 
+    def _run_continue(self, settings_path: Path, root: Path):
+        with patch.dict(
+            PLATFORMS,
+            {
+                "continue": {
+                    **PLATFORMS["continue"],
+                    "config_path": lambda r: settings_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            return install_platform_configs(root, target="continue")
+
     def test_malformed_json_is_preserved_not_overwritten(self, tmp_path, capsys):
         settings = tmp_path / "zed" / "settings.json"
         settings.parent.mkdir(parents=True)
@@ -1838,6 +1851,40 @@ class TestInstallConfigDataLoss:
         # User's existing setting preserved AND our server added.
         assert data["theme"] == "One Dark"
         assert "code-review-graph" in data["context_servers"]
+
+    def test_array_platform_preserves_wrong_typed_server_collection(
+        self, tmp_path, capsys
+    ):
+        config = tmp_path / ".continue" / "config.json"
+        config.parent.mkdir(parents=True)
+        original = '{\n  "mcpServers": {"legacy": "keep-me"}\n}\n'
+        config.write_text(original, encoding="utf-8")
+
+        configured = self._run_continue(config, tmp_path)
+
+        assert "Continue" not in configured
+        assert config.read_text(encoding="utf-8") == original
+        out = capsys.readouterr().out
+        assert "mcpServers" in out
+        assert "expected a JSON array" in out
+        assert "skipping to avoid data loss" in out
+
+    def test_object_platform_preserves_wrong_typed_server_collection(
+        self, tmp_path, capsys
+    ):
+        settings = tmp_path / "zed" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        original = '{\n  "context_servers": ["legacy-server"]\n}\n'
+        settings.write_text(original, encoding="utf-8")
+
+        configured = self._run_zed(settings, tmp_path)
+
+        assert "Zed" not in configured
+        assert settings.read_text(encoding="utf-8") == original
+        out = capsys.readouterr().out
+        assert "context_servers" in out
+        assert "expected a JSON object" in out
+        assert "skipping to avoid data loss" in out
 
 
 class TestGeneratedHooksGuardGitRepo:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -118,7 +118,7 @@ class TestGenerateHooksConfig:
         config = generate_hooks_config(Path("/repo"))
         assert "PostToolUse" in config["hooks"]
         entry = config["hooks"]["PostToolUse"][0]
-        assert entry["matcher"] == "Edit|Write|Bash"
+        assert entry["matcher"] == "Edit|Write"
         inner = entry["hooks"][0]
         assert inner["type"] == "command"
         assert "update" in inner["command"]
@@ -152,17 +152,51 @@ class TestGenerateHooksConfig:
                 assert "hooks" in entry, f"{hook_type} entry missing 'hooks' array"
                 assert "command" not in entry, f"{hook_type} has bare 'command' outside hooks[]"
 
-    def test_repo_root_embedded_in_commands(self):
-        config = generate_hooks_config(Path("/my/project"))
-        post_cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
-        session_cmd = config["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-        assert "/my/project" in post_cmd
-        assert "/my/project" in session_cmd
+    def test_hooks_have_path_guard(self):
+        """Regression test for #549: hooks must guard against missing binary."""
+        config = generate_hooks_config(Path("/repo"))
+        for hook_type, entries in config["hooks"].items():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    assert "command -v code-review-graph" in hook["command"], (
+                        f"{hook_type} hook missing PATH guard — will fail noisily"
+                        " when binary is not on PATH (e.g. project venv)"
+                    )
 
-    def test_quotes_repo_paths_with_spaces(self):
-        config = generate_hooks_config(Path("/repo with spaces"))
-        post_cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
-        assert '"' in post_cmd  # path is JSON-encoded so spaces are quoted
+    def test_hooks_use_dynamic_repo_root(self):
+        """Regression test for #558: hooks must not embed absolute paths.
+
+        The repo root should be resolved at runtime via git rev-parse so
+        settings.json is shareable across collaborators.
+        """
+        config = generate_hooks_config(Path("/my/specific/checkout/path"))
+        for hook_type, entries in config["hooks"].items():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    assert "git rev-parse --show-toplevel" in hook["command"], (
+                        f"{hook_type} hook should use git rev-parse --show-toplevel"
+                        " to resolve repo root dynamically"
+                    )
+
+    def test_hooks_no_absolute_path_embedded(self):
+        """Regression test for #558: no absolute path should appear in commands."""
+        config = generate_hooks_config(Path("/home/user/projects/my-repo"))
+        for hook_type, entries in config["hooks"].items():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    assert "/home/user/projects/my-repo" not in hook["command"], (
+                        f"{hook_type} hook embeds absolute path — settings.json"
+                        " is not shareable across collaborators"
+                    )
+
+    def test_post_tool_use_matcher_excludes_bash(self):
+        """Regression test for #549: Bash matcher fires on every shell command."""
+        config = generate_hooks_config(Path("/repo"))
+        matcher = config["hooks"]["PostToolUse"][0]["matcher"]
+        assert "Bash" not in matcher, (
+            "PostToolUse matcher includes Bash — fires on every shell command"
+            " (git status, ls, test runs), not just file mutations"
+        )
 
     def test_entries_use_claude_code_hook_schema(self):
         """Regression guard for the Claude Code hook schema.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -126,12 +126,12 @@ class TestGenerateSkills:
             "review-changes",
         ]
         for d in skills_dir.iterdir():
-            assert (d / "skill.md").is_file()
+            assert (d / "SKILL.md").is_file()
 
     def test_skill_files_have_frontmatter(self, tmp_path):
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            path = subdir / "skill.md"
+            path = subdir / "SKILL.md"
             content = path.read_text()
             assert content.startswith("---\n")
             assert "name:" in content
@@ -153,7 +153,7 @@ class TestGenerateSkills:
         """Every skill template must reference get_minimal_context."""
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            content = (subdir / "skill.md").read_text()
+            content = (subdir / "SKILL.md").read_text()
             assert "get_minimal_context" in content, (
                 f"{subdir.name} missing get_minimal_context reference"
             )
@@ -162,7 +162,7 @@ class TestGenerateSkills:
         """Every skill template must reference detail_level."""
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
-            content = (subdir / "skill.md").read_text()
+            content = (subdir / "SKILL.md").read_text()
             assert "detail_level" in content, (
                 f"{subdir.name} missing detail_level reference"
             )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -477,8 +477,6 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "update" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
-        assert inner["commandWindows"].startswith("cmd.exe ")
-        assert "code-review-graph update --skip-flows" in inner["commandWindows"]
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -490,8 +488,6 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "status" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
-        assert inner["commandWindows"].startswith("cmd.exe ")
-        assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -369,6 +369,71 @@ class TestRepoRootValidation:
             _validate_repo_root(tmp_path)
 
 
+class TestQueryGraphTestsFor:
+    """Regression tests for #515: query_graph(pattern='tests_for')
+    must follow direct TESTED_BY edges (source=production, target=test)
+    rather than relying on the naming-convention fallback.
+    """
+
+    def setup_method(self):
+        import tempfile as _tempfile
+        self._tmpdir = _tempfile.TemporaryDirectory()
+        self.repo_root = Path(self._tmpdir.name)
+        # _validate_repo_root requires .git or .code-review-graph.
+        (self.repo_root / ".code-review-graph").mkdir()
+        # find_project_root / get_db_path look here for the DB.
+        from code_review_graph.incremental import get_db_path
+        self.db_path = get_db_path(self.repo_root)
+        self.store = GraphStore(str(self.db_path))
+        self._seed_graph()
+
+    def teardown_method(self):
+        self.store.close()
+        self._tmpdir.cleanup()
+
+    def _seed_graph(self):
+        # Production function with an unconventional name so the
+        # naming-convention fallback (test_<name> / Test<name>) cannot match.
+        self.store.upsert_node(NodeInfo(
+            kind="File", name="/src/calc.py", file_path="/src/calc.py",
+            line_start=1, line_end=20, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="combine", file_path="/src/calc.py",
+            line_start=1, line_end=5, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="File", name="/tests/spec.py", file_path="/tests/spec.py",
+            line_start=1, line_end=20, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Test", name="verify_combine_behaviour",
+            file_path="/tests/spec.py",
+            line_start=1, line_end=5, language="python", is_test=True,
+        ))
+        # Parser-canonical direction: source=production, target=test.
+        self.store.upsert_edge(EdgeInfo(
+            kind="TESTED_BY",
+            source="/src/calc.py::combine",
+            target="/tests/spec.py::verify_combine_behaviour",
+            file_path="/tests/spec.py", line=1,
+        ))
+        self.store.commit()
+        # Release the writer connection so query_graph can open its own.
+        self.store.close()
+
+    def test_query_graph_tests_for_finds_direct_edge(self):
+        from code_review_graph.tools import query_graph
+        result = query_graph(
+            pattern="tests_for",
+            target="/src/calc.py::combine",
+            repo_root=str(self.repo_root),
+        )
+        assert result["status"] == "ok"
+        qns = {r["qualified_name"] for r in result["results"]}
+        assert "/tests/spec.py::verify_combine_behaviour" in qns
+
+
 class TestGetDocsSection:
     """Tests for the get_docs_section tool."""
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -307,6 +307,42 @@ def test_generate_html_includes_loading_and_empty_state(store_with_data, tmp_pat
     assert "No nodes to display" in content
 
 
+def test_generate_html_uses_id_selector_for_svg(store_with_data, tmp_path):
+    """Regression test for #523: d3.select("svg") selects the legend icon, not the canvas.
+
+    The legend <nav> contains inline <svg> icons that appear before #graph-svg
+    in document order. d3.select("svg") returns the first match — a 16px legend
+    icon — causing the entire force graph to render inside it. The fix targets
+    #graph-svg by id.
+    """
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "graph.html"
+    generate_html(store_with_data, output_path)
+    content = output_path.read_text()
+    assert 'd3.select("#graph-svg")' in content, (
+        "HTML should use d3.select('#graph-svg') to target the main canvas, "
+        "not d3.select('svg') which selects the first inline legend icon"
+    )
+    assert 'd3.select("svg")' not in content, (
+        "No bare d3.select('svg') should remain — it selects legend icons"
+    )
+
+
+def test_community_mode_uses_id_selector_for_svg(large_store, tmp_path):
+    """Regression test for #523: community/aggregated template must also use #graph-svg."""
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "community.html"
+    generate_html(large_store, output_path, mode="community")
+    content = output_path.read_text()
+    assert 'd3.select("#graph-svg")' in content
+    assert 'd3.select("svg")' not in content
+    assert 'id="graph-svg"' in content, (
+        "Aggregated template's <svg> must have id='graph-svg' for the selector to work"
+    )
+
+
 def test_generate_html_includes_focus_visible(store_with_data, tmp_path):
     """Generated HTML should include :focus-visible styles."""
     from code_review_graph.visualization import generate_html


### PR DESCRIPTION
## Summary

This draft reconciles the strongest independently reviewable local/community fixes after a full maintainer audit. It intentionally does **not** merge PR #559 or review/local-fixes wholesale.

- preserves contributor authorship for selected PR #564, #565, #573, #578, #563, #354, #353, and #393 work;
- ports the four safe patch-equivalent commits from PR #559 (the three-commit TESTED_BY series, including #527 credit, plus Action path rendering);
- adds red/green fixes for #612 and #613;
- closes review gaps in nested platform config preservation, in-source Zig TESTED_BY edges, nested C# namespaces, and deep C# AST traversal;
- explicitly removes the disproven #569 path-normalization changes from this branch;
- moves the Windows Codex-hook work from PR #621 into dedicated draft PR #626 for target-native validation.

The full local/remote inventory and every selected/deferred decision are in [the maintainer reconciliation log](docs/MAINTAINER_RECONCILIATION_2026-07-17.md). It accounts for all 104 open PRs, 84 open issues, 29 discussions, and all local branches/worktrees/stashes/untracked paths.

## Validation

- Python 3.13 non-WatchDaemon suite: **1,446 passed**, 1 optional skip, 13 deselected, 2 xpassed
- isolated coverage gate before the platform split: **72.95%** (required 65%); 1,446 passed, 1 optional skip
- ruff clean; mypy clean in 62 source files; Bandit clean
- Python/VS Code schema sync: version 9
- wheel and sdist built; packaged docs present
- full graph rebuild: 181 files, 3,415 nodes, 24,940 edges, 200 flows, 16 communities, no errors
- independent two-pass review: all discovered P1/P2 findings removed or fixed with regressions

## Remaining tracked risks

- macOS Python 3.13 WatchDaemon tests hit a native watchdog/FSEvents SIGBUS on unchanged main as well; tracked in crg-229 and excluded from comparisons.
- coverage exposes SQLite ResourceWarnings (crg-dtv).
- package inspection shows pre-existing maintainer-only .beads hooks in the sdist (crg-8u4).
- the Windows hook is intentionally absent here and remains draft in #626 until Windows CI and manual Codex validation pass.

Addresses #612, #613, #553, #295, #310, #523, #549, #558, #574, and #515 without claiming complete closure where the decision log records partial work.