### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.hi-IN.md
+++ b/README.hi-IN.md
@@ -265,13 +265,13 @@ node_modules/**
 वैकल्पिक डिपेंडेंसी ग्रुप:
 
 ```bash
-pip install code-review-graph[embeddings]          # लोकल वेक्टर एम्बेडिंग (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini एम्बेडिंग
-pip install code-review-graph[communities]         # कम्युनिटी डिटेक्शन (igraph)
-pip install code-review-graph[enrichment]          # Python call-resolution enrichment (Jedi)
-pip install code-review-graph[eval]                # मूल्यांकन बेंचमार्क (matplotlib)
-pip install code-review-graph[wiki]                # LLM सारांश के साथ विकी जनरेशन (ollama)
-pip install code-review-graph[all]                 # सभी वैकल्पिक डिपेंडेंसीज़
+pip install 'code-review-graph[embeddings]'          # लोकल वेक्टर एम्बेडिंग (sentence-transformers)
+pip install 'code-review-graph[google-embeddings]'   # Google Gemini एम्बेडिंग
+pip install 'code-review-graph[communities]'         # कम्युनिटी डिटेक्शन (igraph)
+pip install 'code-review-graph[enrichment]'          # Python call-resolution enrichment (Jedi)
+pip install 'code-review-graph[eval]'                # मूल्यांकन बेंचमार्क (matplotlib)
+pip install 'code-review-graph[wiki]'                # LLM सारांश के साथ विकी जनरेशन (ollama)
+pip install 'code-review-graph[all]'                 # सभी वैकल्पिक डिपेंडेंसीज़
 ```
 
 OpenAI-compatible एम्बेडिंग्स (असली OpenAI, Azure, या सेल्फ-होस्टेड गेटवे जैसे new-api / LiteLLM / vLLM / LocalAI / Ollama openai मोड) के लिए कोई अतिरिक्त इंस्टॉल की ज़रूरत नहीं — बस एनवायरनमेंट वेरिएबल्स सेट करें और `embed_graph` को `provider="openai"` पास करें:

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -267,13 +267,13 @@ node_modules/**
 オプションの依存グループ：
 
 ```bash
-pip install code-review-graph[embeddings]          # ローカルベクトル埋め込み (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini埋め込み
-pip install code-review-graph[communities]         # コミュニティ検出 (igraph)
-pip install code-review-graph[enrichment]          # Python呼び出し解決の補強 (Jedi)
-pip install code-review-graph[eval]                # 評価ベンチマーク (matplotlib)
-pip install code-review-graph[wiki]                # LLMサマリー付きWiki生成 (ollama)
-pip install code-review-graph[all]                 # 全オプション依存
+pip install 'code-review-graph[embeddings]'          # ローカルベクトル埋め込み (sentence-transformers)
+pip install 'code-review-graph[google-embeddings]'   # Google Gemini埋め込み
+pip install 'code-review-graph[communities]'         # コミュニティ検出 (igraph)
+pip install 'code-review-graph[enrichment]'          # Python呼び出し解決の補強 (Jedi)
+pip install 'code-review-graph[eval]'                # 評価ベンチマーク (matplotlib)
+pip install 'code-review-graph[wiki]'                # LLMサマリー付きWiki生成 (ollama)
+pip install 'code-review-graph[all]'                 # 全オプション依存
 ```
 
 OpenAI互換の埋め込み（本家OpenAI、Azure、または自前のゲートウェイ: new-api / LiteLLM / vLLM / LocalAI / Ollama openaiモード）は追加インストール不要です。環境変数を設定し、`embed_graph` に `provider="openai"` を渡すだけで動作します：

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -267,13 +267,13 @@ node_modules/**
 선택적 의존성 그룹:
 
 ```bash
-pip install code-review-graph[embeddings]          # 로컬 벡터 임베딩 (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini 임베딩
-pip install code-review-graph[communities]         # 커뮤니티 감지 (igraph)
-pip install code-review-graph[enrichment]          # Python 호출 해결 보강 (Jedi)
-pip install code-review-graph[eval]                # 평가 벤치마크 (matplotlib)
-pip install code-review-graph[wiki]                # LLM 요약 위키 생성 (ollama)
-pip install code-review-graph[all]                 # 모든 선택적 의존성
+pip install 'code-review-graph[embeddings]'          # 로컬 벡터 임베딩 (sentence-transformers)
+pip install 'code-review-graph[google-embeddings]'   # Google Gemini 임베딩
+pip install 'code-review-graph[communities]'         # 커뮤니티 감지 (igraph)
+pip install 'code-review-graph[enrichment]'          # Python 호출 해결 보강 (Jedi)
+pip install 'code-review-graph[eval]'                # 평가 벤치마크 (matplotlib)
+pip install 'code-review-graph[wiki]'                # LLM 요약 위키 생성 (ollama)
+pip install 'code-review-graph[all]'                 # 모든 선택적 의존성
 ```
 
 OpenAI 호환 임베딩(실제 OpenAI, Azure, 또는 자체 호스팅 게이트웨이 new-api / LiteLLM / vLLM / LocalAI / Ollama openai 모드)은 추가 설치가 필요하지 않습니다. 환경 변수만 설정하고 `embed_graph`에 `provider="openai"`를 전달하면 됩니다:

--- a/README.md
+++ b/README.md
@@ -475,13 +475,13 @@ Note: in git repos, only tracked files are indexed (`git ls-files`), so gitignor
 Optional dependency groups:
 
 ```bash
-pip install code-review-graph[embeddings]          # Local vector embeddings (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini embeddings
-pip install code-review-graph[communities]         # Community detection (igraph)
-pip install code-review-graph[enrichment]          # Python call-resolution enrichment (Jedi)
-pip install code-review-graph[eval]                # Evaluation benchmarks (matplotlib)
-pip install code-review-graph[wiki]                # Wiki generation with LLM summaries (ollama)
-pip install code-review-graph[all]                 # All optional dependencies
+pip install 'code-review-graph[embeddings]'          # Local vector embeddings (sentence-transformers)
+pip install 'code-review-graph[google-embeddings]'   # Google Gemini embeddings
+pip install 'code-review-graph[communities]'         # Community detection (igraph)
+pip install 'code-review-graph[enrichment]'          # Python call-resolution enrichment (Jedi)
+pip install 'code-review-graph[eval]'                # Evaluation benchmarks (matplotlib)
+pip install 'code-review-graph[wiki]'                # Wiki generation with LLM summaries (ollama)
+pip install 'code-review-graph[all]'                 # All optional dependencies
 ```
 
 ### Environment Variables

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,13 +265,13 @@ node_modules/**
 可选依赖组：
 
 ```bash
-pip install code-review-graph[embeddings]          # 本地向量嵌入 (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini 嵌入
-pip install code-review-graph[communities]         # 社区检测 (igraph)
-pip install code-review-graph[enrichment]          # Python 调用解析增强 (Jedi)
-pip install code-review-graph[eval]                # 评估基准测试 (matplotlib)
-pip install code-review-graph[wiki]                # 使用 LLM 摘要生成 Wiki (ollama)
-pip install code-review-graph[all]                 # 所有可选依赖
+pip install 'code-review-graph[embeddings]'          # 本地向量嵌入 (sentence-transformers)
+pip install 'code-review-graph[google-embeddings]'   # Google Gemini 嵌入
+pip install 'code-review-graph[communities]'         # 社区检测 (igraph)
+pip install 'code-review-graph[enrichment]'          # Python 调用解析增强 (Jedi)
+pip install 'code-review-graph[eval]'                # 评估基准测试 (matplotlib)
+pip install 'code-review-graph[wiki]'                # 使用 LLM 摘要生成 Wiki (ollama)
+pip install 'code-review-graph[all]'                 # 所有可选依赖
 ```
 
 OpenAI 兼容嵌入（真实 OpenAI、Azure，或自建网关如 new-api / LiteLLM / vLLM / LocalAI / Ollama openai 模式）无需额外安装 —— 只需设置环境变量并在 `embed_graph` 中传入 `provider="openai"`：


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.hi-IN.md`
- `README.ja-JP.md`
- `README.ko-KR.md`
- `README.md`
- `README.zh-CN.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`