### PR TITLE
fix(windows): validate Codex hooks through cmd.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,6 @@ jobs:
           tests/test_search.py
           tests/test_tools.py
           tests/test_wiki.py
+          tests/test_skills.py::TestGenerateCodexHooksConfig
           tests/test_skills.py::TestInstallCodexHooks
           tests/test_skills.py::TestInstallCursorHooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@
 - Hardened generated skills/configuration: uppercase `SKILL.md` (PR #563),
   string-safe JSONC plus top-level and nested-container data-preservation guards
   (#553, PR #354), and portable PATH-aware hooks (PR #565).
+- Codex hook installation now emits native Windows commands that drain the
+  hook event from stdin, fail open outside Git repositories, and upgrade
+  existing Unix-only hook entries without duplicating or replacing user hooks
+  (#620, PR #621).
 - Packaged documentation remains reachable through the MCP wrapper (#613),
   Action comments render repository-relative paths, and both visualization
   templates select the graph SVG specifically (PR #564).

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -788,6 +788,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph update --skip-flows"
+                                ' || exit /b 0"'
+                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -805,6 +811,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
+                            ),
+                            "commandWindows": (
+                                'cmd.exe /d /s /c "more >nul & '
+                                "git rev-parse --git-dir >nul 2>&1"
+                                " && code-review-graph status"
+                                ' || echo Not a git repo, skipping"'
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -1007,20 +1007,34 @@ def install_codex_hooks(repo_root: Path) -> Path:
     for hook_name, hook_entries in hooks_config.get("hooks", {}).items():
         if isinstance(merged_hooks.get(hook_name), list):
             merged_list = list(merged_hooks[hook_name])
-            existing_commands = {
-                hook.get("command", "")
-                for entry in merged_list
-                if isinstance(entry, dict)
-                for hook in entry.get("hooks", [])
-                if isinstance(hook, dict)
-            }
             for entry in hook_entries:
-                entry_commands = [
-                    hook.get("command", "")
+                matched_existing_command = False
+                generated_hooks = [
+                    hook
                     for hook in entry.get("hooks", [])
                     if isinstance(hook, dict)
                 ]
-                if not any(command in existing_commands for command in entry_commands):
+                for generated_hook in generated_hooks:
+                    command = generated_hook.get("command")
+                    if not command:
+                        continue
+                    for existing_entry in merged_list:
+                        if not isinstance(existing_entry, dict):
+                            continue
+                        for existing_hook in existing_entry.get("hooks", []):
+                            if not isinstance(existing_hook, dict):
+                                continue
+                            if existing_hook.get("command") != command:
+                                continue
+                            matched_existing_command = True
+                            if "commandWindows" in generated_hook:
+                                existing_hook.setdefault(
+                                    "commandWindows", generated_hook["commandWindows"]
+                                )
+                            break
+                        if matched_existing_command:
+                            break
+                if not matched_existing_command:
                     merged_list.append(entry)
             merged_hooks[hook_name] = merged_list
         else:

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -789,10 +789,10 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " || true"
                             ),
                             "commandWindows": (
-                                'cmd.exe /d /s /c "more >nul & '
+                                "more >nul & "
                                 "git rev-parse --git-dir >nul 2>&1"
                                 " && code-review-graph update --skip-flows"
-                                ' || exit /b 0"'
+                                " || exit /b 0"
                             ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
@@ -813,10 +813,10 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " || echo 'Not a git repo, skipping'"
                             ),
                             "commandWindows": (
-                                'cmd.exe /d /s /c "more >nul & '
+                                "more >nul & "
                                 "git rev-parse --git-dir >nul 2>&1"
                                 " && code-review-graph status"
-                                ' || echo Not a git repo, skipping"'
+                                " || echo Not a git repo, skipping"
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -495,6 +495,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "update" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph update --skip-flows" in inner["commandWindows"]
         assert inner["statusMessage"] == "Updating code-review-graph"
 
     def test_has_session_start(self, tmp_path):
@@ -506,6 +508,8 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "status" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
+        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -601,6 +601,7 @@ class TestGenerateCodexHooksConfig:
 
         assert completed.returncode == 0, completed.stderr.decode(errors="replace")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires a Unix shell")
     def test_post_tool_use_command_handles_large_stdin_payload(self, tmp_path):
         config = generate_codex_hooks_config(tmp_path)
         cmd = config["hooks"]["PostToolUse"][0]["hooks"][0]["command"]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -496,7 +496,7 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "update" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
-        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert inner["commandWindows"].startswith("more >nul & ")
         assert "code-review-graph update --skip-flows" in inner["commandWindows"]
         assert inner["statusMessage"] == "Updating code-review-graph"
 
@@ -509,7 +509,7 @@ class TestGenerateCodexHooksConfig:
         assert inner["type"] == "command"
         assert "status" in inner["command"]
         assert inner["command"].startswith("cat >/dev/null || true; ")
-        assert inner["commandWindows"].startswith("cmd.exe ")
+        assert inner["commandWindows"].startswith("more >nul & ")
         assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
@@ -652,6 +652,7 @@ class TestInstallCodexHooks:
 
     def test_upgrades_existing_hooks_with_windows_commands(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         repo_root = tmp_path / "repo"
         old_config = generate_codex_hooks_config(repo_root)
         expected_windows_commands = {}

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,6 +5,7 @@ import os
 import stat
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -512,6 +513,93 @@ class TestGenerateCodexHooksConfig:
         assert "code-review-graph status" in inner["commandWindows"]
         assert inner["statusMessage"] == "Checking code-review-graph status"
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="requires cmd.exe")
+    @pytest.mark.parametrize(
+        ("hook_name", "expected_args"),
+        [
+            ("PostToolUse", "update --skip-flows"),
+            ("SessionStart", "status"),
+        ],
+    )
+    def test_windows_command_executes_in_git_repo_and_drains_stdin(
+        self, tmp_path, hook_name, expected_args, monkeypatch
+    ):
+        subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        marker = tmp_path / "hook-invocations.txt"
+        (bin_dir / "code-review-graph.cmd").write_text(
+            '@echo off\r\n>>"%CRG_HOOK_MARKER%" echo %*\r\nexit /b 0\r\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CRG_HOOK_MARKER", str(marker))
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+        config = generate_codex_hooks_config(tmp_path)
+        command = config["hooks"][hook_name][0]["hooks"][0]["commandWindows"]
+        comspec = os.environ.get("COMSPEC", "cmd.exe")
+        proc = subprocess.Popen(
+            [comspec, "/c", command],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp_path,
+        )
+        payload = json.dumps({"payload": "x" * (2 * 1024 * 1024)}).encode()
+        assert proc.stdin is not None
+        write_result = {}
+
+        def write_payload():
+            try:
+                write_result["bytes_written"] = proc.stdin.write(payload)
+                proc.stdin.close()
+            except OSError as exc:  # pragma: no cover - Windows regression guard
+                write_result["error"] = exc
+
+        writer = threading.Thread(target=write_payload, daemon=True)
+        writer.start()
+        writer.join(timeout=30)
+        if writer.is_alive():
+            proc.kill()
+            writer.join(timeout=5)
+            proc.wait(timeout=5)
+            pytest.fail("hook command did not drain stdin within 30 seconds")
+        if "error" in write_result:
+            proc.kill()
+            proc.wait(timeout=5)
+            pytest.fail(f"hook command closed stdin early: {write_result['error']}")
+        assert write_result["bytes_written"] == len(payload)
+        proc.stdin = None
+        try:
+            _stdout, stderr = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            _stdout, stderr = proc.communicate()
+            pytest.fail(
+                "hook command did not exit within 30 seconds: "
+                f"{stderr.decode(errors='replace')}"
+            )
+
+        assert proc.returncode == 0, stderr.decode(errors="replace")
+        assert expected_args in marker.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="requires cmd.exe")
+    @pytest.mark.parametrize("hook_name", ["PostToolUse", "SessionStart"])
+    def test_windows_command_fails_open_outside_git_repo(self, tmp_path, hook_name):
+        config = generate_codex_hooks_config(tmp_path)
+        command = config["hooks"][hook_name][0]["hooks"][0]["commandWindows"]
+        comspec = os.environ.get("COMSPEC", "cmd.exe")
+
+        completed = subprocess.run(
+            [comspec, "/c", command],
+            input=b'{"event":"outside-repo"}',
+            cwd=tmp_path,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr.decode(errors="replace")
 
     def test_post_tool_use_command_handles_large_stdin_payload(self, tmp_path):
         config = generate_codex_hooks_config(tmp_path)
@@ -561,6 +649,39 @@ class TestInstallCodexHooks:
         assert "hooks" in data
         assert "PostToolUse" in data["hooks"]
         assert "SessionStart" in data["hooks"]
+
+    def test_upgrades_existing_hooks_with_windows_commands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        repo_root = tmp_path / "repo"
+        old_config = generate_codex_hooks_config(repo_root)
+        expected_windows_commands = {}
+        for hook_name, entries in old_config["hooks"].items():
+            hook = entries[0]["hooks"][0]
+            expected_windows_commands[hook_name] = hook.pop("commandWindows")
+
+        custom_entry = {
+            "matcher": "Custom",
+            "hooks": [{"type": "command", "command": "echo custom"}],
+        }
+        old_config["hooks"]["PostToolUse"].append(custom_entry)
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir(parents=True)
+        (codex_dir / "hooks.json").write_text(
+            json.dumps(old_config), encoding="utf-8"
+        )
+
+        install_codex_hooks(repo_root)
+
+        data = json.loads((codex_dir / "hooks.json").read_text(encoding="utf-8"))
+        assert custom_entry in data["hooks"]["PostToolUse"]
+        for hook_name, expected_command in expected_windows_commands.items():
+            generated_hooks = [
+                hook
+                for entry in data["hooks"][hook_name]
+                for hook in entry.get("hooks", [])
+                if hook.get("commandWindows") == expected_command
+            ]
+            assert len(generated_hooks) == 1
 
     def test_merges_with_existing(self, tmp_path, monkeypatch):
         # Path.home() ignores HOME on Windows; patch it like the cursor tests do.


### PR DESCRIPTION
## Latest refresh — 18 July 2026

- rebased patch-identically onto main 0a3bd6c; current head bdc95c9
- all 15 hosted checks passed after this rebase, including the remote Windows job
- released Codex-on-Windows client validation remains required; this stays draft and is not mergeable by policy## Status

**Draft — do not merge until the released Codex Windows-client checks below pass.**

## Change

This keeps the safe Windows hook work from source PR #621, with Adam White's original authorship preserved. It adds native `commandWindows` bodies for `PostToolUse` and `SessionStart`, drains the full stdin event, upgrades matching Unix-only CRG hooks in place, and preserves unrelated user hooks.

## Why source PR #621 was closed

The source double-wrapped `cmd.exe`, did not upgrade an older Unix-only CRG configuration, and tested strings instead of executing the generated Windows commands. This draft fixes those gaps. Source PR #621 is closed as superseded.

## Automated validation

- patch-equivalent rebase onto current `main` (`0a3bd6c`); current head `bdc95c9`
- focused Codex-hook tests: **12 passed, 4 Windows-only skipped locally**
- complete non-daemon suite: **1,899 passed, 9 skipped, 2 expected deselections, 2 xpassed**
- both multiprocessing parity checks: **2 passed**
- Ruff and `git diff --check`: clean
- GitHub CI run 29619153235: every job passed, including native Windows execution on Windows Server 2025
- PR Review run 29619153205: passed

Automated Windows CI proves the generated command bodies execute through `COMSPEC /C`, drain a 2 MiB event, fail open outside a Git repository, and upgrade the older configuration without duplication.

## Required real-client validation

Do not mark this ready or merge it until all items below are recorded with a released Codex client on Windows:

- [ ] reinstall over an older Unix-only `hooks.json` and confirm the client accepts the installed hooks without an untrusted-hook or configuration error
- [ ] startup and resume invoke the `SessionStart` hook successfully
- [ ] a Write action invokes the `PostToolUse` hook successfully
- [ ] an Edit action invokes the `PostToolUse` hook successfully
- [ ] a Bash action invokes the `PostToolUse` hook successfully
- [ ] reinstall preserves unrelated user hooks and does not duplicate code-review-graph hooks

Addresses #620.
Carries PR #621 with original contributor attribution.