### PR TITLE
maint: port verified community fixes onto current main

### DIFF
--- a/README.hi-IN.md
+++ b/README.hi-IN.md
@@ -265,13 +265,13 @@ node_modules/**
 वैकल्पिक डिपेंडेंसी ग्रुप:
 
 ```bash
-pip install code-review-graph[embeddings]          # लोकल वेक्टर एम्बेडिंग (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini एम्बेडिंग
-pip install code-review-graph[communities]         # कम्युनिटी डिटेक्शन (igraph)
-pip install code-review-graph[enrichment]          # Python call-resolution enrichment (Jedi)
-pip install code-review-graph[eval]                # मूल्यांकन बेंचमार्क (matplotlib)
-pip install code-review-graph[wiki]                # LLM सारांश के साथ विकी जनरेशन (ollama)
-pip install code-review-graph[all]                 # सभी वैकल्पिक डिपेंडेंसीज़
+pip install "code-review-graph[embeddings]"          # लोकल वेक्टर एम्बेडिंग (sentence-transformers)
+pip install "code-review-graph[google-embeddings]"   # Google Gemini एम्बेडिंग
+pip install "code-review-graph[communities]"         # कम्युनिटी डिटेक्शन (igraph)
+pip install "code-review-graph[enrichment]"          # Python call-resolution enrichment (Jedi)
+pip install "code-review-graph[eval]"                # मूल्यांकन बेंचमार्क (matplotlib)
+pip install "code-review-graph[wiki]"                # LLM सारांश के साथ विकी जनरेशन (ollama)
+pip install "code-review-graph[all]"                 # सभी वैकल्पिक डिपेंडेंसीज़
 ```
 
 OpenAI-compatible एम्बेडिंग्स (असली OpenAI, Azure, या सेल्फ-होस्टेड गेटवे जैसे new-api / LiteLLM / vLLM / LocalAI / Ollama openai मोड) के लिए कोई अतिरिक्त इंस्टॉल की ज़रूरत नहीं — बस एनवायरनमेंट वेरिएबल्स सेट करें और `embed_graph` को `provider="openai"` पास करें:

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -267,13 +267,13 @@ node_modules/**
 オプションの依存グループ：
 
 ```bash
-pip install code-review-graph[embeddings]          # ローカルベクトル埋め込み (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini埋め込み
-pip install code-review-graph[communities]         # コミュニティ検出 (igraph)
-pip install code-review-graph[enrichment]          # Python呼び出し解決の補強 (Jedi)
-pip install code-review-graph[eval]                # 評価ベンチマーク (matplotlib)
-pip install code-review-graph[wiki]                # LLMサマリー付きWiki生成 (ollama)
-pip install code-review-graph[all]                 # 全オプション依存
+pip install "code-review-graph[embeddings]"          # ローカルベクトル埋め込み (sentence-transformers)
+pip install "code-review-graph[google-embeddings]"   # Google Gemini埋め込み
+pip install "code-review-graph[communities]"         # コミュニティ検出 (igraph)
+pip install "code-review-graph[enrichment]"          # Python呼び出し解決の補強 (Jedi)
+pip install "code-review-graph[eval]"                # 評価ベンチマーク (matplotlib)
+pip install "code-review-graph[wiki]"                # LLMサマリー付きWiki生成 (ollama)
+pip install "code-review-graph[all]"                 # 全オプション依存
 ```
 
 OpenAI互換の埋め込み（本家OpenAI、Azure、または自前のゲートウェイ: new-api / LiteLLM / vLLM / LocalAI / Ollama openaiモード）は追加インストール不要です。環境変数を設定し、`embed_graph` に `provider="openai"` を渡すだけで動作します：

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -267,13 +267,13 @@ node_modules/**
 선택적 의존성 그룹:
 
 ```bash
-pip install code-review-graph[embeddings]          # 로컬 벡터 임베딩 (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini 임베딩
-pip install code-review-graph[communities]         # 커뮤니티 감지 (igraph)
-pip install code-review-graph[enrichment]          # Python 호출 해결 보강 (Jedi)
-pip install code-review-graph[eval]                # 평가 벤치마크 (matplotlib)
-pip install code-review-graph[wiki]                # LLM 요약 위키 생성 (ollama)
-pip install code-review-graph[all]                 # 모든 선택적 의존성
+pip install "code-review-graph[embeddings]"          # 로컬 벡터 임베딩 (sentence-transformers)
+pip install "code-review-graph[google-embeddings]"   # Google Gemini 임베딩
+pip install "code-review-graph[communities]"         # 커뮤니티 감지 (igraph)
+pip install "code-review-graph[enrichment]"          # Python 호출 해결 보강 (Jedi)
+pip install "code-review-graph[eval]"                # 평가 벤치마크 (matplotlib)
+pip install "code-review-graph[wiki]"                # LLM 요약 위키 생성 (ollama)
+pip install "code-review-graph[all]"                 # 모든 선택적 의존성
 ```
 
 OpenAI 호환 임베딩(실제 OpenAI, Azure, 또는 자체 호스팅 게이트웨이 new-api / LiteLLM / vLLM / LocalAI / Ollama openai 모드)은 추가 설치가 필요하지 않습니다. 환경 변수만 설정하고 `embed_graph`에 `provider="openai"`를 전달하면 됩니다:

--- a/README.md
+++ b/README.md
@@ -475,13 +475,13 @@ Note: in git repos, only tracked files are indexed (`git ls-files`), so gitignor
 Optional dependency groups:
 
 ```bash
-pip install code-review-graph[embeddings]          # Local vector embeddings (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini embeddings
-pip install code-review-graph[communities]         # Community detection (igraph)
-pip install code-review-graph[enrichment]          # Python call-resolution enrichment (Jedi)
-pip install code-review-graph[eval]                # Evaluation benchmarks (matplotlib)
-pip install code-review-graph[wiki]                # Wiki generation with LLM summaries (ollama)
-pip install code-review-graph[all]                 # All optional dependencies
+pip install "code-review-graph[embeddings]"          # Local vector embeddings (sentence-transformers)
+pip install "code-review-graph[google-embeddings]"   # Google Gemini embeddings
+pip install "code-review-graph[communities]"         # Community detection (igraph)
+pip install "code-review-graph[enrichment]"          # Python call-resolution enrichment (Jedi)
+pip install "code-review-graph[eval]"                # Evaluation benchmarks (matplotlib)
+pip install "code-review-graph[wiki]"                # Wiki generation with LLM summaries (ollama)
+pip install "code-review-graph[all]"                 # All optional dependencies
 ```
 
 ### Environment Variables

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,13 +265,13 @@ node_modules/**
 可选依赖组：
 
 ```bash
-pip install code-review-graph[embeddings]          # 本地向量嵌入 (sentence-transformers)
-pip install code-review-graph[google-embeddings]   # Google Gemini 嵌入
-pip install code-review-graph[communities]         # 社区检测 (igraph)
-pip install code-review-graph[enrichment]          # Python 调用解析增强 (Jedi)
-pip install code-review-graph[eval]                # 评估基准测试 (matplotlib)
-pip install code-review-graph[wiki]                # 使用 LLM 摘要生成 Wiki (ollama)
-pip install code-review-graph[all]                 # 所有可选依赖
+pip install "code-review-graph[embeddings]"          # 本地向量嵌入 (sentence-transformers)
+pip install "code-review-graph[google-embeddings]"   # Google Gemini 嵌入
+pip install "code-review-graph[communities]"         # 社区检测 (igraph)
+pip install "code-review-graph[enrichment]"          # Python 调用解析增强 (Jedi)
+pip install "code-review-graph[eval]"                # 评估基准测试 (matplotlib)
+pip install "code-review-graph[wiki]"                # 使用 LLM 摘要生成 Wiki (ollama)
+pip install "code-review-graph[all]"                 # 所有可选依赖
 ```
 
 OpenAI 兼容嵌入（真实 OpenAI、Azure，或自建网关如 new-api / LiteLLM / vLLM / LocalAI / Ollama openai 模式）无需额外安装 —— 只需设置环境变量并在 `embed_graph` 中传入 `provider="openai"`：

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -132,7 +132,7 @@ DEFAULT_IGNORE_PATTERNS = [
     "/coverage/**",
     "**/.cache/**",
     "/.tmp/**",
-    "/tmp/**",
+    "/tmp/**",  # nosec B108 -- repo-relative ignore glob, not a temp-file path
     "*.min.js",
     "*.min.css",
     "*.map",

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -95,37 +95,44 @@ def _run_temporal_resolver(store: GraphStore) -> Optional[dict]:
 
 # Default ignore patterns (in addition to .gitignore).
 #
-# `<dir>/**` patterns are matched at any depth by _should_ignore, so
-# `node_modules/**` also excludes `packages/app/node_modules/react/index.js`
-# inside monorepos. See: #91
+# ``**/<dir>/**`` patterns are safe-anywhere directory exclusions.  A leading
+# slash anchors a pattern to the repository root, which prevents ambiguous
+# output names such as ``build`` and ``dist`` from hiding nested source
+# directories.  See: #91 and PR #92.
 DEFAULT_IGNORE_PATTERNS = [
-    ".code-review-graph/**",
-    "node_modules/**",
-    ".git/**",
-    ".svn/**",
-    "__pycache__/**",
+    "**/.code-review-graph/**",
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/.svn/**",
+    "**/__pycache__/**",
     "*.pyc",
-    ".venv/**",
-    "venv/**",
-    "dist/**",
-    "build/**",
-    ".next/**",
-    "target/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "/dist/**",
+    "/build/**",
+    "/.next/**",
+    "/.nuxt/**",
+    "/target/**",
+    "/bin/**",
+    "/obj/**",
     # PHP / Laravel / Composer
-    "vendor/**",
-    "bootstrap/cache/**",
-    "public/build/**",
+    "**/vendor/**",
+    "/storage/**",
+    "/bootstrap/cache/**",
+    "/public/build/**",
     # Ruby / Bundler
-    ".bundle/**",
+    "**/.bundle/**",
     # Java / Kotlin / Gradle
-    ".gradle/**",
+    "**/.gradle/**",
     "*.jar",
     # Dart / Flutter
-    ".dart_tool/**",
-    ".pub-cache/**",
+    "**/.dart_tool/**",
+    "**/.pub-cache/**",
     # General
-    "coverage/**",
-    ".cache/**",
+    "/coverage/**",
+    "**/.cache/**",
+    "/.tmp/**",
+    "/tmp/**",
     "*.min.js",
     "*.min.css",
     "*.map",
@@ -359,12 +366,20 @@ def _load_ignore_patterns(repo_root: Path) -> list[str]:
         for line in ignore_file.read_text(encoding="utf-8", errors="replace").splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
-                # Treat plain directory entries like `.venv/` or `vendor/` as
-                # recursive globs, matching `.gitignore` behavior for directories.
-                if line.startswith("/"):
-                    line = line[1:]
+                # Directory names without a slash match at any depth, as in
+                # .gitignore. A leading slash remains an explicit root anchor.
                 if line.endswith("/"):
-                    line = f"{line}**"
+                    prefix = line[:-1]
+                    if prefix.startswith("/") or "/" in prefix:
+                        line = f"{prefix}/**"
+                    else:
+                        line = f"**/{prefix}/**"
+                elif line.endswith("/**") and not line.startswith(("/", "**/")):
+                    prefix = line[:-3]
+                    if "/" in prefix:
+                        line = f"/{line}"
+                    else:
+                        line = f"**/{line}"
                 if line:
                     patterns.append(line)
     return patterns
@@ -373,27 +388,33 @@ def _load_ignore_patterns(repo_root: Path) -> list[str]:
 def _should_ignore(path: str, patterns: list[str]) -> bool:
     """Check if a path matches any ignore pattern.
 
-    Handles nested occurrences of ``<dir>/**`` patterns: for example,
-    ``node_modules/**`` also matches ``packages/app/node_modules/foo.js``
-    inside monorepos. ``fnmatch`` alone treats ``*`` as not crossing ``/``
-    and only matches the prefix, so we additionally test each path segment
-    against the bare prefix of ``<dir>/**`` patterns. See: #91
+    ``**/<dir>/**`` and unanchored single-directory patterns match at any
+    depth. A leading slash anchors a pattern to the repository root.
     """
-    # Direct fnmatch first (cheap)
-    if any(fnmatch.fnmatch(path, p) for p in patterns):
-        return True
-    # Then: treat simple single-segment "dir/**" patterns as
-    # "this directory at any depth".
-    parts = PurePosixPath(path).parts
-    for p in patterns:
-        if not p.endswith("/**"):
+    normalized = path.replace("\\", "/").lstrip("/")
+    parts = PurePosixPath(normalized).parts
+    for pattern in patterns:
+        anchored = pattern.startswith("/")
+        candidate = pattern[1:] if anchored else pattern
+
+        if candidate.startswith("**/") and candidate.endswith("/**"):
+            segment = candidate[3:-3]
+            if segment and segment in parts:
+                return True
             continue
-        prefix = p[:-3]
-        # Only single-segment dir patterns (no "/" inside the prefix)
-        # qualify for nested matching.
-        if "/" in prefix or not prefix:
+
+        if candidate.endswith("/**"):
+            prefix = tuple(part for part in candidate[:-3].split("/") if part)
+            if not prefix:
+                continue
+            if anchored or len(prefix) > 1:
+                if parts[: len(prefix)] == prefix:
+                    return True
+            elif prefix[0] in parts:
+                return True
             continue
-        if prefix in parts:
+
+        if fnmatch.fnmatch(normalized, candidate):
             return True
     return False
 

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -32,6 +32,15 @@ def _zed_settings_path() -> Path:
     return Path.home() / ".config" / "zed" / "settings.json"
 
 
+def _opencode_config_path(repo_root: Path) -> Path:
+    """Return OpenCode's existing project config, preferring JSONC."""
+    for name in ("opencode.jsonc", "opencode.json"):
+        path = repo_root / name
+        if path.exists():
+            return path
+    return repo_root / "opencode.jsonc"
+
+
 PLATFORMS: dict[str, dict[str, Any]] = {
     "codex": {
         "name": "Codex",
@@ -83,11 +92,11 @@ PLATFORMS: dict[str, dict[str, Any]] = {
     },
     "opencode": {
         "name": "OpenCode",
-        "config_path": lambda root: root / ".opencode.json",
-        "key": "mcpServers",
+        "config_path": _opencode_config_path,
+        "key": "mcp",
         "detect": lambda: True,
         "format": "object",
-        "needs_type": True,
+        "needs_type": False,
     },
     "antigravity": {
         "name": "Antigravity",
@@ -234,15 +243,41 @@ def _build_server_entry(
 ) -> dict[str, Any]:
     """Build the MCP server entry for a platform."""
     command, args = _detect_serve_command()
+    if key == "opencode":
+        opencode_command = [command, *args]
+        if repo_root is not None:
+            opencode_command.extend(("--repo", str(repo_root)))
+        return {"type": "local", "command": opencode_command}
+
     entry: dict[str, Any] = {"command": command, "args": args}
     # Include cwd so the MCP server can find the graph database
     if repo_root is not None:
         entry["cwd"] = str(repo_root)
     if plat["needs_type"]:
         entry["type"] = "stdio"
-    if key == "opencode":
-        entry["env"] = []
     return entry
+
+
+def _warn_legacy_opencode_config(repo_root: Path) -> None:
+    """Warn without modifying the obsolete Cursor-shaped OpenCode config."""
+    legacy = repo_root / ".opencode.json"
+    if not legacy.exists():
+        return
+    try:
+        parsed = json.loads(
+            _strip_jsonc(legacy.read_text(encoding="utf-8", errors="replace"))
+        )
+    except (json.JSONDecodeError, OSError):
+        return
+    if not isinstance(parsed, dict):
+        return
+    servers = parsed.get("mcpServers")
+    if isinstance(servers, dict) and "code-review-graph" in servers:
+        print(
+            f"  OpenCode: legacy config found at {legacy}; leaving it unchanged. "
+            "OpenCode now reads opencode.json or opencode.jsonc with a top-level "
+            "'mcp' setting."
+        )
 
 
 def _format_toml_value(value: Any) -> str:
@@ -395,6 +430,8 @@ def install_platform_configs(
     configured: list[str] = []
 
     for key, plat in platforms_to_install.items():
+        if key == "opencode":
+            _warn_legacy_opencode_config(repo_root)
         config_path: Path = plat["config_path"](repo_root)
         server_key = plat["key"]
         server_entry = _build_server_entry(plat, key=key, repo_root=repo_root)

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -535,7 +535,7 @@ def install_platform_configs(
 
 _SKILLS: dict[str, dict[str, str]] = {
     "explore-codebase.md": {
-        "name": "Explore Codebase",
+        "name": "explore-codebase",
         "description": "Navigate and understand codebase structure using the knowledge graph",
         "body": (
             "## Explore Codebase\n\n"
@@ -563,7 +563,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "review-changes.md": {
-        "name": "Review Changes",
+        "name": "review-changes",
         "description": "Perform a structured code review using change detection and impact",
         "body": (
             "## Review Changes\n\n"
@@ -591,7 +591,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "debug-issue.md": {
-        "name": "Debug Issue",
+        "name": "debug-issue",
         "description": "Systematically debug issues using graph-powered code navigation",
         "body": (
             "## Debug Issue\n\n"
@@ -617,7 +617,7 @@ _SKILLS: dict[str, dict[str, str]] = {
         ),
     },
     "refactor-safely.md": {
-        "name": "Refactor Safely",
+        "name": "refactor-safely",
         "description": "Plan and execute safe refactoring using dependency analysis",
         "body": (
             "## Refactor Safely\n\n"

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -107,7 +107,7 @@ repo_root: str | None
 model: str | None    # Embedding model name
 provider: str | None # local, openai, google, minimax
 ```
-Local embeddings require: `pip install code-review-graph[embeddings]`. Cloud providers use stdlib HTTP clients and require their provider environment variables.
+Local embeddings require: `pip install "code-review-graph[embeddings]"`. Cloud providers use stdlib HTTP clients and require their provider environment variables.
 
 #### `list_graph_stats_tool`
 ```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -151,7 +151,7 @@ locally. The streamable-HTTP MCP transport binds to localhost by default.
 
 The only network activity is opt-in:
 
-- **Local embeddings** (`pip install code-review-graph[embeddings]`) download the
+- **Local embeddings** (`pip install "code-review-graph[embeddings]"`) download the
   sentence-transformers model from HuggingFace on first use. Your code does not leave
   the machine.
 - **Cloud embeddings** (OpenAI-compatible, Google Gemini, MiniMax) send the text being

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -42,7 +42,7 @@ Or use PostToolUse (Write|Edit|Bash) hooks for automatic background updates.
 </section>
 
 <section name="embeddings">
-Optional: pip install code-review-graph[embeddings]
+Optional: pip install "code-review-graph[embeddings]"
 Then call embed_graph_tool to compute vectors.
 semantic_search_nodes_tool auto-uses vectors when available, falls back to keyword + FTS5.
 Providers: local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, and MiniMax.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -147,7 +147,7 @@ The graph uses SQLite with WAL mode. If you see lock errors:
 - Check that hooks are configured in `.claude/settings.json` (re-run `code-review-graph install` to regenerate)
 
 ## Embeddings not working
-- Install with: `pip install code-review-graph[embeddings]`
+- Install with: `pip install "code-review-graph[embeddings]"`
 - Run `embed_graph_tool` to compute vectors
 - First embedding run downloads the model (~90MB, one time)
 
@@ -168,23 +168,23 @@ The graph uses SQLite with WAL mode. If you see lock errors:
 
 ## Community detection requires igraph
 
-- Install with: `pip install code-review-graph[communities]`
+- Install with: `pip install "code-review-graph[communities]"`
 - Without igraph, community detection falls back to file-based grouping (less precise but functional)
 
 ## Wiki generation with LLM summaries
 
-- Install with: `pip install code-review-graph[wiki]`
+- Install with: `pip install "code-review-graph[wiki]"`
 - Requires a running Ollama instance for LLM-powered summaries
 - Without Ollama, wiki pages are generated with structural information only (no prose summaries)
 
 ## Optional dependency groups
 
 If a tool returns an ImportError, install the relevant optional group:
-- `pip install code-review-graph[embeddings]` for semantic search
-- `pip install code-review-graph[google-embeddings]` for Google Gemini embeddings
+- `pip install "code-review-graph[embeddings]"` for semantic search
+- `pip install "code-review-graph[google-embeddings]"` for Google Gemini embeddings
 - OpenAI-compatible and MiniMax embeddings use stdlib HTTP clients and require only their environment variables
-- `pip install code-review-graph[communities]` for igraph-based community detection
-- `pip install code-review-graph[enrichment]` for Python call-resolution enrichment via Jedi
-- `pip install code-review-graph[eval]` for evaluation benchmarks (matplotlib)
-- `pip install code-review-graph[wiki]` for wiki LLM summaries (ollama)
-- `pip install code-review-graph[all]` for everything
+- `pip install "code-review-graph[communities]"` for igraph-based community detection
+- `pip install "code-review-graph[enrichment]"` for Python call-resolution enrichment via Jedi
+- `pip install "code-review-graph[eval]"` for evaluation benchmarks (matplotlib)
+- `pip install "code-review-graph[wiki]"` for wiki LLM summaries (ollama)
+- `pip install "code-review-graph[all]"` for everything

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -30,7 +30,7 @@ code-review-graph install --platform claude-code
 | **Windsurf** | `~/.codeium/windsurf/mcp_config.json` |
 | **Zed** | `.zed/settings.json` |
 | **Continue** | `.continue/config.json` |
-| **OpenCode** | `.opencode.json` |
+| **OpenCode** | `opencode.jsonc` (preferred) or `opencode.json` |
 | **Antigravity** | `~/.gemini/antigravity/mcp_config.json` |
 | **Gemini CLI** | `.gemini/settings.json` |
 | **Qwen Code** | `~/.qwen/settings.json` |

--- a/skills/debug-issue/SKILL.md
+++ b/skills/debug-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Debug Issue
+name: debug-issue
 description: Systematically debug issues using graph-powered code navigation
 ---
 

--- a/skills/explore-codebase/SKILL.md
+++ b/skills/explore-codebase/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Explore Codebase
+name: explore-codebase
 description: Navigate and understand codebase structure using the knowledge graph
 ---
 

--- a/skills/refactor-safely/SKILL.md
+++ b/skills/refactor-safely/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Refactor Safely
+name: refactor-safely
 description: Plan and execute safe refactoring using dependency analysis
 ---
 

--- a/skills/review-changes/SKILL.md
+++ b/skills/review-changes/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Review Changes
+name: review-changes
 description: Perform a structured code review using change detection and impact
 ---
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,44 @@
+"""Regression checks for user-facing command examples."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+README_FILES = (
+    "README.md",
+    "README.hi-IN.md",
+    "README.ja-JP.md",
+    "README.ko-KR.md",
+    "README.zh-CN.md",
+)
+OPTIONAL_GROUPS = (
+    "embeddings",
+    "google-embeddings",
+    "communities",
+    "enrichment",
+    "eval",
+    "wiki",
+    "all",
+)
+USER_DOC_FILES = README_FILES + (
+    "docs/COMMANDS.md",
+    "docs/FAQ.md",
+    "docs/LLM-OPTIMIZED-REFERENCE.md",
+    "docs/TROUBLESHOOTING.md",
+)
+
+
+def test_pip_extra_examples_use_cross_shell_double_quotes():
+    """Extras must survive zsh globbing without breaking Windows cmd.exe."""
+    for readme_name in README_FILES:
+        content = (ROOT / readme_name).read_text(encoding="utf-8")
+        for group in OPTIONAL_GROUPS:
+            command = f'pip install "code-review-graph[{group}]"'
+            assert command in content, f"{readme_name} is missing {command}"
+
+
+def test_current_user_docs_have_no_unquoted_pip_extras():
+    pattern = re.compile(r"pip install code-review-graph\[[A-Za-z0-9-]+\]")
+    for doc_name in USER_DOC_FILES:
+        content = (ROOT / doc_name).read_text(encoding="utf-8")
+        assert pattern.search(content) is None, f"unquoted pip extras in {doc_name}"

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -188,16 +188,17 @@ class TestEnsureRepoGitignoreExcludesCrg:
 class TestIgnorePatterns:
     def test_default_patterns_loaded(self, tmp_path):
         patterns = _load_ignore_patterns(tmp_path)
-        assert "node_modules/**" in patterns
-        assert ".git/**" in patterns
-        assert "__pycache__/**" in patterns
+        assert "**/node_modules/**" in patterns
+        assert "**/.git/**" in patterns
+        assert "**/__pycache__/**" in patterns
+        assert "/build/**" in patterns
 
     def test_custom_ignore_file(self, tmp_path):
         ignore = tmp_path / ".code-review-graphignore"
         ignore.write_text("custom/\n# comment\n\nvendor/**\n")
         patterns = _load_ignore_patterns(tmp_path)
-        assert "custom/**" in patterns
-        assert "vendor/**" in patterns
+        assert "**/custom/**" in patterns
+        assert "**/vendor/**" in patterns
         # Comments and blanks should be skipped
         assert "# comment" not in patterns
         assert "" not in patterns
@@ -211,13 +212,15 @@ class TestIgnorePatterns:
 
     def test_should_ignore_directory_trailing_slash_pattern(self, tmp_path):
         ignore = tmp_path / ".code-review-graphignore"
-        ignore.write_text("vendor/\ngenerated/\n")
+        ignore.write_text("vendor/\n/generated/\n")
 
         patterns = _load_ignore_patterns(tmp_path)
-        assert "vendor/**" in patterns
-        assert "generated/**" in patterns
+        assert "**/vendor/**" in patterns
+        assert "/generated/**" in patterns
         assert _should_ignore("vendor/autoload.php", patterns)
+        assert _should_ignore("services/api/vendor/autoload.php", patterns)
         assert _should_ignore("generated/code.js", patterns)
+        assert not _should_ignore("packages/app/generated/code.js", patterns)
         assert not _should_ignore("src/vendorized/file.php", patterns)
 
     def test_should_ignore_nested_dependency_dirs(self):
@@ -252,6 +255,27 @@ class TestIgnorePatterns:
         # Coverage/cache
         assert _should_ignore("coverage/lcov.info", patterns)
         assert _should_ignore(".cache/webpack/index.pack", patterns)
+
+    def test_root_output_defaults_do_not_hide_nested_source_directories(self):
+        """Reviewed #92 semantics keep ambiguous output names root-relative."""
+        from code_review_graph.incremental import DEFAULT_IGNORE_PATTERNS
+
+        patterns = DEFAULT_IGNORE_PATTERNS
+        for directory in ("build", "dist", "bin", "obj", "target"):
+            assert _should_ignore(f"{directory}/generated/output.js", patterns)
+            assert not _should_ignore(
+                f"packages/app/{directory}/source.py",
+                patterns,
+            )
+
+    def test_safe_dependency_defaults_still_match_at_any_depth(self):
+        """The monorepo dependency case from #91 remains fixed."""
+        from code_review_graph.incremental import DEFAULT_IGNORE_PATTERNS
+
+        patterns = DEFAULT_IGNORE_PATTERNS
+        assert _should_ignore("packages/app/node_modules/pkg/index.js", patterns)
+        assert _should_ignore("services/api/vendor/pkg/file.php", patterns)
+        assert _should_ignore("src/lib/__pycache__/module.pyc", patterns)
 
 
 class TestDataDir:
@@ -396,7 +420,6 @@ class TestDataDirRegistry:
     def test_registry_fallback_to_env_var(self, tmp_path, monkeypatch):
         """Fall back to CRG_DATA_DIR when registry has no entry."""
         from code_review_graph.incremental import get_data_dir
-        from code_review_graph.registry import Registry
 
         repo = tmp_path / "project"
         repo.mkdir()
@@ -412,7 +435,6 @@ class TestDataDirRegistry:
     def test_registry_fallback_to_default(self, tmp_path, monkeypatch):
         """Fall back to default when neither registry nor env var is set."""
         from code_review_graph.incremental import get_data_dir
-        from code_review_graph.registry import Registry
 
         repo = tmp_path / "project"
         repo.mkdir()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,8 +2,8 @@
 
 import json
 import os
-import subprocess
 import stat
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -19,11 +19,11 @@ from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
     _cursor_hook_scripts,
-    _strip_jsonc,
     _detect_serve_command,
     _in_poetry_project,
     _in_uv_project,
     _opencode_plugin_content,
+    _strip_jsonc,
     generate_codex_hooks_config,
     generate_cursor_hooks_config,
     generate_hooks_config,
@@ -31,9 +31,9 @@ from code_review_graph.skills import (
     inject_claude_md,
     inject_platform_instructions,
     install_codex_hooks,
+    install_cursor_hooks,
     install_gemini_cli_hooks,
     install_gemini_cli_skills,
-    install_cursor_hooks,
     install_git_hook,
     install_hooks,
     install_opencode_plugin,
@@ -865,11 +865,58 @@ class TestInstallPlatformConfigs:
     def test_install_opencode_config(self, tmp_path):
         configured = install_platform_configs(tmp_path, target="opencode")
         assert "OpenCode" in configured
-        config_path = tmp_path / ".opencode.json"
+        config_path = tmp_path / "opencode.jsonc"
         data = json.loads(config_path.read_text())
-        entry = data["mcpServers"]["code-review-graph"]
-        assert entry["type"] == "stdio"
-        assert entry["env"] == []
+        entry = data["mcp"]["code-review-graph"]
+        command, args = _detect_serve_command()
+        assert entry == {
+            "type": "local",
+            "command": [command, *args, "--repo", str(tmp_path)],
+        }
+        assert "cwd" not in entry
+
+    def test_install_opencode_prefers_existing_jsonc_and_preserves_servers(self, tmp_path):
+        config_path = tmp_path / "opencode.jsonc"
+        config_path.write_text(
+            '{\n  // keep this server\n  "mcp": {\n'
+            '    "other": {"type": "local", "command": ["other"]},\n'
+            "  },\n}\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "opencode.json").write_text("{}", encoding="utf-8")
+
+        install_platform_configs(tmp_path, target="opencode")
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "other" in data["mcp"]
+        assert "code-review-graph" in data["mcp"]
+        assert (tmp_path / "opencode.json").read_text(encoding="utf-8") == "{}"
+
+    def test_install_opencode_uses_existing_json(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text(json.dumps({"mcp": {"other": {}}}), encoding="utf-8")
+
+        install_platform_configs(tmp_path, target="opencode")
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "other" in data["mcp"]
+        assert "code-review-graph" in data["mcp"]
+        assert not (tmp_path / "opencode.jsonc").exists()
+
+    def test_install_opencode_warns_about_legacy_dotfile(self, tmp_path, capsys):
+        legacy = tmp_path / ".opencode.json"
+        legacy.write_text(
+            json.dumps({"mcpServers": {"code-review-graph": {"command": "uvx"}}}),
+            encoding="utf-8",
+        )
+
+        install_platform_configs(tmp_path, target="opencode")
+
+        output = capsys.readouterr().out
+        assert ".opencode.json" in output
+        assert "legacy" in output.lower()
+        assert legacy.exists()
+        assert (tmp_path / "opencode.jsonc").exists()
 
     def test_install_gemini_cli_config(self, tmp_path):
         gemini_config = tmp_path / ".gemini" / "settings.json"
@@ -960,7 +1007,7 @@ class TestInstallPlatformConfigs:
         assert "OpenCode" in configured
         assert codex_config.exists()
         assert (tmp_path / ".mcp.json").exists()
-        assert (tmp_path / ".opencode.json").exists()
+        assert (tmp_path / "opencode.jsonc").exists()
 
     def test_merge_existing_servers(self, tmp_path):
         """Should not overwrite existing MCP servers."""
@@ -1472,7 +1519,7 @@ class TestCopilotCLIPlatform:
         assert "code-review-graph" in data["servers"]
 
     def test_copilot_cli_writes_only_copilot_instructions(self, tmp_path):
-        """inject_platform_instructions with target='copilot-cli' writes .github/code-review-graph.instruction.md."""
+        """Copilot CLI injection writes its GitHub instruction file."""
         updated = inject_platform_instructions(tmp_path, target="copilot-cli")
         assert ".github/code-review-graph.instruction.md" in updated
         instructions = tmp_path / ".github" / "code-review-graph.instruction.md"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -142,6 +142,24 @@ class TestGenerateSkills:
             closing_idx = content.index("---", 4)
             assert closing_idx > 0
 
+    def test_skill_frontmatter_names_match_lowercase_directories(self, tmp_path):
+        """Generated and bundled skills use the discovery-safe name format."""
+        generated = generate_skills(tmp_path)
+        bundled = Path(__file__).parents[1] / "skills"
+
+        for skill_name in (
+            "debug-issue",
+            "explore-codebase",
+            "refactor-safely",
+            "review-changes",
+        ):
+            for skill_file in (
+                generated / skill_name / "SKILL.md",
+                bundled / skill_name / "SKILL.md",
+            ):
+                content = skill_file.read_text(encoding="utf-8")
+                assert f"\nname: {skill_name}\n" in content
+
     def test_custom_skills_dir(self, tmp_path):
         custom = tmp_path / "my-skills"
         result = generate_skills(tmp_path, skills_dir=custom)


### PR DESCRIPTION
## Summary

Ports four verified community fixes onto current `main` without restoring their stale/conflicting branch history:

- #92: distinguish safe-anywhere dependency directories from root-only output names, while preserving #583 trailing-slash ignore support.
- #530: use OpenCode's official `opencode.jsonc` / `opencode.json`, top-level `mcp`, and local command-array schema.
- #562: use lowercase-hyphen skill names in all generated and bundled skills, including the static `review-changes` file missing from the stale diff.
- #625: quote pip extras with double quotes across all current user docs, fixing zsh without breaking Windows `cmd.exe`.

Each source contributor is retained through a `Co-Authored-By` trailer on the corresponding commit.

## Verification

- Full suite: **1,476 passed, 2 xpassed**
- Incremental/ignore suite: **62 passed**
- Skills/install suite: **169 passed**
- Documentation regressions: **2 passed**
- Ruff on every changed Python file: **clean**
- `git diff --check`: **clean**

The locally installed repo-wide Ruff version also reports 44 pre-existing findings in untouched files; this branch introduces none and cleans the two touched test modules.

Fixes #91.
Fixes #561.

Source contributions: #92, #530, #562, #625.