### PR TITLE
fix(csharp): emit inheritance edges from base lists

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -195,6 +195,7 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "csharp": [
         "class_declaration", "interface_declaration",
         "enum_declaration", "struct_declaration",
+        "record_declaration", "record_struct_declaration",
     ],
     "ruby": ["class", "module"],
     "r": [],  # Classes detected via call pattern-matching, not AST node types
@@ -6631,7 +6632,36 @@ class CodeParser:
                             for ident in sub.children:
                                 if ident.type in ("type_identifier", "generic_type"):
                                     bases.append(ident.text.decode("utf-8", errors="replace"))
-        elif language in ("csharp", "kotlin"):
+        elif language == "csharp":
+            # C# wraps ``: Base, IFace`` in a base_list. Iterate named type
+            # entries so punctuation is excluded while qualified/generic names
+            # are preserved across tree-sitter-c-sharp grammar versions.
+            # Enum base_list nodes describe storage types, not inheritance.
+            if node.type == "enum_declaration":
+                return bases
+            for child in node.children:
+                if child.type != "base_list":
+                    continue
+                for sub in child.children:
+                    if not sub.is_named or sub.type == "argument_list":
+                        continue
+                    if sub.type == "primary_constructor_base_type":
+                        # Positional records contain Base(args); retain only Base.
+                        type_node = sub.child_by_field_name("type")
+                        if type_node is not None:
+                            bases.append(
+                                type_node.text.decode("utf-8", errors="replace")
+                            )
+                        else:
+                            for nested in sub.children:
+                                if nested.is_named and nested.type != "argument_list":
+                                    bases.append(
+                                        nested.text.decode("utf-8", errors="replace")
+                                    )
+                                    break
+                        continue
+                    bases.append(sub.text.decode("utf-8", errors="replace"))
+        elif language == "kotlin":
             # Look for superclass/interfaces in extends/implements clauses
             for child in node.children:
                 if child.type in (

--- a/tests/fixtures/Sample.cs
+++ b/tests/fixtures/Sample.cs
@@ -45,4 +45,50 @@ namespace SampleApp
             return _repo.FindById(id);
         }
     }
+
+    // Inheritance coverage for C# base_list clauses.
+    public class CachedRepo : InMemoryRepo, IRepository
+    {
+        public new User FindById(int id) { return base.FindById(id); }
+    }
+
+    public class DisposableService : System.IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    public class UserList : List<User> { }
+    public class ScopedUserList : System.Collections.Generic.List<User> { }
+
+    // A generic constraint is not an inheritance clause.
+    public class ConstrainedHolder<T> where T : IRepository
+    {
+        public T Value { get; set; }
+    }
+
+    public record AuditedUser : User, IRepository
+    {
+        public User FindById(int id) { return null; }
+        public void Save(User user) { }
+    }
+
+    public record TaggedUser(int Id, string Tag) : User { }
+
+    public struct Token : IRepository
+    {
+        public User FindById(int id) { return null; }
+        public void Save(User user) { }
+    }
+
+    // Constructor arguments and enum storage types are not bases.
+    public class SeededRepo(int seed) : InMemoryRepo
+    {
+        public int Seed { get; } = seed;
+    }
+
+    public enum Status : byte
+    {
+        Active,
+        Closed,
+    }
 }

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -389,6 +389,36 @@ class TestCSharpParsing:
         names = {f.name for f in funcs}
         assert "FindById" in names or "Save" in names
 
+    def test_finds_inheritance(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        targets = {e.target for e in inherits}
+        assert "IRepository" in targets
+        assert "InMemoryRepo" in targets
+        assert "System.IDisposable" in targets
+        assert "List<User>" in targets
+        assert all(not e.target.startswith(":") for e in inherits)
+        assert all("," not in e.target for e in inherits)
+
+    def test_inheritance_hard_cases(self):
+        inherits = [e for e in self.edges if e.kind == "INHERITS"]
+        by_source = {}
+        for edge in inherits:
+            by_source.setdefault(edge.source.rsplit("::", 1)[-1], set()).add(
+                edge.target
+            )
+
+        assert by_source.get("AuditedUser") == {"User", "IRepository"}
+        assert by_source.get("TaggedUser") == {"User"}
+        assert "IRepository" in by_source.get("Token", set())
+        assert "System.Collections.Generic.List<User>" in {
+            edge.target for edge in inherits
+        }
+        assert "ConstrainedHolder" not in by_source
+        assert by_source.get("SeededRepo") == {"InMemoryRepo"}
+        assert all(not edge.target.startswith("(") for edge in inherits)
+        assert "Status" not in by_source
+        assert "byte" not in {edge.target for edge in inherits}
+
     @pytest.mark.parametrize(
         ("statement", "expected_targets"),
         [


### PR DESCRIPTION
## Summary

- parse tree-sitter-csharp base_list nodes into INHERITS edges
- preserve qualified and generic bases while excluding punctuation
- support records and structs
- exclude generic constraints, primary-constructor arguments, and enum storage types
- incorporates the viable work from #582 with Saeed-Nourizadeh credited as co-author

## Verification

- TDD red: the new C# inheritance cases initially failed with zero INHERITS edges
- 40 passed: C#, Java, and Kotlin parser tests
- 1,427 passed, 2 xpassed: full non-daemon suite
- Ruff clean on changed Python files
- graph rebuild: 3,452 nodes / 25,181 edges; no parse errors

The macOS daemon file is excluded locally because watchdog's native FSEvents teardown reproducibly raises SIGBUS in the existing test_start_spawns_children test. The PR's Linux Python 3.10–3.13 jobs provide the complete clean-room suite.