### PR TITLE
ci: update checkout and cache action majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -26,7 +26,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -39,7 +39,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -52,7 +52,7 @@ jobs:
   schema-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check Python/VSCode schema versions match
         run: |
           PY_VER=$(grep -oP 'LATEST_VERSION\s*=\s*max\(MIGRATIONS\.keys\(\)\)' code_review_graph/migrations.py > /dev/null && python3 -c "
@@ -77,7 +77,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -13,7 +13,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run code-review-graph review
         uses: ./
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: tirth8205/code-review-graph@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
     # tracks LATEST_VERSION in code_review_graph/migrations.py — bump it when
     # the database schema changes so stale caches are not restored.
     - name: Cache knowledge graph
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: .code-review-graph
         key: code-review-graph-schema9-${{ runner.os }}-${{ hashFiles('**/uv.lock', '**/poetry.lock', '**/requirements*.txt', '**/Pipfile.lock', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/go.sum', '**/Cargo.lock', '**/Gemfile.lock', '**/composer.lock') }}

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -37,7 +37,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: tirth8205/code-review-graph@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,6 +45,10 @@ jobs:
 
 That is the whole setup. The default `GITHUB_TOKEN` provided by Actions is
 sufficient — no PAT, no API key, no third-party service.
+
+Self-hosted runners must be version `2.327.1` or newer. The composite action
+uses Node 24-based GitHub actions, including `actions/setup-python@v6`,
+`actions/cache@v6`, and the recommended `actions/checkout@v7` example.
 
 To turn the review into a merge gate:
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -42,3 +42,22 @@ def test_current_user_docs_have_no_unquoted_pip_extras():
     for doc_name in USER_DOC_FILES:
         content = (ROOT / doc_name).read_text(encoding="utf-8")
         assert pattern.search(content) is None, f"unquoted pip extras in {doc_name}"
+
+
+def test_github_action_references_use_current_supported_majors():
+    """Keep active workflows and copy-paste examples on supported majors."""
+    files = [
+        ROOT / "action.yml",
+        ROOT / "README.md",
+        ROOT / "docs/GITHUB_ACTION.md",
+        *(ROOT / ".github/workflows").glob("*.yml"),
+    ]
+    expected_majors = {"checkout": "7", "cache": "6"}
+    for path in files:
+        content = path.read_text(encoding="utf-8")
+        for action, expected in expected_majors.items():
+            for actual in re.findall(rf"actions/{action}@v(\d+)", content):
+                assert actual == expected, (
+                    f"{path.relative_to(ROOT)} uses actions/{action}@v{actual}; "
+                    f"expected v{expected}"
+                )


### PR DESCRIPTION
## Summary

- port #542 directly from cache v4 to the current v6 major
- port #543 directly from checkout v4 to the current v7 major
- update every active workflow and copy-paste example consistently
- document the Actions Runner >=2.327.1 requirement introduced by the Node 24 action generation
- add a regression test that rejects stale active majors
- credit Dependabot as co-author

Official versions verified on 2026-07-17:
- actions/cache v6.1.0
- actions/checkout v7.0.0
- actions/setup-python v6.3.0 (already merged in #544)

## Verification

- TDD red: documentation regression failed on action.yml using cache@v4
- documentation regression: 3 passed
- non-daemon suite: 1,428 passed, 2 xpassed
- Ruff clean
- graph rebuild: 3,453 nodes / 25,192 edges; risk 0.30, no test gaps
- full GitHub CI required before merge