### PR TITLE
fix(windows): harden daemon persistence and PID liveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,34 @@ jobs:
         run: pip install -e ".[dev]" pytest-cov
       - name: Run tests with coverage
         run: pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65
+
+  windows-native:
+    name: Windows daemon and file handles
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Run native daemon and resource-handle tests
+        run: >-
+          python -m pytest --tb=short -q
+          tests/test_windows_compat.py
+          tests/test_daemon.py
+          tests/test_changes.py
+          tests/test_communities.py
+          tests/test_flows.py
+          tests/test_graph.py
+          tests/test_integration_v2.py
+          tests/test_migrations.py
+          tests/test_postprocessing.py
+          tests/test_refactor.py
+          tests/test_search.py
+          tests/test_tools.py
+          tests/test_wiki.py
+          tests/test_skills.py::TestInstallCodexHooks
+          tests/test_skills.py::TestInstallCursorHooks

--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -164,6 +164,40 @@ def load_config(path: Path | None = None) -> DaemonConfig:
 # ---------------------------------------------------------------------------
 
 
+# TOML basic strings have named escapes for these; everything else in
+# the control range must use the \uXXXX form.
+_TOML_SHORT_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
+def _toml_str(value: object) -> str:
+    """Render *value* as a TOML basic string.
+
+    Backslashes and double quotes are escape characters in TOML basic
+    strings, so Windows paths like ``C:\\Users\\x`` must be escaped or
+    the file fails to parse on the next load. Control characters
+    (U+0000-U+001F, U+007F) are forbidden unescaped by the TOML spec,
+    so they are escaped too — ``tomllib`` rejects the file otherwise.
+    """
+    chars: list[str] = []
+    for ch in str(value):
+        esc = _TOML_SHORT_ESCAPES.get(ch)
+        if esc is not None:
+            chars.append(esc)
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            chars.append(f"\\u{ord(ch):04X}")
+        else:
+            chars.append(ch)
+    return '"' + "".join(chars) + '"'
+
+
 def _serialize_toml(config: DaemonConfig) -> str:
     """Serialize a :class:`DaemonConfig` to TOML text.
 
@@ -171,15 +205,15 @@ def _serialize_toml(config: DaemonConfig) -> str:
     """
     lines: list[str] = [
         "[daemon]",
-        f'session_name = "{config.session_name}"',
-        f'log_dir = "{config.log_dir}"',
+        f"session_name = {_toml_str(config.session_name)}",
+        f"log_dir = {_toml_str(config.log_dir)}",
         f"poll_interval = {config.poll_interval}",
     ]
     for repo in config.repos:
         lines.append("")
         lines.append("[[repos]]")
-        lines.append(f'path = "{repo.path}"')
-        lines.append(f'alias = "{repo.alias}"')
+        lines.append(f"path = {_toml_str(repo.path)}")
+        lines.append(f"alias = {_toml_str(repo.alias)}")
     lines.append("")  # trailing newline
     return "\n".join(lines)
 

--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -350,8 +350,10 @@ def clear_pid(path: Path | None = None) -> None:
 
 # Win32 constants for the OpenProcess-based liveness check (#511).
 _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_SYNCHRONIZE = 0x00100000
 _ERROR_ACCESS_DENIED = 5
 _WAIT_OBJECT_0 = 0x0
+_WAIT_FAILED = 0xFFFFFFFF
 
 
 def _pid_alive_windows(
@@ -361,6 +363,11 @@ def _pid_alive_windows(
 ) -> bool:
     """Win32 PID liveness check via OpenProcess/WaitForSingleObject.
 
+    The access mask must include SYNCHRONIZE: a handle opened with only
+    PROCESS_QUERY_LIMITED_INFORMATION cannot be waited on, so
+    WaitForSingleObject returns WAIT_FAILED (ERROR_ACCESS_DENIED) and
+    every exited process reads as alive.
+
     The kernel32 interface is injected so tests can drive handle/wait
     outcomes on non-Windows platforms. *get_last_error* defaults to
     ``kernel32.GetLastError``; the real caller passes
@@ -368,14 +375,24 @@ def _pid_alive_windows(
     """
     if get_last_error is None:
         get_last_error = kernel32.GetLastError
-    handle = kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    handle = kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION | _SYNCHRONIZE, False, pid)
     if not handle:
         # NULL handle: process is dead, or we lack access. ACCESS_DENIED
         # means it exists but is owned by another user — treat as alive.
         return get_last_error() == _ERROR_ACCESS_DENIED
     try:
+        result = kernel32.WaitForSingleObject(handle, 0)
+        if result == _WAIT_FAILED:
+            # The wait itself errored — we cannot prove the process dead,
+            # so err alive, consistent with the ACCESS_DENIED branch.
+            logger.debug(
+                "WaitForSingleObject on PID %d failed (error %d); presuming alive",
+                pid,
+                get_last_error(),
+            )
+            return True
         # WAIT_OBJECT_0 means the process handle is signaled (it exited).
-        return kernel32.WaitForSingleObject(handle, 0) != _WAIT_OBJECT_0
+        return result != _WAIT_OBJECT_0
     finally:
         kernel32.CloseHandle(handle)
 
@@ -389,8 +406,18 @@ def pid_alive(pid: int) -> bool:
     """
     if sys.platform == "win32":
         import ctypes
+        from ctypes import wintypes
 
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        # Explicit prototypes: ctypes otherwise defaults every argument and
+        # return value to c_int, which truncates 64-bit HANDLEs and returns
+        # WAIT_FAILED as -1 — never equal to the unsigned 0xFFFFFFFF constant.
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+        kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
         return _pid_alive_windows(pid, kernel32, ctypes.get_last_error)
     try:
         os.kill(pid, 0)  # signal 0 = existence check

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -19,6 +19,7 @@ from code_review_graph.parser import EdgeInfo, NodeInfo
 class TestChanges:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):
@@ -440,17 +441,18 @@ class TestChanges:
             patch("code_review_graph.tools.review._get_store") as mock_get_store,
             patch("code_review_graph.tools.review.get_changed_files", return_value=[]),
             patch("code_review_graph.tools.review.get_staged_and_unstaged", return_value=[]),
+            # Prevent the tool from closing our shared store, then restore the
+            # real method so teardown releases the database handle on Windows.
+            patch.object(self.store, "close"),
         ):
             mock_get_store.return_value = (self.store, Path("/fake/repo"))
-            # Prevent the store from being closed by the tool
-            # (our teardown handles it).
-            self.store.close = lambda: None
 
             result = detect_changes_func(base="HEAD~1", repo_root="/fake/repo")
             assert result["status"] == "ok"
             assert result["risk_score"] == 0.0
             assert result["changed_functions"] == []
             assert result["test_gaps"] == []
+        assert getattr(self.store.close, "__func__", None) is GraphStore.close
 
     def test_detect_changes_tool_with_changes(self):
         """detect_changes_func returns full analysis for changed files."""
@@ -465,9 +467,9 @@ class TestChanges:
                 "code_review_graph.tools.review.parse_git_diff_ranges",
                 return_value={"app.py": [(1, 10)]},
             ),
+            patch.object(self.store, "close"),
         ):
             mock_get_store.return_value = (self.store, Path("/fake/repo"))
-            self.store.close = lambda: None
 
             result = detect_changes_func(base="HEAD~1", repo_root="/fake/repo")
             assert result["status"] == "ok"
@@ -475,6 +477,7 @@ class TestChanges:
             assert "risk_score" in result
             assert "test_gaps" in result
             assert "review_priorities" in result
+        assert getattr(self.store.close, "__func__", None) is GraphStore.close
 
 
 class TestAnalyzeChangesFunctionCap:
@@ -482,6 +485,7 @@ class TestAnalyzeChangesFunctionCap:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):
@@ -532,6 +536,7 @@ class TestAnalyzeChangesInternalParseRemap:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -24,6 +24,7 @@ from code_review_graph.parser import EdgeInfo, NodeInfo
 class TestCommunities:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -14,6 +14,7 @@ from code_review_graph.daemon import (
     DaemonConfig,
     WatchDaemon,
     WatchRepo,
+    _serialize_toml,
     add_repo_to_config,
     clear_pid,
     is_daemon_running,
@@ -42,18 +43,20 @@ def sample_config_file(tmp_path):
     (repo_b / ".git").mkdir()
 
     config = tmp_path / "watch.toml"
+    # as_posix() keeps hand-written TOML valid on Windows, where native
+    # backslash paths are invalid basic-string escapes.
     config.write_text(
         f"[daemon]\n"
         f'session_name = "test-session"\n'
-        f'log_dir = "{tmp_path / "logs"}"\n'
+        f'log_dir = "{(tmp_path / "logs").as_posix()}"\n'
         f"poll_interval = 5\n"
         f"\n"
         f"[[repos]]\n"
-        f'path = "{repo_a}"\n'
+        f'path = "{repo_a.as_posix()}"\n'
         f'alias = "alpha"\n'
         f"\n"
         f"[[repos]]\n"
-        f'path = "{repo_b}"\n'
+        f'path = "{repo_b.as_posix()}"\n'
         f'alias = "beta"\n',
         encoding="utf-8",
     )
@@ -98,7 +101,7 @@ class TestConfigParsing:
 
         config_file = tmp_path / "watch.toml"
         config_file.write_text(
-            f'[[repos]]\npath = "{repo}"\n',
+            f'[[repos]]\npath = "{repo.as_posix()}"\n',
             encoding="utf-8",
         )
         cfg = load_config(config_file)
@@ -127,8 +130,8 @@ class TestConfigParsing:
 
         config_file = tmp_path / "watch.toml"
         config_file.write_text(
-            f'[[repos]]\npath = "{repo_a}"\nalias = "dup"\n\n'
-            f'[[repos]]\npath = "{repo_b}"\nalias = "dup"\n',
+            f'[[repos]]\npath = "{repo_a.as_posix()}"\nalias = "dup"\n\n'
+            f'[[repos]]\npath = "{repo_b.as_posix()}"\nalias = "dup"\n',
             encoding="utf-8",
         )
         cfg = load_config(config_file)
@@ -142,7 +145,7 @@ class TestConfigParsing:
 
         config_file = tmp_path / "watch.toml"
         config_file.write_text(
-            f'[[repos]]\npath = "{bare}"\nalias = "bare"\n',
+            f'[[repos]]\npath = "{bare.as_posix()}"\nalias = "bare"\n',
             encoding="utf-8",
         )
         cfg = load_config(config_file)
@@ -170,6 +173,36 @@ class TestConfigParsing:
         assert len(loaded.repos) == 1
         assert loaded.repos[0].alias == "rt"
         assert loaded.repos[0].path == str(repo.resolve())
+
+    def test_serialize_toml_escapes_backslashes_and_quotes(self):
+        """Windows paths and quotes must survive serialize -> parse."""
+        from code_review_graph.daemon import tomllib
+
+        config = DaemonConfig(
+            session_name='quo"ted',
+            log_dir=Path(r"C:\Users\example\logs"),
+            poll_interval=2,
+            repos=[WatchRepo(path=r"C:\Users\example\repo", alias="win")],
+        )
+        parsed = tomllib.loads(_serialize_toml(config))
+        assert parsed["daemon"]["session_name"] == 'quo"ted'
+        assert parsed["daemon"]["log_dir"] == str(Path(r"C:\Users\example\logs"))
+        assert parsed["repos"][0]["path"] == r"C:\Users\example\repo"
+
+    def test_serialize_toml_escapes_control_characters(self):
+        """TOML-forbidden control characters must survive serialize -> parse."""
+        from code_review_graph.daemon import tomllib
+
+        weird = "line1\nline2\ttabbed\x01ctrl\x7fdel"
+        config = DaemonConfig(
+            session_name=weird,
+            log_dir=Path("logs"),
+            poll_interval=2,
+            repos=[WatchRepo(path="repo", alias="a\rb")],
+        )
+        parsed = tomllib.loads(_serialize_toml(config))
+        assert parsed["daemon"]["session_name"] == weird
+        assert parsed["repos"][0]["alias"] == "a\rb"
 
     def test_add_repo_to_config(self, tmp_path):
         """add_repo_to_config adds a repo and saves."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -302,6 +302,7 @@ class TestPIDManagement:
         clear_pid(pid_path)
         assert not pid_path.exists()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX os.kill branch")
     @patch("os.kill")
     def test_is_daemon_running_alive(self, mock_kill, pid_path):
         """os.kill(pid, 0) succeeds — daemon is running."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -413,8 +413,8 @@ class TestPidAliveWindows:
 
         kernel32 = _FakeKernel32(handle=1234, wait_result=0x102)
         assert _pid_alive_windows(4242, kernel32) is True
-        # PROCESS_QUERY_LIMITED_INFORMATION, no inherit, the pid
-        assert kernel32.open_calls == [(0x1000, False, 4242)]
+        # PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, no inherit, the pid
+        assert kernel32.open_calls == [(0x1000 | 0x00100000, False, 4242)]
         assert kernel32.wait_calls == [(1234, 0)]
         # The handle must always be closed
         assert kernel32.closed == [1234]
@@ -426,6 +426,43 @@ class TestPidAliveWindows:
         kernel32 = _FakeKernel32(handle=1234, wait_result=0x0)
         assert _pid_alive_windows(4242, kernel32) is False
         assert kernel32.closed == [1234]
+
+    def test_alive_when_wait_fails(self, caplog):
+        """WAIT_FAILED cannot prove death, and records the Win32 error."""
+        from code_review_graph.daemon import _pid_alive_windows
+
+        kernel32 = _FakeKernel32(handle=1234, wait_result=0xFFFFFFFF, last_error=6)
+        with caplog.at_level("DEBUG", logger="code_review_graph.daemon"):
+            assert _pid_alive_windows(4242, kernel32) is True
+        assert "WaitForSingleObject on PID 4242 failed (error 6)" in caplog.text
+        assert kernel32.closed == [1234]
+
+    def test_pid_alive_declares_win32_function_prototypes(self, monkeypatch):
+        """ctypes uses pointer-width HANDLEs and unsigned DWORD wait results."""
+        import ctypes
+        from ctypes import wintypes
+
+        from code_review_graph.daemon import pid_alive
+
+        kernel32 = MagicMock()
+        kernel32.OpenProcess.return_value = 1234
+        kernel32.WaitForSingleObject.return_value = 0x102
+        kernel32.CloseHandle.return_value = 1
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(ctypes, "WinDLL", MagicMock(return_value=kernel32), raising=False)
+        monkeypatch.setattr(ctypes, "get_last_error", MagicMock(return_value=0), raising=False)
+
+        assert pid_alive(4242) is True
+        assert kernel32.OpenProcess.argtypes == (
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        )
+        assert kernel32.OpenProcess.restype is wintypes.HANDLE
+        assert kernel32.WaitForSingleObject.argtypes == (wintypes.HANDLE, wintypes.DWORD)
+        assert kernel32.WaitForSingleObject.restype is wintypes.DWORD
+        assert kernel32.CloseHandle.argtypes == (wintypes.HANDLE,)
+        assert kernel32.CloseHandle.restype is wintypes.BOOL
 
     def test_alive_on_access_denied(self):
         """NULL handle + ERROR_ACCESS_DENIED (5) means alive (other user)."""

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -19,6 +19,7 @@ from code_review_graph.parser import EdgeInfo, NodeInfo
 class TestFlows:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -12,6 +12,7 @@ from code_review_graph.parser import EdgeInfo, NodeInfo
 class TestGraphStore:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):
@@ -396,6 +397,7 @@ class TestImpactRadiusSql:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._build_chain()
 
@@ -460,6 +462,7 @@ class TestGetTransitiveTestsFrontierCap:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_integration_v2.py
+++ b/tests/test_integration_v2.py
@@ -37,6 +37,7 @@ class TestV2Integration:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed_realistic_graph()
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -16,6 +16,7 @@ from code_review_graph.migrations import (
 class TestMigrations:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -21,6 +21,7 @@ def _get_signature(store, qualified_name):
 class TestRunPostProcessing:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed_data()
 
@@ -174,6 +175,7 @@ class TestRunPostProcessing:
 
     def test_empty_store_no_crash(self):
         empty_tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        empty_tmp.close()  # release the handle before GraphStore reopens it on Windows
         empty_store = GraphStore(empty_tmp.name)
         try:
             result = run_post_processing(empty_store)
@@ -213,6 +215,7 @@ class TestRunPostProcessing:
 class TestPostProcessingStepIsolation:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self.store.upsert_node(
             NodeInfo(

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -23,6 +23,7 @@ class TestRenamePreview:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed()
 
@@ -110,6 +111,7 @@ class TestFindDeadCode:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed()
 
@@ -439,6 +441,7 @@ class TestSuggestRefactorings:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed()
 
@@ -723,6 +726,7 @@ class TestFindDeadCodeWithReferences:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed()
 
@@ -810,6 +814,7 @@ class TestFindDeadCodeWithTestedBy:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed()
 
@@ -919,6 +924,7 @@ class TestFindDeadCodeModuleScope:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self.parser = CodeParser()
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,6 +16,7 @@ from code_review_graph.search import (
 class TestHybridSearch:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed_data()
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -548,7 +548,8 @@ class TestGenerateCodexHooksConfig:
 
 class TestInstallCodexHooks:
     def test_creates_hooks_file(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Path.home() ignores HOME on Windows; patch it like the cursor tests do.
+        monkeypatch.setattr("code_review_graph.skills.Path.home", lambda: tmp_path)
         hooks_path = install_codex_hooks(tmp_path / "repo")
         assert hooks_path == tmp_path / ".codex" / "hooks.json"
         assert hooks_path.exists()
@@ -558,7 +559,8 @@ class TestInstallCodexHooks:
         assert "SessionStart" in data["hooks"]
 
     def test_merges_with_existing(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Path.home() ignores HOME on Windows; patch it like the cursor tests do.
+        monkeypatch.setattr("code_review_graph.skills.Path.home", lambda: tmp_path)
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir(parents=True)
         existing = {
@@ -578,7 +580,8 @@ class TestInstallCodexHooks:
         assert "SessionStart" in data["hooks"]
 
     def test_creates_hooks_backup(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Path.home() ignores HOME on Windows; patch it like the cursor tests do.
+        monkeypatch.setattr("code_review_graph.skills.Path.home", lambda: tmp_path)
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir(parents=True)
         existing = {"hooks": {"Stop": []}}
@@ -593,7 +596,8 @@ class TestInstallCodexHooks:
         assert backup == existing
 
     def test_idempotent_by_command(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Path.home() ignores HOME on Windows; patch it like the cursor tests do.
+        monkeypatch.setattr("code_review_graph.skills.Path.home", lambda: tmp_path)
         repo_root = tmp_path / "repo"
         install_codex_hooks(repo_root)
         install_codex_hooks(repo_root)
@@ -1233,6 +1237,7 @@ class TestInstallCursorHooks:
         assert (hooks_dir / "crg-session-start.sh").exists()
         assert (hooks_dir / "crg-pre-commit.sh").exists()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX exec bits")
     def test_scripts_are_executable(self, tmp_path):
         with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
             install_cursor_hooks()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,6 +29,7 @@ from code_review_graph.tools import (
 class TestTools:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed_data()
 
@@ -642,6 +643,7 @@ class TestFindLargeFunctions:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         # Create functions of various sizes
         self.store.upsert_node(NodeInfo(
@@ -1287,6 +1289,7 @@ class TestComputeSummaries:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self._seed_graph()
 

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -17,6 +17,7 @@ from code_review_graph.wiki import (
 class TestWiki:
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()  # release the handle before GraphStore reopens it on Windows
         self.store = GraphStore(self.tmp.name)
         self.wiki_dir = tempfile.mkdtemp()
 

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -1,0 +1,94 @@
+"""Cross-platform guards for Windows-only test-suite constraints."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _qualified_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _qualified_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return None
+
+
+def _is_delete_false_named_tempfile(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    if (_qualified_name(node.func) or "").split(".")[-1] != "NamedTemporaryFile":
+        return False
+    return any(
+        keyword.arg == "delete"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is False
+        for keyword in node.keywords
+    )
+
+
+def _references_temp_name(node: ast.AST, target: str) -> bool:
+    return any(
+        isinstance(child, ast.Attribute)
+        and child.attr == "name"
+        and _qualified_name(child.value) == target
+        for child in ast.walk(node)
+    )
+
+
+def test_delete_false_named_tempfiles_close_before_graphstore_reopens_them():
+    """Windows forbids reopening a NamedTemporaryFile while its handle is open."""
+    failures: list[str] = []
+    tests_dir = Path(__file__).parent
+
+    for path in sorted(tests_dir.glob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        functions = (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+        for function in functions:
+            nodes = list(ast.walk(function))
+            assignments = (
+                node
+                for node in nodes
+                if isinstance(node, (ast.Assign, ast.AnnAssign))
+                and _is_delete_false_named_tempfile(node.value)
+            )
+            for assignment in assignments:
+                raw_targets = (
+                    assignment.targets
+                    if isinstance(assignment, ast.Assign)
+                    else [assignment.target]
+                )
+                targets = [
+                    name
+                    for target in raw_targets
+                    if (name := _qualified_name(target)) is not None
+                ]
+                for target in targets:
+                    close_lines = [
+                        node.lineno
+                        for node in nodes
+                        if isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "close"
+                        and _qualified_name(node.func.value) == target
+                    ]
+                    reopen_lines = [
+                        node.lineno
+                        for node in nodes
+                        if isinstance(node, ast.Call)
+                        and (_qualified_name(node.func) or "").split(".")[-1] == "GraphStore"
+                        and _references_temp_name(node, target)
+                    ]
+                    if not close_lines or (
+                        reopen_lines and min(close_lines) >= min(reopen_lines)
+                    ):
+                        failures.append(f"{path.name}:{assignment.lineno} ({target})")
+
+    assert not failures, "Close temporary handles before GraphStore reopens them:\n" + "\n".join(
+        failures
+    )


### PR DESCRIPTION
## Summary

- Port TOML-safe daemon config serialization from #595, including Windows paths, quotes, and control characters.
- Port the corrected Win32 PID liveness check from #597: request `SYNCHRONIZE`, declare pointer-safe ctypes prototypes, and handle `WAIT_FAILED` explicitly.
- Port the Windows resource-safety work from #596 onto current main: close all 24 non-context-managed temporary DB handles before `GraphStore` reopens them, including the newer `TestFindDeadCodeWithTestedBy` fixture; restore patched `GraphStore.close`; and make hook tests platform-correct.
- Add a real `windows-latest` job covering the native daemon path and every touched resource-handle module.

All three commits preserve SHudici's contribution through `Co-authored-by` trailers. This PR does not merge or close #595, #596, or #597.

## Verification

TDD evidence:
- TOML regressions: 2 expected failures before the fix, then 3 serialization tests passed.
- Win32 regressions: 3 expected failures before the fix, then 18 PID/liveness tests passed.
- Resource guard: failed on 24 open handles before the sweep, then passed after all 24 were closed.
- `GraphStore.close` restoration: 2 expected failures before using `patch.object`, then both passed.

Final local checks:
- `33 passed` — daemon config/PID/liveness subset.
- `342 passed` — Windows/resource-focused suite mirrored by the new CI job.
- `1,425 passed` — wider suite excluding the macOS FSEvents-crashing daemon file; its four sandbox-only failures each passed on rerun with a writable home/required OS permission.
- `ruff check code_review_graph/` passed.
- Focused changed-test lint passed.
- GitHub Actions YAML parsed successfully.
- Knowledge graph rebuilt with no parser errors; review found no affected execution flows.

## Local environment note

Running the entire daemon test file locally triggers an existing macOS watchdog/FSEvents bus error outside these changes. The changed daemon subsets pass locally, and the new Windows job runs the full daemon test file on the target platform.
