### PR TITLE
feat(install): add CodeBuddy Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ code-review-graph build            # parse your codebase
 One command sets up everything. `install` detects which AI coding tools you have, writes the correct MCP configuration for each one, installs platform-native hooks/skills where supported, and injects graph-aware instructions into your platform rules. It auto-detects whether you installed via `uvx` or `pip`/`pipx` and generates the right config. Restart your editor/tool after installing.
 
 <p align="center">
-  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Codex, Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, and GitHub Copilot" width="85%" />
+  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, and GitHub Copilot" width="85%" />
 </p>
 
 To target a specific platform:
@@ -68,6 +68,7 @@ code-review-graph install --platform gemini-cli   # configure only Gemini CLI
 code-review-graph install --platform kiro         # configure only Kiro
 code-review-graph install --platform copilot      # configure only GitHub Copilot (VS Code)
 code-review-graph install --platform copilot-cli  # configure only GitHub Copilot CLI
+code-review-graph install --platform codebuddy    # configure only CodeBuddy Code
 ```
 
 Requires Python 3.10+. For the best experience, install [uv](https://docs.astral.sh/uv/) (the MCP config will use `uvx` if available, otherwise falls back to the `code-review-graph` command directly).
@@ -646,5 +647,5 @@ MIT. See [LICENSE](LICENSE).
 <br>
 <a href="https://code-review-graph.com">code-review-graph.com</a><br><br>
 <code>pip install code-review-graph && code-review-graph install</code><br>
-<sub>Works with Codex, Claude Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, GitHub Copilot, and GitHub Copilot CLI</sub>
+<sub>Works with Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, GitHub Copilot, and GitHub Copilot CLI</sub>
 </p>

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_CHOICES = [
     "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
     "continue", "opencode", "antigravity", "gemini-cli", "qwen", "kiro", "qoder",
-    "copilot", "copilot-cli", "all",
+    "copilot", "copilot-cli", "codebuddy", "all",
 ]
 
 
@@ -243,6 +243,8 @@ def _handle_init(args: argparse.Namespace) -> None:
         generate_skills,
         inject_claude_md,
         inject_platform_instructions,
+        install_codebuddy_hooks,
+        install_codebuddy_skills,
         install_codex_hooks,
         install_cursor_hooks,
         install_gemini_cli_hooks,
@@ -263,6 +265,11 @@ def _handle_init(args: argparse.Namespace) -> None:
         if target in ("gemini-cli", "all"):
             gemini_skills_dir = install_gemini_cli_skills(repo_root)
             print(f"Installed Gemini CLI skills in {gemini_skills_dir}")
+
+        # CodeBuddy discovers project skills under .codebuddy/skills/.
+        if target in ("codebuddy", "all"):
+            codebuddy_skills_dir = install_codebuddy_skills(repo_root)
+            print(f"Installed CodeBuddy skills in {codebuddy_skills_dir}")
 
     # Confirm before writing instruction files (#173). --yes skips the
     # prompt; --no-instructions skips the whole block.
@@ -290,6 +297,12 @@ def _handle_init(args: argparse.Namespace) -> None:
         qoder_skills_dir = install_qoder_skills(repo_root)
         if qoder_skills_dir:
             print(f"Installed Qoder skills to {qoder_skills_dir}")
+    if not skip_hooks and target in ("codebuddy", "all"):
+        try:
+            codebuddy_settings = install_codebuddy_hooks(repo_root)
+            print(f"Installed CodeBuddy hooks in {codebuddy_settings}")
+        except Exception as exc:
+            logger.warning("Could not install CodeBuddy hooks: %s", exc)
     if not skip_hooks and target in ("codex", "all"):
         hooks_path = install_codex_hooks(repo_root)
         print(f"Installed Codex hooks in {hooks_path}")

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -154,6 +154,14 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "format": "object",
         "needs_type": True,
     },
+    "codebuddy": {
+        "name": "CodeBuddy Code",
+        "config_path": lambda root: root / ".mcp.json",
+        "key": "mcpServers",
+        "detect": lambda: True,
+        "format": "object",
+        "needs_type": True,
+    },
 }
 
 
@@ -416,11 +424,30 @@ def install_platform_configs(
     Returns:
         List of platform names that were configured.
     """
+    shared_aliases: dict[str, tuple[str, ...]] = {}
     if target == "all":
         platforms_to_install = {k: v for k, v in PLATFORMS.items() if v["detect"]()}
         # Workspace-level Kiro detection
         if "kiro" not in platforms_to_install and (repo_root / ".kiro").is_dir():
             platforms_to_install["kiro"] = PLATFORMS["kiro"]
+
+        # Claude Code and CodeBuddy intentionally share the official project
+        # .mcp.json/mcpServers contract. Process that exact pair once, but do
+        # not deduplicate arbitrary clients merely because a config path
+        # happens to match: their keys or entry schemas may differ.
+        claude = platforms_to_install.get("claude")
+        codebuddy = platforms_to_install.get("codebuddy")
+        if claude is not None and codebuddy is not None:
+            same_contract = (
+                claude["config_path"](repo_root) == codebuddy["config_path"](repo_root)
+                and all(
+                    claude[field] == codebuddy[field]
+                    for field in ("key", "format", "needs_type")
+                )
+            )
+            if same_contract:
+                shared_aliases["claude"] = ("codebuddy",)
+                del platforms_to_install["codebuddy"]
     else:
         if target not in PLATFORMS:
             logger.error("Unknown platform: %s", target)
@@ -428,6 +455,10 @@ def install_platform_configs(
         platforms_to_install = {target: PLATFORMS[target]}
 
     configured: list[str] = []
+
+    def _record_configured(key: str, plat: dict[str, Any]) -> None:
+        configured.append(plat["name"])
+        configured.extend(PLATFORMS[alias]["name"] for alias in shared_aliases.get(key, ()))
 
     for key, plat in platforms_to_install.items():
         if key == "opencode":
@@ -445,13 +476,13 @@ def install_platform_configs(
             )
             if not changed:
                 print(f"  {plat['name']}: already configured in {config_path}")
-                configured.append(plat["name"])
+                _record_configured(key, plat)
                 continue
             if dry_run:
                 print(f"  [dry-run] {plat['name']}: would write {config_path}")
             else:
                 print(f"  {plat['name']}: configured {config_path}")
-            configured.append(plat["name"])
+            _record_configured(key, plat)
             continue
 
         # Read existing config
@@ -505,7 +536,7 @@ def install_platform_configs(
             # Check if already present
             if any(isinstance(s, dict) and s.get("name") == "code-review-graph" for s in arr):
                 print(f"  {plat['name']}: already configured in {config_path}")
-                configured.append(plat["name"])
+                _record_configured(key, plat)
                 continue
             arr_entry = {"name": "code-review-graph", **server_entry}
             arr.append(arr_entry)
@@ -514,7 +545,7 @@ def install_platform_configs(
             servers = existing.get(server_key, {})
             if "code-review-graph" in servers:
                 print(f"  {plat['name']}: already configured in {config_path}")
-                configured.append(plat["name"])
+                _record_configured(key, plat)
                 continue
             servers["code-review-graph"] = server_entry
             existing[server_key] = servers
@@ -526,7 +557,7 @@ def install_platform_configs(
             config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
             print(f"  {plat['name']}: configured {config_path}")
 
-        configured.append(plat["name"])
+        _record_configured(key, plat)
 
     return configured
 
@@ -855,21 +886,11 @@ fi
     return hook_path
 
 
-def install_hooks(repo_root: Path, platform: str = "claude") -> None:
-    """Write hooks config to platform-specific settings.json.
-
-    Merges new hook entries into existing settings, preserving both
-    non-hook configuration and user-defined hooks.  A backup of the
-    original file is created before any modifications.
-
-    Args:
-        repo_root: Repository root directory.
-        platform: Target platform ("claude" or "qoder").
-    """
-    if platform == "qoder":
-        settings_dir = repo_root / ".qoder"
-    else:
-        settings_dir = repo_root / ".claude"
+def _merge_hooks_into_settings(
+    settings_dir: Path,
+    hooks_config: dict[str, Any],
+) -> Path:
+    """Merge hook entries into a project settings file without clobbering users."""
     settings_dir.mkdir(parents=True, exist_ok=True)
     settings_path = settings_dir / "settings.json"
 
@@ -883,7 +904,6 @@ def install_hooks(repo_root: Path, platform: str = "claude") -> None:
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Could not read existing %s: %s", settings_path, exc)
 
-    hooks_config = generate_hooks_config(repo_root)
     existing_hooks = existing.get("hooks", {})
     if not isinstance(existing_hooks, dict):
         logger.warning("Existing hooks config is not a dict; replacing with defaults")
@@ -904,6 +924,44 @@ def install_hooks(repo_root: Path, platform: str = "claude") -> None:
 
     settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
     logger.info("Wrote hooks config: %s", settings_path)
+    return settings_path
+
+
+def install_hooks(repo_root: Path, platform: str = "claude") -> None:
+    """Write hooks config to platform-specific settings.json.
+
+    Merges new hook entries into existing settings, preserving both
+    non-hook configuration and user-defined hooks.  A backup of the
+    original file is created before any modifications.
+
+    Args:
+        repo_root: Repository root directory.
+        platform: Target platform ("claude" or "qoder").
+    """
+    if platform == "qoder":
+        settings_dir = repo_root / ".qoder"
+    else:
+        settings_dir = repo_root / ".claude"
+    _merge_hooks_into_settings(settings_dir, generate_hooks_config(repo_root))
+
+
+def install_codebuddy_hooks(repo_root: Path) -> Path:
+    """Install runtime-resolved POSIX hooks in .codebuddy/settings.json.
+
+    CodeBuddy uses the same nested hook schema and POSIX-shell execution
+    model as the existing project hooks. The shared generator deliberately
+    resolves the checkout at hook runtime instead of embedding the installer's
+    absolute path, so committed settings work for every collaborator.
+    """
+    hooks_config = generate_hooks_config(repo_root)
+    # CodeBuddy's Bash tool can create or rewrite files without going through
+    # Edit/Write, so its PostToolUse contract also observes Bash. The command
+    # itself still resolves the repository dynamically at hook runtime.
+    hooks_config["hooks"]["PostToolUse"][0]["matcher"] = "Edit|Write|Bash"
+    return _merge_hooks_into_settings(
+        repo_root / ".codebuddy",
+        hooks_config,
+    )
 
 
 def install_codex_hooks(repo_root: Path) -> Path:
@@ -1105,6 +1163,7 @@ _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     "QODER.md": ("qoder",),
     ".kiro/steering/code-review-graph.md": ("kiro",),
     ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
+    "CODEBUDDY.md": ("codebuddy",),
 }
 
 
@@ -1261,6 +1320,29 @@ def install_gemini_cli_skills(repo_root: Path) -> Path:
         )
         skill_path.write_text(content, encoding="utf-8")
         logger.info("Wrote Gemini CLI skill: %s", skill_path)
+
+    return skills_root
+
+
+def install_codebuddy_skills(repo_root: Path) -> Path:
+    """Install project skills in .codebuddy/skills/<name>/SKILL.md."""
+    skills_root = repo_root / ".codebuddy" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    for filename, skill in _SKILLS.items():
+        slug = filename.rsplit(".", 1)[0]
+        skill_dir = skills_root / slug
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path = skill_dir / "SKILL.md"
+        content = (
+            "---\n"
+            f"name: {slug}\n"
+            f"description: {skill['description']}\n"
+            "---\n\n"
+            f"{skill['body']}\n"
+        )
+        skill_path.write_text(content, encoding="utf-8")
+        logger.info("Wrote CodeBuddy skill: %s", skill_path)
 
     return skills_root
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,6 +18,7 @@ To target a specific platform instead of auto-detecting all:
 code-review-graph install --platform codex
 code-review-graph install --platform cursor
 code-review-graph install --platform claude-code
+code-review-graph install --platform codebuddy
 ```
 
 ### Supported Platforms
@@ -26,6 +27,7 @@ code-review-graph install --platform claude-code
 |----------|-------------|
 | **Codex** | `~/.codex/config.toml` + `~/.codex/hooks.json` |
 | **Claude Code** | `.mcp.json` + `.claude/settings.json` |
+| **CodeBuddy Code** | `.mcp.json` + `CODEBUDDY.md` + `.codebuddy/settings.json` + `.codebuddy/skills/<name>/SKILL.md` |
 | **Cursor** | `.cursor/mcp.json` |
 | **Windsurf** | `~/.codeium/windsurf/mcp_config.json` |
 | **Zed** | `.zed/settings.json` |
@@ -38,6 +40,13 @@ code-review-graph install --platform claude-code
 | **Qoder** | `.qoder/mcp.json` |
 | **GitHub Copilot** | `.vscode/mcp.json` |
 | **GitHub Copilot CLI** | `~/.copilot/mcp-config.json` |
+
+The CodeBuddy project layout follows its official documentation for
+[MCP configuration](https://www.codebuddy.ai/docs/cli/mcp),
+[skills](https://www.codebuddy.ai/docs/cli/skills), and
+[hooks](https://www.codebuddy.ai/docs/cli/hooks). The shared `.mcp.json` is
+merged with JSONC awareness, while hook commands resolve the repository at
+runtime so committed settings do not contain one developer's checkout path.
 
 ## Core Workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@
 │                                                              │
 │  MCP clients              Hooks / watch mode                 │
 │  ├── Codex                └── incremental update             │
-│  ├── Claude Code                                             │
+│  ├── Claude Code, CodeBuddy Code                             │
 │  ├── Cursor, Windsurf, Zed, Continue                         │
 │  └── Gemini CLI, Qwen, Qoder, Copilot, OpenCode              │
 │          │                        │                          │

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -96,3 +96,82 @@ def test_handle_init_cursor_installs_cursor_hooks(monkeypatch, tmp_path, capsys)
 
     assert called["cursor_hooks"] is True
     assert "Installed Cursor hooks" in out
+
+
+def test_handle_init_codebuddy_installs_only_codebuddy_native_files(
+    monkeypatch, tmp_path, capsys
+):
+    import code_review_graph.skills as skills_module
+
+    assert "codebuddy" in __import__(
+        "code_review_graph.cli", fromlist=["_PLATFORM_CHOICES"]
+    )._PLATFORM_CHOICES
+
+    monkeypatch.setattr(
+        "code_review_graph.incremental.find_repo_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.ensure_repo_gitignore_excludes_crg",
+        lambda repo_root: "created",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.skills.install_platform_configs",
+        lambda repo_root, target, dry_run=False: ["CodeBuddy Code"],
+    )
+
+    called = {
+        "claude_skills": False,
+        "codebuddy_skills": False,
+        "codebuddy_hooks": False,
+        "codebuddy_instructions": False,
+    }
+
+    def _generate_skills(repo_root):
+        called["claude_skills"] = True
+        return repo_root / ".claude" / "skills"
+
+    def _install_codebuddy_skills(repo_root):
+        called["codebuddy_skills"] = True
+        return repo_root / ".codebuddy" / "skills"
+
+    def _install_codebuddy_hooks(repo_root):
+        called["codebuddy_hooks"] = True
+        return repo_root / ".codebuddy" / "settings.json"
+
+    def _inject_platform_instructions(repo_root, target="all"):
+        called["codebuddy_instructions"] = target == "codebuddy"
+        return ["CODEBUDDY.md"]
+
+    monkeypatch.setattr(skills_module, "generate_skills", _generate_skills)
+    monkeypatch.setattr(
+        skills_module,
+        "install_codebuddy_skills",
+        _install_codebuddy_skills,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        skills_module,
+        "install_codebuddy_hooks",
+        _install_codebuddy_hooks,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        skills_module,
+        "inject_platform_instructions",
+        _inject_platform_instructions,
+    )
+
+    args = _args(tmp_path, "codebuddy")
+    args.no_instructions = False
+    _handle_init(args)
+    out = capsys.readouterr().out
+
+    assert called == {
+        "claude_skills": False,
+        "codebuddy_skills": True,
+        "codebuddy_hooks": True,
+        "codebuddy_instructions": True,
+    }
+    assert "Installed CodeBuddy skills" in out
+    assert "Installed CodeBuddy hooks" in out

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -61,3 +61,17 @@ def test_github_action_references_use_current_supported_majors():
                     f"{path.relative_to(ROOT)} uses actions/{action}@v{actual}; "
                     f"expected v{expected}"
                 )
+
+
+def test_codebuddy_install_docs_cover_project_artifacts():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    usage = (ROOT / "docs/USAGE.md").read_text(encoding="utf-8")
+
+    assert "install --platform codebuddy" in readme
+    for artifact in (
+        ".mcp.json",
+        "CODEBUDDY.md",
+        ".codebuddy/settings.json",
+        ".codebuddy/skills/<name>/SKILL.md",
+    ):
+        assert artifact in usage

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -677,6 +677,7 @@ class TestInjectPlatformInstructionsFiltering:
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
+            "CODEBUDDY.md",
         }
 
     def test_default_is_all(self, tmp_path):
@@ -685,6 +686,7 @@ class TestInjectPlatformInstructionsFiltering:
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
+            "CODEBUDDY.md",
         }
 
     def test_claude_writes_nothing(self, tmp_path):
@@ -731,6 +733,176 @@ class TestInjectPlatformInstructionsFiltering:
         assert not (tmp_path / "GEMINI.md").exists()
         assert not (tmp_path / ".cursorrules").exists()
         assert not (tmp_path / ".windsurfrules").exists()
+
+    def test_codebuddy_writes_only_codebuddy_md_and_is_idempotent(self, tmp_path):
+        first = inject_platform_instructions(tmp_path, target="codebuddy")
+        second = inject_platform_instructions(tmp_path, target="codebuddy")
+
+        assert first == ["CODEBUDDY.md"]
+        assert second == []
+        content = (tmp_path / "CODEBUDDY.md").read_text(encoding="utf-8")
+        assert content.count(_CLAUDE_MD_SECTION_MARKER) == 1
+        assert "detect_changes_tool" in content
+        assert not (tmp_path / "CLAUDE.md").exists()
+        assert not (tmp_path / "AGENTS.md").exists()
+
+
+class TestCodeBuddyPlatform:
+    def test_platform_uses_official_project_mcp_contract(self):
+        assert "codebuddy" in PLATFORMS
+        platform = PLATFORMS["codebuddy"]
+
+        assert platform["name"] == "CodeBuddy Code"
+        assert platform["config_path"](Path("/tmp/project")) == Path(
+            "/tmp/project/.mcp.json"
+        )
+        assert platform["key"] == "mcpServers"
+        assert platform["format"] == "object"
+        assert platform["needs_type"] is True
+
+    def test_install_preserves_jsonc_content(self, tmp_path):
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text(
+            "{\n"
+            "  // CodeBuddy supports JSONC in project MCP files\n"
+            '  "dashboard": "https://example.test/a,b",\n'
+            '  "mcpServers": {\n'
+            '    "existing": {"command": "existing"},\n'
+            "  },\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        configured = install_platform_configs(tmp_path, target="codebuddy")
+
+        assert configured == ["CodeBuddy Code"]
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        assert data["dashboard"] == "https://example.test/a,b"
+        assert data["mcpServers"]["existing"]["command"] == "existing"
+        assert data["mcpServers"]["code-review-graph"]["type"] == "stdio"
+
+    def test_all_dedupes_only_claude_and_codebuddy_shared_contract(
+        self, tmp_path, capsys
+    ):
+        shared_path = tmp_path / ".mcp.json"
+        other_platform = {
+            "name": "Other shared client",
+            "config_path": lambda root: shared_path,
+            "key": "servers",
+            "detect": lambda: True,
+            "format": "object",
+            "needs_type": False,
+        }
+        with patch.dict(
+            PLATFORMS,
+            {
+                "claude": {**PLATFORMS["claude"], "detect": lambda: True},
+                "codebuddy": {**PLATFORMS["codebuddy"], "detect": lambda: True},
+                "other-shared": other_platform,
+            },
+            clear=True,
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+
+        assert configured == ["Claude Code", "CodeBuddy Code", "Other shared client"]
+        data = json.loads(shared_path.read_text(encoding="utf-8"))
+        assert "code-review-graph" in data["mcpServers"]
+        assert "code-review-graph" in data["servers"]
+        # Claude and CodeBuddy share one exact contract/write. A different
+        # contract that happens to share the path must still be processed.
+        assert capsys.readouterr().out.count(f"configured {shared_path}") == 2
+
+    def test_all_does_not_credit_shared_alias_when_write_is_unsafe(
+        self, tmp_path, capsys
+    ):
+        original = "{ this is not valid JSONC }\n"
+        (tmp_path / ".mcp.json").write_text(original, encoding="utf-8")
+        with patch.dict(
+            PLATFORMS,
+            {
+                "claude": {**PLATFORMS["claude"], "detect": lambda: True},
+                "codebuddy": {**PLATFORMS["codebuddy"], "detect": lambda: True},
+            },
+            clear=True,
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+
+        assert configured == []
+        assert (tmp_path / ".mcp.json").read_text(encoding="utf-8") == original
+        assert "skipping to avoid data loss" in capsys.readouterr().out
+
+    def test_project_skills_use_uppercase_skill_file(self, tmp_path):
+        from code_review_graph.skills import install_codebuddy_skills
+
+        skills_root = install_codebuddy_skills(tmp_path)
+
+        assert skills_root == tmp_path / ".codebuddy" / "skills"
+        assert {path.name for path in skills_root.iterdir()} == {
+            "debug-issue",
+            "explore-codebase",
+            "refactor-safely",
+            "review-changes",
+        }
+        for skill_dir in skills_root.iterdir():
+            content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+            assert content.startswith("---\n")
+            assert f"name: {skill_dir.name}\n" in content
+            assert "description:" in content
+            assert "get_minimal_context" in content
+
+    def test_project_hooks_preserve_user_settings_and_resolve_repo_at_runtime(
+        self, tmp_path
+    ):
+        from code_review_graph.skills import install_codebuddy_hooks
+
+        repo_root = tmp_path / "repo with spaces"
+        settings_path = repo_root / ".codebuddy" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        user_hook = {
+            "matcher": "Read",
+            "hooks": [{"type": "command", "command": "echo user"}],
+        }
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "model": "custom-model",
+                    "hooks": {"PostToolUse": [user_hook]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = install_codebuddy_hooks(repo_root)
+
+        assert result == settings_path
+        assert settings_path.with_suffix(".json.bak").exists()
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["model"] == "custom-model"
+        assert user_hook in data["hooks"]["PostToolUse"]
+        installed = [
+            hook
+            for entries in data["hooks"].values()
+            for entry in entries
+            for hook in entry["hooks"]
+            if "code-review-graph" in hook.get("command", "")
+        ]
+        assert installed
+        for hook in installed:
+            command = hook["command"]
+            assert "command -v code-review-graph" in command
+            assert "git rev-parse --show-toplevel" in command
+            assert str(repo_root) not in command
+
+        crg_entry = next(
+            entry
+            for entry in data["hooks"]["PostToolUse"]
+            if any("code-review-graph" in hook.get("command", "") for hook in entry["hooks"])
+        )
+        assert crg_entry["matcher"] == "Edit|Write|Bash"
+
+        first = settings_path.read_text(encoding="utf-8")
+        install_codebuddy_hooks(repo_root)
+        assert settings_path.read_text(encoding="utf-8") == first
 
 
 class TestInstallPlatformConfigs:


### PR DESCRIPTION
## Summary

Ports the viable CodeBuddy Code integration from #584 onto the current installer while preserving the original contributor's attribution.

- registers the official project `.mcp.json` / `mcpServers` contract and keeps the current JSONC-safe, no-data-loss merge behavior
- deduplicates only the exact Claude Code / CodeBuddy shared contract; unrelated clients that happen to share a path are still processed
- writes `CODEBUDDY.md` and `.codebuddy/skills/<name>/SKILL.md`
- installs `.codebuddy/settings.json` hooks for `Edit|Write|Bash`, preserving user settings and resolving the repository at hook runtime rather than embedding an install-machine path
- adds current CLI dispatch, installer regression coverage, and user/architecture documentation

The layout is checked against CodeBuddy's current official [MCP](https://www.codebuddy.ai/docs/cli/mcp), [skills](https://www.codebuddy.ai/docs/cli/skills), and [hooks](https://www.codebuddy.ai/docs/cli/hooks) documentation.

## Attribution

Source contribution: #584 by @chuckiefan, exact reviewed head `b92f4bd69b9aa7fed0873acad187daeb808535b3`.

The implementation commit includes:

`Co-Authored-By: Chuckiefan <chuckiefan@163.com>`

## Validation

- TDD: the nine new CodeBuddy contract tests failed before implementation and passed afterward
- focused installer/CLI/docs: `184 passed`
- complete Python suite: `1492 passed, 2 xpassed`
  - on macOS, the installed native FSEvents extension bus-faults during watcher teardown; the complete run used watchdog's polling observer as a test-only backend and exercised all watcher tests
- changed-file Ruff: clean
- `git diff --check`: clean
- graph review: risk `0.40`, no affected execution flows
