### PR TITLE
fix(ci): support secure fork PR reviews

### DIFF
--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -1,0 +1,165 @@
+# Posts the report produced by the unprivileged PR Review workflow. This
+# workflow runs from the default branch, never checks out PR code, and treats
+# every downloaded artifact byte as untrusted input.
+name: PR Review Comment
+
+on:
+  workflow_run:
+    workflows: ["PR Review"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Locate one bounded report artifact
+        id: artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_ARCHIVE_BYTES: "100000"
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          mapfile -t artifact_rows < <(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            -f per_page=100 \
+            --jq '.artifacts[] | select(
+              .name == "crg-report" and (.expired | not)
+            ) | [.id, .size_in_bytes] | @tsv')
+          if [ "${#artifact_rows[@]}" -ne 1 ]; then
+            echo "Expected exactly one non-expired crg-report artifact." >&2
+            exit 1
+          fi
+
+          IFS=$'\t' read -r artifact_id artifact_size <<< "${artifact_rows[0]}"
+          case "${artifact_id}" in
+            ''|*[!0-9]*) echo "Invalid artifact ID." >&2; exit 1 ;;
+          esac
+          case "${artifact_size}" in
+            ''|*[!0-9]*) echo "Invalid artifact size." >&2; exit 1 ;;
+          esac
+          if [ "${artifact_size}" -eq 0 ] || \
+             [ "${artifact_size}" -gt "${MAX_ARCHIVE_BYTES}" ]; then
+            echo "Artifact archive is empty or exceeds the size cap." >&2
+            exit 1
+          fi
+          printf 'artifact-id=%s\n' "${artifact_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download report artifact into runner temp
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ steps.artifact.outputs.artifact-id }}
+          path: ${{ runner.temp }}/crg-report-download
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate and wrap untrusted report
+        env:
+          COMMENT_BODY: ${{ runner.temp }}/crg-comment-body.md
+          DOWNLOAD_DIR: ${{ runner.temp }}/crg-report-download
+          MAX_BODY_BYTES: "65000"
+          MAX_PR_NUMBER_BYTES: "12"
+          MAX_REPORT_BYTES: "60000"
+          TRUSTED_MARKER: <!-- code-review-graph-report -->
+          VALIDATED_PR_NUMBER: ${{ runner.temp }}/crg-pr-number.txt
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path(os.environ["DOWNLOAD_DIR"])
+          if not root.is_dir() or root.is_symlink():
+              raise SystemExit("Artifact extraction root is not a safe directory")
+
+          entries = {path.name: path for path in root.iterdir()}
+          expected = {"crg-comment.md", "pr-number.txt"}
+          if set(entries) != expected:
+              raise SystemExit("Artifact must contain exactly the expected files")
+          if any(path.is_symlink() or not path.is_file() for path in entries.values()):
+              raise SystemExit("Artifact entries must be regular files")
+
+          pr_file = entries["pr-number.txt"]
+          if pr_file.stat().st_size > int(os.environ["MAX_PR_NUMBER_BYTES"]):
+              raise SystemExit("PR number artifact is too large")
+          try:
+              pr_text = pr_file.read_bytes().decode("ascii")
+          except UnicodeDecodeError as exc:
+              raise SystemExit("PR number must be ASCII") from exc
+          if re.fullmatch(r"[1-9][0-9]{0,9}\n?", pr_text) is None:
+              raise SystemExit("PR number must contain only a positive integer")
+
+          report_file = entries["crg-comment.md"]
+          report_size = report_file.stat().st_size
+          if report_size == 0 or report_size > int(os.environ["MAX_REPORT_BYTES"]):
+              raise SystemExit("Report artifact is empty or too large")
+          try:
+              text = report_file.read_bytes().decode("utf-8")
+          except UnicodeDecodeError as exc:
+              raise SystemExit("Report must be valid UTF-8") from exc
+          if any(ord(char) < 32 and char not in "\n\r\t" for char in text):
+              raise SystemExit("Report contains disallowed control characters")
+          if "\x7f" in text:
+              raise SystemExit("Report contains disallowed control characters")
+
+          marker = os.environ["TRUSTED_MARKER"]
+          text = text.replace(marker, "")
+          text = text.replace("\r\n", "\n").replace("\r", "\n").lstrip("\n")
+          if not text.startswith("## code-review-graph review\n"):
+              raise SystemExit("Report has an unexpected heading")
+          if "*Powered by [code-review-graph]" not in text:
+              raise SystemExit("Report is missing its expected footer")
+
+          # Prevent PR-controlled report text from creating GitHub mentions.
+          text = text.replace("@", "&#64;")
+          body = f"{marker}\n\n{text}"
+          body_bytes = body.encode("utf-8")
+          if len(body_bytes) > int(os.environ["MAX_BODY_BYTES"]):
+              raise SystemExit("Wrapped comment exceeds the GitHub body limit")
+
+          Path(os.environ["COMMENT_BODY"]).write_bytes(body_bytes)
+          Path(os.environ["VALIDATED_PR_NUMBER"]).write_text(
+              str(int(pr_text)), encoding="ascii"
+          )
+          PY
+
+      - name: Upsert sticky PR comment
+        env:
+          COMMENT_BODY: ${{ runner.temp }}/crg-comment-body.md
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER_FILE: ${{ runner.temp }}/crg-pr-number.txt
+        run: |
+          set -euo pipefail
+          pr_number=$(cat "${PR_NUMBER_FILE}")
+          actual_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.head.sha')
+          if [ "${actual_sha}" != "${HEAD_SHA}" ]; then
+            echo "PR head does not match the analyzed commit; refusing to comment." >&2
+            exit 1
+          fi
+
+          comment_id=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+            --paginate \
+            --jq '.[] | select(
+              .user.login == "github-actions[bot]" and
+              (.body | startswith("<!-- code-review-graph-report -->"))
+            ) | .id' | sed -n '1p')
+          if [ -n "${comment_id}" ]; then
+            gh api --method PATCH --silent \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              -F body=@"${COMMENT_BODY}"
+          else
+            gh api --method POST --silent \
+              "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+              -F body=@"${COMMENT_BODY}"
+          fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,4 +1,6 @@
 # Dogfoods the local composite action (action.yml at the repo root) on PRs.
+# This run is intentionally unprivileged. A separate workflow_run workflow
+# validates the rendered report and posts the sticky comment.
 name: PR Review
 
 on:
@@ -7,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   review:
@@ -15,7 +16,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Run code-review-graph review
+        id: review
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment: "false"
           fail-on-risk: none
+      - name: Stage report artifact
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/crg-report
+          COMMENT_FILE: ${{ steps.review.outputs.comment-file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          rm -rf -- "${ARTIFACT_DIR}"
+          mkdir -p -- "${ARTIFACT_DIR}"
+          cp -- "${COMMENT_FILE}" "${ARTIFACT_DIR}/crg-comment.md"
+          printf '%s\n' "${PR_NUMBER}" > "${ARTIFACT_DIR}/pr-number.txt"
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: crg-report
+          path: ${{ runner.temp }}/crg-report/
+          if-no-files-found: error
+          retention-days: 1

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,13 @@ inputs:
     required: false
     default: "3.12"
 
+outputs:
+  comment-file:
+    description: >-
+      Runner-local path to the rendered markdown report. Use with
+      `comment: false` when a separate trusted workflow will publish it.
+    value: ${{ steps.render.outputs.comment-file }}
+
 runs:
   using: "composite"
   steps:
@@ -87,11 +94,13 @@ runs:
           > "${RUNNER_TEMP}/crg-report.json"
 
     - name: Render markdown report
+      id: render
       shell: bash
       run: |
         python "${GITHUB_ACTION_PATH}/scripts/render_pr_comment.py" \
           --input "${RUNNER_TEMP}/crg-report.json" \
           --output "${RUNNER_TEMP}/crg-comment.md"
+        echo "comment-file=${RUNNER_TEMP}/crg-comment.md" >> "${GITHUB_OUTPUT}"
 
     - name: Upsert sticky PR comment
       if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -68,6 +68,12 @@ To turn the review into a merge gate:
 | `fail-on-risk` | no | `none` | Fail the job when the overall risk score reaches a level: `none` (never fail), `high` (risk ≥ 0.70), `critical` (risk ≥ 0.85). |
 | `python-version` | no | `3.12` | Python version used to run code-review-graph (3.10+ supported). |
 
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `comment-file` | Runner-local path to the rendered markdown report. Use with `comment: false` when a separate trusted workflow will publish it. |
+
 ### Risk levels
 
 `detect-changes` produces a 0.0–1.0 overall risk score (max across changed
@@ -127,10 +133,11 @@ database) with `actions/cache`:
 
 ## Security notes
 
-- **Token scope**: the action needs only `pull-requests: write` (to post the
-  comment) and `contents: read` (for checkout). Grant exactly that in the
-  workflow's `permissions:` block — the examples above do. The token is used
-  for nothing except listing/creating/updating the one PR comment.
+- **Token scope**: direct commenting needs `contents: read` for checkout and
+  `pull-requests: write` to post the comment. In the split fork-safe setup,
+  the analysis workflow needs only `contents: read`; the trusted commenter
+  needs only `actions: read` and `pull-requests: write`. Grant exactly those
+  permissions in each workflow.
 - **Local-first**: analysis runs entirely on the runner. No code, diff, or
   metadata leaves GitHub's infrastructure; there is no external API, account,
   or key.
@@ -143,16 +150,29 @@ database) with `actions/cache`:
 - **Pinning**: when consuming the action from another repository, pin
   `uses:` to a release tag or commit SHA rather than `@main`.
 - **Fork PRs**: `pull_request` runs from forks receive a read-only
-  `GITHUB_TOKEN`, so the comment step will fail for fork PRs unless you use
-  `pull_request_target` — which checks out trusted base-branch workflow
-  code; understand [the security implications](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
-  before switching, or set `comment: false` for fork PRs.
+  `GITHUB_TOKEN`, so they cannot post the comment directly. Use an
+  unprivileged `pull_request` workflow with `comment: false`, upload the
+  `comment-file` as an artifact, and publish it from a separate trusted
+  `workflow_run` workflow. See
+  [`.github/workflows/pr-review.yml`](../.github/workflows/pr-review.yml) and
+  [`.github/workflows/pr-review-comment.yml`](../.github/workflows/pr-review-comment.yml).
+  GitHub loads the `workflow_run` workflow from the default branch, so the
+  trusted commenting half becomes active only after that workflow is merged.
+  The privileged workflow must verify the source event and analyzed commit,
+  extract only under `runner.temp`, cap and validate the artifact, and add its
+  own sticky marker before posting. Avoid `pull_request_target` with a checkout
+  of PR code because it can execute untrusted code with a privileged token
+  ([details](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)).
 
 ## Dogfooding
 
 This repository runs the action on its own PRs via
 [`.github/workflows/pr-review.yml`](../.github/workflows/pr-review.yml),
-which `uses: ./` (the local `action.yml`).
+which runs the local `action.yml` without write permissions and uploads the
+rendered report. The trusted
+[`pr-review-comment.yml`](../.github/workflows/pr-review-comment.yml) workflow
+validates that artifact and posts the sticky comment without checking out or
+executing PR-controlled code.
 
 ## Rendering script
 

--- a/tests/test_pr_review_workflows.py
+++ b/tests/test_pr_review_workflows.py
@@ -1,0 +1,81 @@
+"""Static security regressions for the split fork-PR review workflows."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+ANALYSIS_WORKFLOW = ROOT / ".github" / "workflows" / "pr-review.yml"
+COMMENT_WORKFLOW = ROOT / ".github" / "workflows" / "pr-review-comment.yml"
+ACTION = ROOT / "action.yml"
+DOCS = ROOT / "docs" / "GITHUB_ACTION.md"
+
+
+def test_analysis_workflow_is_unprivileged_and_exports_temp_artifact():
+    workflow = ANALYSIS_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "permissions:\n  contents: read\n" in workflow
+    assert "pull-requests: write" not in workflow
+    assert 'comment: "false"' in workflow
+    assert "id: review" in workflow
+    assert "steps.review.outputs.comment-file" in workflow
+    assert "${{ runner.temp }}/crg-report" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "if-no-files-found: error" in workflow
+    assert "retention-days: 1" in workflow
+
+
+def test_action_exposes_the_rendered_comment_file():
+    action = ACTION.read_text(encoding="utf-8")
+
+    assert "outputs:" in action
+    assert "comment-file:" in action
+    assert "value: ${{ steps.render.outputs.comment-file }}" in action
+    assert "id: render" in action
+    assert 'echo "comment-file=${RUNNER_TEMP}/crg-comment.md" >> "${GITHUB_OUTPUT}"' in action
+
+
+def test_privileged_workflow_has_minimal_permissions_and_source_gate():
+    workflow = COMMENT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions: read" in workflow
+    assert "pull-requests: write" in workflow
+    assert "workflow_run.conclusion == 'success'" in workflow
+    assert "workflow_run.event == 'pull_request'" in workflow
+    assert "actions/checkout" not in workflow
+    assert "uses: ./" not in workflow
+
+
+def test_privileged_workflow_confines_and_validates_untrusted_artifact():
+    workflow = COMMENT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "MAX_ARCHIVE_BYTES" in workflow
+    assert "size_in_bytes" in workflow
+    assert "artifact-ids: ${{ steps.artifact.outputs.artifact-id }}" in workflow
+    assert "path: ${{ runner.temp }}/crg-report-download" in workflow
+    assert "actions/download-artifact@v8" in workflow
+    assert "MAX_REPORT_BYTES" in workflow
+    assert "MAX_PR_NUMBER_BYTES" in workflow
+    assert 'decode("utf-8")' in workflow
+    assert "fullmatch" in workflow
+    assert "is_symlink" in workflow
+    assert "workflow_run.head_sha" in workflow
+    assert "actual_sha" in workflow
+
+
+def test_privileged_workflow_adds_its_own_marker_before_posting():
+    workflow = COMMENT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "TRUSTED_MARKER: <!-- code-review-graph-report -->" in workflow
+    assert 'text.replace(marker, "")' in workflow
+    assert 'body = f"{marker}\\n\\n{text}"' in workflow
+    assert '-F body=@"${COMMENT_BODY}"' in workflow
+    assert "-F body=@crg-comment.md" not in workflow
+
+
+def test_docs_recommend_the_split_workflow_instead_of_pull_request_target():
+    docs = DOCS.read_text(encoding="utf-8")
+
+    assert "pr-review-comment.yml" in docs
+    assert "workflow_run" in docs
+    assert "`actions: read`" in docs
+    assert "default branch" in docs
+    assert "Avoid `pull_request_target`" in docs


### PR DESCRIPTION
## Summary

- ports the split fork-PR review design from #556 onto current `main`, preserving Michael Denyer's contribution in the commit attribution
- keeps PR analysis on the unprivileged `pull_request` workflow and exports the rendered comment as a short-lived artifact
- adds a separate trusted `workflow_run` publisher, the composite-action output, documentation, and static security regressions

## Security hardening

- grants the privileged workflow only `actions: read` and `pull-requests: write`
- requires both a successful run and `workflow_run.event == 'pull_request'`
- selects one immutable artifact ID, rejects empty/oversized archives, and downloads only under `runner.temp`
- accepts exactly the expected two regular files; caps sizes; validates ASCII/UTF-8, PR number, report shape, and control characters
- strips any artifact-supplied sticky marker, prepends a trusted marker, prevents mentions, and verifies the PR head SHA before posting
- never checks out or executes PR-controlled code in the privileged workflow

## Validation

- full suite: `1493 passed, 1 skipped, 2 xpassed`
- focused workflow/action/docs suite: `50 passed`
- `ruff check`: clean
- `actionlint v1.7.12`: clean (official release binary, checksum verified)
- code-review graph: low risk, no affected code flows, no test gaps
- `git diff --check`: clean

## Rollout note

GitHub loads a `workflow_run` workflow from the default branch. The privileged commenting half therefore becomes active only after merge, so a real fork end-to-end comment check must be performed post-merge. This PR does not merge or close #556.

Bead: `crg-erd.4.6`
