### PR TITLE
feat(incremental): ignore AWS CDK synth output

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -128,6 +128,8 @@ DEFAULT_IGNORE_PATTERNS = [
     # Dart / Flutter
     "**/.dart_tool/**",
     "**/.pub-cache/**",
+    # AWS CDK
+    "**/cdk.out/**",
     # General
     "/coverage/**",
     "**/.cache/**",

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -268,6 +268,15 @@ class TestIgnorePatterns:
                 patterns,
             )
 
+    def test_cdk_output_default_matches_at_any_depth(self):
+        """AWS CDK synth output is generated in root and monorepo projects."""
+        from code_review_graph.incremental import DEFAULT_IGNORE_PATTERNS
+
+        patterns = DEFAULT_IGNORE_PATTERNS
+        assert _should_ignore("cdk.out/manifest.json", patterns)
+        assert _should_ignore("packages/infra/cdk.out/asset.js", patterns)
+        assert not _should_ignore("packages/infra/cdk.output/source.ts", patterns)
+
     def test_safe_dependency_defaults_still_match_at_any_depth(self):
         """The monorepo dependency case from #91 remains fixed."""
         from code_review_graph.incremental import DEFAULT_IGNORE_PATTERNS


### PR DESCRIPTION
## What changed

- Ignore AWS CDK `cdk.out` synth artifacts at the repository root and inside monorepo packages.
- Add regression coverage for root, nested, and similarly named non-artifact directories.
- Keep `*.bundle.js` out of the built-in defaults because users cannot negate a default ignore pattern.

## Why

This ports only the safe, current-main-compatible part of Gideon Zenz's PR #335 (commit `448e48c`). CDK synth output is generated code that should not pollute the graph, while a global bundle-file default would be irreversible for repositories that intentionally track those files.

Gideon Zenz is preserved as co-author on the commit.

## Validation

- TDD red: the new CDK regression failed on current main because `cdk.out/manifest.json` was not ignored.
- Focused ignore suite: `9 passed`.
- Full suite after rebase: `1489 passed, 2 xpassed`.
- CI lint scope: `ruff check code_review_graph/` passed.
- Changed-file lint and `git diff --check` passed.
- Knowledge-graph review found no affected execution flows; the change is limited to the default ignore constant and its regression test.
