### PR TITLE
feat(parser): port PHP and Laravel semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Large monorepos are where token waste is most painful. The graph cuts through th
 
 Parser support covers functions, classes, imports, call sites, inheritance, and test detection across the current parser surface, using Tree-sitter where available and targeted fallbacks where needed. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
+PHP projects additionally get repository-bounded Composer PSR-4 resolution,
+Blade template references, and Laravel Route/Eloquent semantic edges when the
+source includes explicit framework imports, model inheritance, and receiver
+evidence.
+
 ### Add your own language (no fork needed)
 
 If your repo uses a language the parser does not cover yet, drop a `languages.toml` into `.code-review-graph/` mapping file extensions to any grammar bundled in `tree_sitter_language_pack`, plus the tree-sitter node types for functions, classes, imports, and calls:
@@ -243,7 +248,7 @@ The benchmark also runs an honest **co-change mode**: the predictor is seeded wi
 - **Impact "recall 1.0" is graph-derived and circular:** the historical ground truth comes from the same graph edges the predictor walks, so it is an upper bound by construction. The honest co-change mode (grade against files actually co-changed in the same commit) is measured alongside it; expect those numbers to be substantially lower.
 - **Small single-file changes:** Graph context can exceed naive file reads for trivial edits (see express results above). The overhead is the structural metadata that enables multi-file analysis.
 - **Search quality (MRR 0.35):** Keyword search finds the right result in the top-4 for most queries, but ranking needs improvement. Express queries return 0 hits due to module-pattern naming.
-- **Flow detection (33% recall):** Only reliably detects entry points in Python repos (fastapi, httpx) where framework patterns are recognized. JavaScript and Go flow detection needs work.
+- **Flow detection (33% recall):** Framework and conventional entry patterns are strongest for Python and PHP/Laravel. JavaScript and Go flow detection needs work.
 - **Precision vs recall trade-off:** Impact analysis is deliberately conservative. It flags files that *might* be affected, which means some false positives in large dependency graphs.
 
 ---
@@ -254,6 +259,7 @@ The benchmark also runs an honest **co-change mode**: the predictor is seeded wi
 |---------|---------|
 | **Incremental updates** | Re-parses only changed files. Subsequent updates complete in under 2 seconds. |
 | **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
+| **Framework-aware PHP parsing** | Repository-bounded Composer PSR-4 imports, Blade template references, and evidence-gated Laravel Route-to-controller and Eloquent relationship edges |
 | **Blast-radius analysis** | Shows which functions, classes, and files are likely affected by a change |
 | **Auto-update hooks** | Hooks and watch mode can update the graph on file saves and supported commit hooks |
 | **Semantic search** | Optional vector embeddings via sentence-transformers, Google Gemini, MiniMax, or any OpenAI-compatible endpoint (real OpenAI, Azure, new-api, LiteLLM, vLLM, LocalAI) |

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -109,6 +109,14 @@ _ENTRY_NAME_PATTERNS: list[re.Pattern[str]] = [
     ),
 ]
 
+# Framework and language conventions that must not pollute other parsers.
+_LANGUAGE_ENTRY_NAME_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    "php": (
+        re.compile(r"^(boot|register)$"),
+        re.compile(r"^__invoke$"),
+    ),
+}
+
 
 # ---------------------------------------------------------------------------
 # Entry-point detection
@@ -132,6 +140,9 @@ def _has_framework_decorator(node: GraphNode) -> bool:
 def _matches_entry_name(node: GraphNode) -> bool:
     """Return True if *node*'s name matches a conventional entry-point pattern."""
     for pat in _ENTRY_NAME_PATTERNS:
+        if pat.search(node.name):
+            return True
+    for pat in _LANGUAGE_ENTRY_NAME_PATTERNS.get(node.language, ()):
         if pat.search(node.name):
             return True
     return False

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -991,7 +991,6 @@ class CodeParser:
         self._module_file_cache: dict[str, Optional[str]] = {}
         self._export_symbol_cache: dict[str, Optional[str]] = {}
         self._tsconfig_resolver = TsconfigResolver()
-        self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
         # Config-driven custom languages (.code-review-graph/languages.toml).
@@ -6949,12 +6948,26 @@ class CodeParser:
             # and ``use function`` / ``use const`` targets with no matching
             # file stay unresolved and keep the bare FQN, like JDK imports.
             rel_path = module.replace("\\", "/").lstrip("/") + ".php"
-            current = caller_dir
-            while True:
-                target = current / rel_path
-                if target.is_file():
-                    return str(target.resolve())
-                if current == current.parent:
+            try:
+                boundary = self._php_repository_boundary(caller_dir)
+                current = caller_dir.resolve()
+            except (OSError, RuntimeError, ValueError):
+                return None
+            if boundary is None or not _path_is_within(current, boundary):
+                return None
+
+            while _path_is_within(current, boundary):
+                try:
+                    target = (current / rel_path).resolve()
+                except (OSError, RuntimeError, ValueError):
+                    target = None
+                if (
+                    target is not None
+                    and _path_is_within(target, boundary)
+                    and target.is_file()
+                ):
+                    return str(target)
+                if current == boundary:
                     break
                 current = current.parent
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -13,6 +13,7 @@ import logging
 import re
 import threading
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -49,6 +50,79 @@ _SQL_KEYWORDS: frozenset[str] = frozenset({
 })
 
 logger = logging.getLogger(__name__)
+
+
+_PhpPsr4Mappings = tuple[tuple[str, tuple[str, ...]], ...]
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    """Return whether *path* is inside *root* after both are resolved."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+@lru_cache(maxsize=128)
+def _read_php_composer_psr4(
+    composer_path: str,
+    repo_root: str,
+    _mtime_ns: int,
+    _size: int,
+) -> _PhpPsr4Mappings:
+    """Read immutable, shape-safe PSR-4 mappings from one composer.json."""
+    composer = Path(composer_path)
+    root = Path(repo_root)
+    try:
+        data = json.loads(
+            composer.read_text(encoding="utf-8", errors="replace"),
+        )
+    except (OSError, json.JSONDecodeError):
+        return ()
+    if not isinstance(data, dict):
+        return ()
+
+    combined: dict[str, list[str]] = {}
+    for section_name in ("autoload", "autoload-dev"):
+        section = data.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        psr4 = section.get("psr-4")
+        if not isinstance(psr4, dict):
+            continue
+        for raw_prefix, raw_paths in psr4.items():
+            if not isinstance(raw_prefix, str):
+                continue
+            prefix = raw_prefix.lstrip("\\").rstrip("\\")
+            candidate_paths = (
+                [raw_paths] if isinstance(raw_paths, str)
+                else raw_paths if isinstance(raw_paths, list)
+                else []
+            )
+            destinations = combined.setdefault(prefix, [])
+            for raw_path in candidate_paths:
+                if not isinstance(raw_path, str):
+                    continue
+                try:
+                    destination = (composer.parent / raw_path).resolve()
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                if not _path_is_within(destination, root):
+                    continue
+                destination_str = str(destination)
+                if destination_str not in destinations:
+                    destinations.append(destination_str)
+
+    return tuple(
+        (prefix, tuple(destinations))
+        for prefix, destinations in sorted(
+            combined.items(),
+            key=lambda item: (-len(item[0]), item[0]),
+        )
+        if destinations
+    )
+
 
 # ---------------------------------------------------------------------------
 # Data models for extracted entities
@@ -208,7 +282,10 @@ _CLASS_TYPES: dict[str, list[str]] = {
     "perl": ["package_statement", "class_statement", "role_statement"],
     "kotlin": ["class_declaration", "object_declaration"],
     "swift": ["class_declaration", "struct_declaration", "protocol_declaration"],
-    "php": ["class_declaration", "interface_declaration"],
+    "php": [
+        "class_declaration", "interface_declaration",
+        "trait_declaration", "enum_declaration",
+    ],
     "scala": [
         "class_definition", "trait_definition", "object_definition", "enum_definition",
     ],
@@ -389,6 +466,7 @@ _CALL_TYPES: dict[str, list[str]] = {
         "member_call_expression",
         "scoped_call_expression",
         "nullsafe_member_call_expression",
+        "object_creation_expression",
     ],
     "scala": ["call_expression", "instance_expression", "generic_function"],
     "solidity": ["call_expression"],
@@ -891,6 +969,21 @@ class CodeParser:
     """Parses source files using Tree-sitter and extracts structural information."""
 
     _MODULE_CACHE_MAX = 15_000  # Evict cache to cap memory on huge monorepos
+    _BLADE_COMMENT_RE = re.compile(r"\{\{--.*?(?:--\}\}|$)", re.DOTALL)
+    _BLADE_DIRECTIVE_RE = re.compile(
+        r"""(?<!@)@(extends|include|component|livewire)\s*\(\s*(['"])([^'"]+)\2\s*\)""",
+    )
+    _LARAVEL_ROUTE_FACADE = "Illuminate\\Support\\Facades\\Route"
+    _LARAVEL_ELOQUENT_MODEL = "Illuminate\\Database\\Eloquent\\Model"
+    _LARAVEL_ROUTE_VERBS = frozenset({
+        "get", "post", "put", "patch", "delete", "options",
+        "any", "match", "resource", "apiResource",
+    })
+    _LARAVEL_RELATIONSHIPS = frozenset({
+        "hasMany", "hasOne", "belongsTo", "belongsToMany",
+        "morphTo", "morphMany", "morphOne", "morphToMany",
+        "morphedByMany", "hasManyThrough", "hasOneThrough",
+    })
 
     def __init__(self, repo_root: Optional[Path] = None) -> None:
         self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
@@ -898,6 +991,7 @@ class CodeParser:
         self._module_file_cache: dict[str, Optional[str]] = {}
         self._export_symbol_cache: dict[str, Optional[str]] = {}
         self._tsconfig_resolver = TsconfigResolver()
+        self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
         # Config-driven custom languages (.code-review-graph/languages.toml).
@@ -954,6 +1048,8 @@ class CodeParser:
         only runs when the extension lookup returns ``None`` **and** the path
         has no suffix at all.  See issue #237.
         """
+        if path.name.lower().endswith(".blade.php"):
+            return "blade"
         suffix = path.suffix.lower()
         lang = self._extension_map.get(suffix)
         if lang is not None:
@@ -1046,6 +1142,9 @@ class CodeParser:
         if not language:
             return [], []
 
+        if language == "blade":
+            return self._parse_blade(path, source)
+
         # Vue SFCs: parse with vue parser, then delegate script blocks to JS/TS
         if language == "vue":
             return self._parse_vue(path, source)
@@ -1127,6 +1226,13 @@ class CodeParser:
             import_map=import_map, defined_names=defined_names,
         )
 
+        if language == "php":
+            self._extract_php_laravel_edges(
+                tree.root_node,
+                file_path_str,
+                edges,
+            )
+
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
 
@@ -1148,6 +1254,51 @@ class CodeParser:
                         line=edge.line,
                     ))
 
+        return nodes, edges
+
+    @classmethod
+    def _mask_blade_comments(cls, text: str) -> str:
+        """Mask Blade comments while preserving offsets and line numbers."""
+        def replace_comment(match: re.Match[str]) -> str:
+            return "".join(
+                char if char in "\r\n" else " "
+                for char in match.group(0)
+            )
+
+        return cls._BLADE_COMMENT_RE.sub(replace_comment, text)
+
+    def _parse_blade(
+        self,
+        path: Path,
+        source: bytes,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse static Blade template references without a Tree-sitter grammar."""
+        text = source.decode("utf-8", errors="replace")
+        masked = self._mask_blade_comments(text)
+        file_path = str(path)
+        nodes = [
+            NodeInfo(
+                kind="File",
+                name=file_path,
+                file_path=file_path,
+                line_start=1,
+                line_end=source.count(b"\n") + 1,
+                language="blade",
+                is_test=_is_test_file(file_path),
+            ),
+        ]
+        edges: list[EdgeInfo] = []
+        for match in self._BLADE_DIRECTIVE_RE.finditer(masked):
+            directive = match.group(1)
+            target = match.group(3)
+            edges.append(EdgeInfo(
+                kind="REFERENCES" if directive == "livewire" else "IMPORTS_FROM",
+                source=file_path,
+                target=target,
+                file_path=file_path,
+                line=masked.count("\n", 0, match.start()) + 1,
+                extra={"blade_directive": directive},
+            ))
         return nodes, edges
 
     def _parse_vue(
@@ -5247,6 +5398,518 @@ class CodeParser:
 
         return False
 
+    # ------------------------------------------------------------------
+    # PHP / Laravel semantic constructs
+    # ------------------------------------------------------------------
+
+    def _extract_php_laravel_edges(
+        self,
+        root,
+        file_path: str,
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Run evidence-gated Laravel analysis without altering generic calls."""
+        self._walk_php_laravel_sequence(
+            root,
+            file_path,
+            edges,
+            namespace="",
+        )
+
+    def _walk_php_laravel_sequence(
+        self,
+        container,
+        file_path: str,
+        edges: list[EdgeInfo],
+        namespace: str,
+    ) -> None:
+        """Walk a PHP namespace scope, applying imports in source order."""
+        current_namespace = namespace
+        imports: dict[str, str] = {}
+
+        for child in container.children:
+            if child.type == "namespace_definition":
+                child_namespace = self._php_namespace_name(child)
+                block = next(
+                    (
+                        part for part in child.children
+                        if part.type == "compound_statement"
+                    ),
+                    None,
+                )
+                if block is not None:
+                    self._walk_php_laravel_sequence(
+                        block,
+                        file_path,
+                        edges,
+                        namespace=child_namespace,
+                    )
+                else:
+                    current_namespace = child_namespace
+                    imports = {}
+                continue
+
+            if child.type == "namespace_use_declaration":
+                imports.update(self._php_import_bindings(child))
+                continue
+
+            self._walk_php_laravel_node(
+                child,
+                file_path,
+                edges,
+                current_namespace,
+                imports,
+                enclosing_class=None,
+                enclosing_func=None,
+                eloquent_model=False,
+            )
+
+    def _walk_php_laravel_node(
+        self,
+        node,
+        file_path: str,
+        edges: list[EdgeInfo],
+        namespace: str,
+        imports: dict[str, str],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        eloquent_model: bool,
+    ) -> None:
+        """Walk one PHP subtree with its namespace and enclosing-class evidence."""
+        if node.type in self._class_types["php"]:
+            class_name = self._get_name(node, "php", "class")
+            is_eloquent = (
+                node.type == "class_declaration"
+                and self._php_class_extends_eloquent_model(
+                    node,
+                    namespace,
+                    imports,
+                )
+            )
+            for child in node.children:
+                self._walk_php_laravel_node(
+                    child,
+                    file_path,
+                    edges,
+                    namespace,
+                    imports,
+                    enclosing_class=class_name,
+                    enclosing_func=None,
+                    eloquent_model=is_eloquent,
+                )
+            return
+
+        if node.type in self._function_types["php"]:
+            function_name = self._get_name(node, "php", "function")
+            for child in node.children:
+                self._walk_php_laravel_node(
+                    child,
+                    file_path,
+                    edges,
+                    namespace,
+                    imports,
+                    enclosing_class=enclosing_class,
+                    enclosing_func=function_name or enclosing_func,
+                    eloquent_model=eloquent_model,
+                )
+            return
+
+        if node.type == "scoped_call_expression":
+            self._emit_laravel_route_edge(
+                node,
+                file_path,
+                edges,
+                namespace,
+                imports,
+                enclosing_class,
+                enclosing_func,
+            )
+        elif node.type == "member_call_expression" and eloquent_model:
+            self._emit_laravel_relationship_edge(
+                node,
+                file_path,
+                edges,
+                namespace,
+                imports,
+                enclosing_class,
+                enclosing_func,
+            )
+
+        for child in node.children:
+            self._walk_php_laravel_node(
+                child,
+                file_path,
+                edges,
+                namespace,
+                imports,
+                enclosing_class,
+                enclosing_func,
+                eloquent_model,
+            )
+
+    @staticmethod
+    def _php_namespace_name(node) -> str:
+        for child in node.children:
+            if child.type == "namespace_name":
+                return child.text.decode(
+                    "utf-8", errors="replace",
+                ).strip("\\")
+        return ""
+
+    @staticmethod
+    def _php_import_bindings(node) -> dict[str, str]:
+        """Return case-insensitive local class aliases for a PHP use statement."""
+        statement = node.text.decode("utf-8", errors="replace").lstrip()
+        lowered = statement.casefold()
+        if lowered.startswith("use function ") or lowered.startswith("use const "):
+            return {}
+
+        group = next(
+            (
+                child for child in node.children
+                if child.type == "namespace_use_group"
+            ),
+            None,
+        )
+        prefix = ""
+        if group is not None:
+            for child in node.children:
+                if child.type == "namespace_name":
+                    prefix = child.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip("\\")
+                    break
+            clauses = [
+                child for child in group.children
+                if child.type == "namespace_use_clause"
+            ]
+        else:
+            clauses = [
+                child for child in node.children
+                if child.type == "namespace_use_clause"
+            ]
+
+        bindings: dict[str, str] = {}
+        for clause in clauses:
+            imported: Optional[str] = None
+            alias: Optional[str] = None
+            seen_alias = False
+            for child in clause.children:
+                if child.type == "as":
+                    seen_alias = True
+                    continue
+                if imported is None and child.type in ("qualified_name", "name"):
+                    imported = child.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip("\\")
+                    continue
+                if seen_alias and child.type == "name":
+                    alias = child.text.decode(
+                        "utf-8", errors="replace",
+                    )
+            if not imported:
+                continue
+            qualified = f"{prefix}\\{imported}" if prefix else imported
+            local_name = alias or qualified.rsplit("\\", 1)[-1]
+            bindings[local_name.casefold()] = qualified
+        return bindings
+
+    @staticmethod
+    def _php_resolve_class_reference(
+        reference: str,
+        namespace: str,
+        imports: dict[str, str],
+    ) -> str:
+        """Resolve a PHP class reference through aliases and its namespace."""
+        absolute = reference.startswith("\\")
+        normalized = reference.strip("\\")
+        if not normalized:
+            return ""
+        if absolute:
+            return normalized
+
+        head, separator, tail = normalized.partition("\\")
+        imported = imports.get(head.casefold())
+        if imported:
+            return f"{imported}\\{tail}" if separator else imported
+        if namespace:
+            return f"{namespace}\\{normalized}"
+        return normalized
+
+    def _php_class_extends_eloquent_model(
+        self,
+        node,
+        namespace: str,
+        imports: dict[str, str],
+    ) -> bool:
+        for base in self._get_bases(node, "php", b""):
+            resolved = self._php_resolve_class_reference(
+                base,
+                namespace,
+                imports,
+            )
+            if resolved.casefold() == self._LARAVEL_ELOQUENT_MODEL.casefold():
+                return True
+        return False
+
+    @staticmethod
+    def _php_scoped_call_parts(node) -> tuple[Optional[str], Optional[str]]:
+        named = [
+            child for child in node.children
+            if child.type in ("name", "qualified_name")
+        ]
+        if len(named) < 2:
+            return None, None
+        receiver = named[0].text.decode("utf-8", errors="replace")
+        method = named[-1].text.decode("utf-8", errors="replace")
+        return receiver, method
+
+    @staticmethod
+    def _php_class_constant_reference(node) -> Optional[str]:
+        class_reference: Optional[str] = None
+        constant: Optional[str] = None
+        for child in node.children:
+            if class_reference is None and child.type in ("name", "qualified_name"):
+                class_reference = child.text.decode(
+                    "utf-8", errors="replace",
+                )
+            elif child.type == "name":
+                constant = child.text.decode(
+                    "utf-8", errors="replace",
+                )
+        if class_reference and constant and constant.casefold() == "class":
+            return class_reference
+        return None
+
+    def _php_route_handler(
+        self,
+        node,
+    ) -> Optional[tuple[str, str]]:
+        arguments = next(
+            (child for child in node.children if child.type == "arguments"),
+            None,
+        )
+        if arguments is None:
+            return None
+        args = [
+            child for child in arguments.children
+            if child.type == "argument"
+        ]
+        if len(args) < 2:
+            return None
+        array = next(
+            (
+                child for child in args[1].children
+                if child.type == "array_creation_expression"
+            ),
+            None,
+        )
+        if array is None:
+            return None
+        elements = [
+            child for child in array.children
+            if child.type == "array_element_initializer"
+        ]
+        if len(elements) != 2:
+            return None
+
+        class_access = next(
+            (
+                child for child in elements[0].children
+                if child.type == "class_constant_access_expression"
+            ),
+            None,
+        )
+        method_string = next(
+            (
+                child for child in elements[1].children
+                if child.type in ("string", "encapsed_string")
+            ),
+            None,
+        )
+        if class_access is None or method_string is None:
+            return None
+        class_reference = self._php_class_constant_reference(class_access)
+        method = method_string.text.decode(
+            "utf-8", errors="replace",
+        ).strip("'\"")
+        if (
+            not class_reference
+            or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", method) is None
+        ):
+            return None
+        return class_reference, method
+
+    def _php_semantic_target(
+        self,
+        class_reference: str,
+        namespace: str,
+        imports: dict[str, str],
+        file_path: str,
+        method: Optional[str] = None,
+    ) -> str:
+        qualified_class = self._php_resolve_class_reference(
+            class_reference,
+            namespace,
+            imports,
+        )
+        short_name = qualified_class.rsplit("\\", 1)[-1]
+        resolved_file = self._resolve_module_to_file(
+            qualified_class,
+            file_path,
+            "php",
+        )
+        if resolved_file:
+            target = f"{resolved_file}::{short_name}"
+        else:
+            target = short_name
+        return f"{target}.{method}" if method else target
+
+    def _php_laravel_caller(
+        self,
+        file_path: str,
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+    ) -> str:
+        if enclosing_func:
+            return self._qualify(
+                enclosing_func,
+                file_path,
+                enclosing_class,
+            )
+        if enclosing_class:
+            return self._qualify(enclosing_class, file_path, None)
+        return file_path
+
+    def _emit_laravel_route_edge(
+        self,
+        node,
+        file_path: str,
+        edges: list[EdgeInfo],
+        namespace: str,
+        imports: dict[str, str],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+    ) -> None:
+        receiver, verb = self._php_scoped_call_parts(node)
+        if not receiver or verb not in self._LARAVEL_ROUTE_VERBS:
+            return
+        resolved_receiver = self._php_resolve_class_reference(
+            receiver,
+            namespace,
+            imports,
+        )
+        if resolved_receiver.casefold() != self._LARAVEL_ROUTE_FACADE.casefold():
+            return
+        handler = self._php_route_handler(node)
+        if handler is None:
+            return
+        controller, method = handler
+        edges.append(EdgeInfo(
+            kind="CALLS",
+            source=self._php_laravel_caller(
+                file_path,
+                enclosing_class,
+                enclosing_func,
+            ),
+            target=self._php_semantic_target(
+                controller,
+                namespace,
+                imports,
+                file_path,
+                method,
+            ),
+            file_path=file_path,
+            line=node.start_point[0] + 1,
+            extra={
+                "framework": "laravel",
+                "laravel_kind": "route",
+                "route_verb": verb,
+            },
+        ))
+
+    def _emit_laravel_relationship_edge(
+        self,
+        node,
+        file_path: str,
+        edges: list[EdgeInfo],
+        namespace: str,
+        imports: dict[str, str],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+    ) -> None:
+        if not node.children or node.children[0].type != "variable_name":
+            return
+        receiver = node.children[0].text.decode(
+            "utf-8", errors="replace",
+        )
+        if receiver != "$this":
+            return
+        method_node = next(
+            (
+                child for child in reversed(node.children)
+                if child.type == "name"
+            ),
+            None,
+        )
+        if method_node is None:
+            return
+        relationship = method_node.text.decode(
+            "utf-8", errors="replace",
+        )
+        if relationship not in self._LARAVEL_RELATIONSHIPS:
+            return
+
+        arguments = next(
+            (child for child in node.children if child.type == "arguments"),
+            None,
+        )
+        if arguments is None:
+            return
+        first_argument = next(
+            (
+                child for child in arguments.children
+                if child.type == "argument"
+            ),
+            None,
+        )
+        if first_argument is None:
+            return
+        class_access = next(
+            (
+                child for child in first_argument.children
+                if child.type == "class_constant_access_expression"
+            ),
+            None,
+        )
+        if class_access is None:
+            return
+        target_model = self._php_class_constant_reference(class_access)
+        if target_model is None:
+            return
+
+        edges.append(EdgeInfo(
+            kind="REFERENCES",
+            source=self._php_laravel_caller(
+                file_path,
+                enclosing_class,
+                enclosing_func,
+            ),
+            target=self._php_semantic_target(
+                target_model,
+                namespace,
+                imports,
+                file_path,
+            ),
+            file_path=file_path,
+            line=node.start_point[0] + 1,
+            extra={
+                "framework": "laravel",
+                "laravel_kind": "eloquent_relationship",
+                "relationship": relationship,
+            },
+        ))
+
     @staticmethod
     def _get_java_method_and_receiver(node) -> tuple[Optional[str], Optional[str]]:
         """For a Java method_invocation node, return (method_name, receiver_name).
@@ -6272,6 +6935,12 @@ class CodeParser:
                     current = current.parent
 
         elif language == "php":
+            composer_resolved = self._resolve_php_composer_module(
+                module, caller_dir,
+            )
+            if composer_resolved:
+                return composer_resolved
+
             # ``use App\Domain\Entity\Job;`` — convert namespace separators to
             # a relative path and walk up from the caller's directory to find
             # the file, mirroring the Java resolver. PSR-4 layouts where a
@@ -6290,6 +6959,92 @@ class CodeParser:
                 current = current.parent
 
         return None
+
+    def _resolve_php_composer_module(
+        self,
+        module: str,
+        caller_dir: Path,
+    ) -> Optional[str]:
+        """Resolve a PHP class through the nearest bounded Composer project."""
+        boundary = self._php_repository_boundary(caller_dir)
+        if boundary is None:
+            return None
+        mappings = self._find_php_composer_psr4(caller_dir, boundary)
+        if not mappings:
+            return None
+
+        normalized_module = module.lstrip("\\")
+        for prefix, destinations in mappings:
+            if prefix:
+                if normalized_module == prefix:
+                    relative = ""
+                elif normalized_module.startswith(prefix + "\\"):
+                    relative = normalized_module[len(prefix) + 1:]
+                else:
+                    continue
+            else:
+                relative = normalized_module
+            if not relative:
+                continue
+            relative_path = relative.replace("\\", "/") + ".php"
+            for destination in destinations:
+                try:
+                    target = (Path(destination) / relative_path).resolve()
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                if not _path_is_within(target, boundary):
+                    continue
+                if target.is_file():
+                    return str(target)
+        return None
+
+    def _php_repository_boundary(self, start: Path) -> Optional[Path]:
+        """Return a safe Composer search boundary for *start*."""
+        try:
+            resolved_start = start.resolve()
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+        if self._repo_root is not None:
+            if _path_is_within(resolved_start, self._repo_root):
+                return self._repo_root
+            return None
+
+        current = resolved_start
+        while True:
+            if (current / ".git").exists() or (current / ".svn").exists():
+                return current
+            if current == current.parent:
+                break
+            current = current.parent
+        # With no explicit or discoverable repository, never climb above the
+        # caller directory looking for unrelated Composer configuration.
+        return resolved_start
+
+    def _find_php_composer_psr4(
+        self,
+        start: Path,
+        boundary: Path,
+    ) -> _PhpPsr4Mappings:
+        """Find and parse the nearest composer.json without crossing *boundary*."""
+        current = start.resolve()
+        while _path_is_within(current, boundary):
+            composer = current / "composer.json"
+            if composer.is_file():
+                try:
+                    composer_stat = composer.stat()
+                except OSError:
+                    return ()
+                return _read_php_composer_psr4(
+                    str(composer.resolve()),
+                    str(boundary),
+                    composer_stat.st_mtime_ns,
+                    composer_stat.st_size,
+                )
+            if current == boundary:
+                break
+            current = current.parent
+        return ()
 
     def _find_dart_pubspec_root(
         self, start: Path, pkg_name: str,
@@ -7007,6 +7762,16 @@ class CodeParser:
                             bases.append(
                                 idents[0].text.decode("utf-8", errors="replace"),
                             )
+        elif language == "php":
+            # class Foo extends Bar implements Baz, Qux { ... }
+            for child in node.children:
+                if child.type not in ("base_clause", "class_interface_clause"):
+                    continue
+                for base in child.children:
+                    if base.type in ("name", "qualified_name"):
+                        bases.append(
+                            base.text.decode("utf-8", errors="replace"),
+                        )
         return bases
 
     def _extract_import(self, node, language: str, source: bytes) -> list[str]:
@@ -7308,6 +8073,13 @@ class CodeParser:
                     return f"{parts[0]}::{parts[-1]}"
                 if parts:
                     return parts[0]
+                return None
+
+            if node.type == "object_creation_expression":
+                for child in node.children:
+                    if child.type in ("name", "qualified_name"):
+                        raw = child.text.decode("utf-8", errors="replace")
+                        return _normalize_php_name(raw)
                 return None
 
         # Scala: instance_expression (new Foo(...)) – extract the type name

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,7 @@
 # Features
 
 ## v2.3.6 (Current)
+- **Framework-aware PHP parsing**: traits, enums, object creation, and base clauses are indexed; Composer PSR-4 resolution is longest-prefix, multi-directory, cached, and repository-bounded; Blade references ignore comments/escaped directives; Laravel Route and Eloquent edges require explicit framework/import/receiver evidence.
 - **Custom languages without forking**: drop a `.code-review-graph/languages.toml` into your repo to index any grammar shipped by tree-sitter-language-pack — extension map plus node-type lists, validated and capped, with built-in languages always winning. See [CUSTOM_LANGUAGES.md](CUSTOM_LANGUAGES.md).
 - **GitHub Action for risk-scored PR reviews**: composite `action.yml` builds/restores the graph from CI cache, runs `detect-changes` against the PR base, and upserts a sticky comment with risk table, affected flows, test gaps, and the Token Savings line. Optional `fail-on-risk` merge gate. Dogfooded on this repo via `.github/workflows/pr-review.yml`. See [GITHUB_ACTION.md](GITHUB_ACTION.md).
 - **`agent_baseline` eval benchmark**: compares graph queries against a realistic grep-and-read-top-k agent baseline instead of the whole-corpus strawman; wired into all six pinned eval configs.

--- a/docs/superpowers/plans/2026-07-17-php-laravel-parser.md
+++ b/docs/superpowers/plans/2026-07-17-php-laravel-parser.md
@@ -1,0 +1,167 @@
+# PHP and Laravel Parser Port Implementation Plan
+
+> **Execution:** Follow strict red/green/refactor order. Do not combine surfaces
+> before the preceding focused test is green.
+
+**Goal:** Port the viable PHP/Laravel behavior from closed PR #252 onto current
+`main` while retaining stronger existing PHP calls/imports and adding the
+required correctness, repository-boundary, and process-pool coverage.
+
+**Architecture:** Extend the generic PHP syntax tables minimally. Keep Composer
+resolution in bounded immutable helpers. Parse Blade through a dedicated
+lightweight branch. Add Laravel edges in an independent PHP AST post-pass so
+the generic recursive extractor remains unchanged.
+
+**Source attribution:** The feature commit must include
+`Co-authored-by: Minidoracat <minidora0702@gmail.com>`.
+
+---
+
+## Task 1: PHP syntax and PHP-only flow entry points
+
+**Files:**
+
+- Modify: `tests/test_multilang.py`
+- Modify: `tests/test_flows.py`
+- Modify: `code_review_graph/parser.py`
+- Modify: `code_review_graph/flows.py`
+
+1. Add focused tests for trait and enum Class nodes, `new` CALLS, PHP
+   extends/implements targets, and unchanged existing scoped/member call
+   formatting.
+2. Add flow tests proving called PHP `boot`, `register`, and `__invoke`
+   methods are entries while identically named Python methods are not.
+3. Run both focused commands and confirm the new assertions fail for missing
+   behavior:
+   - `uv run --frozen --no-sync pytest -q tests/test_multilang.py -k PHP`
+   - `uv run --frozen --no-sync pytest -q tests/test_flows.py -k php_entry`
+4. Add only the PHP table, object-creation name, base-clause, and
+   language-scoped flow changes.
+5. Re-run the focused tests and refactor only while green.
+
+## Task 2: Shape-safe, repository-bounded Composer PSR-4
+
+**Files:**
+
+- Create: `tests/test_php_laravel.py`
+- Modify: `code_review_graph/parser.py`
+
+1. Build temporary Composer repositories and add failing tests for:
+   - normal PSR-4 resolution;
+   - longest-prefix selection;
+   - multiple directories for one prefix;
+   - merged `autoload` and `autoload-dev` directories;
+   - malformed document/section/`psr-4`/entry shapes;
+   - caller and mapping paths outside the configured repository;
+   - `..`, absolute-path, and symlink escapes;
+   - compatibility fallback when Composer has no matching file.
+2. Run:
+   `uv run --frozen --no-sync pytest -q tests/test_php_laravel.py -k composer`
+   and confirm failures are missing-resolution failures, not fixture errors.
+3. Store a resolved repository root on `CodeParser`.
+4. Add a bounded Composer ancestor search and immutable mapping loader.
+   Validate JSON shapes, preserve all directories, merge sections, normalize
+   prefixes, sort longest-first, and require resolved paths to stay within the
+   root.
+5. Integrate Composer before the existing PHP ancestor fallback.
+6. Re-run the focused tests.
+
+## Task 3: Composer cache and worker behavior
+
+**Files:**
+
+- Modify: `tests/test_php_laravel.py`
+- Modify: `code_review_graph/parser.py`
+
+1. Add failing cache tests proving:
+   - independent parser instances reuse an unchanged Composer file;
+   - a changed stat key reloads it;
+   - repositories do not share cached mappings.
+2. Add a bounded process-local cache keyed by Composer path, repository root,
+   `mtime_ns`, and size, returning only immutable data.
+3. Re-run Composer tests.
+
+## Task 4: Blade parsing with comments and escapes
+
+**Files:**
+
+- Modify: `tests/test_php_laravel.py`
+- Modify: `code_review_graph/parser.py`
+
+1. Add failing tests for compound-extension detection, File node shape,
+   `@extends`/`@include`/`@component` imports, `@livewire` references,
+   exact line numbers, Blade-comment suppression, `@@` escape suppression,
+   unterminated comments, invalid UTF-8, and ordinary PHP isolation.
+2. Run:
+   `uv run --frozen --no-sync pytest -q tests/test_php_laravel.py -k blade`.
+3. Add Blade detection, comment masking that preserves newlines/offsets, and a
+   negative-lookbehind directive matcher.
+4. Re-run the focused tests.
+
+## Task 5: Evidence-gated Laravel semantic edges
+
+**Files:**
+
+- Modify: `tests/test_php_laravel.py`
+- Modify: `code_review_graph/parser.py`
+
+1. Add positive failing tests for Route facade aliases/FQCNs, controller import
+   aliases/FQCNs, Eloquent Model aliases/FQCNs, relationship targets, namespace
+   blocks, and Composer-qualified graph targets.
+2. Add negative failing tests for unrelated `Route` classes, missing facade
+   imports, dynamic route handlers, non-Model classes, wrong receivers,
+   similarly named methods, and non-`::class` arguments.
+3. Assert each positive case still has the exact generic CALLS target already
+   produced by `main`, with no duplicate generic edge.
+4. Run:
+   `uv run --frozen --no-sync pytest -q tests/test_php_laravel.py -k laravel`.
+5. Add namespace-local PHP import bindings with aliases/grouped imports.
+6. Add the standalone PHP semantic AST post-pass. Resolve semantic targets
+   through Composer where possible; otherwise emit stable short targets.
+7. Re-run the focused tests and inspect edge lists for duplicates.
+
+## Task 6: Serial/process-pool parity
+
+**Files:**
+
+- Modify: `tests/test_php_laravel.py`
+
+1. Add a Composer project with at least eight tracked PHP files.
+2. Build it once with `CRG_SERIAL_PARSE=1` and once with the real process
+   executor. Assert no errors and identical normalized nodes/edges.
+3. Run the process test outside the restricted sandbox when OS semaphore
+   access is required:
+   `uv run --frozen --no-sync pytest -q tests/test_php_laravel.py -k process_pool`.
+
+## Task 7: Documentation and source attribution
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/FEATURES.md`
+
+1. Document Composer/Blade/Laravel support without claiming heuristic-only
+   Route or Eloquent detection.
+2. Run `git diff --check`.
+3. Commit implementation and tests with the Minidoracat co-author trailer.
+
+## Task 8: Verification, graph review, and publication
+
+1. Run focused tests:
+   `uv run --frozen --no-sync pytest -q tests/test_php_laravel.py tests/test_multilang.py tests/test_flows.py tests/test_incremental.py`.
+2. Run all local CI-equivalent gates:
+   - `uv run --frozen --no-sync ruff check code_review_graph/`
+   - `uv run --frozen --no-sync --with mypy --with types-networkx mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
+   - `uv run --frozen --no-sync --with 'bandit[toml]' bandit -r code_review_graph/ -c pyproject.toml`
+   - a portable local equivalent of the schema-sync comparison in
+     `.github/workflows/ci.yml`
+   - `uv run --frozen --no-sync pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65`
+3. Use the repository graph to detect changed risk, affected flows, and test
+   coverage; inspect any high-risk context.
+4. Fetch and rebase latest `origin/main`, rerun focused/full gates, and
+   confirm `git diff --check`.
+5. Push `codex/port-php-laravel`, open a draft PR (CI runs only for pushes to
+   `main` or pull requests), wait for the full PR CI to pass, then mark it
+   ready.
+6. Do not change source PR #252. Update/close bead `crg-erd.2.1` only after
+   the ready PR and required CI are confirmed.

--- a/docs/superpowers/specs/2026-07-17-php-laravel-parser-design.md
+++ b/docs/superpowers/specs/2026-07-17-php-laravel-parser-design.md
@@ -1,0 +1,139 @@
+# PHP and Laravel Parser Port Design
+
+## Context
+
+Pull request #252 contains useful PHP, Composer, Blade, and Laravel parsing
+work, but its branch predates stronger PHP call and `use` handling that is
+already on `main`. This port takes only the remaining behavior and preserves
+the current generic parser path.
+
+The source implementation is credited to Minidoracat
+(`minidora0702@gmail.com`). The port commit will retain that attribution.
+
+## Goals
+
+- Recognize PHP traits, enums, object creation, and inheritance/interface
+  clauses without changing existing PHP call or import formatting.
+- Treat PHP `boot`, `register`, and `__invoke` methods as language-scoped
+  entry points. Existing universal `handle`, `up`, and `down` behavior
+  remains unchanged.
+- Resolve PHP namespaces through Composer PSR-4 mappings safely and
+  deterministically.
+- Parse Blade template references while ignoring Blade comments and escaped
+  directives.
+- Add Laravel Route-to-controller and Eloquent relationship edges only when
+  the AST contains explicit framework and receiver evidence.
+- Keep serial and process-pool builds behaviorally equivalent.
+
+## Non-goals
+
+- Replacing the existing PHP parser or import resolver.
+- Inferring Laravel semantics from method names alone.
+- Supporting every Blade directive or dynamic route target.
+- Resolving Composer dependencies outside the repository.
+- Reopening, merging, or otherwise modifying source PR #252.
+
+## Design
+
+### PHP syntax and entry points
+
+The existing Tree-sitter tables gain PHP `trait_declaration`,
+`enum_declaration`, and `object_creation_expression`. The current PHP
+`_get_call_name` branch is extended only for object creation, and
+`_get_bases` gains PHP `base_clause` and `class_interface_clause`
+handling.
+
+Flow detection gains a PHP-only pattern set for `boot`, `register`, and
+`__invoke`. Names that are already universal are not duplicated.
+
+### Composer PSR-4 resolution
+
+`CodeParser` records its resolved repository root. Composer lookup starts at
+the caller directory and stops at that root, inclusive. If no root was supplied,
+the parser uses the nearest VCS root; without a safe boundary it does not climb
+above the caller directory.
+
+Composer data is accepted only when each container has the expected JSON shape:
+
+- document, `autoload`, and `autoload-dev`: objects;
+- `psr-4`: object;
+- prefix: string;
+- mapped path: string or list of strings.
+
+Mappings from both sections are combined without overwriting. All valid mapped
+directories are retained in declaration order. Prefixes are normalized and
+searched longest-first. Resolved base directories and target files must remain
+inside the repository after symlink resolution; absolute paths and `..`
+escapes that leave the repository are ignored.
+
+The parsed mapping is immutable. A bounded process-local cache is keyed by the
+Composer path, repository root, file modification time, and size. This lets
+serial parsers and long-lived process-pool workers reuse configuration without
+stale cross-repository results.
+
+The current ancestor-walk resolver remains as a compatibility fallback after
+Composer resolution.
+
+### Blade templates
+
+Compound `.blade.php` names are detected before ordinary `.php` suffix
+handling. A dedicated lightweight parser emits one File node and:
+
+- `IMPORTS_FROM` for `@extends`, `@include`, and `@component`;
+- `REFERENCES` for `@livewire`.
+
+Blade comment spans (`{{-- ... --}}`) are masked while preserving newlines and
+character offsets. The directive matcher requires an unescaped `@`, so
+`@@include` and equivalent escaped forms do not emit edges. Edge line numbers
+therefore remain aligned with the original source.
+
+### Laravel semantic evidence
+
+Laravel analysis runs as a separate PHP AST post-pass after generic extraction.
+It never consumes a Tree-sitter node and never recreates the ordinary CALLS
+edge. This preserves current targets such as `Route::get`, `hasMany`, and
+all nested calls.
+
+The post-pass builds namespace-local class import bindings, including aliases
+and grouped imports, and tracks the enclosing class.
+
+A Route controller CALLS edge is emitted only when:
+
+1. the scoped call is a supported route verb;
+2. its receiver is an alias imported from
+   `Illuminate\\Support\\Facades\\Route`, or that full class name is used;
+3. the handler has the static array form
+   `[Controller::class, 'method']`.
+
+An Eloquent REFERENCES edge is emitted only when:
+
+1. the call uses a supported relationship method;
+2. the receiver is exactly `$this`;
+3. the enclosing class extends an imported/fully-qualified
+   `Illuminate\\Database\\Eloquent\\Model`;
+4. the first relevant argument is `Target::class`.
+
+Imported or fully-qualified controller/model names are resolved through
+Composer. When a target file exists, the semantic edge uses the graph's real
+qualified-name shape (`file.php::Class.method` for routes and
+`file.php::Class` for models). Otherwise it retains a stable short semantic
+target rather than inventing a file.
+
+## Testing
+
+Each surface is implemented red-first:
+
+1. PHP traits, enums, `new`, base clauses, and language-scoped entry points.
+2. Composer malformed shapes, longest prefix, multi-directory mappings,
+   `autoload-dev` merging, cache invalidation/reuse, repository traversal,
+   absolute paths, and symlink escape.
+3. Blade directives, line numbers, comments, escaped directives, malformed
+   input, and ordinary PHP isolation.
+4. Laravel positive alias/FQCN cases and negative unrelated `Route`,
+   non-model relationship, wrong receiver, dynamic handler, and missing-import
+   cases.
+5. Serial/process-pool parity on a Composer PHP project with enough files to
+   enter the parallel path.
+
+After focused tests, the full suite, Ruff, schema generation check, graph change
+review, and GitHub CI must pass before the ready PR is opened.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -35,6 +35,7 @@ class TestFlows:
         parent: str | None = None,
         is_test: bool = False,
         extra: dict | None = None,
+        language: str = "python",
     ) -> int:
         node = NodeInfo(
             kind="Test" if is_test else "Function",
@@ -42,7 +43,7 @@ class TestFlows:
             file_path=path,
             line_start=1,
             line_end=10,
-            language="python",
+            language=language,
             parent_name=parent,
             is_test=is_test,
             extra=extra or {},
@@ -109,6 +110,28 @@ class TestFlows:
         assert "on_message" in ep_names
         assert "handle_request" in ep_names
         assert "regular_func" not in ep_names
+
+    def test_php_entry_names_are_language_scoped(self):
+        """PHP framework and magic method names must not pollute other languages."""
+        names = ("boot", "register", "__invoke")
+        for name in names:
+            self._add_func(name, path="app.php", language="php")
+            self._add_func(name, path="app.py", language="python")
+            self._add_call("app.php::caller", f"app.php::{name}", "app.php")
+            self._add_call("app.py::caller", f"app.py::{name}", "app.py")
+
+        entries = detect_entry_points(self.store)
+        php_entries = {
+            node.name for node in entries
+            if node.file_path == "app.php"
+        }
+        python_entries = {
+            node.name for node in entries
+            if node.file_path == "app.py"
+        }
+
+        assert php_entries == set(names)
+        assert python_entries.isdisjoint(names)
 
     # ---------------------------------------------------------------
     # detect_entry_points -- expanded decorator patterns

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -751,7 +751,7 @@ class TestPHPImportResolution:
             "class MatchService {}\n"
         )
 
-        parser = CodeParser()
+        parser = CodeParser(tmp_path)
         _, edges = parser.parse_file(svc / "MatchService.php")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
@@ -788,7 +788,7 @@ class TestPHPImportResolution:
             "use App\\Domain\\Embedded\\Contact as ContactEmbedded;\n"
             "class Job {}\n"
         )
-        parser = CodeParser()
+        parser = CodeParser(tmp_path)
         _, edges = parser.parse_file(job / "Job.php")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
@@ -813,7 +813,7 @@ class TestPHPImportResolution:
             "use App\\Domain\\{Entity\\Job, Model\\Status};\n"
             "class C {}\n"
         )
-        parser = CodeParser()
+        parser = CodeParser(tmp_path)
         _, edges = parser.parse_file(consumer / "C.php")
         targets = {e.target for e in edges if e.kind == "IMPORTS_FROM"}
         assert str((base / "Entity/Job.php").resolve()) in targets

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -701,6 +701,37 @@ class TestPHPParsing:
         # Global namespaced calls should normalize to a stable name
         assert "dirname" in target_names
 
+    def test_finds_extended_php_types_bases_and_object_creation(self):
+        source = b"""<?php
+trait Auditable {}
+enum Status: string { case Active = 'active'; }
+interface Contract {}
+
+class Service extends \\Framework\\Base implements Contract, \\Other\\Marker {
+    public function run(): void {
+        $worker = new \\App\\Worker();
+        $worker->save();
+        Service::factory();
+    }
+}
+"""
+
+        nodes, edges = self.parser.parse_bytes(Path("extended.php"), source)
+
+        class_names = {node.name for node in nodes if node.kind == "Class"}
+        assert {"Auditable", "Status", "Contract", "Service"} <= class_names
+
+        inherited = {edge.target for edge in edges if edge.kind == "INHERITS"}
+        assert "\\Framework\\Base" in inherited
+        assert "Contract" in inherited
+        assert "\\Other\\Marker" in inherited
+
+        calls = {edge.target for edge in edges if edge.kind == "CALLS"}
+        assert "App\\Worker" in calls
+        # Existing PHP call formatting must stay unchanged.
+        assert "save" in calls
+        assert "Service::factory" in calls
+
 
 class TestPHPImportResolution:
     """PHP ``use`` imports resolve to absolute file paths (PSR-4 layout)."""

--- a/tests/test_php_laravel.py
+++ b/tests/test_php_laravel.py
@@ -215,6 +215,80 @@ class TestComposerPsr4:
 
         assert resolved is None
 
+    def test_php_ancestor_fallback_does_not_escape_configured_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"Other\\": "other/"}}})
+        caller = _write_php(repo / "src/Caller.php")
+        _write_php(tmp_path / "Outside/Foo.php")
+
+        resolved = CodeParser(repo)._resolve_module_to_file(
+            "Outside\\Foo", str(caller), "php",
+        )
+
+        assert resolved is None
+
+    def test_php_ancestor_fallback_without_repo_does_not_climb_above_caller(
+        self, tmp_path,
+    ):
+        caller = _write_php(tmp_path / "project/src/Caller.php")
+        _write_php(tmp_path / "project/Outside/Foo.php")
+
+        resolved = CodeParser()._resolve_module_to_file(
+            "Outside\\Foo", str(caller), "php",
+        )
+
+        assert resolved is None
+
+    def test_php_ancestor_fallback_rejects_symlink_target_outside_repo(
+        self, tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        _write_composer(repo, {"autoload": {"psr-4": {"Other\\": "other/"}}})
+        caller = _write_php(repo / "src/Caller.php")
+        _write_php(outside / "Foo.php")
+        try:
+            (repo / "src/Outside").symlink_to(
+                outside,
+                target_is_directory=True,
+            )
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+
+        resolved = CodeParser(repo)._resolve_module_to_file(
+            "Outside\\Foo", str(caller), "php",
+        )
+
+        assert resolved is None
+
+    def test_php_ancestor_fallback_fails_soft_when_start_resolution_raises(
+        self, tmp_path, monkeypatch,
+    ):
+        repo = tmp_path / "repo"
+        caller = _write_php(repo / "src/Caller.php")
+        target = _write_php(repo / "src/App/Foo.php")
+        parser = CodeParser(repo)
+        monkeypatch.setattr(
+            parser,
+            "_resolve_php_composer_module",
+            lambda _module, _caller_dir: None,
+        )
+        original_resolve = Path.resolve
+
+        def raise_for_caller(path, *args, **kwargs):
+            if path == caller.parent:
+                raise RuntimeError("synthetic resolution failure")
+            return original_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", raise_for_caller)
+
+        resolved = parser._resolve_module_to_file(
+            "App\\Foo", str(caller), "php",
+        )
+
+        assert target.is_file()
+        assert resolved is None
+
     def test_composer_keeps_existing_php_ancestor_fallback(self, tmp_path):
         repo = tmp_path / "repo"
         _write_composer(repo, {"autoload": {"psr-4": {"Other\\": "other/"}}})

--- a/tests/test_php_laravel.py
+++ b/tests/test_php_laravel.py
@@ -1,0 +1,737 @@
+"""Focused coverage for the PHP, Composer, Blade, and Laravel parser port."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from code_review_graph import parser as parser_module
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.parser import CodeParser
+
+
+def _write_composer(repo: Path, data: object) -> Path:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".git").mkdir(exist_ok=True)
+    composer = repo / "composer.json"
+    composer.write_text(json.dumps(data), encoding="utf-8")
+    return composer
+
+
+def _write_php(path: Path, source: str = "<?php\nclass Placeholder {}\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _php_import_target(parser: CodeParser, caller: Path, module: str) -> str:
+    _write_php(
+        caller,
+        "<?php\n"
+        f"use {module};\n"
+        "class Caller {}\n",
+    )
+    _, edges = parser.parse_file(caller)
+    imports = [edge.target for edge in edges if edge.kind == "IMPORTS_FROM"]
+    assert len(imports) == 1, imports
+    return imports[0]
+
+
+@pytest.fixture(autouse=True)
+def _clear_composer_loader_cache():
+    clear = getattr(parser_module._read_php_composer_psr4, "cache_clear", None)
+    if clear is not None:
+        clear()
+    yield
+    if clear is not None:
+        clear()
+
+
+class TestComposerPsr4:
+    def test_composer_resolves_standard_psr4_mapping(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        target = _write_php(repo / "app/Models/User.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "app/Services/Report.php",
+            "App\\Models\\User",
+        )
+
+        assert resolved == str(target.resolve())
+
+    def test_composer_uses_longest_matching_prefix(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(
+            repo,
+            {
+                "autoload": {
+                    "psr-4": {
+                        "App\\": "fallback/",
+                        "App\\Domain\\": "domain/",
+                    },
+                },
+            },
+        )
+        _write_php(repo / "fallback/Domain/Thing.php")
+        target = _write_php(repo / "domain/Thing.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/Caller.php",
+            "App\\Domain\\Thing",
+        )
+
+        assert resolved == str(target.resolve())
+
+    def test_composer_checks_every_directory_for_prefix(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"App\\": ["missing/", "src/"]}}},
+        )
+        target = _write_php(repo / "src/Thing.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "app/Caller.php",
+            "App\\Thing",
+        )
+
+        assert resolved == str(target.resolve())
+
+    def test_composer_merges_autoload_and_autoload_dev_directories(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(
+            repo,
+            {
+                "autoload": {"psr-4": {"App\\": "app/"}},
+                "autoload-dev": {"psr-4": {"App\\": "dev/"}},
+            },
+        )
+        target = _write_php(repo / "dev/Tests/Factory.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "tests/Caller.php",
+            "App\\Tests\\Factory",
+        )
+
+        assert resolved == str(target.resolve())
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            [],
+            {"autoload": []},
+            {"autoload": {"psr-4": []}},
+            {"autoload": {"psr-4": {"App\\": 7}}},
+            {"autoload": {"psr-4": {"App\\": [7, None]}}},
+            {"autoload-dev": None},
+        ],
+    )
+    def test_composer_malformed_shapes_are_ignored(self, tmp_path, data):
+        repo = tmp_path / "repo"
+        _write_composer(repo, data)
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/Caller.php",
+            "App\\Missing",
+        )
+
+        assert resolved == "App\\Missing"
+
+    def test_composer_rejects_parent_traversal_outside_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"Evil\\": "../outside/"}}},
+        )
+        _write_php(outside / "Secret.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/Caller.php",
+            "Evil\\Secret",
+        )
+
+        assert resolved == "Evil\\Secret"
+
+    def test_composer_rejects_absolute_mapping_outside_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        target = _write_php(outside / "Secret.php")
+        _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"Evil\\": str(outside)}}},
+        )
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/Caller.php",
+            "Evil\\Secret",
+        )
+
+        assert resolved != str(target.resolve())
+        assert resolved == "Evil\\Secret"
+
+    def test_composer_rejects_symlink_mapping_outside_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        _write_php(outside / "Secret.php")
+        _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"Evil\\": "linked/"}}},
+        )
+        try:
+            (repo / "linked").symlink_to(outside, target_is_directory=True)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/Caller.php",
+            "Evil\\Secret",
+        )
+
+        assert resolved == "Evil\\Secret"
+
+    def test_composer_does_not_resolve_caller_outside_configured_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        _write_php(repo / "app/User.php")
+        caller = _write_php(tmp_path / "outside/Caller.php")
+
+        resolved = CodeParser(repo)._resolve_module_to_file(
+            "App\\User", str(caller), "php",
+        )
+
+        assert resolved is None
+
+    def test_composer_keeps_existing_php_ancestor_fallback(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"Other\\": "other/"}}})
+        target = _write_php(repo / "src/App/Domain/Thing.php")
+
+        resolved = _php_import_target(
+            CodeParser(repo),
+            repo / "src/App/Service/Caller.php",
+            "App\\Domain\\Thing",
+        )
+
+        assert resolved == str(target.resolve())
+
+
+class TestComposerCache:
+    def test_composer_cache_is_bounded(self):
+        cache_info = getattr(
+            parser_module._read_php_composer_psr4,
+            "cache_info",
+            None,
+        )
+
+        assert cache_info is not None
+        assert cache_info().maxsize == 128
+
+    def test_composer_cache_reuses_unchanged_file_across_parsers(
+        self, tmp_path, monkeypatch,
+    ):
+        repo = tmp_path / "repo"
+        composer = _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"App\\": "app/"}}},
+        ).resolve()
+        target = _write_php(repo / "app/User.php")
+        caller = _write_php(repo / "src/Caller.php")
+        original_read_text = Path.read_text
+        composer_reads = 0
+
+        def counting_read_text(path, *args, **kwargs):
+            nonlocal composer_reads
+            if path.resolve() == composer:
+                composer_reads += 1
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+        first = CodeParser(repo)._resolve_module_to_file(
+            "App\\User", str(caller), "php",
+        )
+        second = CodeParser(repo)._resolve_module_to_file(
+            "App\\User", str(caller), "php",
+        )
+
+        assert first == second == str(target.resolve())
+        assert composer_reads == 1
+
+    def test_composer_cache_reloads_after_stat_change(self, tmp_path):
+        repo = tmp_path / "repo"
+        composer = _write_composer(
+            repo,
+            {"autoload": {"psr-4": {"App\\": "app/"}}},
+        )
+        _write_php(repo / "app/User.php")
+        caller = _write_php(repo / "src/Caller.php")
+
+        first = CodeParser(repo)._resolve_module_to_file(
+            "App\\User", str(caller), "php",
+        )
+
+        composer.write_text(
+            json.dumps(
+                {"autoload": {"psr-4": {"App\\": "updated-source/"}}},
+            ),
+            encoding="utf-8",
+        )
+        updated = _write_php(repo / "updated-source/User.php")
+        second = CodeParser(repo)._resolve_module_to_file(
+            "App\\User", str(caller), "php",
+        )
+
+        assert first != second
+        assert second == str(updated.resolve())
+
+    def test_composer_cache_isolated_between_repositories(self, tmp_path):
+        first_repo = tmp_path / "first"
+        second_repo = tmp_path / "second"
+        _write_composer(
+            first_repo,
+            {"autoload": {"psr-4": {"App\\": "one/"}}},
+        )
+        _write_composer(
+            second_repo,
+            {"autoload": {"psr-4": {"App\\": "two/"}}},
+        )
+        first_target = _write_php(first_repo / "one/User.php")
+        second_target = _write_php(second_repo / "two/User.php")
+        first_caller = _write_php(first_repo / "src/Caller.php")
+        second_caller = _write_php(second_repo / "src/Caller.php")
+
+        first = CodeParser(first_repo)._resolve_module_to_file(
+            "App\\User", str(first_caller), "php",
+        )
+        second = CodeParser(second_repo)._resolve_module_to_file(
+            "App\\User", str(second_caller), "php",
+        )
+
+        assert first == str(first_target.resolve())
+        assert second == str(second_target.resolve())
+
+
+class TestBladeParsing:
+    def test_blade_compound_extension_and_directives(self, tmp_path):
+        template = tmp_path / "resources/views/home.blade.php"
+        source = b"""{{-- @include('commented.out') --}}
+@@include('escaped.out')
+@extends('layouts.app')
+@include("partials.header")
+@component('components.alert')
+@livewire('counter')
+"""
+        parser = CodeParser(tmp_path)
+
+        nodes, edges = parser.parse_bytes(template, source)
+
+        assert parser.detect_language(template) == "blade"
+        assert len(nodes) == 1
+        assert nodes[0].kind == "File"
+        assert nodes[0].name == str(template)
+        assert nodes[0].file_path == str(template)
+        assert nodes[0].language == "blade"
+        assert nodes[0].line_end == 7
+
+        imports = {
+            edge.target: edge.line
+            for edge in edges
+            if edge.kind == "IMPORTS_FROM"
+        }
+        references = {
+            edge.target: edge.line
+            for edge in edges
+            if edge.kind == "REFERENCES"
+        }
+        assert imports == {
+            "layouts.app": 3,
+            "partials.header": 4,
+            "components.alert": 5,
+        }
+        assert references == {"counter": 6}
+
+    def test_blade_detection_is_case_insensitive(self):
+        assert CodeParser().detect_language(Path("HOME.BLADE.PHP")) == "blade"
+
+    def test_blade_ignores_multiline_and_unterminated_comments(self, tmp_path):
+        parser = CodeParser(tmp_path)
+        commented = b"""{{-- start
+@include('hidden.one')
+--}}
+@include('visible')
+"""
+        unterminated = b"""@extends('visible.before')
+{{-- @include('hidden.two')
+@livewire('hidden.three')
+"""
+
+        _, commented_edges = parser.parse_bytes(
+            tmp_path / "commented.blade.php",
+            commented,
+        )
+        _, unterminated_edges = parser.parse_bytes(
+            tmp_path / "unterminated.blade.php",
+            unterminated,
+        )
+
+        assert [(edge.target, edge.line) for edge in commented_edges] == [
+            ("visible", 4),
+        ]
+        assert [(edge.target, edge.line) for edge in unterminated_edges] == [
+            ("visible.before", 1),
+        ]
+
+    def test_blade_ignores_all_escaped_directive_forms(self, tmp_path):
+        source = b"""@@extends('escaped.layout')
+@@include('escaped.partial')
+@@component('escaped.component')
+@@livewire('escaped.livewire')
+"""
+
+        _, edges = CodeParser(tmp_path).parse_bytes(
+            tmp_path / "escaped.blade.php",
+            source,
+        )
+
+        assert edges == []
+
+    def test_blade_replaces_invalid_utf8_without_losing_directive(self, tmp_path):
+        source = b"\xff\n@extends('layouts.app')\n"
+
+        nodes, edges = CodeParser(tmp_path).parse_bytes(
+            tmp_path / "invalid.blade.php",
+            source,
+        )
+
+        assert nodes[0].line_end == 3
+        assert [(edge.target, edge.line) for edge in edges] == [
+            ("layouts.app", 2),
+        ]
+
+    def test_blade_handling_does_not_change_regular_php(self, tmp_path):
+        path = tmp_path / "ordinary.php"
+        source = b"<?php\n// @include('not.blade')\nclass Ordinary {}\n"
+
+        nodes, edges = CodeParser(tmp_path).parse_bytes(path, source)
+
+        assert any(
+            node.kind == "File" and node.language == "php"
+            for node in nodes
+        )
+        assert any(
+            node.kind == "Class" and node.name == "Ordinary"
+            for node in nodes
+        )
+        assert not any(
+            edge.kind == "IMPORTS_FROM" and edge.target == "not.blade"
+            for edge in edges
+        )
+
+
+def _laravel_edges(edges, kind: str | None = None):
+    return [
+        edge for edge in edges
+        if edge.extra.get("framework") == "laravel"
+        and (kind is None or edge.kind == kind)
+    ]
+
+
+class TestLaravelSemantics:
+    def test_laravel_route_alias_resolves_grouped_controller_import(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        controller = _write_php(
+            repo / "app/Http/Controllers/UserController.php",
+            "<?php\nnamespace App\\Http\\Controllers;\n"
+            "class UserController { public function index(): void {} }\n",
+        )
+        source = br"""<?php
+use Illuminate\Support\Facades\Route as Router;
+use App\Http\Controllers\{UserController as Users};
+Router::get('/users', [Users::class, 'index']);
+"""
+
+        _, edges = CodeParser(repo).parse_bytes(repo / "routes/web.php", source)
+
+        semantic = _laravel_edges(edges, "CALLS")
+        assert [(edge.target, edge.extra["laravel_kind"]) for edge in semantic] == [
+            (f"{controller.resolve()}::UserController.index", "route"),
+        ]
+        assert len([
+            edge for edge in edges
+            if edge.kind == "CALLS" and edge.target == "Router::get"
+        ]) == 1
+
+    def test_laravel_route_accepts_fully_qualified_framework_and_controller(
+        self, tmp_path,
+    ):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        controller = _write_php(
+            repo / "app/Http/Controllers/UserController.php",
+        )
+        source = br"""<?php
+\Illuminate\Support\Facades\Route::post(
+    '/users',
+    [\App\Http\Controllers\UserController::class, "store"]
+);
+"""
+
+        _, edges = CodeParser(repo).parse_bytes(repo / "routes/api.php", source)
+
+        semantic = _laravel_edges(edges, "CALLS")
+        assert [edge.target for edge in semantic] == [
+            f"{controller.resolve()}::UserController.store",
+        ]
+        assert len([
+            edge for edge in edges
+            if edge.kind == "CALLS"
+            and edge.target == "Illuminate\\Support\\Facades\\Route::post"
+        ]) == 1
+
+    def test_laravel_eloquent_aliases_resolve_model_reference(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        post = _write_php(
+            repo / "app/Models/Post.php",
+            "<?php\nnamespace App\\Models;\nclass Post {}\n",
+        )
+        source = br"""<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use App\Models\Post as Article;
+
+class User extends BaseModel {
+    public function posts() {
+        return $this->hasMany(Article::class);
+    }
+}
+"""
+
+        _, edges = CodeParser(repo).parse_bytes(repo / "app/Models/User.php", source)
+
+        semantic = _laravel_edges(edges, "REFERENCES")
+        assert [(edge.target, edge.extra["relationship"]) for edge in semantic] == [
+            (f"{post.resolve()}::Post", "hasMany"),
+        ]
+        assert len([
+            edge for edge in edges
+            if edge.kind == "CALLS" and edge.target == "hasMany"
+        ]) == 1
+
+    def test_laravel_eloquent_accepts_fully_qualified_model_names(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        post = _write_php(repo / "app/Models/Post.php")
+        source = br"""<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function post() {
+        return $this->belongsTo(\App\Models\Post::class);
+    }
+}
+"""
+
+        _, edges = CodeParser(repo).parse_bytes(repo / "app/Models/User.php", source)
+
+        semantic = _laravel_edges(edges, "REFERENCES")
+        assert [edge.target for edge in semantic] == [
+            f"{post.resolve()}::Post",
+        ]
+        assert semantic[0].extra["relationship"] == "belongsTo"
+
+    def test_laravel_namespace_block_imports_do_not_leak(self, tmp_path):
+        repo = tmp_path / "repo"
+        _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+        post = _write_php(repo / "app/Models/Post.php")
+        source = br"""<?php
+namespace App\Good {
+    use Illuminate\Database\Eloquent\Model;
+    use App\Models\Post;
+    class User extends Model {
+        public function posts() { return $this->hasOne(Post::class); }
+    }
+}
+namespace App\Bad {
+    class Pretender extends Model {
+        public function posts() { return $this->hasOne(Post::class); }
+    }
+}
+"""
+
+        _, edges = CodeParser(repo).parse_bytes(repo / "app/Mixed.php", source)
+
+        semantic = _laravel_edges(edges, "REFERENCES")
+        assert [edge.target for edge in semantic] == [
+            f"{post.resolve()}::Post",
+        ]
+        assert semantic[0].source.endswith("::User.posts")
+
+    def test_laravel_requires_route_framework_and_static_handler_evidence(
+        self, tmp_path,
+    ):
+        source = br"""<?php
+use Acme\Routing\Route;
+use App\Http\Controllers\UserController;
+Route::get('/unrelated', [UserController::class, 'index']);
+
+use Illuminate\Support\Facades\Route as Router;
+$method = 'show';
+Router::get('/dynamic', [UserController::class, $method]);
+"""
+
+        _, edges = CodeParser(tmp_path).parse_bytes(tmp_path / "routes.php", source)
+
+        assert _laravel_edges(edges, "CALLS") == []
+        generic_targets = {
+            edge.target for edge in edges if edge.kind == "CALLS"
+        }
+        assert {"Route::get", "Router::get"} <= generic_targets
+
+    def test_laravel_requires_route_import_when_short_facade_is_used(self, tmp_path):
+        source = br"""<?php
+Route::get('/users', [UserController::class, 'index']);
+"""
+
+        _, edges = CodeParser(tmp_path).parse_bytes(tmp_path / "routes.php", source)
+
+        assert _laravel_edges(edges, "CALLS") == []
+        assert any(
+            edge.kind == "CALLS" and edge.target == "Route::get"
+            for edge in edges
+        )
+
+    def test_laravel_requires_model_class_receiver_and_class_argument(self, tmp_path):
+        source = br"""<?php
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Post;
+
+class Plain {
+    public function falsePositive() { return $this->hasMany(Post::class); }
+}
+class User extends Model {
+    public function wrongReceiver($builder) {
+        return $builder->hasMany(Post::class);
+    }
+    public function similarName() {
+        return $this->hasManyCustom(Post::class);
+    }
+    public function stringArgument() {
+        return $this->belongsTo('Post');
+    }
+}
+"""
+
+        _, edges = CodeParser(tmp_path).parse_bytes(tmp_path / "Models.php", source)
+
+        assert _laravel_edges(edges, "REFERENCES") == []
+        generic_targets = [
+            edge.target for edge in edges if edge.kind == "CALLS"
+        ]
+        assert generic_targets.count("hasMany") == 2
+        assert "hasManyCustom" in generic_targets
+        assert "belongsTo" in generic_targets
+
+    def test_laravel_unresolved_model_keeps_stable_short_target(self, tmp_path):
+        source = br"""<?php
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Missing;
+class User extends Model {
+    public function missing() { return $this->morphOne(Missing::class); }
+}
+"""
+
+        _, edges = CodeParser(tmp_path).parse_bytes(tmp_path / "User.php", source)
+
+        semantic = _laravel_edges(edges, "REFERENCES")
+        assert [edge.target for edge in semantic] == ["Missing"]
+
+
+def _graph_snapshot(store: GraphStore) -> tuple[list[tuple], list[tuple]]:
+    nodes = sorted(
+        (
+            node.kind,
+            node.name,
+            node.qualified_name,
+            node.file_path,
+            node.language,
+            json.dumps(node.extra, sort_keys=True),
+        )
+        for node in store.get_all_nodes(exclude_files=False)
+    )
+    edges = sorted(
+        (
+            edge.kind,
+            edge.source_qualified,
+            edge.target_qualified,
+            edge.file_path,
+            edge.line,
+            json.dumps(edge.extra, sort_keys=True),
+        )
+        for edge in store.get_all_edges()
+    )
+    return nodes, edges
+
+
+def test_composer_process_pool_matches_serial_build(tmp_path):
+    repo = tmp_path / "repo"
+    _write_composer(repo, {"autoload": {"psr-4": {"App\\": "app/"}}})
+    user = _write_php(
+        repo / "app/Models/User.php",
+        "<?php\nnamespace App\\Models;\nclass User {}\n",
+    )
+    callers = []
+    for index in range(8):
+        callers.append(_write_php(
+            repo / f"app/Services/Service{index}.php",
+            "<?php\n"
+            f"namespace App\\Services;\nuse App\\Models\\User;\n"
+            f"class Service{index} {{\n"
+            "    public function build(): User { return new User(); }\n"
+            "}\n",
+        ))
+    tracked = [
+        str(path.relative_to(repo))
+        for path in [user, *callers]
+    ]
+
+    serial_store = GraphStore(repo / "serial.db")
+    parallel_store = GraphStore(repo / "parallel.db")
+    try:
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=tracked,
+        ):
+            with patch.dict(
+                "os.environ",
+                {"CRG_SERIAL_PARSE": "1", "CRG_PARSE_EXECUTOR": "process"},
+            ):
+                serial_result = full_build(repo, serial_store)
+            parser_module._read_php_composer_psr4.cache_clear()
+            with patch.dict(
+                "os.environ",
+                {"CRG_SERIAL_PARSE": "", "CRG_PARSE_EXECUTOR": "process"},
+            ):
+                parallel_result = full_build(repo, parallel_store)
+
+        assert serial_result["errors"] == []
+        assert parallel_result["errors"] == []
+        assert serial_result["files_parsed"] == parallel_result["files_parsed"] == 9
+        assert _graph_snapshot(serial_store) == _graph_snapshot(parallel_store)
+    finally:
+        serial_store.close()
+        parallel_store.close()


### PR DESCRIPTION
## Summary

- Port the useful PHP, Composer, Blade, and Laravel behavior from closed PR #252 without reopening or modifying that source PR.
- Index PHP traits, enums, object construction, base clauses, and PHP-specific flow entry conventions.
- Add repository-bounded Composer PSR-4 resolution, Blade references, and evidence-gated Laravel Route and Eloquent edges.

## Safety and compatibility

- Composer parsing validates malformed JSON shapes, merges autoload and autoload-dev, preserves multiple directories, uses longest-prefix matching, and has a bounded stat-aware cache.
- Composer paths and resolved targets cannot escape the configured repository through parent traversal, absolute paths, or symlinks.
- Blade comments and escaped directives are ignored while source line numbers are preserved.
- Laravel semantics require explicit framework import or fully qualified receiver evidence; Eloquent relationships additionally require direct Model inheritance and a $this receiver.
- Existing generic PHP call extraction remains intact.

## Verification

- Focused parser and incremental suite: 473 passed.
- Full suite with coverage: 1,544 passed, 1 skipped, 2 xpassed; 75.31% coverage.
- Ruff, mypy, Bandit, schema synchronization, and diff checks pass locally.
- Knowledge-graph review reports low overall risk (0.40) and no affected existing execution flows.

Tracking: crg-erd.2.1

Source attribution is retained in the implementation commit: Co-authored-by: Minidoracat <minidora0702@gmail.com>.
