### PR TITLE
feat(review): add opt-in churn risk scoring

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -167,7 +167,100 @@ def _parse_unified_diff(diff_text: str) -> dict[str, list[tuple[int, int]]]:
 
 
 # ---------------------------------------------------------------------------
-# 2. map_changes_to_nodes
+# 2. compute_file_churn
+# ---------------------------------------------------------------------------
+
+_CHURN_SATURATION = 10.0
+_CHURN_WEIGHT = 0.15
+_NUMSTAT_COUNT = re.compile(r"^(?:\d+|-)$")
+
+
+def _parse_numstat(log_text: str) -> dict[str, int]:
+    """Parse NUL-terminated ``git log --numstat -z`` records.
+
+    NUL termination is required for correctness: Git's default line format
+    quotes unusual paths, while ``-z`` preserves tabs and newlines in file
+    names without making the graph-path lookup ambiguous.
+    """
+    counts: dict[str, int] = {}
+    for record in log_text.split("\0"):
+        if not record:
+            continue
+        fields = record.split("\t", 2)
+        if len(fields) != 3:
+            continue
+        added, deleted, path = fields
+        if (
+            not path
+            or _NUMSTAT_COUNT.fullmatch(added) is None
+            or _NUMSTAT_COUNT.fullmatch(deleted) is None
+        ):
+            continue
+        counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+def compute_file_churn(
+    repo_root: str,
+    window_days: int | None = None,
+) -> dict[str, int]:
+    """Count commits touching each file over a trailing window.
+
+    Returns an empty mapping when the window is invalid or Git cannot be
+    queried. Renames are deliberately not followed: churn belongs to the path
+    that existed in each commit.
+    """
+    if window_days is None:
+        raw_window = os.environ.get("CRG_CHURN_WINDOW_DAYS", "90")
+        try:
+            window_days = int(raw_window)
+        except ValueError:
+            logger.warning(
+                "Invalid CRG_CHURN_WINDOW_DAYS value %r; churn disabled",
+                raw_window,
+            )
+            return {}
+    if window_days <= 0:
+        return {}
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.quotepath=off",
+                "log",
+                f"--since={window_days}.days.ago",
+                "--numstat",
+                "--no-renames",
+                "--format=",
+                "-z",
+                "--",
+            ],
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=repo_root,
+            timeout=_GIT_TIMEOUT,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "git log failed (rc=%d): %s",
+                result.returncode,
+                result.stderr[:200],
+            )
+            return {}
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("git log error: %s", exc)
+        return {}
+
+    return _parse_numstat(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# 3. map_changes_to_nodes
 # ---------------------------------------------------------------------------
 
 
@@ -212,11 +305,15 @@ def map_changes_to_nodes(
 
 
 # ---------------------------------------------------------------------------
-# 3. compute_risk_score
+# 4. compute_risk_score
 # ---------------------------------------------------------------------------
 
 
-def compute_risk_score(store: GraphStore, node: GraphNode) -> float:
+def compute_risk_score(
+    store: GraphStore,
+    node: GraphNode,
+    churn_counts: dict[str, int] | None = None,
+) -> float:
     """Compute a risk score (0.0 - 1.0) for a single node.
 
     Scoring factors:
@@ -225,6 +322,8 @@ def compute_risk_score(store: GraphStore, node: GraphNode) -> float:
       - Test coverage: 0.30 (untested) scaling down to 0.05 (5+ TESTED_BY edges)
       - Security sensitivity: 0.20 if name matches security keywords
       - Caller count: callers / 20, capped at 0.10
+      - Change frequency (opt-in): commits touching the file / 10, capped
+        at 0.15
     """
     score = 0.0
 
@@ -266,11 +365,16 @@ def compute_risk_score(store: GraphStore, node: GraphNode) -> float:
     caller_count = len(caller_edges)
     score += min(caller_count / 20.0, 0.10)
 
+    # --- Change frequency (opt-in, cap 0.15) ---
+    if churn_counts and node.file_path:
+        commit_count = churn_counts.get(node.file_path, 0)
+        score += min(commit_count / _CHURN_SATURATION, 1.0) * _CHURN_WEIGHT
+
     return round(min(max(score, 0.0), 1.0), 4)
 
 
 # ---------------------------------------------------------------------------
-# 4. analyze_changes
+# 5. analyze_changes
 # ---------------------------------------------------------------------------
 
 
@@ -280,6 +384,7 @@ def analyze_changes(
     changed_ranges: dict[str, list[tuple[int, int]]] | None = None,
     repo_root: str | None = None,
     base: str = "HEAD~1",
+    include_churn: bool = False,
 ) -> dict[str, Any]:
     """Analyze changes and produce risk-scored review guidance.
 
@@ -291,6 +396,9 @@ def analyze_changes(
             (Git or SVN).
         repo_root: Repository root (for git/svn diff).
         base: Git ref or SVN revision range to diff against.
+        include_churn: Add an opt-in change-frequency term to each node's
+            risk score. The trailing window defaults to 90 days and can be
+            configured with ``CRG_CHURN_WINDOW_DAYS``.
 
     Returns:
         Dict with ``summary``, ``risk_score``, ``changed_functions``,
@@ -332,10 +440,18 @@ def analyze_changes(
     if funcs_truncated:
         changed_funcs = changed_funcs[:_max_funcs]
 
+    churn_counts: dict[str, int] | None = None
+    if include_churn and repo_root is not None:
+        churn_counts = {}
+        root_path = Path(repo_root)
+        for key, count in compute_file_churn(repo_root).items():
+            churn_counts[key] = count
+            churn_counts[str(root_path / key)] = count
+
     # Compute per-node risk scores.
     node_risks: list[dict[str, Any]] = []
     for node in changed_funcs:
-        risk = compute_risk_score(store, node)
+        risk = compute_risk_score(store, node, churn_counts)
         node_risks.append({
             **node_to_dict(node),
             "risk_score": risk,

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -649,6 +649,13 @@ def main() -> None:
     )
     detect_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
     detect_cmd.add_argument(
+        "--churn",
+        action="store_true",
+        help="Add an opt-in change-frequency term to risk scores. Counts "
+             "commits per file over 90 days by default; set "
+             "CRG_CHURN_WINDOW_DAYS to adjust.",
+    )
+    detect_cmd.add_argument(
         "--verify",
         action="store_true",
         help="Calibrate the estimated savings against tiktoken's "
@@ -1221,6 +1228,7 @@ def main() -> None:
                     changed,
                     repo_root=str(repo_root),
                     base=base,
+                    include_churn=getattr(args, "churn", False),
                 )
                 original_tokens = estimate_file_tokens(repo_root, changed)
                 attach_context_savings(

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -325,6 +325,7 @@ code-review-graph detect-changes               # Risk-scored change analysis
 code-review-graph detect-changes --base HEAD~3 # Custom base ref
 code-review-graph detect-changes --brief       # Compact panel with token-savings estimate
 code-review-graph detect-changes --brief --verify  # ...and cross-check vs tiktoken
+code-review-graph detect-changes --churn       # Add opt-in change-frequency risk
 
 # detect-changes vs update --brief — which one?
 # • detect-changes --brief: read-only. Asks "what's the impact of my current

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,12 +1,17 @@
 """Tests for change impact analysis (changes.py)."""
 
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from code_review_graph.changes import (
+    _parse_numstat,
     _parse_unified_diff,
     analyze_changes,
+    compute_file_churn,
     compute_risk_score,
     map_changes_to_nodes,
     parse_git_diff_ranges,
@@ -637,3 +642,151 @@ class TestAnalyzeChangesInternalParseRemap:
         # No remapping: keys passed through exactly as the caller gave them.
         assert list(captured["ranges"]) == ["app.py"]
         assert any(f["name"] == "rel_func" for f in result["changed_functions"])
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a deterministic, non-interactive Git command in *repo*."""
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        capture_output=True,
+        check=True,
+        cwd=repo,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestFileChurn:
+    """Per-file commit counts used by opt-in temporal risk scoring."""
+
+    def test_parse_nul_numstat_preserves_tabs_and_newlines_in_paths(self):
+        unusual = "src/has\ttab\nand-newline.py"
+        raw = f"3\t1\tsrc/app.py\0-\t-\t{unusual}\0" + "1\t0\tsrc/app.py\0"
+
+        assert _parse_numstat(raw) == {
+            "src/app.py": 2,
+            unusual: 1,
+        }
+
+    def test_compute_file_churn_counts_commits(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+
+        app = repo / "app.py"
+        app.write_text("a = 1\n", encoding="utf-8")
+        _git(repo, "add", "app.py")
+        _git(repo, "commit", "-q", "-m", "one")
+
+        app.write_text("a = 2\n", encoding="utf-8")
+        util = repo / "util.py"
+        util.write_text("b = 1\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "two")
+
+        assert compute_file_churn(str(repo)) == {
+            "app.py": 2,
+            "util.py": 1,
+        }
+
+    def test_invalid_environment_window_is_fail_soft(self, monkeypatch):
+        monkeypatch.setenv("CRG_CHURN_WINDOW_DAYS", "not-an-integer")
+        with patch("code_review_graph.changes.subprocess.run") as run:
+            assert compute_file_churn("/repo") == {}
+        run.assert_not_called()
+
+    def test_git_log_uses_nul_terminated_paths(self):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="1\t0\tapp.py\0", stderr="",
+        )
+        with patch(
+            "code_review_graph.changes.subprocess.run",
+            return_value=completed,
+        ) as run:
+            assert compute_file_churn("/repo", window_days=30) == {"app.py": 1}
+
+        command = run.call_args.args[0]
+        assert "-z" in command
+        assert "--no-renames" in command
+
+
+class TestRiskScoreChurn:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = GraphStore(self.tmp.name)
+        self.store.upsert_node(NodeInfo(
+            kind="Function",
+            name="hot_func",
+            file_path="app.py",
+            line_start=1,
+            line_end=10,
+            language="python",
+        ))
+        self.store.commit()
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def test_churn_is_default_off_and_saturates_at_point_fifteen(self):
+        node = self.store.get_node("app.py::hot_func")
+        assert node is not None
+
+        baseline = compute_risk_score(self.store, node)
+        assert compute_risk_score(self.store, node, churn_counts=None) == baseline
+        saturated = compute_risk_score(
+            self.store, node, churn_counts={"app.py": 10},
+        )
+        extreme = compute_risk_score(
+            self.store, node, churn_counts={"app.py": 10_000},
+        )
+
+        assert saturated - baseline == pytest.approx(0.15)
+        assert extreme == saturated
+
+    def test_analyze_changes_matches_absolute_graph_paths(self, tmp_path):
+        absolute = str(tmp_path / "app.py")
+        self.store.upsert_node(NodeInfo(
+            kind="Function",
+            name="absolute_hot_func",
+            file_path=absolute,
+            line_start=1,
+            line_end=10,
+            language="python",
+        ))
+        self.store.commit()
+        kwargs = {
+            "changed_files": [absolute],
+            "changed_ranges": {absolute: [(1, 2)]},
+            "repo_root": str(tmp_path),
+        }
+
+        baseline = analyze_changes(self.store, **kwargs)
+        with patch(
+            "code_review_graph.changes.compute_file_churn",
+            return_value={"app.py": 10},
+        ):
+            churned = analyze_changes(self.store, include_churn=True, **kwargs)
+
+        assert churned["risk_score"] - baseline["risk_score"] == pytest.approx(0.15)
+
+    def test_analyze_changes_does_not_compute_churn_by_default(self, tmp_path):
+        with patch("code_review_graph.changes.compute_file_churn") as churn:
+            analyze_changes(
+                self.store,
+                changed_files=["app.py"],
+                changed_ranges={"app.py": [(1, 2)]},
+                repo_root=str(tmp_path),
+            )
+        churn.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,6 +178,37 @@ class TestBuildUpdateCommands:
 
 
 class TestDetectChangesCommand:
+    def test_churn_flag_is_forwarded_to_analysis(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+        argv = [
+            "code-review-graph",
+            "detect-changes",
+            "--repo",
+            str(repo),
+            "--churn",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.incremental.get_changed_files",
+                        return_value=["app.py"],
+                    ):
+                        with patch(
+                            "code_review_graph.changes.analyze_changes",
+                            return_value={"summary": "with churn"},
+                        ) as analyze:
+                            cli.main()
+
+        assert json.loads(capsys.readouterr().out)["summary"] == "with churn"
+        assert analyze.call_args.kwargs["include_churn"] is True
+
     def test_brief_output_includes_token_savings_panel(self, tmp_path, capsys):
         """v2.3.5: --brief output renders a boxed Token Savings panel.
 


### PR DESCRIPTION
## Summary\n- port the opt-in change-frequency risk term from #555 onto current main\n- keep structural scoring byte-for-byte unchanged unless detect-changes --churn is requested\n- parse git numstat with NUL-terminated filenames so tabs and newlines are not misidentified\n- make invalid CRG_CHURN_WINDOW_DAYS values fail soft instead of aborting analysis\n- preserve the 90-day default and 0.15 saturation cap\n\n## Verification\n- focused change/CLI tests: 37 passed\n- full suite on the final rebased branch: 1,524 passed, 2 xpassed\n- Ruff passed on all touched Python files\n- git diff --check passed\n- graph review completed; production risk score 0.40, with explicit regression coverage for every new path\n\n## Attribution\nThe implementation preserves Michael Denyer's contribution through a Co-authored-by trailer.