### PR TITLE
fix(communities): reconcile naming, test placement, and splitting

### DIFF
--- a/code_review_graph/communities.py
+++ b/code_review_graph/communities.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Stay well under SQLite's default 999-variable limit per statement.
 _SQL_BATCH = 450
+_SLUG_MAX_LEN = 30
 
 # ---------------------------------------------------------------------------
 # Optional igraph import
@@ -57,12 +58,26 @@ _COMMON_WORDS = frozenset({
     "add", "remove", "make", "build", "from", "to", "for", "with",
     "the", "and", "test", "main", "run", "do", "is", "has", "on",
     "of", "in", "at", "by", "my", "this", "that", "all", "none",
+    "should", "when", "then", "given", "return", "returns", "raise",
+    "raises", "expect", "expected", "assert", "tests", "be", "it", "if",
+    "not",
 })
 
 
 # ---------------------------------------------------------------------------
 # Community naming
 # ---------------------------------------------------------------------------
+
+
+def _is_test_node(node: GraphNode) -> bool:
+    """Return whether a graph node represents test code."""
+    return node.kind == "Test" or node.is_test
+
+
+def _naming_members(members: list[GraphNode]) -> list[GraphNode]:
+    """Prefer production nodes as the source of community name vocabulary."""
+    production_members = [member for member in members if not _is_test_node(member)]
+    return production_members or members
 
 
 def _generate_community_name(members: list[GraphNode]) -> str:
@@ -77,22 +92,24 @@ def _generate_community_name(members: list[GraphNode]) -> str:
     if not members:
         return "empty"
 
+    naming_members = _naming_members(members)
+
     # 1. Find common file prefix
-    file_paths = [m.file_path for m in members]
+    file_paths = [m.file_path for m in naming_members]
     prefix = _extract_file_prefix(file_paths)
 
     # 2. Check for dominant class
-    class_names = [m.name for m in members if m.kind == "Class"]
+    class_names = [m.name for m in naming_members if m.kind == "Class"]
     if class_names:
         class_counts = Counter(class_names)
         top_class, top_count = class_counts.most_common(1)[0]
-        if top_count > len(members) * 0.4:
+        if top_count > len(naming_members) * 0.4:
             if prefix:
                 return f"{prefix}-{_to_slug(top_class)}"
             return _to_slug(top_class)
 
     # 3. Most frequent keyword from function/class names
-    keywords = _extract_keywords(members)
+    keywords = _extract_keywords(naming_members)
     keyword = keywords[0] if keywords else ""
 
     if prefix and keyword:
@@ -150,8 +167,16 @@ def _split_name(name: str) -> list[str]:
 
 
 def _to_slug(s: str) -> str:
-    """Convert a string to a short lowercase slug."""
-    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:30]
+    """Convert a string to a short lowercase slug at a word boundary."""
+    normalized = re.sub(r"[^A-Za-z0-9]+", " ", s)
+    slug = "-".join(word.lower() for word in _split_name(normalized))
+    if len(slug) <= _SLUG_MAX_LEN:
+        return slug
+
+    boundary = slug.rfind("-", 0, _SLUG_MAX_LEN + 1)
+    if boundary > 0:
+        return slug[:boundary]
+    return slug[:_SLUG_MAX_LEN]
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +258,98 @@ def _compute_cohesion(
 # ---------------------------------------------------------------------------
 
 
+def _reassign_test_nodes(
+    clusters: list[list[int]],
+    idx_to_node: dict[int, GraphNode],
+    qn_to_idx: dict[str, int],
+    edges: list[GraphEdge],
+    resolution_nodes: list[GraphNode] | None = None,
+) -> list[list[int]]:
+    """Move tests to the community containing most unique tested subjects.
+
+    Edge direction is ignored, ambiguous bare names are skipped, ties retain
+    the current cluster, and rebuilding from the original partition keeps the
+    result deterministic without repeated linear-time list removals.
+    """
+    vertex_to_cluster = {
+        vertex: cluster_id
+        for cluster_id, cluster in enumerate(clusters)
+        for vertex in cluster
+    }
+
+    names_to_qns: dict[str, str | None] = {}
+    nodes_for_resolution = resolution_nodes or list(idx_to_node.values())
+    for node in nodes_for_resolution:
+        names_to_qns[node.name] = (
+            None
+            if node.name in names_to_qns
+            else node.qualified_name
+        )
+
+    def _resolve(endpoint: str) -> int | None:
+        exact = qn_to_idx.get(endpoint)
+        if exact is not None:
+            return exact
+        qualified_name = names_to_qns.get(endpoint)
+        if qualified_name is None:
+            return None
+        return qn_to_idx.get(qualified_name)
+
+    subjects_by_test: dict[int, set[int]] = defaultdict(set)
+    for edge in edges:
+        if edge.kind != "TESTED_BY":
+            continue
+        source = _resolve(edge.source_qualified)
+        target = _resolve(edge.target_qualified)
+        if source is None or target is None:
+            continue
+
+        source_is_test = _is_test_node(idx_to_node[source])
+        target_is_test = _is_test_node(idx_to_node[target])
+        if source_is_test == target_is_test:
+            continue
+
+        test_index, subject_index = (
+            (source, target) if source_is_test else (target, source)
+        )
+        subjects_by_test[test_index].add(subject_index)
+
+    target_by_test: dict[int, int] = {}
+    for test_index, subject_indices in subjects_by_test.items():
+        current_cluster = vertex_to_cluster.get(test_index)
+        if current_cluster is None:
+            continue
+
+        votes = Counter(
+            vertex_to_cluster[subject_index]
+            for subject_index in subject_indices
+            if subject_index in vertex_to_cluster
+        )
+        if not votes:
+            continue
+
+        highest_vote = max(votes.values())
+        tied_clusters = sorted(
+            cluster_id
+            for cluster_id, vote_count in votes.items()
+            if vote_count == highest_vote
+        )
+        target_cluster = (
+            current_cluster
+            if current_cluster in tied_clusters
+            else tied_clusters[0]
+        )
+        target_by_test[test_index] = target_cluster
+
+    reassigned: list[list[int]] = [[] for _ in clusters]
+    for current_cluster, cluster in enumerate(clusters):
+        for vertex in cluster:
+            target_cluster = target_by_test.get(vertex, current_cluster)
+            reassigned[target_cluster].append(vertex)
+
+    return reassigned
+
+
 def _detect_leiden(
     nodes: list[GraphNode],
     edges: list[GraphEdge],
@@ -309,8 +426,15 @@ def _detect_leiden(
         len(partition),
     )
 
+    clusters = _reassign_test_nodes(
+        [list(cluster_ids) for cluster_ids in partition],
+        idx_to_node,
+        qn_to_idx,
+        edges,
+    )
+
     pending: list[tuple[list[GraphNode], set[str]]] = []
-    for cluster_ids in partition:
+    for cluster_ids in clusters:
         if len(cluster_ids) < min_size:
             continue
         members = [idx_to_node[i] for i in cluster_ids if i in idx_to_node]
@@ -494,16 +618,22 @@ def _split_oversized(
             n.qualified_name: i
             for i, n in enumerate(member_nodes)
         }
-        ig_edges: list[tuple[int, int]] = []
-        ig_weights: list[float] = []
+        idx_to_node = {i: node for i, node in enumerate(member_nodes)}
+        # GraphStore preserves one edge per call site. Leiden needs one stable
+        # edge per vertex pair so duplicate call sites cannot bias a split.
+        weights_by_pair: dict[tuple[int, int], float] = {}
         for e in member_edges:
             si = qn_to_idx.get(e.source_qualified)
             ti = qn_to_idx.get(e.target_qualified)
             if si is not None and ti is not None and si != ti:
-                ig_edges.append((si, ti))
-                ig_weights.append(
-                    EDGE_WEIGHTS.get(e.kind, 0.5)
+                pair = (min(si, ti), max(si, ti))
+                weights_by_pair[pair] = max(
+                    weights_by_pair.get(pair, 0.0),
+                    EDGE_WEIGHTS.get(e.kind, 0.5),
                 )
+
+        ig_edges = sorted(weights_by_pair)
+        ig_weights = [weights_by_pair[pair] for pair in ig_edges]
 
         if not ig_edges:
             result.append(comm)
@@ -527,11 +657,22 @@ def _split_oversized(
                 resolution=0.5,
             )
 
-            sub_communities: dict[int, list[str]] = {}
+            partition_clusters: dict[int, list[int]] = {}
             for idx, cid in enumerate(partition.membership):
-                sub_communities.setdefault(cid, []).append(
-                    member_nodes[idx].qualified_name
-                )
+                partition_clusters.setdefault(cid, []).append(idx)
+
+            reassigned_clusters = _reassign_test_nodes(
+                list(partition_clusters.values()),
+                idx_to_node,
+                qn_to_idx,
+                edges,
+                resolution_nodes=nodes,
+            )
+            sub_communities = [
+                [idx_to_node[idx] for idx in cluster]
+                for cluster in reassigned_clusters
+                if cluster
+            ]
 
             if len(sub_communities) <= 1:
                 result.append(comm)
@@ -539,15 +680,26 @@ def _split_oversized(
 
             parent_id = comm.get("id", 0)
             comm_name = comm.get("name", "")
-            for sub_members in sub_communities.values():
+            sub_member_qns = [
+                {node.qualified_name for node in sub_nodes}
+                for sub_nodes in sub_communities
+            ]
+            cohesions = _compute_cohesion_batch(sub_member_qns, edges)
+
+            for sub_nodes, member_qns, cohesion in zip(
+                sub_communities, sub_member_qns, cohesions
+            ):
+                generated_name = _generate_community_name(sub_nodes)
+                if generated_name in {"", "empty", "cluster"}:
+                    generated_name = f"{comm_name}-{next_id}"
                 sub_comm = {
                     "id": next_id,
-                    "name": comm_name + f"-sub{next_id}",
+                    "name": generated_name,
                     "level": comm.get("level", 0) + 1,
                     "parent_id": parent_id,
-                    "members": sub_members,
-                    "size": len(sub_members),
-                    "cohesion": 0.0,
+                    "members": [node.qualified_name for node in sub_nodes],
+                    "size": len(member_qns),
+                    "cohesion": cohesion,
                     "dominant_language": comm.get(
                         "dominant_language"
                     ),
@@ -575,6 +727,67 @@ def _split_oversized(
             result.append(comm)
 
     return result
+
+
+def _dedupe_community_names(
+    communities: list[dict[str, Any]],
+    nodes: list[GraphNode],
+) -> None:
+    """Disambiguate exact duplicate names while keeping the largest unchanged."""
+    communities_by_name: dict[str, list[tuple[int, dict[str, Any]]]] = (
+        defaultdict(list)
+    )
+    for position, community in enumerate(communities):
+        communities_by_name[community.get("name", "")].append(
+            (position, community)
+        )
+
+    nodes_by_qn = {node.qualified_name: node for node in nodes}
+    taken_names = {
+        community.get("name", "")
+        for community in communities
+        if community.get("name", "")
+    }
+
+    for base_name, duplicates in communities_by_name.items():
+        if not base_name or len(duplicates) <= 1:
+            continue
+
+        ordered = sorted(
+            duplicates,
+            key=lambda item: (
+                -item[1].get("size", len(item[1].get("members", []))),
+                item[1].get("id", item[0]),
+                item[0],
+            ),
+        )
+        base_words = set(base_name.split("-"))
+
+        for _, community in ordered[1:]:
+            member_nodes = [
+                nodes_by_qn[qualified_name]
+                for qualified_name in community.get("members", [])
+                if qualified_name in nodes_by_qn
+            ]
+            candidate_name = ""
+            for keyword in _extract_keywords(_naming_members(member_nodes)):
+                suffix = _to_slug(keyword)
+                if not suffix or suffix in base_words:
+                    continue
+                candidate = f"{base_name}-{suffix}"
+                if candidate not in taken_names:
+                    candidate_name = candidate
+                    break
+
+            if not candidate_name:
+                suffix_number = 2
+                candidate_name = f"{base_name}-{suffix_number}"
+                while candidate_name in taken_names:
+                    suffix_number += 1
+                    candidate_name = f"{base_name}-{suffix_number}"
+
+            community["name"] = candidate_name
+            taken_names.add(candidate_name)
 
 
 # ---------------------------------------------------------------------------
@@ -621,6 +834,7 @@ def detect_communities(
     results = _split_oversized(
         results, unique_nodes, all_edges,
     )
+    _dedupe_community_names(results, unique_nodes)
 
     # Convert member_qns (internal set) to a list for serialization safety,
     # then strip it from the returned dicts to avoid leaking internal state.

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import code_review_graph.communities as communities_module
 from code_review_graph.communities import (
     IGRAPH_AVAILABLE,
     _compute_cohesion,
@@ -19,6 +20,53 @@ from code_review_graph.communities import (
 )
 from code_review_graph.graph import GraphEdge, GraphNode, GraphStore
 from code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+def _community_node(
+    node_id: int,
+    qualified_name: str,
+    *,
+    kind: str = "Function",
+    is_test: bool = False,
+    file_path: str | None = None,
+) -> GraphNode:
+    """Build a compact GraphNode fixture for community algorithm tests."""
+    path, _, name = qualified_name.partition("::")
+    return GraphNode(
+        id=node_id,
+        kind=kind,
+        name=name,
+        qualified_name=qualified_name,
+        file_path=file_path or path,
+        line_start=1,
+        line_end=2,
+        language="python",
+        parent_name=None,
+        params=None,
+        return_type=None,
+        is_test=is_test,
+        file_hash="fixture",
+        extra={},
+    )
+
+
+def _community_edge(
+    edge_id: int,
+    source: str,
+    target: str,
+    *,
+    kind: str = "CALLS",
+) -> GraphEdge:
+    """Build a compact GraphEdge fixture for community algorithm tests."""
+    return GraphEdge(
+        id=edge_id,
+        kind=kind,
+        source_qualified=source,
+        target_qualified=target,
+        file_path="fixture.py",
+        line=edge_id,
+        extra={},
+    )
 
 
 class TestCommunities:
@@ -591,3 +639,372 @@ class TestCommunities:
         # Pass a file that IS part of existing communities
         result = incremental_detect_communities(self.store, ["auth.py"])
         assert result > 0
+
+
+class TestCommunityPrReconciliation:
+    """Regression coverage retained from overlapping PRs #600/#603/#605."""
+
+    def test_slug_splits_camel_case(self):
+        assert communities_module._to_slug("AuthService") == "auth-service"
+
+    def test_slug_truncates_at_a_word_boundary(self):
+        assert (
+            communities_module._to_slug(
+                "SuperLongAuthenticationServiceManager"
+            )
+            == "super-long-authentication"
+        )
+
+    def test_mixed_community_name_uses_production_members(self):
+        production = _community_node(
+            1,
+            "src/auth.py::authenticate_user",
+            file_path="src/auth.py",
+        )
+        tests = [
+            _community_node(
+                2,
+                "tests/test_auth.py::should_return_user",
+                kind="Test",
+                is_test=True,
+                file_path="src/auth.py",
+            ),
+            _community_node(
+                3,
+                "tests/test_auth.py::expected_user_when_valid",
+                kind="Test",
+                is_test=True,
+                file_path="src/auth.py",
+            ),
+        ]
+
+        assert communities_module._generate_community_name(
+            [production, *tests]
+        ) == communities_module._generate_community_name([production])
+
+    def test_pure_test_name_filters_bdd_noise(self):
+        tests = [
+            _community_node(
+                1,
+                "tests/test_auth.py::should_return_token",
+                kind="Test",
+                is_test=True,
+            ),
+            _community_node(
+                2,
+                "tests/test_auth.py::should_raise_error",
+                kind="Test",
+                is_test=True,
+            ),
+        ]
+
+        name = communities_module._generate_community_name(tests)
+
+        assert all(word not in name for word in ("should", "return", "raise"))
+
+    def test_test_reassignment_counts_unique_subjects(self):
+        nodes = {
+            0: _community_node(1, "a.py::alpha"),
+            1: _community_node(2, "b.py::bravo"),
+            2: _community_node(3, "b.py::charlie"),
+            3: _community_node(
+                4,
+                "tests/test_feature.py::test_feature",
+                kind="Test",
+                is_test=True,
+            ),
+        }
+        qn_to_idx = {node.qualified_name: idx for idx, node in nodes.items()}
+        test_qn = nodes[3].qualified_name
+        edges = [
+            _community_edge(1, nodes[0].qualified_name, test_qn, kind="TESTED_BY"),
+            _community_edge(2, nodes[0].qualified_name, test_qn, kind="TESTED_BY"),
+            _community_edge(3, test_qn, nodes[1].qualified_name, kind="TESTED_BY"),
+            _community_edge(4, nodes[2].qualified_name, test_qn, kind="TESTED_BY"),
+        ]
+
+        reassigned = communities_module._reassign_test_nodes(
+            [[0, 3], [1, 2]], nodes, qn_to_idx, edges
+        )
+
+        assert reassigned == [[0], [3, 1, 2]]
+
+    def test_test_reassignment_keeps_current_cluster_on_a_tie(self):
+        nodes = {
+            0: _community_node(1, "a.py::alpha"),
+            1: _community_node(2, "b.py::bravo"),
+            2: _community_node(
+                3,
+                "tests/test_feature.py::test_feature",
+                kind="Test",
+                is_test=True,
+            ),
+        }
+        qn_to_idx = {node.qualified_name: idx for idx, node in nodes.items()}
+        edges = [
+            _community_edge(
+                1,
+                nodes[0].qualified_name,
+                nodes[2].qualified_name,
+                kind="TESTED_BY",
+            ),
+            _community_edge(
+                2,
+                nodes[2].qualified_name,
+                nodes[1].qualified_name,
+                kind="TESTED_BY",
+            ),
+        ]
+
+        reassigned = communities_module._reassign_test_nodes(
+            [[0, 2], [1]], nodes, qn_to_idx, edges
+        )
+
+        assert reassigned == [[0, 2], [1]]
+
+    def test_test_reassignment_is_independent_of_edge_order(self):
+        nodes = {
+            0: _community_node(
+                1,
+                "tests/test_feature.py::test_alpha",
+                kind="Test",
+                is_test=True,
+            ),
+            1: _community_node(
+                2,
+                "tests/test_feature.py::test_bravo",
+                kind="Test",
+                is_test=True,
+            ),
+            2: _community_node(3, "src/feature.py::subject"),
+        }
+        qn_to_idx = {node.qualified_name: idx for idx, node in nodes.items()}
+        edges = [
+            _community_edge(
+                1,
+                nodes[0].qualified_name,
+                nodes[2].qualified_name,
+                kind="TESTED_BY",
+            ),
+            _community_edge(
+                2,
+                nodes[1].qualified_name,
+                nodes[2].qualified_name,
+                kind="TESTED_BY",
+            ),
+        ]
+
+        forward = communities_module._reassign_test_nodes(
+            [[0, 1], [2]], nodes, qn_to_idx, edges
+        )
+        reverse = communities_module._reassign_test_nodes(
+            [[0, 1], [2]], nodes, qn_to_idx, list(reversed(edges))
+        )
+
+        assert forward == reverse == [[], [0, 1, 2]]
+
+    def test_duplicate_names_keep_largest_name_and_make_others_unique(self):
+        communities = [
+            {
+                "id": 10,
+                "name": "services-auth",
+                "size": 3,
+                "members": ["auth.py::login", "auth.py::logout", "auth.py::token"],
+            },
+            {
+                "id": 11,
+                "name": "services-auth",
+                "size": 2,
+                "members": ["billing.py::invoice", "billing.py::charge"],
+            },
+        ]
+        nodes = [
+            _community_node(1, "auth.py::login"),
+            _community_node(2, "auth.py::logout"),
+            _community_node(3, "auth.py::token"),
+            _community_node(4, "billing.py::invoice"),
+            _community_node(5, "billing.py::charge"),
+        ]
+
+        communities_module._dedupe_community_names(communities, nodes)
+
+        assert communities[0]["name"] == "services-auth"
+        assert communities[1]["name"].startswith("services-auth-")
+        assert len({community["name"] for community in communities}) == 2
+
+    def test_duplicate_name_suffix_ignores_test_vocabulary(self):
+        communities = [
+            {
+                "id": 10,
+                "name": "services",
+                "size": 5,
+                "members": [f"auth.py::auth_{index}" for index in range(5)],
+            },
+            {
+                "id": 11,
+                "name": "services",
+                "size": 4,
+                "members": [
+                    "billing.py::invoice",
+                    "tests/test_billing.py::mock_gateway_one",
+                    "tests/test_billing.py::mock_gateway_two",
+                    "tests/test_billing.py::mock_gateway_three",
+                ],
+            },
+        ]
+        nodes = [
+            *[
+                _community_node(index, f"auth.py::auth_{index}")
+                for index in range(5)
+            ],
+            _community_node(6, "billing.py::invoice"),
+            *[
+                _community_node(
+                    index + 7,
+                    f"tests/test_billing.py::mock_gateway_{name}",
+                    kind="Test",
+                    is_test=True,
+                )
+                for index, name in enumerate(("one", "two", "three"))
+            ],
+        ]
+
+        communities_module._dedupe_community_names(communities, nodes)
+
+        assert communities[1]["name"] == "services-invoice"
+
+    @pytest.mark.skipif(not IGRAPH_AVAILABLE, reason="igraph not installed")
+    def test_oversized_split_uses_member_names_and_real_cohesion(self):
+        nodes = [
+            *[
+                _community_node(i, f"services/auth.py::auth_{name}")
+                for i, name in enumerate(("load", "save", "delete"), start=1)
+            ],
+            *[
+                _community_node(i, f"services/billing.py::billing_{name}")
+                for i, name in enumerate(("load", "save", "delete"), start=4)
+            ],
+        ]
+        left = [node.qualified_name for node in nodes[:3]]
+        right = [node.qualified_name for node in nodes[3:]]
+        edges = [
+            _community_edge(1, left[0], left[1]),
+            _community_edge(2, left[0], left[2]),
+            _community_edge(3, left[1], left[2]),
+            _community_edge(4, right[0], right[1]),
+            _community_edge(5, right[0], right[2]),
+            _community_edge(6, right[1], right[2]),
+            _community_edge(7, left[0], right[0]),
+        ]
+        parent = {
+            "id": 7,
+            "name": "services-parent",
+            "level": 0,
+            "size": 6,
+            "members": [node.qualified_name for node in nodes],
+            "dominant_language": "python",
+        }
+
+        split = communities_module._split_oversized(
+            [parent], nodes, edges, threshold_pct=0.1, min_split_size=2
+        )
+
+        assert len(split) == 2
+        assert any("auth" in community["name"] for community in split)
+        assert any("billing" in community["name"] for community in split)
+        assert {community["cohesion"] for community in split} == {0.75}
+
+        duplicate_bridge_edges = [
+            *edges,
+            *[
+                _community_edge(edge_id, left[0], right[0])
+                for edge_id in range(8, 48)
+            ],
+        ]
+        duplicate_split = communities_module._split_oversized(
+            [parent],
+            nodes,
+            duplicate_bridge_edges,
+            threshold_pct=0.1,
+            min_split_size=2,
+        )
+        expected_partition = {
+            frozenset(community["members"])
+            for community in split
+        }
+        duplicate_partition = {
+            frozenset(community["members"])
+            for community in duplicate_split
+        }
+
+        assert duplicate_partition == expected_partition
+
+    @pytest.mark.parametrize("bare_subjects", [False, True])
+    @pytest.mark.skipif(not IGRAPH_AVAILABLE, reason="igraph not installed")
+    def test_oversized_split_keeps_tests_with_their_subjects(
+        self, bare_subjects: bool
+    ):
+        production = [
+            _community_node(i, f"src/feature.py::feature_{i}")
+            for i in range(1, 5)
+        ]
+        tests = [
+            _community_node(
+                i + 4,
+                f"tests/test_feature.py::test_feature_{i}",
+                kind="Test",
+                is_test=True,
+            )
+            for i in range(1, 5)
+        ]
+        nodes = [*production, *tests]
+        edges: list[GraphEdge] = []
+        edge_id = 1
+        for group in (production, tests):
+            for left_idx, left_node in enumerate(group):
+                for right_node in group[left_idx + 1:]:
+                    edges.append(
+                        _community_edge(
+                            edge_id,
+                            left_node.qualified_name,
+                            right_node.qualified_name,
+                        )
+                    )
+                    edge_id += 1
+        for production_node, test_node in zip(production, tests):
+            edges.append(
+                _community_edge(
+                    edge_id,
+                    (
+                        production_node.name
+                        if bare_subjects
+                        else production_node.qualified_name
+                    ),
+                    test_node.qualified_name,
+                    kind="TESTED_BY",
+                )
+            )
+            edge_id += 1
+        parent = {
+            "id": 8,
+            "name": "feature-parent",
+            "level": 0,
+            "size": len(nodes),
+            "members": [node.qualified_name for node in nodes],
+            "dominant_language": "python",
+        }
+
+        split = communities_module._split_oversized(
+            [parent], nodes, edges, threshold_pct=0.1, min_split_size=2
+        )
+        member_to_community = {
+            member: index
+            for index, community in enumerate(split)
+            for member in community["members"]
+        }
+
+        for production_node, test_node in zip(production, tests):
+            assert (
+                member_to_community[production_node.qualified_name]
+                == member_to_community[test_node.qualified_name]
+            )


### PR DESCRIPTION
## Summary

This is a current-`main` replacement for the overlapping community-detection work in #600, #603, and #605.

- names mixed communities from production members and filters BDD/test grammar
- attaches tests to the community containing most unique tested subjects
- names oversized splits from their own members and computes real cohesion
- makes exact community names unique
- splits camelCase slugs and truncates at word boundaries

## Why one replacement

All three source PRs branch from the same old base and edit the same community implementation and test file. Merging them separately would make later PRs conflict with or overwrite earlier behavior. This port retains their compatible behavior together on protected `main` at `50a8ad3`.

## Overlap fixes

The combined implementation also handles interactions the isolated PRs could not cover:

- repeated `TESTED_BY` call-site edges count once per unique subject
- test reassignment is linear-time and independent of edge order
- globally ambiguous bare endpoint names are ignored safely
- oversized splitting reapplies test-to-subject placement
- duplicate graph pairs cannot bias the Leiden sub-split
- deduplicated name suffixes also ignore test vocabulary

## Attribution

The retained work is credited to Stefan Hudici (@SHudici) through the commit's `Co-authored-by` trailer.

## Validation

- `uv run --frozen --no-sync pytest -q tests/test_communities.py` — 39 passed
- `uv run --frozen --no-sync pytest -q` — 1,536 passed, 2 existing XPASS
- `uv run --frozen --no-sync ruff check code_review_graph/communities.py` — passed
- new test scope passes Ruff (excluding two pre-existing F541 findings in the file)
- `git diff --check origin/main...HEAD` — passed
- full knowledge-graph rebuild — 185 files, 3,558 nodes, 26,370 edges, 0 errors
- affected-flow review — 0 flows
