### PR TITLE
fix(visualization): recover responsive graph layout

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -855,7 +855,10 @@ function moveTooltip(ev) {
   tooltip.style.left = x + "px"; tooltip.style.top = y + "px";
 }
 function hideTooltip() { tooltip.classList.remove("visible"); }
-var W = innerWidth, H = innerHeight;
+var svgEl = document.getElementById("graph-svg");
+function getW() { return svgEl.clientWidth || window.innerWidth || 800; }
+function getH() { return svgEl.clientHeight || window.innerHeight || 600; }
+var W = getW(), H = getH();
 var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
@@ -1071,13 +1074,27 @@ if (N > 2000) {
   nodes.forEach(function(n) { if (n.kind === "File") collapsedFiles.add(n.qualified_name); });
 }
 updateNodes();
-function fitGraph() {
+function syncViewport() {
+  W = getW(); H = getH();
+  svg.attr("viewBox", [0, 0, W, H]);
+  simulation.force("center", d3.forceCenter(W / 2, H / 2));
+  simulation.force("x", d3.forceX(W / 2).strength(0.03));
+  simulation.force("y", d3.forceY(H / 2).strength(0.03));
+}
+function fitGraph(retries) {
+  if (retries === undefined) retries = 10;
   var b = gRoot.node().getBBox();
-  if (b.width === 0 || b.height === 0) return;
+  if (b.width === 0 || b.height === 0) {
+    if (retries > 0) requestAnimationFrame(function() { fitGraph(retries - 1); });
+    return;
+  }
   var pad = 0.1;
   var fw = b.width * (1 + 2*pad), fh = b.height * (1 + 2*pad);
-  var s = Math.min(W / fw, H / fh, 2.5);
-  var tx = W/2 - (b.x + b.width/2)*s, ty = H/2 - (b.y + b.height/2)*s;
+  var cw = getW(), ch = getH();
+  W = cw; H = ch;
+  svg.attr("viewBox", [0, 0, W, H]);
+  var s = Math.min(cw / fw, ch / fh, 2.5);
+  var tx = cw/2 - (b.x + b.width/2)*s, ty = ch/2 - (b.y + b.height/2)*s;
   svg.transition().duration(600).call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, ty).scale(s));
 }
 var loadingOverlay = document.getElementById("loading-overlay");
@@ -1088,7 +1105,12 @@ if (nodes.length === 0) {
 }
 simulation.on("end", function() {
   loadingOverlay.classList.add("hidden");
-  fitGraph();
+  syncViewport();
+  requestAnimationFrame(function() { fitGraph(); });
+});
+window.addEventListener("resize", function() {
+  syncViewport();
+  requestAnimationFrame(function() { fitGraph(); });
 });
 function zoomToNode(qn) {
   var nd = nodeById.get(qn);
@@ -1097,7 +1119,7 @@ function zoomToNode(qn) {
   var tx = W/2 - nd.x*s, ty = H/2 - nd.y*s;
   svg.transition().duration(600).call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, ty).scale(s));
 }
-document.getElementById("btn-fit").addEventListener("click", fitGraph);
+document.getElementById("btn-fit").addEventListener("click", function() { fitGraph(); });
 document.getElementById("btn-labels").addEventListener("click", function() {
   showLabels = !showLabels;
   this.classList.toggle("active");
@@ -1755,7 +1777,10 @@ function moveTooltip(ev) {
 function hideTooltip() { tooltip.classList.remove("visible"); }
 
 /* --- SVG setup --- */
-var W = innerWidth, H = innerHeight;
+var svgEl = document.getElementById("graph-svg");
+function getW() { return svgEl.clientWidth || window.innerWidth || 800; }
+function getH() { return svgEl.clientHeight || window.innerHeight || 600; }
+var W = getW(), H = getH();
 var svg = d3.select("#graph-svg").attr("viewBox", [0, 0, W, H]);
 var gRoot = svg.append("g");
 var currentTransform = d3.zoomIdentity;
@@ -1922,7 +1947,10 @@ function renderGraph(nodesData, edgesData, drillDown) {
       .attr("y", function(d) { return d.y; });
   });
 
-  simulation.on("end", fitGraph);
+  simulation.on("end", function() {
+    syncViewport();
+    requestAnimationFrame(function() { fitGraph(); });
+  });
   updateLabelVisibility();
 }
 
@@ -1974,15 +2002,37 @@ function highlightConnected(d, on) {
   }
 }
 
-function fitGraph() {
+function syncViewport() {
+  W = getW(); H = getH();
+  svg.attr("viewBox", [0, 0, W, H]);
+  if (simulation) {
+    simulation.force("center", d3.forceCenter(W / 2, H / 2));
+    simulation.force("x", d3.forceX(W / 2).strength(0.03));
+    simulation.force("y", d3.forceY(H / 2).strength(0.03));
+  }
+}
+
+function fitGraph(retries) {
+  if (retries === undefined) retries = 10;
   var b = gRoot.node().getBBox();
-  if (b.width === 0 || b.height === 0) return;
+  if (b.width === 0 || b.height === 0) {
+    if (retries > 0) requestAnimationFrame(function() { fitGraph(retries - 1); });
+    return;
+  }
   var pad = 0.1;
   var fw = b.width * (1 + 2 * pad), fh = b.height * (1 + 2 * pad);
-  var s = Math.min(W / fw, H / fh, 2.5);
-  var tx = W / 2 - (b.x + b.width / 2) * s, ty = H / 2 - (b.y + b.height / 2) * s;
+  var cw = getW(), ch = getH();
+  W = cw; H = ch;
+  svg.attr("viewBox", [0, 0, W, H]);
+  var s = Math.min(cw / fw, ch / fh, 2.5);
+  var tx = cw / 2 - (b.x + b.width / 2) * s, ty = ch / 2 - (b.y + b.height / 2) * s;
   svg.transition().duration(600).call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, ty).scale(s));
 }
+
+window.addEventListener("resize", function() {
+  syncViewport();
+  requestAnimationFrame(function() { fitGraph(); });
+});
 
 function zoomToNode(qn) {
   var nd = currentNodes.find(function(n) { return n.qualified_name === qn; });
@@ -2102,7 +2152,7 @@ document.getElementById("btn-back").addEventListener("click", function() {
 });
 
 /* --- Controls --- */
-document.getElementById("btn-fit").addEventListener("click", fitGraph);
+document.getElementById("btn-fit").addEventListener("click", function() { fitGraph(); });
 document.getElementById("btn-labels").addEventListener("click", function() {
   showLabels = !showLabels;
   this.classList.toggle("active");

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,6 +1,9 @@
 """Tests for graph visualization export."""
 
 import json
+import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -341,6 +344,53 @@ def test_community_mode_uses_id_selector_for_svg(large_store, tmp_path):
     assert 'id="graph-svg"' in content, (
         "Aggregated template's <svg> must have id='graph-svg' for the selector to work"
     )
+
+
+def _assert_responsive_graph_script(content):
+    """Check the generated graph script remains responsive and valid JavaScript."""
+    assert 'var svgEl = document.getElementById("graph-svg");' in content
+    assert "function getW()" in content
+    assert "function getH()" in content
+    assert "function fitGraph(retries)" in content
+    assert "if (retries === undefined) retries = 10;" in content
+    assert "requestAnimationFrame(function() { fitGraph(retries - 1); });" in content
+    assert 'window.addEventListener("resize", function() {' in content
+    assert r'window.addEventListener(\"resize\"' not in content
+
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for generated JavaScript syntax validation")
+    inline_scripts = re.findall(r"<script(?:\s[^>]*)?>(.*?)</script>", content, re.DOTALL)
+    assert inline_scripts
+    for script in inline_scripts:
+        if not script.strip():
+            continue
+        result = subprocess.run(
+            [node, "--check"],
+            input=script,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+def test_full_mode_retries_layout_and_tracks_viewport(store_with_data, tmp_path):
+    """Full mode must recover if layout is unavailable before the first paint."""
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "graph.html"
+    generate_html(store_with_data, output_path, mode="full")
+    _assert_responsive_graph_script(output_path.read_text())
+
+
+def test_community_mode_retries_layout_and_tracks_viewport(large_store, tmp_path):
+    """Aggregated mode must use the same bounded layout recovery path."""
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "community.html"
+    generate_html(large_store, output_path, mode="community")
+    _assert_responsive_graph_script(output_path.read_text())
 
 
 def test_generate_html_includes_focus_visible(store_with_data, tmp_path):


### PR DESCRIPTION
Supersedes #477 on current main while preserving Mit Parikh attribution.

What is retained from #477:
- live dimensions from the actual #graph-svg canvas, with safe viewport fallbacks;
- a bounded 10-frame requestAnimationFrame retry when getBBox() is temporarily zero;
- post-layout and resize viewport/force synchronization in full and aggregated modes;
- plain JavaScript quotes in the aggregated resize listener.

Overlap reconciliation:
- Current main already contains the #graph-svg selector fix through #564 / 辛亥. This PR does not duplicate or claim that code.
- The source branch cannot merge directly because it conflicts with current templates and emits literal backslash-quotes in raw JavaScript, causing a SyntaxError in aggregated modes.
- Fit button and simulation callbacks are wrapped so DOM/D3 event objects are not mistaken for the retry counter.

Verification:
- 1526 passed, 2 xpassed (full local suite)
- focused full + aggregated responsive-layout tests pass
- generated inline JavaScript parses under node --check in both modes
- Ruff and git diff --check pass
- Local file browser automation was unavailable because the host browser blocks file:// navigation; protected CI remains required before merge.