### PR TITLE
fix(parser): persist Python class decorators

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -898,6 +898,21 @@ def _modifier_annotation_names(node) -> list[str]:
     return names
 
 
+def _python_decorator_names(node) -> list[str]:
+    """Return decorators wrapping a Python definition in source order."""
+    parent = node.parent
+    if parent is None or parent.type != "decorated_definition":
+        return []
+
+    names: list[str] = []
+    for sibling in parent.children:
+        if sibling.type != "decorator":
+            continue
+        text = sibling.text.decode("utf-8", errors="replace")
+        names.append(text.lstrip("@").strip())
+    return names
+
+
 def _csharp_attribute_names(node) -> list[str]:
     """Return C# attribute names from ``attribute_list`` children of *node*.
 
@@ -4951,6 +4966,8 @@ class CodeParser:
             class_decorators = list(class_annotations)
         else:
             class_decorators = _modifier_annotation_names(child)
+            if language == "python":
+                class_decorators.extend(_python_decorator_names(child))
             if language == "csharp":
                 class_decorators.extend(_csharp_attribute_names(child))
         class_modifiers: Optional[str] = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -179,6 +179,31 @@ class TestCodeParser:
         assert "create_auth_service" in func_names
         assert "process_request" in func_names
 
+    def test_parse_python_class_decorators_persisted(self):
+        """Stacked Python class decorators reach downstream metadata consumers."""
+        from code_review_graph.flows import _has_framework_decorator
+
+        source = b"""
+@Component(\"widget-card\")
+@dataclass(frozen=True)
+class Widget:
+    pass
+
+class Plain:
+    pass
+"""
+        nodes, _ = self.parser.parse_bytes(Path("models.py"), source)
+        widget = next(node for node in nodes if node.name == "Widget")
+        plain = next(node for node in nodes if node.name == "Plain")
+
+        expected = ["Component(\"widget-card\")", "dataclass(frozen=True)"]
+        assert widget.kind == "Class"
+        assert widget.modifiers == ",".join(expected)
+        assert widget.extra["decorators"] == expected
+        assert _has_framework_decorator(widget)
+        assert plain.modifiers is None
+        assert "decorators" not in plain.extra
+
     def test_parse_python_edges(self):
         nodes, edges = self.parser.parse_file(FIXTURES / "sample_python.py")
 

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -423,6 +423,21 @@ class TestFindDeadCode:
         dead_names = {d["name"] for d in dead}
         assert "ClipboardButtonComponent" not in dead_names
 
+    def test_find_dead_code_excludes_parsed_python_decorated_class(self):
+        """Decorator metadata must survive parsing before dead-code analysis."""
+        from code_review_graph.parser import CodeParser
+
+        nodes, _ = CodeParser().parse_bytes(
+            Path("/repo/widget.py"),
+            b'@Component("widget-card")\nclass Widget:\n    pass\n',
+        )
+        widget = next(node for node in nodes if node.name == "Widget")
+        self.store.upsert_node(widget)
+        self.store.commit()
+
+        dead_names = {item["name"] for item in find_dead_code(self.store)}
+        assert "Widget" not in dead_names
+
     def test_find_dead_code_excludes_property(self):
         """Functions decorated with @property are not dead code."""
         self.store.upsert_node(NodeInfo(


### PR DESCRIPTION
Focused current-main replacement for the remaining class-decorator gap from #332, with Gideon Zenz attribution.

Overlap reconciliation:
- #624 already persists decorated functions and class annotations for Java, Kotlin, and C#.
- Python class_definition nodes are children of decorated_definition, so the existing modifiers-child helper cannot see their decorators.
- This PR ports only that missing behavior; it does not replay the cumulative source branch.

Behavior:
- captures stacked Python class decorators in source order;
- stores the comma-joined contract in NodeInfo.modifiers;
- stores the list contract in NodeInfo.extra[decorators];
- leaves undecorated classes unchanged;
- proves parsed metadata reaches framework-entry detection and find_dead_code.

Verification:
- 1,538 passed, 2 xpassed (full local suite)
- focused parser and end-to-end dead-code regressions pass
- repository lint scope passes for code_review_graph/parser.py
- git diff --check passes