### PR TITLE
feat: attach graph provenance to MCP responses

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -57,6 +57,7 @@ from .tools import (
     run_postprocess,
     semantic_search_nodes,
     traverse_graph_func,
+    with_provenance,
 )
 
 logger = logging.getLogger(__name__)
@@ -122,14 +123,15 @@ async def build_or_update_graph_tool(
         recurse_submodules: If True, include files from git submodules.
             When None (default), falls back to CRG_RECURSE_SUBMODULES env var.
     """
-    return await asyncio.to_thread(
-        build_or_update_graph,
-        full_rebuild=full_rebuild,
-        repo_root=_resolve_repo_root(repo_root),
-        base=base,
-        postprocess=postprocess,
-        recurse_submodules=recurse_submodules,
-    )
+    root = _resolve_repo_root(repo_root)
+
+    def _run() -> dict:
+        return with_provenance(build_or_update_graph(
+            full_rebuild=full_rebuild, repo_root=root, base=base,
+            postprocess=postprocess, recurse_submodules=recurse_submodules,
+        ), root)
+
+    return await asyncio.to_thread(_run)
 
 
 @mcp.tool()
@@ -154,11 +156,14 @@ async def run_postprocess_tool(
         fts: Rebuild FTS index. Default: True.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return await asyncio.to_thread(
-        run_postprocess,
-        flows=flows, communities=communities, fts=fts,
-        repo_root=_resolve_repo_root(repo_root),
-    )
+    root = _resolve_repo_root(repo_root)
+
+    def _run() -> dict:
+        return with_provenance(run_postprocess(
+            flows=flows, communities=communities, fts=fts, repo_root=root,
+        ), root)
+
+    return await asyncio.to_thread(_run)
 
 
 @mcp.tool()
@@ -180,10 +185,11 @@ def get_minimal_context_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         base: Git ref for diff comparison. Default: HEAD~1.
     """
-    return get_minimal_context(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_minimal_context(
         task=task, changed_files=changed_files,
-        repo_root=_resolve_repo_root(repo_root), base=base,
-    )
+        repo_root=root, base=base,
+    ), root)
 
 
 @mcp.tool()
@@ -206,10 +212,11 @@ def get_impact_radius_tool(
         base: Git ref for auto-detecting changes. Default: HEAD~1.
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
-    return get_impact_radius(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_impact_radius(
         changed_files=changed_files, max_depth=max_depth,
-        repo_root=_resolve_repo_root(repo_root), base=base, detail_level=detail_level,
-    )
+        repo_root=root, base=base, detail_level=detail_level,
+    ), root)
 
 
 @mcp.tool()
@@ -237,10 +244,11 @@ def query_graph_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
-    return query_graph(
-        pattern=pattern, target=target, repo_root=_resolve_repo_root(repo_root),
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(query_graph(
+        pattern=pattern, target=target, repo_root=root,
         detail_level=detail_level,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -268,11 +276,12 @@ def get_review_context_tool(
         detail_level: "standard" for full output, "minimal" for
             token-efficient summary. Default: standard.
     """
-    return get_review_context(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_review_context(
         changed_files=changed_files, max_depth=max_depth,
         include_source=include_source, max_lines_per_file=max_lines_per_file,
-        repo_root=_resolve_repo_root(repo_root), base=base, detail_level=detail_level,
-    )
+        repo_root=root, base=base, detail_level=detail_level,
+    ), root)
 
 
 @mcp.tool()
@@ -305,10 +314,11 @@ def semantic_search_nodes_tool(
                   or "minimax". Must match the provider used during embed_graph.
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
-    return semantic_search_nodes(
-        query=query, kind=kind, limit=limit, repo_root=_resolve_repo_root(repo_root),
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(semantic_search_nodes(
+        query=query, kind=kind, limit=limit, repo_root=root,
         model=model, provider=provider, detail_level=detail_level,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -345,12 +355,14 @@ async def embed_graph_tool(
                   CRG_OPENAI_MODEL env vars and accepts any OpenAI-compatible
                   endpoint (real OpenAI, Azure, new-api, LiteLLM, vLLM, etc.).
     """
-    return await asyncio.to_thread(
-        embed_graph,
-        repo_root=_resolve_repo_root(repo_root),
-        model=model,
-        provider=provider,
-    )
+    root = _resolve_repo_root(repo_root)
+
+    def _run() -> dict:
+        return with_provenance(embed_graph(
+            repo_root=root, model=model, provider=provider,
+        ), root)
+
+    return await asyncio.to_thread(_run)
 
 
 @mcp.tool()
@@ -365,7 +377,8 @@ def list_graph_stats_tool(
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return list_graph_stats(repo_root=_resolve_repo_root(repo_root))
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(list_graph_stats(repo_root=root), root)
 
 
 @mcp.tool()
@@ -411,10 +424,11 @@ def find_large_functions_tool(
         limit: Maximum results. Default: 50.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return find_large_functions(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(find_large_functions(
         min_lines=min_lines, kind=kind, file_path_pattern=file_path_pattern,
-        limit=limit, repo_root=_resolve_repo_root(repo_root),
-    )
+        limit=limit, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -439,10 +453,11 @@ def list_flows_tool(
                       returns only name, criticality, and node_count per flow.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return list_flows(
-        repo_root=_resolve_repo_root(repo_root), sort_by=sort_by, limit=limit, kind=kind,
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(list_flows(
+        repo_root=root, sort_by=sort_by, limit=limit, kind=kind,
         detail_level=detail_level,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -465,10 +480,11 @@ def get_flow_tool(
         include_source: Include source code snippets for each step. Default: False.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_flow(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_flow(
         flow_id=flow_id, flow_name=flow_name,
-        include_source=include_source, repo_root=_resolve_repo_root(repo_root),
-    )
+        include_source=include_source, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -488,9 +504,10 @@ def get_affected_flows_tool(
         base: Git ref for auto-detecting changes. Default: HEAD~1.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_affected_flows_func(
-        changed_files=changed_files, base=base, repo_root=_resolve_repo_root(repo_root),
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_affected_flows_func(
+        changed_files=changed_files, base=base, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -514,10 +531,11 @@ def list_communities_tool(
                       per community.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return list_communities_func(
-        repo_root=_resolve_repo_root(repo_root), sort_by=sort_by, min_size=min_size,
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(list_communities_func(
+        repo_root=root, sort_by=sort_by, min_size=min_size,
         detail_level=detail_level,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -541,10 +559,11 @@ def get_community_tool(
         include_members: Include full member node details. Default: False.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_community_func(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_community_func(
         community_name=community_name, community_id=community_id,
-        include_members=include_members, repo_root=_resolve_repo_root(repo_root),
-    )
+        include_members=include_members, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -565,10 +584,11 @@ def get_architecture_overview_tool(
                       community pair (typical reduction: 600KB -> <5KB);
                       "standard" returns full per-edge detail.
     """
-    return get_architecture_overview_func(
-        repo_root=_resolve_repo_root(repo_root),
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_architecture_overview_func(
+        repo_root=root,
         detail_level=detail_level,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -599,12 +619,16 @@ async def detect_changes_tool(
         detail_level: "standard" for full output, "minimal" for
             token-efficient summary. Default: standard.
     """
-    coro = asyncio.to_thread(
-        detect_changes_func,
-        base=base, changed_files=changed_files,
-        include_source=include_source, max_depth=max_depth,
-        repo_root=_resolve_repo_root(repo_root), detail_level=detail_level,
-    )
+    root = _resolve_repo_root(repo_root)
+
+    def _run() -> dict:
+        return with_provenance(detect_changes_func(
+            base=base, changed_files=changed_files,
+            include_source=include_source, max_depth=max_depth,
+            repo_root=root, detail_level=detail_level,
+        ), root)
+
+    coro = asyncio.to_thread(_run)
     tool_timeout = int(os.environ.get("CRG_TOOL_TIMEOUT", "0"))
     if tool_timeout > 0:
         try:
@@ -615,11 +639,12 @@ async def detect_changes_tool(
                 "Reduce scope with CRG_MAX_CHANGED_FUNCS / CRG_MAX_TRANSITIVE_FRONTIER, "
                 "or increase CRG_TOOL_TIMEOUT."
             )
-            return {
+            error_response = {
                 "status": "error",
                 "error": message,
                 "summary": message,
             }
+            return await asyncio.to_thread(with_provenance, error_response, root)
     return await coro
 
 
@@ -653,10 +678,11 @@ def refactor_tool(
         file_pattern: (dead_code) Filter by file path substring.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return refactor_func(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(refactor_func(
         mode=mode, old_name=old_name, new_name=new_name,
-        kind=kind, file_pattern=file_pattern, repo_root=_resolve_repo_root(repo_root),
-    )
+        kind=kind, file_pattern=file_pattern, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -683,10 +709,11 @@ def apply_refactor_tool(
             dry_run. Use this for a human-in-the-loop review before
             committing changes to disk. See: #176
     """
-    return apply_refactor_func(
-        refactor_id=refactor_id, repo_root=_resolve_repo_root(repo_root),
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(apply_refactor_func(
+        refactor_id=refactor_id, repo_root=root,
         dry_run=dry_run,
-    )
+    ), root)
 
 
 @mcp.tool()
@@ -708,11 +735,14 @@ async def generate_wiki_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         force: If True, regenerate all pages even if content unchanged. Default: False.
     """
-    return await asyncio.to_thread(
-        generate_wiki_func,
-        repo_root=_resolve_repo_root(repo_root),
-        force=force,
-    )
+    root = _resolve_repo_root(repo_root)
+
+    def _run() -> dict:
+        return with_provenance(generate_wiki_func(
+            repo_root=root, force=force,
+        ), root)
+
+    return await asyncio.to_thread(_run)
 
 
 @mcp.tool()
@@ -729,9 +759,10 @@ def get_wiki_page_tool(
         community_name: Community name to look up.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_wiki_page_func(
-        community_name=community_name, repo_root=_resolve_repo_root(repo_root),
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_wiki_page_func(
+        community_name=community_name, repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -748,9 +779,10 @@ def get_hub_nodes_tool(
         top_n: Number of top hubs to return. Default: 10.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_hub_nodes_func(
-        repo_root=_resolve_repo_root(repo_root), top_n=top_n,
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_hub_nodes_func(
+        repo_root=root, top_n=top_n,
+    ), root)
 
 
 @mcp.tool()
@@ -768,9 +800,10 @@ def get_bridge_nodes_tool(
         top_n: Number of top bridges to return. Default: 10.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_bridge_nodes_func(
-        repo_root=_resolve_repo_root(repo_root), top_n=top_n,
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_bridge_nodes_func(
+        repo_root=root, top_n=top_n,
+    ), root)
 
 
 @mcp.tool()
@@ -786,9 +819,10 @@ def get_knowledge_gaps_tool(
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_knowledge_gaps_func(
-        repo_root=_resolve_repo_root(repo_root),
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_knowledge_gaps_func(
+        repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -806,9 +840,10 @@ def get_surprising_connections_tool(
         top_n: Number of top surprises to return. Default: 15.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_surprising_connections_func(
-        repo_root=_resolve_repo_root(repo_root), top_n=top_n,
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_surprising_connections_func(
+        repo_root=root, top_n=top_n,
+    ), root)
 
 
 @mcp.tool()
@@ -824,9 +859,10 @@ def get_suggested_questions_tool(
     Args:
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return get_suggested_questions_func(
-        repo_root=_resolve_repo_root(repo_root),
-    )
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(get_suggested_questions_func(
+        repo_root=root,
+    ), root)
 
 
 @mcp.tool()
@@ -852,11 +888,12 @@ def traverse_graph_tool(
             Default: 2000.
         repo_root: Repository root path. Auto-detected if omitted.
     """
-    return traverse_graph_func(
+    root = _resolve_repo_root(repo_root)
+    return with_provenance(traverse_graph_func(
         query=query, mode=mode, depth=depth,
         token_budget=token_budget,
-        repo_root=_resolve_repo_root(repo_root) or "",
-    )
+        repo_root=root or "",
+    ), root)
 
 
 @mcp.tool()

--- a/code_review_graph/tools/__init__.py
+++ b/code_review_graph/tools/__init__.py
@@ -49,6 +49,7 @@ from ._common import (
     _BUILTIN_CALL_NAMES,
     _get_store,
     _validate_repo_root,
+    with_provenance,
 )
 
 # -- analysis_tools ---------------------------------------------------------
@@ -107,6 +108,7 @@ __all__ = [
     "_BUILTIN_CALL_NAMES",
     "_get_store",
     "_validate_repo_root",
+    "with_provenance",
     # build
     "build_or_update_graph",
     "run_postprocess",

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import sqlite3
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from ..graph import GraphStore
 from ..incremental import find_project_root, get_db_path
+
+_PROVENANCE_READ_TIMEOUT_SECONDS = 0.05
 
 
 def _error_response(
@@ -14,6 +18,76 @@ def _error_response(
 ) -> dict[str, Any]:
     """Build a standardised error response dict."""
     return {"status": status, "error": message, "summary": message, **extra}
+
+
+def graph_provenance(repo_root: str | None = None) -> dict[str, Any] | None:
+    """Return best-effort build metadata for one repository's graph.
+
+    The metadata read is deliberately read-only. Missing, incomplete, or
+    unreadable graph databases must never make the enclosing tool call fail.
+    """
+    try:
+        root = _resolve_root(repo_root)
+        db_path = get_db_path(root)
+        if not db_path.exists():
+            return None
+
+        # ``as_uri`` escapes URI-significant path characters before the
+        # read-only mode query is appended. It also handles Windows drives.
+        database_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        # Provenance is optional and reads only three local metadata rows.
+        # Allow a brief commit boundary, but never inherit sqlite3's 5-second
+        # default wait when a build or migration holds an exclusive lock.
+        connection = sqlite3.connect(
+            database_uri,
+            uri=True,
+            timeout=_PROVENANCE_READ_TIMEOUT_SECONDS,
+        )
+        try:
+            rows = dict(connection.execute(
+                "SELECT key, value FROM metadata WHERE key IN "
+                "('last_updated', 'git_branch', 'git_head_sha')"
+            ).fetchall())
+        finally:
+            connection.close()
+
+        updated_at = rows.get("last_updated")
+        if not isinstance(updated_at, str) or not updated_at:
+            return None
+
+        provenance: dict[str, Any] = {"updated_at": updated_at}
+        try:
+            built_at = datetime.fromisoformat(updated_at)
+            # Match aware timestamps with an aware ``now`` in the same
+            # timezone; None preserves the stored naive/local format.
+            now = datetime.now(tz=built_at.tzinfo)
+            provenance["age_seconds"] = max(
+                0, int((now - built_at).total_seconds()),
+            )
+        except (OverflowError, TypeError, ValueError):
+            # A malformed timestamp only removes the derived age. The raw
+            # timestamp and independently valid branch/SHA remain useful.
+            pass
+
+        branch = rows.get("git_branch")
+        if isinstance(branch, str) and branch:
+            provenance["built_on_branch"] = branch
+        head_sha = rows.get("git_head_sha")
+        if isinstance(head_sha, str) and head_sha:
+            provenance["built_at_sha"] = head_sha
+        return provenance
+    except Exception:
+        return None
+
+
+def with_provenance(result: Any, repo_root: str | None = None) -> Any:
+    """Attach a ``_graph`` envelope without changing existing fields."""
+    if not isinstance(result, dict) or "_graph" in result:
+        return result
+    provenance = graph_provenance(repo_root)
+    if provenance:
+        result["_graph"] = provenance
+    return result
 
 # Common JS/TS builtin method names filtered from callers_of results.
 # "Who calls .map()?" returns hundreds of hits and is never useful.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import threading
 
 import pytest
 
@@ -144,6 +145,14 @@ class TestLongRunningToolsAreAsync:
         "generate_wiki_tool",
     }
 
+    HEAVY_TOOL_IMPLS = {
+        "build_or_update_graph_tool": "build_or_update_graph",
+        "run_postprocess_tool": "run_postprocess",
+        "embed_graph_tool": "embed_graph",
+        "detect_changes_tool": "detect_changes_func",
+        "generate_wiki_tool": "generate_wiki_func",
+    }
+
     def test_heavy_tools_are_coroutines(self):
         """Regression guard for #46/#136: the 5 long-running MCP tools must
         stay ``async def`` so FastMCP can offload their blocking work via
@@ -195,6 +204,35 @@ class TestLongRunningToolsAreAsync:
                 f"blocking work; otherwise Windows MCP clients will hang. "
                 f"See #46, #136."
             )
+
+    @pytest.mark.parametrize("tool_name,impl_name", HEAVY_TOOL_IMPLS.items())
+    @pytest.mark.asyncio
+    async def test_provenance_sqlite_read_runs_off_event_loop(
+        self, tool_name, impl_name, monkeypatch,
+    ):
+        event_loop_thread = threading.get_ident()
+        provenance_threads = []
+
+        def fake_impl(*args, **kwargs):
+            return {"status": "ok", "impl": impl_name}
+
+        def fake_with_provenance(result, repo_root=None):
+            provenance_threads.append(threading.get_ident())
+            return {**result, "_graph": {"updated_at": "worker"}}
+
+        monkeypatch.delenv("CRG_TOOL_TIMEOUT", raising=False)
+        monkeypatch.setattr(crg_main, impl_name, fake_impl)
+        monkeypatch.setattr(
+            crg_main, "with_provenance", fake_with_provenance, raising=False,
+        )
+        tool = getattr(crg_main, tool_name)
+        underlying = getattr(tool, "fn", None) or tool
+        result = await underlying()
+
+        assert result["impl"] == impl_name
+        assert result["_graph"]["updated_at"] == "worker"
+        assert provenance_threads
+        assert all(tid != event_loop_thread for tid in provenance_threads)
 
     @pytest.mark.asyncio
     async def test_detect_changes_timeout_uses_error_response_shape(
@@ -271,6 +309,55 @@ class TestLongRunningToolsAreAsync:
                         f"and will silently break the guard.  Use "
                         f"getattr(crg_main, tool_name) instead."
                     )
+
+
+class TestGraphBackedToolProvenanceCoverage:
+    """Every single-repository graph tool must expose freshness metadata."""
+
+    TOOL_CATEGORIES = {
+        "build": {"build_or_update_graph_tool", "run_postprocess_tool"},
+        "context_and_search": {
+            "get_minimal_context_tool", "get_impact_radius_tool",
+            "query_graph_tool", "get_review_context_tool",
+            "semantic_search_nodes_tool", "find_large_functions_tool",
+            "traverse_graph_tool",
+        },
+        "embeddings_and_stats": {"embed_graph_tool", "list_graph_stats_tool"},
+        "flows_and_communities": {
+            "list_flows_tool", "get_flow_tool", "get_affected_flows_tool",
+            "list_communities_tool", "get_community_tool",
+            "get_architecture_overview_tool",
+        },
+        "review_and_refactor": {
+            "detect_changes_tool", "refactor_tool", "apply_refactor_tool",
+        },
+        "wiki_and_analysis": {
+            "generate_wiki_tool", "get_wiki_page_tool", "get_hub_nodes_tool",
+            "get_bridge_nodes_tool", "get_knowledge_gaps_tool",
+            "get_surprising_connections_tool", "get_suggested_questions_tool",
+        },
+    }
+
+    @pytest.mark.parametrize("category,tool_names", TOOL_CATEGORIES.items())
+    def test_every_graph_backed_tool_category_attaches_provenance(
+        self, category, tool_names,
+    ):
+        assert tool_names, f"{category} must name at least one tool"
+        for tool_name in tool_names:
+            tool = getattr(crg_main, tool_name, None)
+            assert tool is not None, f"{category}: missing {tool_name}"
+            underlying = getattr(tool, "fn", None) or tool
+            assert "with_provenance" in inspect.getsource(underlying), (
+                f"{category}: {tool_name} does not attach graph provenance"
+            )
+
+    @pytest.mark.parametrize("tool_name", [
+        "get_docs_section_tool", "list_repos_tool", "cross_repo_search_tool",
+    ])
+    def test_non_single_repository_tools_do_not_claim_one_graph(self, tool_name):
+        tool = getattr(crg_main, tool_name)
+        underlying = getattr(tool, "fn", None) or tool
+        assert "with_provenance" not in inspect.getsource(underlying)
 
 class TestApplyToolFilter:
     """Tests for _apply_tool_filter (``serve --tools`` / ``CRG_TOOLS``).

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,8 @@
 """Tests for MCP tool functions."""
 
+import os
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -22,6 +24,7 @@ from code_review_graph.tools import (
     get_review_context,
     list_communities_func,
     list_flows,
+    list_graph_stats,
     query_graph,
 )
 
@@ -1735,3 +1738,210 @@ class TestGetMinimalContext:
             task="refactor auth module", repo_root=str(self.root),
         )
         assert "refactor" in result["next_tool_suggestions"]
+
+
+class TestGraphProvenance:
+    """Freshness metadata attached to single-repository graph responses."""
+
+    @staticmethod
+    def _make_repo(tmp_path, metadata=None, name="repo"):
+        repo = tmp_path / name
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        graph_dir = repo / ".code-review-graph"
+        graph_dir.mkdir()
+        store = GraphStore(graph_dir / "graph.db")
+        try:
+            store.upsert_node(NodeInfo(
+                kind="Function", name="handle", file_path="src/app.py",
+                line_start=1, line_end=3, language="python",
+            ))
+            for key, value in (metadata or {}).items():
+                store.set_metadata(key, value)
+            store.commit()
+        finally:
+            store.close()
+        return repo
+
+    def test_reads_all_metadata_via_read_only_sqlite_uri(
+        self, tmp_path, monkeypatch,
+    ):
+        repo = self._make_repo(tmp_path, {
+            "last_updated": "2000-01-02T03:04:05",
+            "git_branch": "feature/x",
+            "git_head_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+        })
+        real_connect = common_module.sqlite3.connect
+        connection_args = {}
+
+        def recording_connect(database, *args, **kwargs):
+            connection_args.update(database=database, uri=kwargs.get("uri"))
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(common_module.sqlite3, "connect", recording_connect)
+        provenance = common_module.graph_provenance(str(repo))
+
+        assert provenance["updated_at"] == "2000-01-02T03:04:05"
+        assert provenance["built_on_branch"] == "feature/x"
+        assert provenance["built_at_sha"] == (
+            "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+        )
+        assert provenance["age_seconds"] > 0
+        assert connection_args["database"].endswith("?mode=ro")
+        assert connection_args["uri"] is True
+
+    def test_exclusive_lock_fails_soft_promptly(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"},
+        )
+        db_path = repo / ".code-review-graph" / "graph.db"
+        locker = common_module.sqlite3.connect(db_path)
+        try:
+            # GraphStore uses WAL, where writers do not block readers. Switch
+            # this fixture to rollback journalling so BEGIN EXCLUSIVE models a
+            # build or migration holding a database-wide lock.
+            journal_mode = locker.execute(
+                "PRAGMA journal_mode=DELETE",
+            ).fetchone()[0]
+            assert journal_mode == "delete"
+            locker.execute("BEGIN EXCLUSIVE")
+
+            started = time.monotonic()
+            provenance = common_module.graph_provenance(str(repo))
+            elapsed = time.monotonic() - started
+        finally:
+            locker.rollback()
+            locker.close()
+
+        assert provenance is None
+        assert elapsed < 1.0
+
+    @pytest.mark.parametrize("repo_name", [
+        "repo %40 #fragment",
+        "repo [windows-like] %23 #hash",
+    ])
+    def test_reads_metadata_from_uri_significant_paths(self, tmp_path, repo_name):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"}, repo_name,
+        )
+        provenance = common_module.graph_provenance(str(repo))
+        assert provenance["updated_at"] == "2000-01-02T03:04:05"
+
+    @pytest.mark.skipif(os.name != "nt", reason="native Windows path semantics")
+    def test_reads_metadata_from_native_windows_path(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"},
+            "repo %23 #windows",
+        )
+        assert "\\" in str(repo)
+        provenance = common_module.graph_provenance(str(repo))
+        assert provenance["updated_at"] == "2000-01-02T03:04:05"
+
+    def test_timezone_aware_timestamp_keeps_metadata_and_age(self, tmp_path):
+        repo = self._make_repo(tmp_path, {
+            "last_updated": "2000-01-02T03:04:05+05:30",
+            "git_branch": "feature/timezone",
+            "git_head_sha": "deadbeef",
+        })
+        provenance = common_module.graph_provenance(str(repo))
+
+        assert provenance["updated_at"] == "2000-01-02T03:04:05+05:30"
+        assert provenance["built_on_branch"] == "feature/timezone"
+        assert provenance["built_at_sha"] == "deadbeef"
+        assert provenance["age_seconds"] > 0
+
+    def test_timezone_aware_future_timestamp_clamps_age(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2999-01-01T00:00:00-07:00"},
+        )
+        assert common_module.graph_provenance(str(repo))["age_seconds"] == 0
+
+    def test_malformed_timestamp_omits_only_age(self, tmp_path):
+        repo = self._make_repo(tmp_path, {
+            "last_updated": "not-a-date",
+            "git_branch": "feature/malformed-time",
+            "git_head_sha": "cafebabe",
+        })
+        assert common_module.graph_provenance(str(repo)) == {
+            "updated_at": "not-a-date",
+            "built_on_branch": "feature/malformed-time",
+            "built_at_sha": "cafebabe",
+        }
+
+    def test_naive_future_timestamp_clamps_age(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2999-01-01T00:00:00"},
+        )
+        assert common_module.graph_provenance(str(repo))["age_seconds"] == 0
+
+    def test_branch_and_sha_are_optional(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"},
+        )
+        provenance = common_module.graph_provenance(str(repo))
+        assert "built_on_branch" not in provenance
+        assert "built_at_sha" not in provenance
+
+    def test_missing_last_updated_has_no_envelope(self, tmp_path):
+        repo = self._make_repo(tmp_path, {"git_branch": "main"})
+        assert common_module.graph_provenance(str(repo)) is None
+
+    def test_missing_graph_database_has_no_envelope(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        assert common_module.graph_provenance(str(repo)) is None
+
+    def test_corrupt_graph_database_has_no_envelope(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        graph_dir = repo / ".code-review-graph"
+        graph_dir.mkdir()
+        (graph_dir / "graph.db").write_bytes(b"not a sqlite database")
+        assert common_module.graph_provenance(str(repo)) is None
+
+    def test_invalid_repo_root_has_no_envelope(self, tmp_path):
+        assert common_module.graph_provenance(str(tmp_path / "missing")) is None
+
+    def test_with_provenance_preserves_response_fields(self, tmp_path):
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"},
+        )
+        response = {"status": "ok", "results": [{"name": "handle"}]}
+        result = common_module.with_provenance(response, str(repo))
+        assert result is response
+        assert result["status"] == "ok"
+        assert result["results"] == [{"name": "handle"}]
+        assert result["_graph"]["updated_at"] == "2000-01-02T03:04:05"
+
+    def test_with_provenance_handles_noop_cases(self, tmp_path):
+        repo_without_metadata = self._make_repo(tmp_path, name="empty")
+        response = {"status": "ok"}
+        assert common_module.with_provenance(
+            response, str(repo_without_metadata),
+        ) == response
+
+        repo = self._make_repo(
+            tmp_path, {"last_updated": "2000-01-02T03:04:05"}, "full",
+        )
+        assert common_module.with_provenance([1, 2], str(repo)) == [1, 2]
+        assert common_module.with_provenance(None, str(repo)) is None
+        existing = {"_graph": {"updated_at": "existing"}}
+        assert common_module.with_provenance(existing, str(repo)) is existing
+        assert existing["_graph"] == {"updated_at": "existing"}
+
+    def test_registered_sync_tool_preserves_existing_fields(self, tmp_path):
+        from code_review_graph.main import list_graph_stats_tool
+
+        repo = self._make_repo(tmp_path, {
+            "last_updated": "2000-01-02T03:04:05",
+            "git_branch": "main",
+        })
+        expected = list_graph_stats(repo_root=str(repo))
+        underlying = getattr(list_graph_stats_tool, "fn", None) or list_graph_stats_tool
+        result = underlying(repo_root=str(repo))
+
+        envelope = result.pop("_graph")
+        assert result == expected
+        assert envelope["updated_at"] == "2000-01-02T03:04:05"
+        assert envelope["built_on_branch"] == "main"


### PR DESCRIPTION
## Summary

- Port Stefan Hudici's graph-response provenance work from #604 onto current protected main.
- Attach a compact `_graph` envelope to every single-repository graph-backed MCP response while leaving documentation, registry-list, and cross-repository tools unchanged.
- Read `last_updated`, `git_branch`, and `git_head_sha` through a read-only SQLite URI; failures remain best-effort and never replace the underlying response.
- Limit the optional metadata read to 50 ms, so a build or migration holding an exclusive SQLite lock cannot add the driver's default five-second wait.
- Keep provenance database reads inside worker threads for all five async graph tools.
- Handle timezone-aware timestamps with a matching timezone so `updated_at`, branch, and SHA survive while malformed timestamps omit only `age_seconds`.

## Compatibility and coverage

- Existing MCP tool signatures and response fields are unchanged; `_graph` is additive.
- Tests cover URI-significant paths, native Windows path behavior, missing/corrupt graph data, naive and timezone-aware timestamps, no-op cases, all wrapped tool categories, and off-event-loop provenance reads.
- A lock-contention regression holds an exclusive SQLite lock and verifies provenance fails softly in under one second.
- The commit retains Stefan Hudici's `Co-authored-by` attribution.

## Verification

- `pytest -q tests/test_tools.py tests/test_main.py`: 147 passed, 1 skipped
- `pytest -q`: 1611 passed, 1 skipped, 2 xpassed
- `ruff check code_review_graph/ tests/test_tools.py tests/test_main.py`: passed
- CI-parity `mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`: passed (62 files)
- `bandit -r code_review_graph/ -c pyproject.toml`: no issues
- `git diff --check origin/main...HEAD`: passed
- Graph review: 5 changed files, 0 affected execution flows

Source contribution: #604 by @SHudici.
