### PR TITLE
feat(parser): reconcile Julia qualified scopes

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2450,6 +2450,11 @@ class CodeParser:
 
         External calls (names not defined in this file) remain bare.
         """
+        if any(node.language == "julia" for node in nodes):
+            return self._resolve_julia_call_targets(
+                nodes, edges, file_path,
+            )
+
         # Build symbol table: bare_name -> qualified_name
         symbols: dict[str, str] = {}
         for node in nodes:
@@ -2461,6 +2466,12 @@ class CodeParser:
 
         resolved: list[EdgeInfo] = []
         for edge in edges:
+            if (
+                edge.kind == "REFERENCES"
+                and edge.extra.get("julia_qualified_def")
+            ):
+                resolved.append(edge)
+                continue
             if edge.kind in ("CALLS", "REFERENCES") and "::" not in edge.target:
                 if edge.target in symbols:
                     edge = EdgeInfo(
@@ -2471,6 +2482,63 @@ class CodeParser:
                         line=edge.line,
                         extra=edge.extra,
                     )
+            resolved.append(edge)
+        return resolved
+
+    def _resolve_julia_call_targets(
+        self,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        file_path: str,
+    ) -> list[EdgeInfo]:
+        """Resolve Julia calls from the nearest lexical scope outward."""
+        symbols: dict[str, str] = {}
+        prefix = f"{file_path}::"
+        for node in nodes:
+            if node.kind not in ("Function", "Class", "Type", "Test"):
+                continue
+            qualified = self._qualify(
+                node.name, file_path, node.parent_name,
+            )
+            symbols[qualified.removeprefix(prefix)] = qualified
+
+        resolved: list[EdgeInfo] = []
+        for edge in edges:
+            if (
+                edge.kind == "REFERENCES"
+                and edge.extra.get("julia_qualified_def")
+            ):
+                resolved.append(edge)
+                continue
+            if (
+                edge.kind not in ("CALLS", "REFERENCES")
+                or "::" in edge.target
+            ):
+                resolved.append(edge)
+                continue
+
+            source_tail = (
+                edge.source.removeprefix(prefix)
+                if edge.source.startswith(prefix)
+                else ""
+            )
+            scope_parts = source_tail.split(".") if source_tail else []
+            target = None
+            for size in range(len(scope_parts), -1, -1):
+                scope = ".".join(scope_parts[:size])
+                candidate = f"{scope}.{edge.target}" if scope else edge.target
+                target = symbols.get(candidate)
+                if target is not None:
+                    break
+            if target is not None:
+                edge = EdgeInfo(
+                    kind=edge.kind,
+                    source=edge.source,
+                    target=target,
+                    file_path=edge.file_path,
+                    line=edge.line,
+                    extra=edge.extra,
+                )
             resolved.append(edge)
         return resolved
 
@@ -3423,6 +3491,101 @@ class CodeParser:
         qualifier = ".".join(qualifier_parts) or None
         return qualifier, name
 
+    @staticmethod
+    def _julia_scope_join(
+        outer: Optional[str], inner: Optional[str],
+    ) -> Optional[str]:
+        """Join Julia scope paths without repeating an existing prefix."""
+        if not outer:
+            return inner
+        if not inner:
+            return outer
+        if inner == outer or inner.startswith(f"{outer}."):
+            return inner
+        return f"{outer}.{inner}"
+
+    def _julia_signature_callee(self, function_node):
+        """Return the definition target inside a Julia signature."""
+        signature = next(
+            (
+                child for child in function_node.children
+                if child.type == "signature"
+            ),
+            None,
+        )
+        if signature is None:
+            return None
+        scope = signature
+        for _ in range(4):
+            call = next(
+                (
+                    child for child in scope.children
+                    if child.type == "call_expression"
+                ),
+                None,
+            )
+            if call is not None:
+                return call.children[0] if call.children else None
+            direct = next(
+                (
+                    child for child in scope.children
+                    if child.type in (
+                        "field_expression", "identifier", "operator",
+                    )
+                ),
+                None,
+            )
+            if direct is not None:
+                return direct
+            wrapper = next(
+                (
+                    child for child in scope.children
+                    if child.type in (
+                        "where_expression", "typed_expression",
+                    )
+                ),
+                None,
+            )
+            if wrapper is None:
+                break
+            scope = wrapper
+        return None
+
+    def _julia_definition_qualifier(
+        self, function_node,
+    ) -> Optional[str]:
+        callee = self._julia_signature_callee(function_node)
+        if callee is None or callee.type != "field_expression":
+            return None
+        qualifier, _ = self._julia_field_info(callee)
+        return qualifier
+
+    def _julia_short_qualifier(self, call_expr) -> Optional[str]:
+        if not call_expr.children:
+            return None
+        callee = call_expr.children[0]
+        if callee.type != "field_expression":
+            return None
+        qualifier, _ = self._julia_field_info(callee)
+        return qualifier
+
+    def _resolve_julia_import_alias(
+        self,
+        alias: str,
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: dict[str, str],
+    ) -> Optional[str]:
+        """Resolve a Julia import alias from the nearest lexical scope."""
+        scope = self._julia_scope_join(enclosing_class, enclosing_func)
+        scope_parts = scope.split(".") if scope else []
+        for size in range(len(scope_parts), -1, -1):
+            prefix = ".".join(scope_parts[:size])
+            key = f"{prefix}.{alias}" if prefix else alias
+            if key in import_map:
+                return import_map[key]
+        return None
+
     def _julia_short_func_name(self, call_expr) -> Optional[str]:
         """Extract the name from a ``call_expression`` that is the LHS of
         a short-form function ``f(x) = expr`` or ``Base.f(x) = expr`` or
@@ -3552,9 +3715,19 @@ class CodeParser:
                 if name:
                     is_test = _is_test_function(name, file_path, ())
                     kind = "Test" if is_test else "Function"
-                    qualified = self._qualify(
-                        name, file_path, enclosing_class,
+                    lexical_parent = self._julia_scope_join(
+                        enclosing_class, enclosing_func,
                     )
+                    qualifier = self._julia_short_qualifier(lhs)
+                    identity_parent = self._julia_scope_join(
+                        lexical_parent, qualifier,
+                    )
+                    qualified = self._qualify(
+                        name, file_path, identity_parent,
+                    )
+                    extra = {}
+                    if qualifier:
+                        extra["julia_module_qualifier"] = qualifier
                     nodes.append(NodeInfo(
                         kind=kind,
                         name=name,
@@ -3562,12 +3735,13 @@ class CodeParser:
                         line_start=child.start_point[0] + 1,
                         line_end=child.end_point[0] + 1,
                         language=language,
-                        parent_name=enclosing_class,
+                        parent_name=identity_parent,
                         is_test=is_test,
+                        extra=extra,
                     ))
                     container = (
-                        self._qualify(enclosing_class, file_path, None)
-                        if enclosing_class
+                        self._qualify(lexical_parent, file_path, None)
+                        if lexical_parent
                         else file_path
                     )
                     edges.append(EdgeInfo(
@@ -3577,20 +3751,38 @@ class CodeParser:
                         file_path=file_path,
                         line=child.start_point[0] + 1,
                     ))
+                    if qualifier:
+                        edges.append(EdgeInfo(
+                            kind="REFERENCES",
+                            source=qualified,
+                            target=qualifier,
+                            file_path=file_path,
+                            line=child.start_point[0] + 1,
+                            extra={"julia_qualified_def": True},
+                        ))
                     # Recurse into the RHS only (children after the ``=``
                     # operator) with this function as the enclosing scope
                     # so internal calls wire up correctly. Visiting the
                     # whole assignment would re-treat the LHS
                     # ``call_expression`` as a self-call.
+                    call_types = set(_CALL_TYPES.get(language, []))
                     seen_op = False
                     for sub in child.children:
                         if not seen_op:
                             if sub.type == "operator":
                                 seen_op = True
                             continue
+                        # The RHS call itself sits at this level, while the
+                        # generic walker only visits a node's children.
+                        if sub.type in call_types:
+                            self._extract_calls(
+                                sub, source, language, file_path,
+                                nodes, edges, identity_parent, name,
+                                import_map, defined_names, _depth + 1,
+                            )
                         self._extract_from_tree(
                             sub, source, language, file_path, nodes, edges,
-                            enclosing_class=enclosing_class,
+                            enclosing_class=identity_parent,
                             enclosing_func=name,
                             import_map=import_map,
                             defined_names=defined_names,
@@ -3762,8 +3954,11 @@ class CodeParser:
                 line_no = child.start_point[0] + 1
                 synth_base = f"testset:{desc}" if desc else "testset"
                 synth_name = f"{synth_base}@L{line_no}"
+                lexical_parent = self._julia_scope_join(
+                    enclosing_class, enclosing_func,
+                )
                 qualified = self._qualify(
-                    synth_name, file_path, enclosing_class,
+                    synth_name, file_path, lexical_parent,
                 )
                 nodes.append(NodeInfo(
                     kind="Test",
@@ -3772,14 +3967,12 @@ class CodeParser:
                     line_start=child.start_point[0] + 1,
                     line_end=child.end_point[0] + 1,
                     language=language,
-                    parent_name=enclosing_class,
+                    parent_name=lexical_parent,
                     is_test=True,
                 ))
                 container = (
-                    self._qualify(
-                        enclosing_func, file_path, enclosing_class,
-                    )
-                    if enclosing_func
+                    self._qualify(lexical_parent, file_path, None)
+                    if lexical_parent
                     else file_path
                 )
                 edges.append(EdgeInfo(
@@ -3792,7 +3985,7 @@ class CodeParser:
                 if body_parent is not None:
                     self._extract_from_tree(
                         body_parent, source, language, file_path, nodes, edges,
-                        enclosing_class=enclosing_class,
+                        enclosing_class=lexical_parent,
                         enclosing_func=synth_name,
                         import_map=import_map, defined_names=defined_names,
                         _depth=_depth + 1,
@@ -5089,9 +5282,14 @@ class CodeParser:
         nodes.append(node)
 
         # CONTAINS edge
+        class_container = (
+            self._qualify(enclosing_class, file_path, None)
+            if language == "julia" and enclosing_class
+            else file_path
+        )
         edges.append(EdgeInfo(
             kind="CONTAINS",
-            source=file_path,
+            source=class_container,
             target=self._qualify(name, file_path, enclosing_class),
             file_path=file_path,
             line=child.start_point[0] + 1,
@@ -5121,9 +5319,14 @@ class CodeParser:
             self._emit_kafka_edges_from_class(child, name, file_path, edges)
 
         # Recurse into class body
+        recursive_class = (
+            self._julia_scope_join(enclosing_class, name)
+            if language == "julia"
+            else name
+        )
         self._extract_from_tree(
             child, source, language, file_path, nodes, edges,
-            enclosing_class=name, enclosing_func=None,
+            enclosing_class=recursive_class, enclosing_func=None,
             import_map=import_map, defined_names=defined_names,
             _depth=_depth + 1,
         )
@@ -5204,14 +5407,18 @@ class CodeParser:
         is_test = _is_test_function(name, file_path, decorators)
         kind = "Test" if is_test else "Function"
 
-        # Julia: nested functions (``function inner`` inside another
-        # ``function outer``) should wire up to their enclosing function,
-        # not skip past it to the enclosing class/module.
         parent_name = enclosing_class
         container_scope = enclosing_class
-        if language == "julia" and enclosing_func:
-            parent_name = enclosing_func
-            container_scope = enclosing_func
+        julia_qualifier: Optional[str] = None
+        if language == "julia":
+            lexical_parent = self._julia_scope_join(
+                enclosing_class, enclosing_func,
+            )
+            julia_qualifier = self._julia_definition_qualifier(child)
+            parent_name = self._julia_scope_join(
+                lexical_parent, julia_qualifier,
+            )
+            container_scope = lexical_parent
 
         qualified = self._qualify(name, file_path, parent_name)
         params = self._get_params(child, language, source)
@@ -5219,6 +5426,8 @@ class CodeParser:
 
         # Java: detect Temporal method-level annotations and Kafka listeners
         method_extra: dict = {}
+        if julia_qualifier:
+            method_extra["julia_module_qualifier"] = julia_qualifier
         if language == "java" and deco_list:
             temporal_method_annots = [
                 a for a in deco_list if a in _TEMPORAL_METHOD_ANNOTATIONS
@@ -5270,57 +5479,17 @@ class CodeParser:
             line=child.start_point[0] + 1,
         ))
 
-        # Julia: ``function Base.show(io, x)`` extends a foreign module's
-        # method. Record a REFERENCES edge from the function to the
-        # qualifier module so cross-module links stay visible even though
-        # the function's local name is just the method name.
-        if language == "julia" and child.type == "function_definition":
-            for sub in child.children:
-                if sub.type != "signature":
-                    continue
-                call_expr = None
-                scope = sub
-                # Peel where_expression / typed_expression wrappers so we
-                # land on the inner call_expression regardless of
-                # ``func(x) where T`` or ``func(x)::T`` sugar.
-                for _ in range(2):
-                    found_wrapper = False
-                    for inner in scope.children:
-                        if inner.type in (
-                            "where_expression", "typed_expression",
-                        ):
-                            scope = inner
-                            found_wrapper = True
-                            break
-                    if not found_wrapper:
-                        break
-                for inner in scope.children:
-                    if inner.type == "call_expression":
-                        call_expr = inner
-                        break
-                if call_expr is None:
-                    break
-                if call_expr.children and call_expr.children[0].type == "field_expression":
-                    field_expr = call_expr.children[0]
-                    parts: list[str] = []
-                    for ident in field_expr.children:
-                        if ident.type == "identifier":
-                            parts.append(
-                                ident.text.decode("utf-8", errors="replace"),
-                            )
-                    # Module qualifier = everything except the final method
-                    # name.
-                    if len(parts) >= 2:
-                        qualifier = ".".join(parts[:-1])
-                        edges.append(EdgeInfo(
-                            kind="REFERENCES",
-                            source=qualified,
-                            target=qualifier,
-                            file_path=file_path,
-                            line=child.start_point[0] + 1,
-                            extra={"julia_qualified_def": True},
-                        ))
-                break
+        # Qualified Julia methods extend a foreign module while remaining
+        # structurally contained by their lexical module.
+        if julia_qualifier:
+            edges.append(EdgeInfo(
+                kind="REFERENCES",
+                source=qualified,
+                target=julia_qualifier,
+                file_path=file_path,
+                line=child.start_point[0] + 1,
+                extra={"julia_qualified_def": True},
+            ))
 
         # Solidity: modifier invocations on functions -> CALLS edges
         if language == "solidity":
@@ -5340,9 +5509,12 @@ class CodeParser:
                             break
 
         # Recurse to find calls inside the function
+        recursive_class = (
+            parent_name if language == "julia" else enclosing_class
+        )
         self._extract_from_tree(
             child, source, language, file_path, nodes, edges,
-            enclosing_class=enclosing_class, enclosing_func=name,
+            enclosing_class=recursive_class, enclosing_func=name,
             import_map=import_map, defined_names=defined_names,
             _depth=_depth + 1,
         )
@@ -5468,14 +5640,14 @@ class CodeParser:
             # any function called only from top-level script glue, CLI
             # entrypoints, or Jupyter/Databricks notebook cells is flagged
             # as dead by find_dead_code.
-            # For Verilog module instantiations, create CALLS edges from the
-            # enclosing module (enclosing_class), not just from functions.
+            # For Verilog module instantiations and Julia module-level calls,
+            # create CALLS edges from the enclosing module. Julia needs this
+            # lexical source so same-file resolution can find module members.
             if enclosing_func:
                 caller = self._qualify(
                     enclosing_func, file_path, enclosing_class,
                 )
-            elif language == "verilog" and enclosing_class:
-                # Verilog module instantiation happen at module level
+            elif language in ("verilog", "julia") and enclosing_class:
                 caller = self._qualify(
                     enclosing_class, file_path, None
                 )
@@ -5491,6 +5663,36 @@ class CodeParser:
                     call_name = method_name
                 if receiver:
                     call_extra["receiver"] = receiver
+
+            # Keep Julia module qualification in the canonical target. The
+            # same-file resolver can then distinguish ``run`` from ``A.B.run``.
+            if (
+                language == "julia"
+                and child.children
+                and child.children[0].type == "field_expression"
+            ):
+                qualifier, qualified_name = self._julia_field_info(
+                    child.children[0],
+                )
+                if qualifier and qualified_name:
+                    module_parts = qualifier.split(".")
+                    imported_module = self._resolve_julia_import_alias(
+                        module_parts[0], enclosing_class, enclosing_func,
+                        import_map or {},
+                    )
+                    if imported_module:
+                        module_parts[0] = imported_module
+                    resolved_qualifier = ".".join(module_parts)
+                    call_name = f"{resolved_qualifier}.{qualified_name}"
+                    call_extra["julia_call_module"] = resolved_qualifier
+
+            if language == "julia" and "." not in call_name:
+                imported_symbol = self._resolve_julia_import_alias(
+                    call_name, enclosing_class, enclosing_func,
+                    import_map or {},
+                )
+                if imported_symbol:
+                    call_name = imported_symbol
 
             # When a receiver is present, skip scope-based resolution: the method
             # lives on the receiver's type, not in the current file's scope.
@@ -6607,7 +6809,47 @@ class CodeParser:
             if node_type in import_types:
                 self._collect_import_names(child, language, source, import_map)
 
+        if language == "julia":
+            self._collect_julia_scoped_import_names(
+                root, source, import_map,
+            )
+
         return import_map, defined_names
+
+    def _collect_julia_scoped_import_names(
+        self,
+        node,
+        source: bytes,
+        import_map: dict[str, str],
+        scope: Optional[str] = None,
+    ) -> None:
+        """Collect Julia aliases without leaking them across modules."""
+        current_scope = scope
+        if node.type == "module_definition":
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                module_name = name_node.text.decode(
+                    "utf-8", errors="replace",
+                )
+                current_scope = self._julia_scope_join(
+                    current_scope, module_name,
+                )
+
+        import_types = set(self._import_types.get("julia", []))
+        for child in node.children:
+            if child.type in import_types:
+                local_imports: dict[str, str] = {}
+                self._collect_import_names(
+                    child, "julia", source, local_imports,
+                )
+                for alias, target in local_imports.items():
+                    key = self._julia_scope_join(current_scope, alias)
+                    if key:
+                        import_map[key] = target
+                continue
+            self._collect_julia_scoped_import_names(
+                child, source, import_map, current_scope,
+            )
 
     def _expand_python_star_imports(
         self,
@@ -6859,6 +7101,50 @@ class CodeParser:
                 for child in node.children:
                     if child.type == "import_clause":
                         self._collect_js_import_names(child, module, import_map)
+
+        elif language == "julia":
+            def _alias_parts(alias_node) -> tuple[Optional[str], Optional[str]]:
+                names: list[str] = []
+                for part in alias_node.children:
+                    if part.type == "identifier":
+                        names.append(
+                            part.text.decode("utf-8", errors="replace"),
+                        )
+                    elif part.type == "import_path":
+                        names.append(
+                            ".".join(
+                                child.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                                for child in part.children
+                                if child.type == "identifier"
+                            ),
+                        )
+                if len(names) < 2:
+                    return None, None
+                return names[0], names[-1]
+
+            for child in node.children:
+                if child.type == "import_alias":
+                    real_name, alias = _alias_parts(child)
+                    if real_name and alias:
+                        import_map[alias] = real_name
+                    continue
+                if child.type != "selected_import":
+                    continue
+                module_name: Optional[str] = None
+                seen_colon = False
+                for part in child.children:
+                    if part.type == ":":
+                        seen_colon = True
+                    elif not seen_colon and part.type == "identifier":
+                        module_name = part.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                    elif seen_colon and part.type == "import_alias":
+                        real_name, alias = _alias_parts(part)
+                        if module_name and real_name and alias:
+                            import_map[alias] = f"{module_name}.{real_name}"
 
     def _collect_js_import_names(
         self, clause_node, module: str, import_map: dict[str, str],
@@ -7218,6 +7504,8 @@ class CodeParser:
         if call_name in defined_names:
             return self._qualify(call_name, file_path, None)
         if call_name in import_map:
+            if language == "julia":
+                return import_map[call_name]
             resolved = self._resolve_imported_symbol(
                 call_name, import_map[call_name], file_path, language,
             )

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -3373,6 +3373,56 @@ class CodeParser:
     # Julia-specific helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _julia_component_name(node) -> Optional[str]:
+        """Return an identifier or quoted operator component name."""
+        if node.type in ("identifier", "operator"):
+            return node.text.decode("utf-8", errors="replace")
+        if node.type in ("quote_expression", "parenthesized_expression"):
+            for child in node.children:
+                name = CodeParser._julia_component_name(child)
+                if name is not None:
+                    return name
+        return None
+
+    def _julia_field_parts(self, field_expr) -> list[str]:
+        """Flatten the identifier prefix of a Julia field expression."""
+        parts: list[str] = []
+        for child in field_expr.children:
+            if child.type == "field_expression":
+                parts.extend(self._julia_field_parts(child))
+            elif child.type == "identifier":
+                parts.append(
+                    child.text.decode("utf-8", errors="replace"),
+                )
+        return parts
+
+    def _julia_field_info(
+        self, field_expr,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return ``(qualifier, leaf)`` for a Julia field expression."""
+        semantic_children = [
+            child for child in field_expr.children
+            if child.type in (
+                "field_expression",
+                "identifier",
+                "quote_expression",
+            )
+        ]
+        if not semantic_children:
+            return None, None
+        name = self._julia_component_name(semantic_children[-1])
+        qualifier_parts: list[str] = []
+        for child in semantic_children[:-1]:
+            if child.type == "field_expression":
+                qualifier_parts.extend(self._julia_field_parts(child))
+            elif child.type == "identifier":
+                qualifier_parts.append(
+                    child.text.decode("utf-8", errors="replace"),
+                )
+        qualifier = ".".join(qualifier_parts) or None
+        return qualifier, name
+
     def _julia_short_func_name(self, call_expr) -> Optional[str]:
         """Extract the name from a ``call_expression`` that is the LHS of
         a short-form function ``f(x) = expr`` or ``Base.f(x) = expr`` or
@@ -3381,11 +3431,11 @@ class CodeParser:
         for child in call_expr.children:
             if child.type == "identifier":
                 return child.text.decode("utf-8", errors="replace")
+            if child.type == "operator":
+                return child.text.decode("utf-8", errors="replace")
             if child.type == "field_expression":
-                for ident in reversed(child.children):
-                    if ident.type == "identifier":
-                        return ident.text.decode("utf-8", errors="replace")
-                return None
+                _, name = self._julia_field_info(child)
+                return name
             if child.type == "parametrized_type_expression":
                 for ident in child.children:
                     if ident.type == "identifier":
@@ -3436,6 +3486,55 @@ class CodeParser:
         Returns True if the child was fully handled and should be skipped
         by the main dispatch loop.
         """
+        # Parameterized const aliases are type declarations. Ordinary value
+        # constants stay on the generic path.
+        if node_type == "const_statement":
+            assignment = next(
+                (
+                    sub for sub in child.children
+                    if sub.type == "assignment"
+                ),
+                None,
+            )
+            if assignment is not None and len(assignment.children) >= 3:
+                name_node = assignment.children[0]
+                value_node = assignment.children[-1]
+                if (
+                    name_node.type == "identifier"
+                    and value_node.type in (
+                        "parametrized_type_expression",
+                        "curly_expression",
+                    )
+                ):
+                    name = name_node.text.decode(
+                        "utf-8", errors="replace",
+                    )
+                    qualified = self._qualify(
+                        name, file_path, enclosing_class,
+                    )
+                    nodes.append(NodeInfo(
+                        kind="Type",
+                        name=name,
+                        file_path=file_path,
+                        line_start=child.start_point[0] + 1,
+                        line_end=child.end_point[0] + 1,
+                        language=language,
+                        parent_name=enclosing_class,
+                    ))
+                    container = (
+                        self._qualify(enclosing_class, file_path, None)
+                        if enclosing_class
+                        else file_path
+                    )
+                    edges.append(EdgeInfo(
+                        kind="CONTAINS",
+                        source=container,
+                        target=qualified,
+                        file_path=file_path,
+                        line=child.start_point[0] + 1,
+                    ))
+                    return True
+
         # --- Short-form function: assignment with call_expression LHS ---
         # ``f(x) = expr`` or ``Base.f(x) = expr``.  Anything else with an
         # ``=`` (plain variable, const) is left to the generic path.
@@ -7491,6 +7590,13 @@ class CodeParser:
                                                     "utf-8", errors="replace",
                                                 )
                                 return None
+                        # Generic-function stub: ``function foo end`` has a
+                        # direct identifier in the signature and no call.
+                        for sub in call.children:
+                            if sub.type == "identifier":
+                                return sub.text.decode(
+                                    "utf-8", errors="replace",
+                                )
                 return None
             if node.type in ("struct_definition", "abstract_definition"):
                 for child in node.children:
@@ -7937,6 +8043,19 @@ class CodeParser:
                         parts.append(sub.text.decode("utf-8", errors="replace"))
                 return ".".join(parts)
 
+            def _alias_real_name(alias_node) -> Optional[str]:
+                for sub in alias_node.children:
+                    if sub.type == "as":
+                        break
+                    if sub.type == "identifier":
+                        return sub.text.decode(
+                            "utf-8", errors="replace",
+                        )
+                    if sub.type == "import_path":
+                        path = _import_path_text(sub)
+                        return path or None
+                return None
+
             for child in node.children:
                 if child.type == "identifier":
                     imports.append(
@@ -7946,6 +8065,10 @@ class CodeParser:
                     path = _import_path_text(child)
                     if path:
                         imports.append(path)
+                elif child.type == "import_alias":
+                    real_name = _alias_real_name(child)
+                    if real_name:
+                        imports.append(real_name)
                 elif child.type == "selected_import":
                     module_name: Optional[str] = None
                     seen_colon = False
@@ -7968,6 +8091,12 @@ class CodeParser:
                                     "utf-8", errors="replace",
                                 )
                                 imports.append(f"{module_name}.{imported}")
+                            elif sub.type == "import_alias" and module_name:
+                                real_name = _alias_real_name(sub)
+                                if real_name:
+                                    imports.append(
+                                        f"{module_name}.{real_name}",
+                                    )
         elif language == "gdscript":
             # ``extends Node`` → type > identifier("Node")
             # ``extends "res://path.gd"`` → string literal

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2492,15 +2492,65 @@ class CodeParser:
         file_path: str,
     ) -> list[EdgeInfo]:
         """Resolve Julia calls from the nearest lexical scope outward."""
-        symbols: dict[str, str] = {}
         prefix = f"{file_path}::"
+
+        # Qualified definitions have two paths: an identity path retaining
+        # the explicit qualifier (``Demo.Base.show``), and a lexical path
+        # used for bare-name lookup inside the body (``Demo.show``). Build
+        # prefix rewrites so descendants of qualified methods inherit the
+        # lexical path without losing their collision-free stored identity.
+        lexical_rewrites: list[tuple[str, str]] = []
+        for node in nodes:
+            qualifier = node.extra.get("julia_module_qualifier")
+            if not isinstance(qualifier, str) or not qualifier:
+                continue
+            identity_parent = node.parent_name or ""
+            parent_parts = identity_parent.split(".") if identity_parent else []
+            qualifier_parts = qualifier.split(".")
+            if parent_parts[-len(qualifier_parts):] != qualifier_parts:
+                continue
+            lexical_parent = ".".join(
+                parent_parts[:-len(qualifier_parts)],
+            )
+            identity_path = ".".join(
+                part for part in (identity_parent, node.name) if part
+            )
+            lexical_path = ".".join(
+                part for part in (lexical_parent, node.name) if part
+            )
+            lexical_rewrites.append((identity_path, lexical_path))
+        lexical_rewrites.sort(key=lambda item: len(item[0]), reverse=True)
+
+        def _lexical_path(identity_path: str) -> str:
+            result = identity_path
+            for _ in range(len(lexical_rewrites) + 1):
+                updated = result
+                for identity_prefix, lexical_prefix in lexical_rewrites:
+                    if result == identity_prefix:
+                        updated = lexical_prefix
+                        break
+                    if result.startswith(f"{identity_prefix}."):
+                        updated = f"{lexical_prefix}{result[len(identity_prefix):]}"
+                        break
+                if updated == result:
+                    return result
+                result = updated
+            return result
+
+        symbols: dict[str, str] = {}
         for node in nodes:
             if node.kind not in ("Function", "Class", "Type", "Test"):
                 continue
             qualified = self._qualify(
                 node.name, file_path, node.parent_name,
             )
-            symbols[qualified.removeprefix(prefix)] = qualified
+            identity_path = qualified.removeprefix(prefix)
+            if node.extra.get("julia_module_qualifier"):
+                # A qualified method is only reachable through its explicit
+                # module path; it does not create a bare lexical binding.
+                symbols[identity_path] = qualified
+            else:
+                symbols[_lexical_path(identity_path)] = qualified
 
         resolved: list[EdgeInfo] = []
         for edge in edges:
@@ -2522,6 +2572,7 @@ class CodeParser:
                 if edge.source.startswith(prefix)
                 else ""
             )
+            source_tail = _lexical_path(source_tail)
             scope_parts = source_tail.split(".") if source_tail else []
             target = None
             for size in range(len(scope_parts), -1, -1):
@@ -3586,6 +3637,18 @@ class CodeParser:
                 return import_map[key]
         return None
 
+    @staticmethod
+    def _julia_call_is_in_signature(call_node) -> bool:
+        """Return whether a Julia call belongs to a wrapped signature."""
+        parent = call_node.parent
+        while parent is not None:
+            if parent.type == "signature":
+                return True
+            if parent.type in ("block", "source_file"):
+                return False
+            parent = parent.parent
+        return False
+
     def _julia_short_func_name(self, call_expr) -> Optional[str]:
         """Extract the name from a ``call_expression`` that is the LHS of
         a short-form function ``f(x) = expr`` or ``Base.f(x) = expr`` or
@@ -3793,10 +3856,11 @@ class CodeParser:
         # --- Skip call_expression nodes that are actually function
         # signatures (``function foo(x) ... end`` has a ``signature >
         # call_expression`` that describes the definition, not a call).
-        if node_type == "call_expression":
-            parent = child.parent
-            if parent is not None and parent.type == "signature":
-                return True
+        if (
+            node_type == "call_expression"
+            and self._julia_call_is_in_signature(child)
+        ):
+            return True
 
         # --- include("file.jl") -> IMPORTS_FROM edge ---
         if node_type == "call_expression":
@@ -3912,8 +3976,11 @@ class CodeParser:
                         vname = variant.text.decode(
                             "utf-8", errors="replace",
                         )
+                        variant_parent = self._julia_scope_join(
+                            enclosing_class, type_name,
+                        )
                         qualified_v = self._qualify(
-                            vname, file_path, type_name,
+                            vname, file_path, variant_parent,
                         )
                         nodes.append(NodeInfo(
                             kind="Function",
@@ -3922,7 +3989,7 @@ class CodeParser:
                             line_start=variant.start_point[0] + 1,
                             line_end=variant.end_point[0] + 1,
                             language=language,
-                            parent_name=type_name,
+                            parent_name=variant_parent,
                             extra={"julia_kind": "enum_variant"},
                         ))
                         edges.append(EdgeInfo(
@@ -7141,6 +7208,14 @@ class CodeParser:
                         module_name = part.text.decode(
                             "utf-8", errors="replace",
                         )
+                    elif not seen_colon and part.type == "import_path":
+                        module_name = ".".join(
+                            component.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                            for component in part.children
+                            if component.type == "identifier"
+                        )
                     elif seen_colon and part.type == "import_alias":
                         real_name, alias = _alias_parts(part)
                         if module_name and real_name and alias:
@@ -7842,50 +7917,21 @@ class CodeParser:
         # ``parametrized_type_expression`` (``{T}``).
         if language == "julia":
             if node.type in ("function_definition", "macro_definition"):
-                for child in node.children:
-                    if child.type == "signature":
-                        call = child
-                        # Unwrap where_expression: signature > where_expression > call_expression
-                        for sub in call.children:
-                            if sub.type == "where_expression":
-                                call = sub
-                                break
-                        # Unwrap typed_expression: signature > typed_expression > call_expression
-                        # (``function foo(x)::ReturnType``)
-                        for sub in call.children:
-                            if sub.type == "typed_expression":
-                                call = sub
-                                break
-                        for sub in call.children:
-                            if sub.type == "call_expression":
-                                for target in sub.children:
-                                    if target.type == "identifier":
-                                        return target.text.decode(
-                                            "utf-8", errors="replace",
-                                        )
-                                    if target.type == "field_expression":
-                                        # Qualified: last identifier is method name
-                                        for ident in reversed(target.children):
-                                            if ident.type == "identifier":
-                                                return ident.text.decode(
-                                                    "utf-8", errors="replace",
-                                                )
-                                    if target.type == "parametrized_type_expression":
-                                        # Parametric constructor: Foo{T}(x) = ...
-                                        for p in target.children:
-                                            if p.type == "identifier":
-                                                return p.text.decode(
-                                                    "utf-8", errors="replace",
-                                                )
-                                return None
-                        # Generic-function stub: ``function foo end`` has a
-                        # direct identifier in the signature and no call.
-                        for sub in call.children:
-                            if sub.type == "identifier":
-                                return sub.text.decode(
-                                    "utf-8", errors="replace",
-                                )
-                return None
+                callee = self._julia_signature_callee(node)
+                if callee is None:
+                    return None
+                if callee.type == "field_expression":
+                    _, name = self._julia_field_info(callee)
+                    return name
+                if callee.type == "parametrized_type_expression":
+                    # Parametric constructor: ``Foo{T}(x)``.
+                    for part in callee.children:
+                        if part.type == "identifier":
+                            return part.text.decode(
+                                "utf-8", errors="replace",
+                            )
+                    return None
+                return self._julia_component_name(callee)
             if node.type in ("struct_definition", "abstract_definition"):
                 for child in node.children:
                     if child.type == "type_head":

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2494,12 +2494,11 @@ class CodeParser:
         """Resolve Julia calls from the nearest lexical scope outward."""
         prefix = f"{file_path}::"
 
-        # Qualified definitions have two paths: an identity path retaining
-        # the explicit qualifier (``Demo.Base.show``), and a lexical path
-        # used for bare-name lookup inside the body (``Demo.show``). Build
-        # prefix rewrites so descendants of qualified methods inherit the
-        # lexical path without losing their collision-free stored identity.
-        lexical_rewrites: list[tuple[str, str]] = []
+        # Qualified methods retain their explicit identity path, but that
+        # module qualifier is not a lexical parent. Record the method
+        # boundary and the scope to jump to after searching definitions
+        # nested inside that exact method body.
+        qualified_boundaries: list[tuple[str, str]] = []
         for node in nodes:
             qualifier = node.extra.get("julia_module_qualifier")
             if not isinstance(qualifier, str) or not qualifier:
@@ -2515,27 +2514,10 @@ class CodeParser:
             identity_path = ".".join(
                 part for part in (identity_parent, node.name) if part
             )
-            lexical_path = ".".join(
-                part for part in (lexical_parent, node.name) if part
-            )
-            lexical_rewrites.append((identity_path, lexical_path))
-        lexical_rewrites.sort(key=lambda item: len(item[0]), reverse=True)
-
-        def _lexical_path(identity_path: str) -> str:
-            result = identity_path
-            for _ in range(len(lexical_rewrites) + 1):
-                updated = result
-                for identity_prefix, lexical_prefix in lexical_rewrites:
-                    if result == identity_prefix:
-                        updated = lexical_prefix
-                        break
-                    if result.startswith(f"{identity_prefix}."):
-                        updated = f"{lexical_prefix}{result[len(identity_prefix):]}"
-                        break
-                if updated == result:
-                    return result
-                result = updated
-            return result
+            qualified_boundaries.append((identity_path, lexical_parent))
+        qualified_boundaries.sort(
+            key=lambda item: len(item[0]), reverse=True,
+        )
 
         symbols: dict[str, str] = {}
         for node in nodes:
@@ -2545,12 +2527,34 @@ class CodeParser:
                 node.name, file_path, node.parent_name,
             )
             identity_path = qualified.removeprefix(prefix)
-            if node.extra.get("julia_module_qualifier"):
-                # A qualified method is only reachable through its explicit
-                # module path; it does not create a bare lexical binding.
-                symbols[identity_path] = qualified
-            else:
-                symbols[_lexical_path(identity_path)] = qualified
+            symbols[identity_path] = qualified
+
+        def _search_scopes(
+            source_scope: str,
+            seen: frozenset[str] = frozenset(),
+        ):
+            if source_scope in seen:
+                return
+            next_seen = seen | {source_scope}
+            boundary = next(
+                (
+                    item for item in qualified_boundaries
+                    if source_scope == item[0]
+                    or source_scope.startswith(f"{item[0]}.")
+                ),
+                None,
+            )
+            scope_parts = source_scope.split(".") if source_scope else []
+            if boundary is None:
+                for size in range(len(scope_parts), -1, -1):
+                    yield ".".join(scope_parts[:size])
+                return
+
+            identity_boundary, lexical_parent = boundary
+            boundary_depth = len(identity_boundary.split("."))
+            for size in range(len(scope_parts), boundary_depth - 1, -1):
+                yield ".".join(scope_parts[:size])
+            yield from _search_scopes(lexical_parent, next_seen)
 
         resolved: list[EdgeInfo] = []
         for edge in edges:
@@ -2572,11 +2576,8 @@ class CodeParser:
                 if edge.source.startswith(prefix)
                 else ""
             )
-            source_tail = _lexical_path(source_tail)
-            scope_parts = source_tail.split(".") if source_tail else []
             target = None
-            for size in range(len(scope_parts), -1, -1):
-                scope = ".".join(scope_parts[:size])
+            for scope in _search_scopes(source_tail):
                 candidate = f"{scope}.{edge.target}" if scope else edge.target
                 target = symbols.get(candidate)
                 if target is not None:
@@ -3555,8 +3556,8 @@ class CodeParser:
             return inner
         return f"{outer}.{inner}"
 
-    def _julia_signature_callee(self, function_node):
-        """Return the definition target inside a Julia signature."""
+    def _julia_signature_call(self, function_node):
+        """Return the outer definition call inside a Julia signature."""
         signature = next(
             (
                 child for child in function_node.children
@@ -3576,18 +3577,7 @@ class CodeParser:
                 None,
             )
             if call is not None:
-                return call.children[0] if call.children else None
-            direct = next(
-                (
-                    child for child in scope.children
-                    if child.type in (
-                        "field_expression", "identifier", "operator",
-                    )
-                ),
-                None,
-            )
-            if direct is not None:
-                return direct
+                return call
             wrapper = next(
                 (
                     child for child in scope.children
@@ -3601,6 +3591,30 @@ class CodeParser:
                 break
             scope = wrapper
         return None
+
+    def _julia_signature_callee(self, function_node):
+        """Return the definition target inside a Julia signature."""
+        call = self._julia_signature_call(function_node)
+        if call is not None:
+            return call.children[0] if call.children else None
+        signature = next(
+            (
+                child for child in function_node.children
+                if child.type == "signature"
+            ),
+            None,
+        )
+        if signature is None:
+            return None
+        return next(
+            (
+                child for child in signature.children
+                if child.type in (
+                    "field_expression", "identifier", "operator",
+                )
+            ),
+            None,
+        )
 
     def _julia_definition_qualifier(
         self, function_node,
@@ -3637,15 +3651,14 @@ class CodeParser:
                 return import_map[key]
         return None
 
-    @staticmethod
-    def _julia_call_is_in_signature(call_node) -> bool:
-        """Return whether a Julia call belongs to a wrapped signature."""
+    def _julia_call_is_in_signature(self, call_node) -> bool:
+        """Return whether this is the signature's definition call."""
         parent = call_node.parent
         while parent is not None:
-            if parent.type == "signature":
-                return True
-            if parent.type in ("block", "source_file"):
-                return False
+            if parent.type in ("function_definition", "macro_definition"):
+                return self._julia_signature_call(parent) == call_node
+            if parent.type == "source_file":
+                break
             parent = parent.parent
         return False
 

--- a/docs/superpowers/plans/2026-07-17-julia-parser-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-17-julia-parser-reconciliation.md
@@ -1,0 +1,378 @@
+# Julia Parser Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the safe Julia parser behavior from PR #560 while giving nested and module-qualified definitions collision-free identities and resolvable downstream graph edges.
+
+**Architecture:** Keep the existing parser and graph schema. Julia-only AST helpers derive field components, operator names, aliases, and complete lexical scopes; parser nodes encode lexical scope plus explicit qualifier in `parent_name`, while post-parse call resolution searches from the caller's nearest scope outward.
+
+**Tech Stack:** Python 3.10+, Tree-sitter via `tree-sitter-language-pack`, pytest, SQLite `GraphStore`, Ruff, mypy, Bandit.
+
+## Global Constraints
+
+- Do not change the graph schema or generic behavior for other languages.
+- Do not infer definitions from Tree-sitter `ERROR` nodes.
+- Do not turn scalar Julia `const` bindings into Type nodes.
+- Keep source PR #560 unchanged and credit `dan <danvinci@fastmail.net>` in the implementation commit.
+- Every production change must follow a witnessed red-green-refactor cycle.
+- Preserve all existing Julia macros, enums, testsets, exports, includes, and fixture tests.
+
+---
+
+## File structure
+
+- Create `tests/test_julia_reconciliation.py`: focused parser, scope, fail-soft,
+  persistence, and downstream query regressions independent of the shared
+  multi-language fixture.
+- Modify `code_review_graph/parser.py`: Julia-only helpers and extraction,
+  scope, import-alias, call-target, and same-file resolution behavior.
+- Keep `tests/fixtures/sample.jl` and `tests/test_multilang.py` unchanged so
+  they remain an independent no-regression check of existing Julia behavior.
+
+### Task 1: Julia leaf constructs and fail-soft extraction
+
+**Files:**
+- Create: `tests/test_julia_reconciliation.py`
+- Modify: `code_review_graph/parser.py:3361-3695,7431-7475,7909-7950`
+
+**Interfaces:**
+- Consumes: `CodeParser.parse_bytes(Path, bytes) -> tuple[list[NodeInfo], list[EdgeInfo]]`.
+- Produces: `_julia_component_name(node) -> Optional[str]`,
+  `_julia_field_parts(node) -> list[str]`,
+  `_julia_field_info(node) -> tuple[Optional[str], Optional[str]]`, and valid
+  Function/Type/import outputs for the source constructs.
+
+- [ ] **Step 1: Write focused failing tests**
+
+Create a helper that writes no production files and parses snippets directly:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse(source: str):
+    return CodeParser().parse_bytes(Path("/repo/case.jl"), source.encode())
+
+
+def test_function_stub_is_a_function():
+    nodes, _ = _parse("function hook end")
+    assert [(n.kind, n.name) for n in nodes if n.kind != "File"] == [
+        ("Function", "hook"),
+    ]
+
+
+@pytest.mark.parametrize("signature", ["+(a, b) = a", "Base.:+(a, b) = a"])
+def test_operator_definition_uses_operator_name(signature):
+    nodes, _ = _parse(signature)
+    functions = [n for n in nodes if n.kind == "Function"]
+    assert [n.name for n in functions] == ["+"]
+
+
+def test_parameterized_const_only_is_a_type():
+    nodes, _ = _parse(
+        "const FloatVec = Vector{Float64}\nconst MAX_RETRIES = 3\n"
+    )
+    assert {n.name for n in nodes if n.kind == "Type"} == {"FloatVec"}
+
+
+def test_import_alias_records_real_dependency():
+    _, edges = _parse(
+        "import DataFrames as DF\nimport Tables: AbstractColumns as Columns\n"
+    )
+    assert {e.target for e in edges if e.kind == "IMPORTS_FROM"} == {
+        "DataFrames",
+        "Tables.AbstractColumns",
+    }
+
+
+def test_malformed_qualified_stub_fails_soft():
+    nodes, edges = _parse("function A.B.hook end")
+    assert [n.kind for n in nodes] == ["File"]
+    assert edges == []
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+uv run --frozen --no-sync pytest -q \
+  tests/test_julia_reconciliation.py::test_function_stub_is_a_function \
+  tests/test_julia_reconciliation.py::test_operator_definition_uses_operator_name \
+  tests/test_julia_reconciliation.py::test_parameterized_const_only_is_a_type \
+  tests/test_julia_reconciliation.py::test_import_alias_records_real_dependency \
+  tests/test_julia_reconciliation.py::test_malformed_qualified_stub_fails_soft
+```
+
+Expected: stub, operator, type-alias, and import-alias assertions fail for
+missing behavior; malformed input already passes and guards the implementation.
+
+- [ ] **Step 3: Implement minimal Julia leaf handling**
+
+Add helpers that return `None` for unknown shapes, use them from
+`_julia_short_func_name` and Julia `_get_name`, add a `const_statement` branch
+to `_extract_julia_constructs`, and extend `_extract_import` for direct and
+selected `import_alias` nodes. The concrete scope-free helper contract is:
+
+```python
+@staticmethod
+def _julia_component_name(node) -> Optional[str]:
+    if node.type in ("identifier", "operator"):
+        return node.text.decode("utf-8", errors="replace")
+    if node.type == "quote_expression":
+        for child in node.children:
+            name = CodeParser._julia_component_name(child)
+            if name is not None:
+                return name
+    if node.type == "parenthesized_expression":
+        for child in node.children:
+            if child.type == "operator":
+                return child.text.decode("utf-8", errors="replace")
+    return None
+```
+
+For a parameterized const, append `NodeInfo(kind="Type", ...)` and a matching
+`CONTAINS` edge, then return `True`. Do not consume any other const statement.
+
+- [ ] **Step 4: Verify GREEN and no Julia regressions**
+
+Run:
+
+```bash
+uv run --frozen --no-sync pytest -q \
+  tests/test_julia_reconciliation.py tests/test_multilang.py::TestJuliaParsing
+```
+
+Expected: all selected tests pass.
+
+### Task 2: Canonical qualified identities and scoped call resolution
+
+**Files:**
+- Modify: `tests/test_julia_reconciliation.py`
+- Modify: `code_review_graph/parser.py:2423-2460,3361-3695,4889-5225,5257-5360`
+
+**Interfaces:**
+- Consumes: Julia field helpers from Task 1.
+- Produces: `_julia_scope_join(left, right) -> Optional[str]`,
+  `_julia_definition_qualifier(node) -> Optional[str]`, canonical parent names,
+  dotted call targets, and nearest-scope resolution in `_resolve_call_targets`.
+
+- [ ] **Step 1: Write collision and call failures**
+
+Add tests using a module that defines local `show`, `Base.show`,
+`Base.length`, `Base.:+`, `A.B.run`, a one-line delegate, and dotted calls.
+Assert these exact identities and edges:
+
+```python
+assert ("show", "Demo") in identities
+assert ("show", "Demo.Base") in identities
+assert ("length", "Demo.Base") in identities
+assert ("+", "Demo.Base") in identities
+assert ("run", "Demo.A.B") in identities
+assert ("Demo.delegate", "Demo.show") in call_tails
+assert ("Demo.caller", "Demo.A.B.run") in call_tails
+assert any(
+    e.target == "LinearAlgebra.BLAS.gemv"
+    and e.extra["julia_call_module"] == "LinearAlgebra.BLAS"
+    for e in calls
+)
+```
+
+Also assert the qualifier reference from `Demo.Base.show` targets literal
+`Base`, even when the file contains a local function named `Base`.
+
+- [ ] **Step 2: Verify RED**
+
+Run the new collision/call tests individually with `pytest -vv`. Expected:
+qualified identities collapse under `Demo`, `Base.:+` becomes a bogus `Base`
+function, one-line calls are missing, and dotted targets remain bare leaves.
+
+- [ ] **Step 3: Implement canonical scope and qualified calls**
+
+Use this identity rule in long and short definitions:
+
+```python
+lexical_parent = self._julia_scope_join(enclosing_class, enclosing_func)
+identity_parent = self._julia_scope_join(lexical_parent, qualifier)
+```
+
+When `qualifier` is absent, `identity_parent` is `lexical_parent`. Store the
+explicit qualifier in `extra["julia_module_qualifier"]`; create `CONTAINS` from
+`lexical_parent`; recurse into the function with
+`enclosing_class=identity_parent` and `enclosing_func=name`.
+
+In `_extract_calls`, replace a Julia field-expression callee with its complete
+`qualifier.leaf` text and set `julia_call_module`. Dispatch a short-form RHS
+call node directly before descending into its children.
+
+In `_resolve_call_targets`, retain the current implementation for non-Julia
+files. For Julia, index every definition by the tail of its canonical
+qualified name and test candidates in this order for source
+`file::Outer.Inner.caller` and target `f`: `Outer.Inner.caller.f`,
+`Outer.Inner.f`, `Outer.f`, `f`. Skip local rewriting for REFERENCES edges
+whose extra contains `julia_qualified_def`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the new tests plus `tests/test_multilang.py::TestJuliaParsing`; expected:
+all pass and no existing Julia assertion changes.
+
+### Task 3: Nested scopes, aliases, macros, and testsets
+
+**Files:**
+- Modify: `tests/test_julia_reconciliation.py`
+- Modify: `code_review_graph/parser.py:3630-3695,4889-5020,6707-6760`
+
+**Interfaces:**
+- Consumes: canonical scope and resolver from Task 2.
+- Produces: full lexical paths for nested modules/functions/testsets and Julia
+  alias bindings in `import_map`.
+
+- [ ] **Step 1: Write nested and alias failures**
+
+Add a nested `Outer.Inner` snippet with shadowed `f`, a nested function, a
+function-local `@testset`, `@inline`/ordinary macro calls, and
+`import DataFrames as DF`. Assert:
+
+```python
+assert "Outer.Inner" in class_parents_and_names
+assert ("f", "Outer.Inner") in identities
+assert ("leaf", "Outer.Inner.wrapper") in identities
+assert any(e.target.endswith("::Outer.Inner.f") for e in calls_from_inner)
+assert any(n.kind == "Test" and n.parent_name == "Outer.Inner.wrapper" for n in nodes)
+assert any(e.target == "DataFrames.transform" for e in alias_calls)
+assert any(e.target == "@inline" for e in calls)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run only these tests. Expected: nested functions/modules use truncated parent
+names, the nearest call picks `Outer.f`, the testset identity differs from its
+edge source, and the alias call remains `DF.transform`.
+
+- [ ] **Step 3: Implement nested scope and alias normalization**
+
+For Julia class/module extraction, recurse with the joined scope and emit
+`CONTAINS` from the enclosing scope rather than always from the File. For
+testsets, use joined lexical function scope as `parent_name`, containment
+source, and recursion scope.
+
+Extend `_collect_import_names` for Julia aliases so:
+
+```python
+import_map["DF"] = "DataFrames"
+import_map["Columns"] = "Tables.AbstractColumns"
+```
+
+When a qualified call's first module segment is an alias, replace it before
+forming the final dotted target. Leave direct modules unchanged.
+
+- [ ] **Step 4: Verify GREEN and refactor**
+
+Run the focused file and existing Julia class. Remove duplicate AST walks only
+after all tests pass, then rerun the same command.
+
+### Task 4: GraphStore and downstream query persistence
+
+**Files:**
+- Modify: `tests/test_julia_reconciliation.py`
+
+**Interfaces:**
+- Consumes: `full_build(Path, GraphStore) -> dict` and canonical parser output.
+- Produces: an integration regression proving the SQLite node and edge API sees
+  the same identities as the parser.
+
+- [ ] **Step 1: Write the full-build test**
+
+Create `.git` and a Julia source under `tmp_path`, run `full_build`, then assert:
+
+```python
+local = store.get_node(f"{source_path}::Demo.show")
+base = store.get_node(f"{source_path}::Demo.Base.show")
+assert local is not None and base is not None and local.id != base.id
+
+callers = store.get_edges_by_target(f"{source_path}::Demo.Base.show")
+assert any(edge.kind == "CALLS" and edge.source.endswith("::Demo.invoke")
+           for edge in callers)
+assert result["errors"] == []
+```
+
+Also query the persisted nested target and Type alias, and close the store in a
+`finally` block.
+
+- [ ] **Step 2: Verify RED or prove prior task coverage**
+
+Run this test before any integration-specific production change. It must fail
+against pre-port production code; if Tasks 1-3 already make it pass, temporarily
+revert the parser changes, confirm the expected identity/call failure, restore
+them, and rerun green.
+
+- [ ] **Step 3: Verify focused and full suites**
+
+Run:
+
+```bash
+uv run --frozen --no-sync pytest -q tests/test_julia_reconciliation.py \
+  tests/test_multilang.py::TestJuliaParsing
+uv run --frozen --no-sync pytest -q
+```
+
+Expected baseline delta: all 1,573 prior passes remain green plus the new Julia
+tests; existing skips/xpasses remain non-failures.
+
+### Task 5: Static checks, graph review, attribution, rebase, and publication
+
+**Files:**
+- Verify: `code_review_graph/parser.py`
+- Verify: `tests/test_julia_reconciliation.py`
+- Verify: design and plan documents
+
+**Interfaces:**
+- Produces: a ready replacement PR based on the latest `origin/main`, with Dan
+  credited and source PR #560 unchanged.
+
+- [ ] **Step 1: Run local quality gates**
+
+```bash
+uv run --frozen --no-sync ruff check code_review_graph tests
+uv run --frozen --no-sync ruff format --check code_review_graph tests
+uv run --frozen --no-sync mypy code_review_graph
+uv run --frozen --no-sync bandit -q -r code_review_graph
+uv run --frozen --no-sync python scripts/check_schema_sync.py
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Review the graph and diff**
+
+Incrementally rebuild the knowledge graph, then run change detection, affected
+flows, tests-for queries, and focused review context against `origin/main`.
+Inspect `git diff --stat`, `git diff`, and ensure only the approved files and
+behavior changed.
+
+- [ ] **Step 3: Commit with attribution**
+
+Commit production/tests with this trailer:
+
+```text
+Co-authored-by: dan <danvinci@fastmail.net>
+```
+
+- [ ] **Step 4: Rebase and repeat fresh verification**
+
+Fetch `origin/main`, rebase the branch, rerun focused/full tests and every
+static check, update the graph, and inspect the final diff. Resolve no unrelated
+changes and never force-push without explicit approval.
+
+- [ ] **Step 5: Push and open a ready replacement PR**
+
+The PR body must name source PR #560 and its exact head, enumerate overlap and
+ported behavior, explain the extra-only collision/call-resolution blocker,
+state the exact base/head and local test evidence, credit Dan, and say source
+PR #560 was not modified. Wait for every required check, including Windows, to
+finish successfully before reporting readiness.

--- a/docs/superpowers/specs/2026-07-17-julia-parser-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-17-julia-parser-reconciliation-design.md
@@ -1,0 +1,143 @@
+# Julia Parser Reconciliation Design
+
+## Context
+
+Pull request #560 adds useful Julia coverage, but its head
+`f66721a6f63cc352ea515ddf9ca6e9cba21c4666` is stale and conflicts with
+current `main`. Current `main` already parses Julia modules, structs, long- and
+short-form functions, imports, includes, exports/public symbols, macros,
+enums, and testsets. The remaining source behavior is function stubs,
+operators, parameterized constant aliases, aliased imports, one-line call
+bodies, and complete module qualifiers.
+
+The source implementation stores qualifiers only in `extra`. That preserves
+display metadata but does not change graph identity or call targets. As a
+result, a local `show` can collide with `Base.show`, a qualified call can be
+reduced to `show`, and downstream graph queries cannot distinguish them.
+Current nested Julia modules and functions also lose their outer lexical scope.
+
+The source work is credited to Dan (`danvinci`, `danvinci@fastmail.net`). The
+port commit will preserve that recognized attribution. Source PR #560 remains
+untouched.
+
+## Goals
+
+- Port the safe, non-overlapping Julia behavior from PR #560.
+- Give qualified Julia definitions collision-free canonical identities.
+- Resolve bare and qualified calls to the nearest matching lexical symbol.
+- Preserve complete nested module and function scopes through persistence.
+- Record real modules for aliased imports and normalize calls through aliases.
+- Keep malformed or unsupported Julia syntax fail-soft and free of bogus nodes.
+- Preserve existing macros, enums, testsets, exports, includes, and Julia tests.
+
+## Non-goals
+
+- Replacing the Julia parser or changing the graph schema.
+- Modeling Julia method dispatch by argument types or multiple dispatch.
+- Creating nodes for ordinary scalar `const` bindings.
+- Inventing definitions for external modules that are not present in the file.
+- Supporting malformed qualified function stubs that the bundled grammar emits
+  only as `ERROR` nodes.
+- Merging, closing, reopening, or commenting on source PR #560.
+
+## Canonical scope and containment
+
+The implementation reuses the existing `NodeInfo.parent_name` identity model.
+For Julia only, lexical scopes are joined instead of replacing each other:
+
+- a function `f` in `Outer.Inner` has parent `Outer.Inner` and qualified name
+  `file.jl::Outer.Inner.f`;
+- a nested function `g` inside that function has parent `Outer.Inner.f` and
+  qualified name `file.jl::Outer.Inner.f.g`;
+- `function Base.show` written inside `Outer.Inner` has parent
+  `Outer.Inner.Base`, name `show`, and qualified name
+  `file.jl::Outer.Inner.Base.show`.
+
+The explicit qualifier remains in `extra["julia_module_qualifier"]` for
+consumers that need it directly. A qualified definition's `CONTAINS` source is
+still its lexical module (`file.jl::Outer.Inner`), not a synthetic `Base` node.
+This preserves source structure while making identity collision-free.
+
+Nested `module` definitions recurse with their complete lexical path. Nested
+functions and testsets likewise use their enclosing function path, so every
+persisted `CONTAINS`, `CALLS`, and `TESTED_BY` endpoint refers to the same
+qualified name as its node.
+
+## Julia AST helpers
+
+Small Julia-only helpers handle grammar shapes without changing generic
+language behavior:
+
+- flatten nested `field_expression` nodes in source order;
+- read the final identifier or quoted operator component;
+- split a field into qualifier and leaf name;
+- find the callable inside signature wrappers such as `where_expression` and
+  `typed_expression` with bounded traversal;
+- join lexical scopes without duplicating path segments;
+- read import aliases from `import_alias` nodes.
+
+Every helper returns `None` or an empty result for an unknown shape. It does
+not index children without checking them and does not recover definitions from
+Tree-sitter `ERROR` nodes.
+
+## Definitions and imports
+
+Long- and short-form qualified definitions use the canonical scope described
+above. Bare and quoted operators use the operator text as the function name,
+including short forms such as `+(a, b) = a` and `Base.:+(a, b) = a`. A stub
+such as `function hook end` becomes a normal Function node when Tree-sitter
+provides a valid `function_definition`.
+
+A `const` assignment becomes a Type node only when its right-hand side is a
+parameterized/curly type expression, such as
+`const FloatVec = Vector{Float64}`. Value constants remain on the existing
+generic path.
+
+Aliased Julia imports emit dependencies on the real imported module or symbol:
+`import DataFrames as DF` records `DataFrames`, and selected aliases retain the
+selected symbol path. The file-scope alias map records the local alias so a
+qualified call through that alias can be normalized to the real module path.
+
+## Call extraction and resolution
+
+Qualified calls retain their dotted callee target instead of collapsing to a
+leaf. For example, `LinearAlgebra.BLAS.gemv(x)` initially targets
+`LinearAlgebra.BLAS.gemv` and records
+`extra["julia_call_module"] = "LinearAlgebra.BLAS"`. An alias head is replaced
+with its real import path before resolution.
+
+The post-parse same-file resolver builds scoped Julia symbol keys from the
+canonical node identities. For each unresolved Julia call it searches from the
+caller's nearest parent scope outward, then checks the file-level symbol. Thus
+a bare `f()` inside `Outer.Inner.g` prefers `Outer.Inner.f` over `Outer.f`, and
+`Base.show()` can resolve to `Outer.Inner.Base.show` in the same lexical module.
+Unmatched external calls remain stable dotted targets.
+
+Julia qualifier `REFERENCES` edges are not rewritten as local functions. This
+prevents a definition named `Base` elsewhere in the file from changing the
+meaning of the qualifier reference.
+
+Short-form definitions dispatch a right-hand side call node directly before
+recursing into its children. This captures `delegate(x) = greet(x)` without
+revisiting the left-hand signature as a self-call.
+
+## Testing
+
+Implementation proceeds in witnessed red-green cycles in a dedicated Julia
+test module:
+
+1. function stubs and malformed qualified-stub fail-soft behavior;
+2. bare, quoted, qualified, and multi-segment operator definitions;
+3. parameterized constant aliases versus scalar constants;
+4. top-level and selected aliased imports plus alias-qualified calls;
+5. one-line right-hand calls;
+6. long/short qualified definitions, local-name collisions, and complete
+   multi-segment call targets;
+7. nested modules, nested functions, nearest-scope calls, macros, and testsets;
+8. a `full_build`/`GraphStore` integration proving distinct persisted nodes,
+   canonical call targets, and downstream caller lookup.
+
+The existing Julia fixture tests run after each focused cycle. Final validation
+includes the complete test suite, Ruff, type/schema/security checks used by CI,
+diff inspection, graph change/flow review, and all GitHub checks (including
+Windows) before the replacement PR is marked ready.

--- a/tests/test_julia_reconciliation.py
+++ b/tests/test_julia_reconciliation.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import CodeParser
 
 
@@ -14,14 +16,20 @@ def _parse(source: str):
     )
 
 
+def _qualified(node) -> str:
+    if node.kind == "File":
+        return node.file_path
+    if node.parent_name:
+        return f"{node.file_path}::{node.parent_name}.{node.name}"
+    return f"{node.file_path}::{node.name}"
+
+
 def test_function_stub_is_a_function():
     nodes, _ = _parse("function hook end")
 
-    assert [
-        (node.kind, node.name)
-        for node in nodes
-        if node.kind != "File"
-    ] == [("Function", "hook")]
+    assert [(node.kind, node.name) for node in nodes if node.kind != "File"] == [
+        ("Function", "hook")
+    ]
 
 
 def test_malformed_qualified_stub_fails_soft():
@@ -42,9 +50,7 @@ def test_malformed_qualified_stub_fails_soft():
 def test_operator_definition_uses_operator_name(signature, expected):
     nodes, _ = _parse(signature)
 
-    assert [
-        node.name for node in nodes if node.kind == "Function"
-    ] == [expected]
+    assert [node.name for node in nodes if node.kind == "Function"] == [expected]
 
 
 def test_parameterized_const_only_is_a_type():
@@ -54,17 +60,257 @@ def test_parameterized_const_only_is_a_type():
         "const MAX_RETRIES = 3\n"
     )
 
-    assert {
-        node.name for node in nodes if node.kind == "Type"
-    } == {"FloatVec", "PairMap"}
+    assert {node.name for node in nodes if node.kind == "Type"} == {"FloatVec", "PairMap"}
 
 
 def test_import_alias_records_real_dependency():
-    _, edges = _parse(
-        "import DataFrames as DF\n"
-        "import Tables: AbstractColumns as Columns\n"
+    _, edges = _parse("import DataFrames as DF\nimport Tables: AbstractColumns as Columns\n")
+
+    assert {edge.target for edge in edges if edge.kind == "IMPORTS_FROM"} == {
+        "DataFrames",
+        "Tables.AbstractColumns",
+    }
+
+
+def test_qualified_definitions_have_collision_free_identities():
+    nodes, edges = _parse(
+        "module Demo\n"
+        "function show(x)\n"
+        "    x\n"
+        "end\n"
+        "function Base.show(x)\n"
+        "    x\n"
+        "end\n"
+        "Base.length(x) = x\n"
+        "Base.:+(a, b) = a\n"
+        "function A.B.run(x)\n"
+        "    x\n"
+        "end\n"
+        "function Base()\n"
+        "end\n"
+        "end\n"
     )
 
+    functions = [node for node in nodes if node.kind == "Function"]
+    assert {(node.name, node.parent_name) for node in functions} >= {
+        ("show", "Demo"),
+        ("show", "Demo.Base"),
+        ("length", "Demo.Base"),
+        ("+", "Demo.Base"),
+        ("run", "Demo.A.B"),
+        ("Base", "Demo"),
+    }
     assert {
-        edge.target for edge in edges if edge.kind == "IMPORTS_FROM"
-    } == {"DataFrames", "Tables.AbstractColumns"}
+        node.extra.get("julia_module_qualifier")
+        for node in functions
+        if node.name in {"length", "+", "run"}
+    } == {"Base", "A.B"}
+
+    qualifier_refs = [
+        edge
+        for edge in edges
+        if edge.kind == "REFERENCES" and edge.extra.get("julia_qualified_def")
+    ]
+    assert any(
+        edge.source == "/repo/case.jl::Demo.Base.show" and edge.target == "Base"
+        for edge in qualifier_refs
+    )
+
+
+def test_short_form_body_call_resolves_to_local_function():
+    _, edges = _parse("module Demo\ngreet(x) = x\ndelegate(x) = greet(x)\nend\n")
+
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.delegate"
+        and edge.target == "/repo/case.jl::Demo.greet"
+        for edge in edges
+    )
+
+
+def test_module_scope_call_resolves_within_current_module():
+    _, edges = _parse("module Demo\ninitialize() = nothing\ninitialize()\nend\n")
+
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo"
+        and edge.target == "/repo/case.jl::Demo.initialize"
+        for edge in edges
+    )
+
+
+def test_qualified_calls_keep_full_module_and_resolve_collisions():
+    _, edges = _parse(
+        "module Demo\n"
+        "run(x) = x\n"
+        "function A.B.run(x)\n"
+        "    x\n"
+        "end\n"
+        "function caller(x)\n"
+        "    run(x)\n"
+        "    A.B.run(x)\n"
+        "    LinearAlgebra.BLAS.gemv(x)\n"
+        "end\n"
+        "end\n"
+    )
+
+    calls = [edge for edge in edges if edge.kind == "CALLS"]
+    targets = {edge.target for edge in calls}
+    assert "/repo/case.jl::Demo.run" in targets
+    assert "/repo/case.jl::Demo.A.B.run" in targets
+    assert "LinearAlgebra.BLAS.gemv" in targets
+    assert any(
+        edge.target == "LinearAlgebra.BLAS.gemv"
+        and edge.extra.get("julia_call_module") == "LinearAlgebra.BLAS"
+        for edge in calls
+    )
+
+
+def test_nested_modules_and_functions_keep_complete_scope():
+    nodes, edges = _parse(
+        "module Outer\n"
+        "f(x) = x\n"
+        "module Inner\n"
+        "f(x) = x + 1\n"
+        "function wrapper(x)\n"
+        "    function leaf(y)\n"
+        "        f(y)\n"
+        "    end\n"
+        "    leaf(x)\n"
+        "end\n"
+        "end\n"
+        "end\n"
+    )
+
+    identities = {
+        (node.name, node.parent_name) for node in nodes if node.kind in {"Class", "Function"}
+    }
+    assert ("Inner", "Outer") in identities
+    assert ("f", "Outer.Inner") in identities
+    assert ("wrapper", "Outer.Inner") in identities
+    assert ("leaf", "Outer.Inner.wrapper") in identities
+    assert any(
+        edge.kind == "CONTAINS"
+        and edge.source == "/repo/case.jl::Outer"
+        and edge.target == "/repo/case.jl::Outer.Inner"
+        for edge in edges
+    )
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Outer.Inner.wrapper.leaf"
+        and edge.target == "/repo/case.jl::Outer.Inner.f"
+        for edge in edges
+    )
+
+
+def test_calls_through_import_aliases_use_real_module_paths():
+    _, edges = _parse(
+        "module Demo\n"
+        "import DataFrames as DF\n"
+        "import Tables: AbstractColumns as Columns\n"
+        "function caller(x)\n"
+        "    DF.transform(x)\n"
+        "    Columns(x)\n"
+        "end\n"
+        "end\n"
+        "module Other\n"
+        "import OtherFrames as DF\n"
+        "function caller(x)\n"
+        "    DF.transform(x)\n"
+        "end\n"
+        "end\n"
+    )
+
+    calls = [edge for edge in edges if edge.kind == "CALLS"]
+    assert any(
+        edge.source == "/repo/case.jl::Demo.caller"
+        and edge.target == "DataFrames.transform"
+        and edge.extra.get("julia_call_module") == "DataFrames"
+        for edge in calls
+    )
+    assert any(edge.target == "Tables.AbstractColumns" for edge in calls)
+    assert any(
+        edge.source == "/repo/case.jl::Other.caller"
+        and edge.target == "OtherFrames.transform"
+        and edge.extra.get("julia_call_module") == "OtherFrames"
+        for edge in calls
+    )
+
+
+def test_function_local_testset_and_macros_keep_canonical_scope():
+    nodes, edges = _parse(
+        "module Demo\n"
+        "macro passthrough(ex)\n"
+        "    ex\n"
+        "end\n"
+        "subject(x) = x\n"
+        "function wrapper(x)\n"
+        '    @testset "nested" begin\n'
+        "        @test subject(x) == x\n"
+        "    end\n"
+        "    @inline subject(x)\n"
+        "end\n"
+        "end\n"
+    )
+
+    assert any(
+        node.kind == "Function" and node.name == "passthrough" and node.parent_name == "Demo"
+        for node in nodes
+    )
+    nested_testset = next(
+        node for node in nodes if node.kind == "Test" and "testset:nested" in node.name
+    )
+    assert nested_testset.parent_name == "Demo.wrapper"
+    testset_qn = _qualified(nested_testset)
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == testset_qn
+        and edge.target == "/repo/case.jl::Demo.subject"
+        for edge in edges
+    )
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.wrapper"
+        and edge.target == "@inline"
+        for edge in edges
+    )
+
+
+def test_full_build_persists_distinct_qualified_nodes_and_callers(tmp_path):
+    (tmp_path / ".git").mkdir()
+    source_path = tmp_path / "analysis.jl"
+    source_path.write_text(
+        "module Demo\n"
+        "show(x) = x\n"
+        "function Base.show(x)\n"
+        "    x\n"
+        "end\n"
+        "invoke(x) = Base.show(x)\n"
+        "const FloatVec = Vector{Float64}\n"
+        "end\n",
+        encoding="utf-8",
+    )
+
+    store = GraphStore(tmp_path / "graph.db")
+    try:
+        result = full_build(tmp_path, store)
+        local_qn = f"{source_path}::Demo.show"
+        base_qn = f"{source_path}::Demo.Base.show"
+        alias_qn = f"{source_path}::Demo.FloatVec"
+
+        local_node = store.get_node(local_qn)
+        base_node = store.get_node(base_qn)
+        assert local_node is not None
+        assert base_node is not None
+        assert local_node.id != base_node.id
+        assert base_node.extra["julia_module_qualifier"] == "Base"
+        assert store.get_node(alias_qn) is not None
+
+        callers = store.get_edges_by_target(base_qn)
+        assert any(
+            edge.kind == "CALLS" and edge.source_qualified == f"{source_path}::Demo.invoke"
+            for edge in callers
+        )
+        assert result["errors"] == []
+    finally:
+        store.close()

--- a/tests/test_julia_reconciliation.py
+++ b/tests/test_julia_reconciliation.py
@@ -1,0 +1,70 @@
+"""Regression coverage for the safe Julia behavior ported from PR #560."""
+
+from pathlib import Path
+
+import pytest
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse(source: str):
+    return CodeParser().parse_bytes(
+        Path("/repo/case.jl"),
+        source.encode("utf-8"),
+    )
+
+
+def test_function_stub_is_a_function():
+    nodes, _ = _parse("function hook end")
+
+    assert [
+        (node.kind, node.name)
+        for node in nodes
+        if node.kind != "File"
+    ] == [("Function", "hook")]
+
+
+def test_malformed_qualified_stub_fails_soft():
+    nodes, edges = _parse("function A.B.hook end")
+
+    assert [node.kind for node in nodes] == ["File"]
+    assert edges == []
+
+
+@pytest.mark.parametrize(
+    ("signature", "expected"),
+    [
+        ("+(a, b) = a", "+"),
+        ("Base.:+(a, b) = a", "+"),
+        ("Base.:(==)(a, b) = true", "=="),
+    ],
+)
+def test_operator_definition_uses_operator_name(signature, expected):
+    nodes, _ = _parse(signature)
+
+    assert [
+        node.name for node in nodes if node.kind == "Function"
+    ] == [expected]
+
+
+def test_parameterized_const_only_is_a_type():
+    nodes, _ = _parse(
+        "const FloatVec = Vector{Float64}\n"
+        "const PairMap = Dict{String, Tuple{Int, Int}}\n"
+        "const MAX_RETRIES = 3\n"
+    )
+
+    assert {
+        node.name for node in nodes if node.kind == "Type"
+    } == {"FloatVec", "PairMap"}
+
+
+def test_import_alias_records_real_dependency():
+    _, edges = _parse(
+        "import DataFrames as DF\n"
+        "import Tables: AbstractColumns as Columns\n"
+    )
+
+    assert {
+        edge.target for edge in edges if edge.kind == "IMPORTS_FROM"
+    } == {"DataFrames", "Tables.AbstractColumns"}

--- a/tests/test_julia_reconciliation.py
+++ b/tests/test_julia_reconciliation.py
@@ -214,6 +214,41 @@ def test_qualified_method_body_uses_lexical_scope_for_bare_calls():
     }
 
 
+def test_nested_symbols_do_not_collide_between_local_and_qualified_methods():
+    nodes, edges = _parse(
+        "module Demo\n"
+        "function show()\n"
+        "    inner() = 1\n"
+        "    inner()\n"
+        "end\n"
+        "function Base.show()\n"
+        "    inner() = 2\n"
+        "    inner()\n"
+        "end\n"
+        "end\n"
+    )
+
+    assert {
+        (node.name, node.parent_name)
+        for node in nodes
+        if node.name == "inner"
+    } == {
+        ("inner", "Demo.show"),
+        ("inner", "Demo.Base.show"),
+    }
+    calls = [edge for edge in edges if edge.kind == "CALLS"]
+    assert any(
+        edge.source == "/repo/case.jl::Demo.show"
+        and edge.target == "/repo/case.jl::Demo.show.inner"
+        for edge in calls
+    )
+    assert any(
+        edge.source == "/repo/case.jl::Demo.Base.show"
+        and edge.target == "/repo/case.jl::Demo.Base.show.inner"
+        for edge in calls
+    )
+
+
 def test_wrapped_qualified_signature_is_not_a_self_call():
     nodes, edges = _parse(
         "function A.B.f(x)::Int where {T}\n"
@@ -224,6 +259,23 @@ def test_wrapped_qualified_signature_is_not_a_self_call():
     function = next(node for node in nodes if node.kind == "Function")
     assert (function.name, function.parent_name) == ("f", "A.B")
     assert not [edge for edge in edges if edge.kind == "CALLS"]
+
+
+def test_wrapped_signature_keeps_evaluated_return_type_call():
+    _, edges = _parse(
+        "g() = Int\n"
+        "function f(x)::g()\n"
+        "    x\n"
+        "end\n"
+    )
+
+    calls = [edge for edge in edges if edge.kind == "CALLS"]
+    assert not any(edge.target == "/repo/case.jl::f" for edge in calls)
+    assert any(
+        edge.source == "/repo/case.jl::f"
+        and edge.target == "/repo/case.jl::g"
+        for edge in calls
+    )
 
 
 def test_nested_function_in_qualified_method_keeps_identity_and_lexical_lookup():

--- a/tests/test_julia_reconciliation.py
+++ b/tests/test_julia_reconciliation.py
@@ -53,6 +53,29 @@ def test_operator_definition_uses_operator_name(signature, expected):
     assert [node.name for node in nodes if node.kind == "Function"] == [expected]
 
 
+@pytest.mark.parametrize(
+    ("signature", "expected_name", "expected_parent", "expected_qualifier"),
+    [
+        ("function +(a, b)\n    a\nend", "+", None, None),
+        ("function (==)(a, b)\n    true\nend", "==", None, None),
+        ("function Base.:+(a, b)\n    a\nend", "+", "Base", "Base"),
+        ("function Base.:(==)(a, b)\n    true\nend", "==", "Base", "Base"),
+        ("function A.B.:+(a, b)\n    a\nend", "+", "A.B", "A.B"),
+    ],
+)
+def test_long_form_operator_definition_uses_operator_identity(
+    signature, expected_name, expected_parent, expected_qualifier,
+):
+    nodes, _ = _parse(signature)
+
+    function = next(node for node in nodes if node.kind == "Function")
+    assert (function.name, function.parent_name) == (
+        expected_name,
+        expected_parent,
+    )
+    assert function.extra.get("julia_module_qualifier") == expected_qualifier
+
+
 def test_parameterized_const_only_is_a_type():
     nodes, _ = _parse(
         "const FloatVec = Vector{Float64}\n"
@@ -166,6 +189,72 @@ def test_qualified_calls_keep_full_module_and_resolve_collisions():
     )
 
 
+def test_qualified_method_body_uses_lexical_scope_for_bare_calls():
+    _, edges = _parse(
+        "module Demo\n"
+        "helper() = 1\n"
+        "function Base.helper()\n"
+        "end\n"
+        "function Base.show()\n"
+        "    helper()\n"
+        "    Base.helper()\n"
+        "end\n"
+        "end\n"
+    )
+
+    targets = {
+        edge.target
+        for edge in edges
+        if edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.Base.show"
+    }
+    assert targets == {
+        "/repo/case.jl::Demo.helper",
+        "/repo/case.jl::Demo.Base.helper",
+    }
+
+
+def test_wrapped_qualified_signature_is_not_a_self_call():
+    nodes, edges = _parse(
+        "function A.B.f(x)::Int where {T}\n"
+        "    x\n"
+        "end\n"
+    )
+
+    function = next(node for node in nodes if node.kind == "Function")
+    assert (function.name, function.parent_name) == ("f", "A.B")
+    assert not [edge for edge in edges if edge.kind == "CALLS"]
+
+
+def test_nested_function_in_qualified_method_keeps_identity_and_lexical_lookup():
+    nodes, edges = _parse(
+        "module Demo\n"
+        "helper() = 1\n"
+        "function Base.show()\n"
+        "    function inner()\n"
+        "        helper()\n"
+        "    end\n"
+        "    inner()\n"
+        "end\n"
+        "end\n"
+    )
+
+    inner = next(node for node in nodes if node.name == "inner")
+    assert inner.parent_name == "Demo.Base.show"
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.Base.show.inner"
+        and edge.target == "/repo/case.jl::Demo.helper"
+        for edge in edges
+    )
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.Base.show"
+        and edge.target == "/repo/case.jl::Demo.Base.show.inner"
+        for edge in edges
+    )
+
+
 def test_nested_modules_and_functions_keep_complete_scope():
     nodes, edges = _parse(
         "module Outer\n"
@@ -234,6 +323,39 @@ def test_calls_through_import_aliases_use_real_module_paths():
         and edge.target == "OtherFrames.transform"
         and edge.extra.get("julia_call_module") == "OtherFrames"
         for edge in calls
+    )
+
+
+def test_selected_import_alias_keeps_multi_segment_module_path():
+    _, edges = _parse(
+        "module Demo\n"
+        "import Foo.Bar: thing as alias\n"
+        "f() = alias()\n"
+        "end\n"
+    )
+
+    assert any(
+        edge.kind == "CALLS"
+        and edge.source == "/repo/case.jl::Demo.f"
+        and edge.target == "Foo.Bar.thing"
+        for edge in edges
+    )
+
+
+def test_enum_variants_use_the_full_lexical_type_parent():
+    nodes, edges = _parse("module Demo\n@enum Color RED\nend\n")
+
+    variant = next(
+        node
+        for node in nodes
+        if node.extra.get("julia_kind") == "enum_variant"
+    )
+    assert (variant.name, variant.parent_name) == ("RED", "Demo.Color")
+    assert any(
+        edge.kind == "CONTAINS"
+        and edge.source == "/repo/case.jl::Demo.Color"
+        and edge.target == "/repo/case.jl::Demo.Color.RED"
+        for edge in edges
     )
 
 


### PR DESCRIPTION
## Summary

- reconcile the safe Julia parser behavior from #560 onto current `main`
- parse empty function stubs, bare/quoted operators, parameterized `const` aliases, and aliased imports
- preserve collision-free lexical plus explicit-qualified identities such as `file::Outer.Inner.Base.show`
- resolve calls from the nearest Julia scope, including nested functions, module-level calls, and multi-segment qualified calls
- keep import aliases module-scoped so the same alias can safely mean different things in different modules
- preserve Julia testsets/macros and fail softly on malformed qualified stubs
- add parser-to-`GraphStore` integration coverage; no schema change

## Why this replacement

PR #560 contains valuable Julia parsing work but is based on a stale branch and currently conflicts with `main`. This PR ports and strengthens the safe behavior without modifying or merging #560.

Dan's contribution is preserved in the implementation commits with:

`Co-authored-by: dan <danvinci@fastmail.net>`

## Compatibility and deliberate changes

- `parent_name` remains the identity mechanism; there is no database migration.
- `CONTAINS` remains lexical, while explicit Julia qualifiers are also retained in node metadata and literal `REFERENCES` edges.
- Qualified call targets keep their full module path instead of collapsing to a leaf name.
- Bare calls inside qualified methods jump back to the true lexical scope; explicit qualified calls remain resolvable.
- Alias lookup walks outward through lexical scopes and does not leak between sibling modules.
- Signature-call suppression applies only to the outer definition call, so evaluated return-type calls are retained.
- Non-Julia parsing continues through the existing resolver path.

## Validation

On rebased head `30d855700bd3d1faed578775b547e2050d5f659e` over `5b028798e90bd5c7e46215b3a0265227cee94416`:

- focused Julia parser tests: 51 passed
- full suite with coverage: 1,674 passed, 5 skipped, 2 xpassed; 76.29% coverage
- `ruff check code_review_graph/ tests/test_julia_reconciliation.py`
- `mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` (63 source files)
- `bandit -q -r code_review_graph/ -c pyproject.toml`
- `git diff --check origin/main...HEAD`
- schema sync: Python 9 = VS Code 9
- full knowledge-graph rebuild: 189 files, 3,784 nodes, 28,687 edges, no errors; 202 flows and 16 communities
- independent maintainer re-review approved the resolver boundaries and signature-call handling, including a separate nested identity/call-resolution probe
- all 11 fresh GitHub checks passed, including Python 3.10-3.13 and the native Windows job

Ready for review and intentionally unmerged.

Related source work: #560
