### PR TITLE
feat(parser): resolve typed member calls with import evidence

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1234,6 +1234,14 @@ class CodeParser:
                 tree.root_node, file_path_str, import_map,
             )
 
+        typed_call_targets = self._collect_typed_call_targets(
+            tree.root_node,
+            language,
+            file_path_str,
+            import_map,
+            defined_names,
+        )
+
         # Walk the tree
         self._extract_from_tree(
             tree.root_node, source, language, file_path_str, nodes, edges,
@@ -1246,6 +1254,8 @@ class CodeParser:
                 file_path_str,
                 edges,
             )
+
+        edges = self._apply_typed_call_targets(edges, typed_call_targets)
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -2472,7 +2482,12 @@ class CodeParser:
             ):
                 resolved.append(edge)
                 continue
-            if edge.kind in ("CALLS", "REFERENCES") and "::" not in edge.target:
+            has_receiver = bool(edge.extra.get("receiver"))
+            if (
+                edge.kind in ("CALLS", "REFERENCES")
+                and "::" not in edge.target
+                and not has_receiver
+            ):
                 if edge.target in symbols:
                     edge = EdgeInfo(
                         kind=edge.kind,
@@ -2590,6 +2605,388 @@ class CodeParser:
                     file_path=edge.file_path,
                     line=edge.line,
                     extra=edge.extra,
+                )
+            resolved.append(edge)
+        return resolved
+
+    _TYPED_CALL_LANGUAGES = frozenset({
+        "python", "kotlin", "java", "javascript", "typescript", "tsx",
+    })
+    _TRANSPARENT_TYPE_WRAPPERS = frozenset({"Annotated", "Optional", "Type"})
+    _NON_RECEIVER_TYPE_NAMES = frozenset({
+        "Array", "Collection", "Dict", "Iterable", "List", "Map", "Mapping",
+        "MutableList", "MutableMap", "MutableMapping", "ReadonlyArray",
+        "Sequence", "Set", "Tuple", "Union", "dict", "frozenset", "list",
+        "set", "tuple",
+    })
+
+    def _collect_typed_call_targets(
+        self,
+        root,
+        language: str,
+        file_path: str,
+        import_map: dict[str, str],
+        defined_names: set[str],
+    ) -> dict[tuple[int, str, str], tuple[str, str, str]]:
+        """Collect evidence-backed targets for calls on typed receivers.
+
+        The result is keyed by source line, receiver, and method so the normal
+        call extractor remains the single producer of CALLS edges. Only
+        repository-local imported types and same-file classes are qualified;
+        unknown or ambiguous types keep their existing bare targets.
+        """
+        if language not in self._TYPED_CALL_LANGUAGES:
+            return {}
+
+        class_types = set(self._class_types.get(language, []))
+        function_types = set(self._function_types.get(language, []))
+        call_types = set(self._call_types.get(language, []))
+        block_types = {
+            "java": {"block"},
+            "kotlin": {"statements"},
+            "javascript": {"statement_block"},
+            "typescript": {"statement_block"},
+            "tsx": {"statement_block"},
+        }.get(language, set())
+        targets: dict[tuple[int, str, str], tuple[str, str, str]] = {}
+
+        def walk(
+            node,
+            bindings: dict[str, str],
+            class_fields: dict[str, str],
+            depth: int = 0,
+        ) -> None:
+            if depth > self._MAX_AST_DEPTH:
+                return
+            if node.type in class_types:
+                fields = self._collect_class_typed_fields(
+                    node, language, function_types, class_types,
+                )
+                class_bindings = dict(bindings)
+                class_bindings.update(fields)
+                for child in node.children:
+                    walk(child, class_bindings, fields, depth + 1)
+                return
+
+            if node.type in function_types:
+                scoped = dict(bindings)
+                scoped.update(class_fields)
+                scoped.update(self._collect_function_typed_parameters(node, language))
+                for child in node.children:
+                    walk(child, scoped, class_fields, depth + 1)
+                return
+
+            if node.type in block_types:
+                scoped = dict(bindings)
+                for child in node.children:
+                    walk(child, scoped, class_fields, depth + 1)
+                return
+
+            new_bindings = self._typed_bindings_from_node(node, language)
+            if new_bindings:
+                # Initializers are evaluated before their declaration becomes
+                # visible, so visit children with the previous environment.
+                for child in node.children:
+                    walk(child, bindings, class_fields, depth + 1)
+                bindings.update(new_bindings)
+                return
+
+            if node.type in call_types:
+                receiver, method = self._get_member_call_receiver_method(
+                    node, language,
+                )
+                if receiver and method:
+                    type_name = bindings.get(receiver)
+                    evidence = "typed_receiver"
+                    if type_name is None and receiver[:1].isupper():
+                        if receiver in import_map or receiver in defined_names:
+                            type_name = receiver
+                            evidence = "class_receiver"
+                    if type_name:
+                        target = self._resolve_typed_method_target(
+                            type_name,
+                            method,
+                            file_path,
+                            language,
+                            import_map,
+                            defined_names,
+                        )
+                        if target:
+                            key = (node.start_point[0] + 1, receiver, method)
+                            targets[key] = (target, type_name, evidence)
+
+            for child in node.children:
+                walk(child, bindings, class_fields, depth + 1)
+
+        walk(root, {}, {})
+        return targets
+
+    def _collect_class_typed_fields(
+        self,
+        class_node,
+        language: str,
+        function_types: set[str],
+        class_types: set[str],
+    ) -> dict[str, str]:
+        """Return declared instance-field types for one class."""
+        fields: dict[str, str] = {}
+
+        def visit(node, depth: int = 0) -> None:
+            if depth > self._MAX_AST_DEPTH:
+                return
+            if node is not class_node and node.type in class_types:
+                return
+            if node is not class_node and node.type in function_types:
+                if language in ("javascript", "typescript", "tsx"):
+                    name = node.child_by_field_name("name")
+                    if name is not None and name.text == b"constructor":
+                        fields.update(self._collect_ts_parameter_properties(node))
+                return
+            fields.update(self._typed_bindings_from_node(node, language))
+            for child in node.children:
+                visit(child, depth + 1)
+
+        visit(class_node)
+        return fields
+
+    def _collect_function_typed_parameters(
+        self,
+        function_node,
+        language: str,
+    ) -> dict[str, str]:
+        """Return typed parameters declared directly by one function."""
+        bindings: dict[str, str] = {}
+        parameter_types = {
+            "python": {"typed_parameter", "typed_default_parameter"},
+            "kotlin": {"parameter"},
+            "java": {"formal_parameter", "spread_parameter"},
+            "javascript": {"required_parameter", "optional_parameter"},
+            "typescript": {"required_parameter", "optional_parameter"},
+            "tsx": {"required_parameter", "optional_parameter"},
+        }.get(language, set())
+
+        def visit(node, depth: int = 0) -> None:
+            if depth > self._MAX_AST_DEPTH:
+                return
+            if node is not function_node and node.type in self._function_types.get(
+                language, []
+            ):
+                return
+            if node.type in parameter_types:
+                bindings.update(self._typed_bindings_from_node(node, language))
+                return
+            # Function bodies cannot contain parameters of this function.
+            if node.type in ("block", "statement_block", "function_body"):
+                return
+            for child in node.children:
+                visit(child, depth + 1)
+
+        visit(function_node)
+        return bindings
+
+    def _collect_ts_parameter_properties(self, constructor_node) -> dict[str, str]:
+        """Return TypeScript constructor parameters that declare fields."""
+        bindings: dict[str, str] = {}
+
+        def visit(node, depth: int = 0) -> None:
+            if depth > self._MAX_AST_DEPTH:
+                return
+            if node.type in ("required_parameter", "optional_parameter"):
+                has_field_modifier = any(
+                    child.type in (
+                        "accessibility_modifier", "override_modifier", "readonly",
+                    )
+                    for child in node.children
+                )
+                if has_field_modifier:
+                    bindings.update(
+                        self._typed_bindings_from_node(node, "typescript"),
+                    )
+                return
+            if node.type == "statement_block":
+                return
+            for child in node.children:
+                visit(child, depth + 1)
+
+        visit(constructor_node)
+        return bindings
+
+    def _typed_bindings_from_node(
+        self,
+        node,
+        language: str,
+    ) -> dict[str, str]:
+        """Extract typed variable declarations from one AST node."""
+        result: dict[str, str] = {}
+
+        if language == "python" and node.type in (
+            "assignment", "typed_parameter", "typed_default_parameter",
+        ):
+            name_node = node.child_by_field_name("left")
+            if name_node is None:
+                name_node = next(
+                    (child for child in node.children if child.type == "identifier"),
+                    None,
+                )
+            type_node = node.child_by_field_name("type")
+            self._store_typed_binding(result, name_node, type_node)
+
+        elif language == "kotlin" and node.type in (
+            "class_parameter", "parameter", "variable_declaration",
+        ):
+            name_node = next(
+                (
+                    child
+                    for child in node.children
+                    if child.type == "simple_identifier"
+                ),
+                None,
+            )
+            type_node = next(
+                (
+                    child
+                    for child in node.children
+                    if child.type in ("user_type", "nullable_type")
+                ),
+                None,
+            )
+            self._store_typed_binding(result, name_node, type_node)
+
+        elif language == "java" and node.type in (
+            "formal_parameter", "spread_parameter",
+        ):
+            self._store_typed_binding(
+                result,
+                node.child_by_field_name("name"),
+                node.child_by_field_name("type"),
+            )
+
+        elif language == "java" and node.type in (
+            "field_declaration", "local_variable_declaration",
+        ):
+            type_node = node.child_by_field_name("type")
+            for child in node.children:
+                if child.type == "variable_declarator":
+                    self._store_typed_binding(
+                        result,
+                        child.child_by_field_name("name"),
+                        type_node,
+                    )
+
+        elif language in ("javascript", "typescript", "tsx") and node.type in (
+            "required_parameter", "optional_parameter", "variable_declarator",
+            "public_field_definition",
+        ):
+            name_node = (
+                node.child_by_field_name("name")
+                or node.child_by_field_name("pattern")
+            )
+            if name_node is None:
+                name_node = next(
+                    (child for child in node.children if child.type == "identifier"),
+                    None,
+                )
+            self._store_typed_binding(
+                result,
+                name_node,
+                node.child_by_field_name("type"),
+            )
+
+        return result
+
+    @classmethod
+    def _store_typed_binding(cls, result: dict[str, str], name_node, type_node) -> None:
+        if name_node is None or type_node is None:
+            return
+        name = name_node.text.decode("utf-8", errors="replace")
+        type_name = cls._base_type_name(
+            type_node.text.decode("utf-8", errors="replace"),
+        )
+        if name and type_name:
+            result[name] = type_name
+
+    @classmethod
+    def _base_type_name(cls, annotation: str) -> Optional[str]:
+        """Return the receiver class from a generic/nullable annotation."""
+        current = annotation.strip()
+        for _ in range(4):
+            match = re.search(r"[\"']?([A-Za-z_][A-Za-z0-9_.]*)", current)
+            if match is None:
+                return None
+            outer = match.group(1).rsplit(".", 1)[-1]
+            remainder = current[match.end():].lstrip()
+            if remainder.startswith("[]"):
+                return None
+            if outer in cls._TRANSPARENT_TYPE_WRAPPERS:
+                openings = [
+                    index for index in (current.find("["), current.find("<"))
+                    if index >= 0
+                ]
+                if not openings:
+                    return None
+                current = current[min(openings) + 1:].lstrip()
+                continue
+            if outer in cls._NON_RECEIVER_TYPE_NAMES:
+                return None
+            if outer in (
+                "None", "bool", "boolean", "float", "int", "number", "str",
+                "string", "unknown", "void",
+            ):
+                return None
+            return outer
+        return None
+
+    def _resolve_typed_method_target(
+        self,
+        type_name: str,
+        method: str,
+        file_path: str,
+        language: str,
+        import_map: dict[str, str],
+        defined_names: set[str],
+    ) -> Optional[str]:
+        base_type = self._base_type_name(type_name)
+        if not base_type:
+            return None
+        if base_type in import_map:
+            resolved = self._resolve_imported_symbol(
+                base_type,
+                import_map[base_type],
+                file_path,
+                language,
+            )
+            if resolved:
+                return f"{resolved}.{method}"
+        if base_type in defined_names:
+            return f"{file_path}::{base_type}.{method}"
+        return None
+
+    @staticmethod
+    def _apply_typed_call_targets(
+        edges: list[EdgeInfo],
+        targets: dict[tuple[int, str, str], tuple[str, str, str]],
+    ) -> list[EdgeInfo]:
+        if not targets:
+            return edges
+        resolved: list[EdgeInfo] = []
+        for edge in edges:
+            receiver = edge.extra.get("receiver")
+            method = edge.target.rsplit(".", 1)[-1].rsplit("::", 1)[-1]
+            evidence = targets.get((edge.line, receiver, method)) if receiver else None
+            if edge.kind == "CALLS" and evidence:
+                target, type_name, evidence_kind = evidence
+                extra = dict(edge.extra)
+                extra.update({
+                    "receiver_type": type_name,
+                    "receiver_resolution": evidence_kind,
+                })
+                edge = EdgeInfo(
+                    kind=edge.kind,
+                    source=edge.source,
+                    target=target,
+                    file_path=edge.file_path,
+                    line=edge.line,
+                    extra=extra,
                 )
             resolved.append(edge)
         return resolved
@@ -5734,11 +6131,14 @@ class CodeParser:
             else:
                 caller = file_path
 
-            # Java method_invocation: extract actual method name and receiver
-            # separately so the Spring DI resolver can rewrite the target.
+            # Preserve simple member-call receivers. Typed-receiver resolution
+            # uses this evidence during parsing, and the Spring DI resolver
+            # consumes the same metadata for Java injected fields.
             call_extra: dict = {}
-            if language == "java" and child.type == "method_invocation":
-                method_name, receiver = self._get_java_method_and_receiver(child)
+            if language in self._TYPED_CALL_LANGUAGES:
+                receiver, method_name = self._get_member_call_receiver_method(
+                    child, language,
+                )
                 if method_name:
                     call_name = method_name
                 if receiver:
@@ -5777,7 +6177,10 @@ class CodeParser:
             # When a receiver is present, skip scope-based resolution: the method
             # lives on the receiver's type, not in the current file's scope.
             # The spring_resolver post-pass will do the correct cross-type lookup.
-            if call_extra.get("receiver"):
+            receiver_name = call_extra.get("receiver")
+            if receiver_name in ("self", "cls", "this") and enclosing_class:
+                target = self._qualify(call_name, file_path, enclosing_class)
+            elif receiver_name:
                 target = call_name
             else:
                 target = self._resolve_call_target(
@@ -5794,6 +6197,86 @@ class CodeParser:
             ))
 
         return False
+
+    def _get_member_call_receiver_method(
+        self,
+        node,
+        language: str,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return a simple receiver name and method for a member call.
+
+        ``self.field.save()`` and ``this.field.save()`` use ``field`` as the
+        receiver so class-field annotations can resolve them. More complex
+        receiver expressions are deliberately left unresolved.
+        """
+        if language == "java" and node.type == "method_invocation":
+            method, receiver = self._get_java_method_and_receiver(node)
+            return receiver, method
+
+        callee = node.child_by_field_name("function")
+        if callee is None and node.children:
+            callee = node.children[0]
+        if callee is None:
+            return None, None
+
+        if language == "kotlin" and callee.type == "navigation_expression":
+            receiver = next(
+                (
+                    child.text.decode("utf-8", errors="replace")
+                    for child in callee.children
+                    if child.type == "simple_identifier"
+                ),
+                None,
+            )
+            method = None
+            for child in callee.children:
+                if child.type != "navigation_suffix":
+                    continue
+                method = next(
+                    (
+                        part.text.decode("utf-8", errors="replace")
+                        for part in child.children
+                        if part.type == "simple_identifier"
+                    ),
+                    None,
+                )
+            return receiver, method
+
+        if callee.type not in ("attribute", "member_expression"):
+            return None, None
+        object_node = callee.child_by_field_name("object")
+        property_node = (
+            callee.child_by_field_name("attribute")
+            or callee.child_by_field_name("property")
+        )
+        if object_node is None or property_node is None:
+            return None, None
+
+        method = property_node.text.decode("utf-8", errors="replace")
+        if object_node.type in ("identifier", "simple_identifier", "self", "this"):
+            return (
+                object_node.text.decode("utf-8", errors="replace"),
+                method,
+            )
+
+        if object_node.type in ("attribute", "member_expression"):
+            root = object_node.child_by_field_name("object")
+            field_node = (
+                object_node.child_by_field_name("attribute")
+                or object_node.child_by_field_name("property")
+            )
+            if (
+                root is not None
+                and field_node is not None
+                and root.type in ("identifier", "self", "this")
+                and root.text in (b"self", b"this")
+            ):
+                return (
+                    field_node.text.decode("utf-8", errors="replace"),
+                    method,
+                )
+
+        return None, method
 
     # ------------------------------------------------------------------
     # PHP / Laravel semantic constructs
@@ -6841,6 +7324,16 @@ class CodeParser:
         for child in root.children:
             node_type = child.type
 
+            # Kotlin groups top-level imports under an ``import_list`` node,
+            # while the generic import table contains ``import_header``.
+            if language == "kotlin" and node_type == "import_list":
+                for import_node in child.children:
+                    if import_node.type == "import_header":
+                        self._collect_import_names(
+                            import_node, language, source, import_map,
+                        )
+                continue
+
             # Unwrap decorator wrappers to reach the inner definition
             target = child
             if node_type in decorator_wrappers:
@@ -7234,6 +7727,18 @@ class CodeParser:
                         if module_name and real_name and alias:
                             import_map[alias] = f"{module_name}.{real_name}"
 
+        elif language in ("java", "kotlin"):
+            text = node.text.decode("utf-8", errors="replace").strip()
+            if not text.startswith("import "):
+                return
+            imported = text[len("import "):].rstrip(";").strip()
+            if imported.startswith("static ") or imported.endswith(".*"):
+                return
+            original, separator, alias = imported.partition(" as ")
+            local_name = alias.strip() if separator else original.rsplit(".", 1)[-1]
+            if local_name:
+                import_map[local_name] = original.strip()
+
     def _collect_js_import_names(
         self, clause_node, module: str, import_map: dict[str, str],
     ) -> None:
@@ -7422,6 +7927,20 @@ class CodeParser:
                     if current == current.parent:
                         break
                     current = current.parent
+
+        elif language == "kotlin":
+            if module.endswith(".*"):
+                return None
+            relative = module.replace(".", "/")
+            current = caller_dir
+            while True:
+                for suffix in (".kt", ".kts"):
+                    target = current / f"{relative}{suffix}"
+                    if target.is_file():
+                        return str(target.resolve())
+                if current == current.parent:
+                    break
+                current = current.parent
 
         elif language == "php":
             composer_resolved = self._resolve_php_composer_module(

--- a/tests/test_typed_receiver_calls.py
+++ b/tests/test_typed_receiver_calls.py
@@ -1,0 +1,247 @@
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _calls_from(edges, source_suffix: str) -> list[str]:
+    return [
+        edge.target
+        for edge in edges
+        if edge.kind == "CALLS" and edge.source.endswith(source_suffix)
+    ]
+
+
+def test_python_imported_class_and_typed_receivers_resolve(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    service = pkg / "service.py"
+    service.write_text(
+        "class Service:\n    @classmethod\n    def build(cls): ...\n    def work(self): ...\n",
+        encoding="utf-8",
+    )
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from pkg.service import Service\n\n"
+        "def run(service: Service[list[str]]):\n"
+        "    Service.build()\n"
+        "    service.work()\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
+
+    targets = _calls_from(edges, "::run")
+    assert targets.count(f"{service.resolve()}::Service.build") == 1
+    assert targets.count(f"{service.resolve()}::Service.work") == 1
+    assert "build" not in targets
+    assert "work" not in targets
+
+
+def test_python_typed_receiver_scope_does_not_leak(tmp_path: Path) -> None:
+    source = tmp_path / "scopes.py"
+    source.write_text(
+        "class OuterService:\n"
+        "    def work(self): ...\n\n"
+        "class InnerService:\n"
+        "    def work(self): ...\n\n"
+        "def outer(value: OuterService):\n"
+        "    value.work()\n"
+        "    def inner(value: InnerService):\n"
+        "        value.work()\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
+
+    assert f"{source.resolve()}::OuterService.work" in _calls_from(edges, "::outer")
+    inner_targets = _calls_from(edges, "::inner")
+    assert f"{source.resolve()}::InnerService.work" in inner_targets
+    assert f"{source.resolve()}::OuterService.work" not in inner_targets
+
+
+def test_unimported_cross_file_class_name_is_not_guessed(tmp_path: Path) -> None:
+    other = tmp_path / "other.py"
+    other.write_text(
+        "class Service:\n    @classmethod\n    def build(cls): ...\n",
+        encoding="utf-8",
+    )
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "def run():\n    Service.build()\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
+
+    assert _calls_from(edges, "::run") == ["build"]
+
+
+def test_untyped_common_method_is_retained_but_not_guessed(tmp_path: Path) -> None:
+    source = tmp_path / "service.py"
+    source.write_text(
+        "class Service:\n    def update(self): ...\n\ndef run(obj):\n    obj.update()\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
+
+    # PR #337 deleted common method names globally. Preserve the uncertain
+    # call instead, but do not bind it to Service without type/import evidence.
+    assert _calls_from(edges, "::run") == ["update"]
+
+
+def test_container_annotation_is_not_mistaken_for_element_type(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "container.py"
+    source.write_text(
+        "class Service:\n"
+        "    def append(self): ...\n\n"
+        "def run(values: list[Service]):\n"
+        "    values.append()\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
+
+    assert _calls_from(edges, "::run") == ["append"]
+
+
+def test_kotlin_generic_parameter_local_and_field_types_resolve(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    app = tmp_path / "app"
+    pkg.mkdir()
+    app.mkdir()
+    service = pkg / "Service.kt"
+    service.write_text(
+        "package pkg\nclass Service<T> {\n  fun work() {}\n  fun done() {}\n  fun save() {}\n}\n",
+        encoding="utf-8",
+    )
+    consumer = app / "Consumer.kt"
+    consumer.write_text(
+        "package app\n"
+        "import pkg.Service\n"
+        "class Consumer(private val field: Service<String>) {\n"
+        "  fun run(param: Service<Int>) {\n"
+        "    val local: Service<Long> = param\n"
+        "    local.work()\n"
+        "    param.done()\n"
+        "    field.save()\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
+
+    targets = _calls_from(edges, "::Consumer.run")
+    assert f"{service.resolve()}::Service.work" in targets
+    assert f"{service.resolve()}::Service.done" in targets
+    assert f"{service.resolve()}::Service.save" in targets
+
+
+def test_java_generic_parameter_local_and_field_types_resolve(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    app = tmp_path / "app"
+    pkg.mkdir()
+    app.mkdir()
+    service = pkg / "Service.java"
+    service.write_text(
+        "package pkg;\n"
+        "class Service<T> {\n"
+        "  void work() {}\n"
+        "  void done() {}\n"
+        "  void save() {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    consumer = app / "Consumer.java"
+    consumer.write_text(
+        "package app;\n"
+        "import pkg.Service;\n"
+        "class Consumer {\n"
+        "  private Service<String> field;\n"
+        "  void run(Service<Integer> param) {\n"
+        "    Service<Long> local = param;\n"
+        "    local.work();\n"
+        "    param.done();\n"
+        "    field.save();\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
+
+    targets = _calls_from(edges, "::Consumer.run")
+    assert f"{service.resolve()}::Service.work" in targets
+    assert f"{service.resolve()}::Service.done" in targets
+    assert f"{service.resolve()}::Service.save" in targets
+
+
+def test_typescript_generic_parameter_local_and_field_types_resolve(
+    tmp_path: Path,
+) -> None:
+    service = tmp_path / "service.ts"
+    service.write_text(
+        "export class Service<T> {\n  work() {}\n  done() {}\n  save() {}\n}\n",
+        encoding="utf-8",
+    )
+    consumer = tmp_path / "consumer.ts"
+    consumer.write_text(
+        "import { Service } from './service';\n"
+        "class Consumer {\n"
+        "  constructor(private field: Service<string>) {}\n"
+        "  run(param: Service<number>) {\n"
+        "    const local: Service<boolean> = param;\n"
+        "    local.work();\n"
+        "    param.done();\n"
+        "    this.field.save();\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
+
+    targets = _calls_from(edges, "::Consumer.run")
+    assert f"{service.resolve()}::Service.work" in targets
+    assert f"{service.resolve()}::Service.done" in targets
+    assert f"{service.resolve()}::Service.save" in targets
+
+
+def test_typescript_block_shadowing_restores_outer_type(tmp_path: Path) -> None:
+    source = tmp_path / "scopes.ts"
+    source.write_text(
+        "class OuterService { work() {} }\n"
+        "class InnerService { work() {} }\n"
+        "function run(value: OuterService) {\n"
+        "  value.work();\n"
+        "  {\n"
+        "    const value: InnerService = new InnerService();\n"
+        "    value.work();\n"
+        "  }\n"
+        "  value.work();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
+
+    targets = _calls_from(edges, "::run")
+    assert targets.count(f"{source.resolve()}::OuterService.work") == 2
+    assert targets.count(f"{source.resolve()}::InnerService.work") == 1
+
+
+def test_this_call_resolves_to_its_enclosing_class(tmp_path: Path) -> None:
+    source = tmp_path / "this-call.ts"
+    source.write_text(
+        "class First { work() {} }\nclass Second {\n  work() {}\n  run() { this.work(); }\n}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
+
+    assert _calls_from(edges, "::Second.run") == [
+        f"{source.resolve()}::Second.work",
+    ]


### PR DESCRIPTION
## Summary

- Resolves static class and typed receiver calls only when same-file or repository-local import evidence identifies the target.
- Supports Python, Kotlin, Java, JavaScript, TypeScript, and TSX while preserving function, class, and block scope.
- Keeps uncertain receiver calls as bare CALLS edges instead of deleting or guessing them.
- Records receiver type and resolution evidence on qualified edges.

## Reconciliation

This ports the safe intent from #330 and #338 and preserves attribution to Gideon Zenz in the commit trailer.

It deliberately does not port:

- #331 directory-proximity guessing, because proximity is not semantic evidence and ties must remain unresolved.
- #337 the global method-name blocklist, because it deletes legitimate get, find, write, remove, and update calls.
- #339 function-reference CALLS changes, because current main already models callback values as REFERENCES and the remaining patch leaks class and lexical scope.

The branch is rebased onto current main commit 31feb78 and includes the Julia parser reconciliation from #647. The parser conflict was resolved by preserving the Julia lexical/qualified-call resolver unchanged and applying typed-receiver handling only to its six supported non-Julia languages.

## Verification

- 37 focused typed-receiver and Julia reconciliation tests passed.
- 565 parser, language, notebook, Laravel, Julia, and focused receiver tests passed.
- 1 existing process-pool sandbox test was deselected locally; 2 existing tests xpassed.
- Ruff lint passed for production and test changes.
- Ruff format check passed for the new test file.
- Python syntax compilation and git diff checks passed.
- Hosted CI passed lint, review, type-check, schema, security, Python 3.10 through 3.13, GitGuardian, and Windows daemon/file-handle jobs.

A full local run also reproduced the already-tracked macOS iCloud ConfigWatcher native crash in crg-799; hosted CI is the authoritative full-suite run.