### PR TITLE
fix(git): preserve literal paths in change discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Fixed
 
+- Incremental Git change discovery now reads NUL-delimited byte output, so
+  Unicode, whitespace, newline, and literal arrow paths are preserved while
+  rename/copy records keep destination-only semantics (PR #618).
 - Corrected TESTED_BY edge direction across graph, refactor, and transitive-test
   consumers, with a parser-to-store-to-query regression (#527/#559/#598 class).
 - C# receiver calls now capture bare, chained, member, and null-conditional

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -505,6 +505,11 @@ _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
 _SAFE_SVN_REV = re.compile(r"^r?\d+(:r?\d+|:HEAD|:BASE|:COMMITTED)?$", re.IGNORECASE)
 
 
+def _decode_nul_paths(output: bytes) -> list[str]:
+    """Decode Git's NUL-delimited path output without quote mangling."""
+    return [os.fsdecode(path) for path in output.split(b"\0") if path]
+
+
 def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
     """Persist VCS branch/revision info into the graph metadata table."""
     vcs = detect_vcs(repo_root)
@@ -538,9 +543,8 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         return []
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", base, "--"],
+            ["git", "diff", "--name-only", "-z", base, "--"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
@@ -548,16 +552,17 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
             result = subprocess.run(
-                ["git", "diff", "--name-only", "--cached"],
+                ["git", "diff", "--name-only", "-z", "--cached"],
                 capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
                 stdin=subprocess.DEVNULL,
             )
-        files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
-        return files
-    except (FileNotFoundError, subprocess.TimeoutExpired, UnicodeDecodeError):
+        if result.returncode != 0:
+            logger.warning("git diff failed while discovering changed files")
+            return []
+        return _decode_nul_paths(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 
 def _get_svn_changed_files(repo_root: Path, rev_range: str | None = None) -> list[str]:
@@ -612,23 +617,30 @@ def get_staged_and_unstaged(repo_root: Path) -> list[str]:
         return _get_svn_changed_files(repo_root)
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain=v1", "-z"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
         )
-        files = []
-        for line in result.stdout.splitlines():
-            if len(line) > 3:
-                entry = line[3:].strip()
-                # Handle renamed files: "R  old -> new"
-                if " -> " in entry:
-                    entry = entry.split(" -> ", 1)[1]
-                files.append(entry)
+        if result.returncode != 0:
+            logger.warning("git status failed while discovering working-tree files")
+            return []
+        files: list[str] = []
+        records = result.stdout.split(b"\0")
+        index = 0
+        while index < len(records):
+            record = records[index]
+            if len(record) > 3:
+                status = record[:2]
+                files.append(os.fsdecode(record[3:]))
+                # With porcelain -z, a rename/copy record stores the
+                # destination first and its source in the following record.
+                if b"R" in status or b"C" in status:
+                    index += 1
+            index += 1
         return files
-    except (FileNotFoundError, subprocess.TimeoutExpired, UnicodeDecodeError):
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 
 def get_all_tracked_files(

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -496,25 +496,37 @@ class TestGitOperations:
     def test_get_changed_files(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="src/a.py\nsrc/b.py\n",
+            stdout=b"src/a.py\0src/b.py\0",
         )
         result = get_changed_files(tmp_path)
         assert result == ["src/a.py", "src/b.py"]
         mock_run.assert_called_once()
         call_args = mock_run.call_args
         assert "git" in call_args[0][0]
+        assert "-z" in call_args[0][0]
         assert call_args[1].get("timeout") == 30
+        assert "text" not in call_args[1]
 
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_changed_files_fallback(self, mock_run, tmp_path):
         # First call fails, second succeeds
         mock_run.side_effect = [
-            MagicMock(returncode=1, stdout=""),
-            MagicMock(returncode=0, stdout="staged.py\n"),
+            MagicMock(returncode=1, stdout=b""),
+            MagicMock(returncode=0, stdout=b"staged.py\0"),
         ]
         result = get_changed_files(tmp_path)
         assert result == ["staged.py"]
         assert mock_run.call_count == 2
+        assert "-z" in mock_run.call_args_list[1].args[0]
+
+    @patch("code_review_graph.incremental.subprocess.run")
+    def test_get_changed_files_rejects_failed_fallback(self, mock_run, tmp_path):
+        mock_run.side_effect = [
+            MagicMock(returncode=128, stdout=b""),
+            MagicMock(returncode=128, stdout=b"misleading.py\0"),
+        ]
+
+        assert get_changed_files(tmp_path) == []
 
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_changed_files_timeout(self, mock_run, tmp_path):
@@ -526,14 +538,37 @@ class TestGitOperations:
     def test_get_staged_and_unstaged(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=" M src/a.py\n?? new.py\nR  old.py -> new_name.py\n",
+            stdout=(
+                b" M src/a.py\0"
+                b"?? new.py\0"
+                b"R  new_name.py\0old.py\0"
+                b"C  copied.py\0source.py\0"
+                b" M path -> literal.py\0"
+                b" M  leading and trailing.py \0"
+            ),
         )
         result = get_staged_and_unstaged(tmp_path)
         assert "src/a.py" in result
         assert "new.py" in result
         assert "new_name.py" in result
-        # old.py should NOT be in results (renamed away)
+        assert "copied.py" in result
+        assert "path -> literal.py" in result
+        assert " leading and trailing.py " in result
+        # Rename/copy sources should NOT be in results (destination-only).
         assert "old.py" not in result
+        assert "source.py" not in result
+
+    @patch("code_review_graph.incremental.subprocess.run")
+    def test_get_staged_and_unstaged_rejects_failed_status(
+        self, mock_run, tmp_path
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=128,
+            stdout=b"?? misleading.py\0",
+            stderr=b"fatal: not a git repository",
+        )
+
+        assert get_staged_and_unstaged(tmp_path) == []
 
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_all_tracked_files(self, mock_run, tmp_path):

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -11,6 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from code_review_graph.incremental import (
     full_build,
     get_all_tracked_files,
     get_changed_files,
+    get_staged_and_unstaged,
     incremental_update,
 )
 from code_review_graph.wiki import get_wiki_page
@@ -79,6 +81,92 @@ def test_get_changed_files_real_git(git_repo: Path) -> None:
     """get_changed_files should list hello.py as changed between HEAD~1..HEAD."""
     changed = get_changed_files(git_repo, base="HEAD~1")
     assert "hello.py" in changed
+
+
+@pytest.fixture()
+def git_repo_with_unicode_path(tmp_path: Path) -> Path:
+    """Create a real repository with a committed non-ASCII Python path."""
+    repo = tmp_path / "unicode-repo"
+    repo.mkdir()
+    assert _git(repo, "init").returncode == 0
+    assert _git(repo, "config", "user.email", "test@test.com").returncode == 0
+    assert _git(repo, "config", "user.name", "Test").returncode == 0
+    (repo / "café.py").write_text("value = 1\n", encoding="utf-8")
+    assert _git(repo, "add", "--", "café.py").returncode == 0
+    assert _git(repo, "commit", "-m", "add unicode path").returncode == 0
+    return repo
+
+
+def test_get_changed_files_preserves_unicode_path(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """Committed Git changes preserve a literal path on every platform."""
+    source = git_repo_with_unicode_path / "café.py"
+    source.write_text("value = 2\n", encoding="utf-8")
+    assert _git(git_repo_with_unicode_path, "add", "--", "café.py").returncode == 0
+    assert (
+        _git(git_repo_with_unicode_path, "commit", "-m", "modify unicode path").returncode
+        == 0
+    )
+
+    assert get_changed_files(git_repo_with_unicode_path, base="HEAD~1") == [
+        "café.py"
+    ]
+
+
+def test_get_staged_and_unstaged_preserves_unicode_path(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """Working-tree Git changes preserve a literal path on every platform."""
+    source = git_repo_with_unicode_path / "café.py"
+    source.write_text("value = 2\n", encoding="utf-8")
+
+    assert get_staged_and_unstaged(git_repo_with_unicode_path) == ["café.py"]
+
+
+def test_get_staged_and_unstaged_uses_rename_destination(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """NUL porcelain returns only the destination record for a staged rename."""
+    destination = "renamed café.py"
+    assert (
+        _git(
+            git_repo_with_unicode_path,
+            "mv",
+            "--",
+            "café.py",
+            destination,
+        ).returncode
+        == 0
+    )
+
+    assert get_staged_and_unstaged(git_repo_with_unicode_path) == [destination]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filenames cannot contain '>' or newline characters",
+)
+def test_git_discovery_preserves_literal_separator_characters(
+    git_repo_with_unicode_path: Path,
+) -> None:
+    """NUL output preserves arrows and newlines as filename characters."""
+    names = ["path -> literal.py", "line\nbreak.py"]
+    for name in names:
+        (git_repo_with_unicode_path / name).write_text("value = 1\n")
+    assert _git(git_repo_with_unicode_path, "add", "--", *names).returncode == 0
+    assert (
+        _git(git_repo_with_unicode_path, "commit", "-m", "add literal paths").returncode
+        == 0
+    )
+
+    assert set(
+        get_changed_files(git_repo_with_unicode_path, base="HEAD~1")
+    ) == set(names)
+
+    for name in names:
+        (git_repo_with_unicode_path / name).write_text("value = 2\n")
+    assert set(get_staged_and_unstaged(git_repo_with_unicode_path)) == set(names)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Safe current-main replacement for #618, retaining Teïlo Millet as co-author.

- Read `git diff --name-only -z` and `git status --porcelain=v1 -z` as bytes.
- Decode literal paths with `os.fsdecode` so Git quoting and line splitting cannot alter filenames.
- Preserve destination-only semantics for porcelain rename and copy records.
- Return no paths when Git diff fallback or status fails.

## Reconciliation

The source fix was correct in direction but lacked the requested current-main and platform evidence. This replacement adds:

- real-Git Unicode path tests that run on Windows;
- a real staged rename test proving destination-first NUL porcelain ordering;
- real arrow and newline filename tests on platforms that allow those characters;
- mocked NUL records for literal arrows, leading/trailing whitespace, rename, and copy destination-only handling;
- nonzero-command regressions so failed Git output is never treated as valid.

The branch is based exactly on current main bfe1a13ed3aecaea173319964ee04fbf0e35384f.

## Verification

- TDD red: all seven initial changed-path regressions failed on old code.
- Post-implementation and post-rebase: 78 Git/incremental tests passed.
- Ruff lint passed for production and test changes.
- Git diff checks passed.
- Full hosted Python and native Windows CI are the merge gates.