### PR TITLE
feat(cli): add safe local JSON graph export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added an explicit local JSON visualization export. The output is written
+  atomically inside the ignored graph data directory and is documented as
+  potentially containing absolute paths and code-structure metadata (PR #449).
 - Added `code-review-graph uninstall` as a safe, symmetric counterpart to
   `install` (#482, replacing PR #491). It derives MCP cleanup from the live
   platform specifications, preserves unrelated shared configuration and JSONC

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ code-review-graph update           # Incremental update (changed files only)
 code-review-graph status           # Graph statistics
 code-review-graph watch            # Auto-update on file changes
 code-review-graph visualize        # Generate interactive HTML graph
+code-review-graph visualize --format json      # Export local graph data as JSON
 code-review-graph visualize --format graphml   # Export as GraphML
 code-review-graph visualize --format svg       # Export as SVG
 code-review-graph visualize --format obsidian  # Export as Obsidian vault
@@ -353,6 +354,10 @@ code-review-graph daemon status    # Show daemon status and repos
 code-review-graph eval             # Run evaluation benchmarks
 code-review-graph serve            # Start MCP server
 ```
+
+JSON exports stay inside the local graph data directory, which Git ignores by
+default. They can contain absolute paths and code-structure metadata, so inspect
+and sanitize an export before publishing it outside your machine.
 
 </details>
 

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -617,7 +617,7 @@ def main() -> None:
     )
     vis_cmd.add_argument(
         "--format",
-        choices=["html", "graphml", "cypher", "obsidian", "svg"],
+        choices=["html", "json", "graphml", "cypher", "obsidian", "svg"],
         default="html",
         help="Export format (default: html)",
     )
@@ -1228,7 +1228,13 @@ def main() -> None:
             data_dir = get_data_dir(repo_root)
             fmt = getattr(args, "format", "html") or "html"
 
-            if fmt == "graphml":
+            if fmt == "json":
+                from .exports import export_json
+
+                out = data_dir / "graph.json"
+                export_json(store, out)
+                print(f"JSON exported: {out}")
+            elif fmt == "graphml":
                 from .exports import export_graphml
 
                 out = data_dir / "graph.graphml"

--- a/code_review_graph/exports.py
+++ b/code_review_graph/exports.py
@@ -1,16 +1,54 @@
-"""Additional export formats: GraphML, Neo4j Cypher, Obsidian vault, SVG."""
+"""Additional export formats: JSON, GraphML, Neo4j Cypher, Obsidian, SVG."""
 
 from __future__ import annotations
 
 import html
+import json
 import logging
+import os
 import re
+import tempfile
 from pathlib import Path
 
 from .graph import GraphStore, _sanitize_name
 from .visualization import export_graph_data
 
 logger = logging.getLogger(__name__)
+
+
+# -------------------------------------------------------------------
+# JSON export
+# -------------------------------------------------------------------
+
+def export_json(store: GraphStore, output_path: Path) -> Path:
+    """Export the complete local graph payload as UTF-8 JSON atomically.
+
+    The payload can contain absolute local paths and code-structure metadata.
+    Callers are responsible for deciding whether it is safe to publish.
+    """
+    data = export_graph_data(store)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(data, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, output_path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    logger.info("JSON exported to %s", output_path)
+    return output_path
 
 
 # -------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,6 +102,39 @@ class TestWatchInteraction:
                             assert exc.code == 1
 
 
+def test_visualize_json_uses_local_export(tmp_path, capsys):
+    argv = [
+        "code-review-graph",
+        "visualize",
+        "--repo",
+        str(tmp_path),
+        "--format",
+        "json",
+    ]
+    data_dir = tmp_path / ".code-review-graph"
+    store = MagicMock()
+
+    with patch.object(sys, "argv", argv):
+        with patch("code_review_graph.graph.GraphStore", return_value=store):
+            with patch(
+                "code_review_graph.incremental.get_db_path",
+                return_value=data_dir / "graph.db",
+            ):
+                with patch(
+                    "code_review_graph.incremental.get_data_dir",
+                    return_value=data_dir,
+                ):
+                    with patch(
+                        "code_review_graph.exports.export_json",
+                        return_value=data_dir / "graph.json",
+                    ) as export_json:
+                        cli.main()
+
+    export_json.assert_called_once_with(store, data_dir / "graph.json")
+    assert "JSON exported:" in capsys.readouterr().out
+    store.close.assert_called_once()
+
+
 class TestBuildUpdateCommands:
     def test_build_skip_postprocess_does_not_run_extra_cli_postprocess(self):
         argv = [

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -131,6 +131,45 @@ def test_export_graph_data(store_with_data):
     json.dumps(data)  # must be serializable
 
 
+def test_export_json_writes_utf8_graph_data(store_with_data, tmp_path):
+    from code_review_graph.exports import export_json
+
+    output_path = tmp_path / "nested" / "graph.json"
+    result = export_json(store_with_data, output_path)
+
+    assert result == output_path
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert {node["name"] for node in payload["nodes"]} >= {
+        "auth.py",
+        "AuthService",
+        "login",
+    }
+    assert {edge["kind"] for edge in payload["edges"]} == {
+        "CALLS",
+        "CONTAINS",
+    }
+
+
+def test_export_json_failure_preserves_existing_file(
+    store_with_data, tmp_path, monkeypatch
+):
+    from code_review_graph import exports
+
+    output_path = tmp_path / "graph.json"
+    output_path.write_text("existing export\n", encoding="utf-8")
+    monkeypatch.setattr(
+        exports,
+        "export_graph_data",
+        lambda _store: {"not_json": {object()}},
+    )
+
+    with pytest.raises(TypeError):
+        exports.export_json(store_with_data, output_path)
+
+    assert output_path.read_text(encoding="utf-8") == "existing export\n"
+    assert list(tmp_path.glob(".graph.json.*.tmp")) == []
+
+
 def test_generate_html(store_with_data, tmp_path):
     from code_review_graph.visualization import generate_html
 


### PR DESCRIPTION
## Summary

Safe current-main subset of #449, retaining Alex Macdonald-Smith as co-author.

- Adds `visualize --format json` using the existing complete graph export payload.
- Writes UTF-8 JSON atomically so a serialization or replacement failure cannot corrupt a previous export.
- Keeps the output inside the ignored local graph data directory.
- Documents that exports can contain absolute paths and code-structure metadata and must be inspected before publication.

## Reconciliation

The hardcoded Understand Quickly dispatch is deliberately not ported. The source writes `.code-review-graph/graph.json` into a directory that code-review-graph itself always ignores, then tells an external registry to fetch that uncommitted and unpushed file. It therefore dispatches stale or absent data. The source also sends absolute local paths and commit metadata without a privacy-safe schema and cannot prove that the current HEAD, origin repository, branch, dirty working tree, and remotely fetched artifact are the same revision.

A generic local JSON export is independently useful and does not require external service coupling, credentials, or network behavior.

## Verification

- TDD red: the JSON export, atomic-failure, and CLI routing tests all failed before implementation.
- 39 visualization, CLI, and Windows-compatibility tests passed after the final rebase.
- Ruff passed for production and test changes.
- Git diff checks passed.
- Full hosted Python and native Windows CI are the merge gates.