### PR TITLE
feat: add documentation-aware, opt-in embedding refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 - Added an explicit local JSON visualization export. The output is written
   atomically inside the ignored graph data directory and is documented as
   potentially containing absolute paths and code-structure metadata (PR #449).
+- Functions and classes now retain a bounded, first-paragraph documentation
+  summary in backward-compatible node metadata across Python, JSDoc/Javadoc,
+  C# XML docs, Doxygen, Rust, and Go. Semantic embedding text includes the
+  normalized summary, so behavior-oriented queries no longer depend only on
+  identifier overlap (replacing PR #602, with Stefan Hudici attribution).
+- Explicit provider-and-model-scoped embedding refresh is available on build,
+  update, postprocess, and watch paths. It is default-off, refuses silent
+  provider/model/endpoint migration, remains fail-soft, and purges vectors for
+  deleted or renamed nodes; manual `embed` also purges orphans (replacing PR
+  #599, with Stefan Hudici attribution).
 - Added `code-review-graph uninstall` as a safe, symmetric counterpart to
   `install` (#482, replacing PR #491). It derives MCP cleanup from the live
   platform specifications, preserves unrelated shared configuration and JSONC

--- a/README.md
+++ b/README.md
@@ -565,12 +565,14 @@ The cloud-egress warning is auto-skipped when the base URL points to localhost
 > `gemini-embedding-001` (via the native Gemini provider, which requires
 > `GOOGLE_API_KEY` instead of the OpenAI-compatible path).
 >
-> Also note: `code-review-graph` currently embeds **function signatures only**
-> (~10 tokens per node, e.g. `"parse_file function (path: str) returns Tree"`).
-> Models whose headline quality comes from long-context body understanding
-> (such as Gemini 2 or Qwen3-8B at their MTEB-code SOTA scores) will see a
-> much narrower quality gap against smaller models at this input length.
-> Body/docstring embedding is tracked as a follow-up enhancement.
+> `code-review-graph` embeds identifiers, signatures, structural context, and a
+> bounded first-paragraph docstring/doc-comment summary. It does not transmit
+> function bodies. Graphs created before documentation extraction was added
+> need one full `code-review-graph build` before re-embedding so every file is
+> reparsed. Routine builds never refresh embeddings by default. To refresh an
+> existing index after a build, explicitly pass both `--embedding-provider`
+> and `--embedding-model`; cloud choices may transmit this source-derived text
+> and incur API cost.
 
 #### Tool Filtering
 

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -41,9 +41,11 @@ import argparse
 import json
 import logging
 import os
+from functools import partial
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,11 @@ _PLATFORM_CHOICES = [
     "continue", "opencode", "antigravity", "gemini-cli", "qwen", "kiro", "qoder",
     "copilot", "copilot-cli", "codebuddy", "all",
 ]
+
+
+class _EmbeddingRefreshKwargs(TypedDict, total=False):
+    embedding_provider: str
+    embedding_model: str
 
 
 def _get_version() -> str:
@@ -362,6 +369,43 @@ def _handle_data_dir_option(args, repo_root: Path) -> None:
             sys.exit(1)
 
 
+def _add_embedding_refresh_args(command) -> None:
+    """Add explicit, provider-scoped refresh options to a CLI command."""
+    command.add_argument(
+        "--embedding-provider",
+        choices=["local", "openai", "google", "minimax"],
+        default=None,
+        help=(
+            "Explicitly refresh an existing embedding index with this provider; "
+            "requires --embedding-model (default: disabled)"
+        ),
+    )
+    command.add_argument(
+        "--embedding-model",
+        default=None,
+        help=(
+            "Exact model for --embedding-provider. Cloud providers may transmit "
+            "source-derived text and incur API cost"
+        ),
+    )
+
+
+def _embedding_refresh_kwargs(args, parser) -> _EmbeddingRefreshKwargs:
+    """Validate the all-or-nothing provider/model opt-in."""
+    provider = getattr(args, "embedding_provider", None)
+    model = getattr(args, "embedding_model", None)
+    if bool(provider) != bool(model):
+        parser.error(
+            "--embedding-provider and --embedding-model must be supplied together",
+        )
+    if not provider:
+        return {}
+    return {
+        "embedding_provider": provider,
+        "embedding_model": model,
+    }
+
+
 def main() -> None:
     """Main CLI entry point."""
     ap = argparse.ArgumentParser(
@@ -505,6 +549,7 @@ def main() -> None:
         default=None,
         help="External directory to store graph database (useful for network shares)"
     )
+    _add_embedding_refresh_args(build_cmd)
 
     # update
     update_cmd = sub.add_parser("update", help="Incremental update (only changed files)")
@@ -543,6 +588,7 @@ def main() -> None:
         default=None,
         help="External directory to store graph database (useful for network shares)"
     )
+    _add_embedding_refresh_args(update_cmd)
 
     # postprocess
     pp_cmd = sub.add_parser(
@@ -558,6 +604,7 @@ def main() -> None:
         default=None,
         help="External directory to store graph database (useful for network shares)"
     )
+    _add_embedding_refresh_args(pp_cmd)
 
     # embed
     embed_cmd = sub.add_parser(
@@ -591,6 +638,7 @@ def main() -> None:
         default=None,
         help="External directory to store graph database (useful for network shares)"
     )
+    _add_embedding_refresh_args(watch_cmd)
 
     # status
     status_cmd = sub.add_parser("status", help="Show graph statistics")
@@ -833,6 +881,8 @@ def main() -> None:
         _print_banner()
         return
 
+    embedding_refresh_kwargs = _embedding_refresh_kwargs(args, ap)
+
     if args.command in ("serve", "mcp"):
         from .main import main as serve_main
 
@@ -1033,6 +1083,7 @@ def main() -> None:
                 communities=not getattr(args, "no_communities", False),
                 fts=not getattr(args, "no_fts", False),
                 repo_root=str(repo_root),
+                **embedding_refresh_kwargs,
             )
             parts = []
             if result.get("flows_detected"):
@@ -1096,6 +1147,7 @@ def main() -> None:
                 full_rebuild=True,
                 repo_root=str(repo_root),
                 postprocess=pp,
+                **embedding_refresh_kwargs,
             )
             parsed = result.get("files_parsed", 0)
             nodes = result.get("total_nodes", 0)
@@ -1117,6 +1169,7 @@ def main() -> None:
                 repo_root=str(repo_root),
                 base=args.base,
                 postprocess=pp,
+                **embedding_refresh_kwargs,
             )
             updated = result.get("files_updated", 0)
             nodes = result.get("total_nodes", 0)
@@ -1217,7 +1270,12 @@ def main() -> None:
             from .postprocessing import run_post_processing
 
             try:
-                watch(repo_root, store, on_files_updated=run_post_processing)
+                callback = (
+                    partial(run_post_processing, **embedding_refresh_kwargs)
+                    if embedding_refresh_kwargs
+                    else run_post_processing
+                )
+                watch(repo_root, store, on_files_updated=callback)
             except RuntimeError as exc:
                 print(f"Error: {exc}", file=sys.stderr)
                 sys.exit(1)

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -778,6 +778,7 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 
 
 _IDENTIFIER_SPLIT_RE = re.compile(r"([a-z])([A-Z])|[_./\-]+")
+_MAX_EMBEDDED_DOCSTRING_CHARS = 400
 
 
 def _split_identifier(name: str) -> str:
@@ -838,14 +839,23 @@ def _node_to_text(node: GraphNode) -> str:
     if node.return_type:
         parts.append(f"returns {node.return_type}")
 
-    # 7. Module / directory context from the file path — gives queries a
+    # 7. Documentation summary.  Existing databases may contain arbitrary
+    # values in ``extra`` so accept strings only, normalize whitespace, and
+    # re-apply the parser's bound before the text enters a provider request.
+    raw_docstring = node.extra.get("docstring") if node.extra else None
+    if isinstance(raw_docstring, str):
+        docstring = " ".join(raw_docstring.split())[:_MAX_EMBEDDED_DOCSTRING_CHARS]
+        if docstring:
+            parts.append(docstring)
+
+    # 8. Module / directory context from the file path — gives queries a
     # term like "routing" or "client" to anchor against.
     if node.file_path:
         parent_dir = Path(node.file_path).parent.name
         if parent_dir and parent_dir not in (".", "src", "lib"):
             parts.append(parent_dir)
 
-    # 8. Language
+    # 9. Language
     if node.language:
         parts.append(node.language)
 
@@ -968,12 +978,36 @@ class EmbeddingStore:
         )
         self._conn.commit()
 
+    def purge_orphans(self) -> int:
+        """Delete vectors whose graph node no longer exists.
+
+        Embeddings and graph nodes normally share a SQLite file.  Standalone
+        embedding databases remain supported, so a missing ``nodes`` table is
+        an intentional no-op rather than an error.
+        """
+        has_nodes = self._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'nodes'",
+        ).fetchone()
+        if has_nodes is None:
+            return 0
+        cursor = self._conn.execute(
+            "DELETE FROM embeddings "
+            "WHERE NOT EXISTS ("
+            "SELECT 1 FROM nodes "
+            "WHERE nodes.qualified_name = embeddings.qualified_name"
+            ")",
+        )
+        self._conn.commit()
+        return max(cursor.rowcount, 0)
+
     def count(self) -> int:
         return self._conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
 
 
 def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) -> int:
-    """Embed all non-file nodes in the graph."""
+    """Purge deleted nodes, then embed all current non-file nodes."""
+    embedding_store.purge_orphans()
     if not embedding_store.available:
         return 0
 
@@ -983,6 +1017,88 @@ def embed_all_nodes(graph_store: GraphStore, embedding_store: EmbeddingStore) ->
         all_nodes.extend(graph_store.get_nodes_by_file(f))
 
     return embedding_store.embed_nodes(all_nodes)
+
+
+def refresh_embeddings(
+    graph_store: GraphStore,
+    *,
+    provider: str,
+    model: str,
+) -> dict[str, int] | None:
+    """Refresh a previously embedded graph under one exact provider identity.
+
+    This function is deliberately not called by default build paths.  Callers
+    must supply both provider and model explicitly.  A graph with no existing
+    vectors returns before provider resolution, so routine builds cannot load
+    a local model, contact a cloud service, or incur API cost.
+
+    Existing vectors must all use the identity resolved from the requested
+    provider/model (including the endpoint for OpenAI-compatible providers).
+    Refresh never silently migrates an index to another model or endpoint.
+    """
+    provider = provider.strip().lower()
+    model = model.strip()
+    if not provider or not model:
+        raise ValueError(
+            "Embedding refresh requires an explicit provider and model.",
+        )
+
+    has_table = graph_store._conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type = 'table' AND name = 'embeddings'",
+    ).fetchone()
+    if has_table is None:
+        return None
+    has_rows = graph_store._conn.execute(
+        "SELECT 1 FROM embeddings LIMIT 1",
+    ).fetchone()
+    if has_rows is None:
+        return None
+    try:
+        rows = graph_store._conn.execute(
+            "SELECT DISTINCT provider FROM embeddings ORDER BY provider",
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such column" in str(exc).lower() and "provider" in str(exc).lower():
+            raise ValueError(
+                "Embedding refresh refused: existing rows have no provider identity; "
+                "run an explicit embed to migrate and rebuild the index.",
+            ) from exc
+        raise
+    identities = {str(row["provider"]) for row in rows}
+
+    embedding_store = EmbeddingStore(
+        graph_store.db_path,
+        provider=provider,
+        model=model,
+    )
+    try:
+        if not embedding_store.available or embedding_store.provider is None:
+            raise RuntimeError(
+                f"Embedding provider '{provider}' is unavailable in this environment.",
+            )
+        resolved_identity = embedding_store.provider.name
+        if provider == "minimax":
+            resolved_model = resolved_identity.partition(":")[2]
+            if model != resolved_model:
+                raise ValueError(
+                    f"MiniMax refresh model must be '{resolved_model}', got '{model}'.",
+                )
+        if identities != {resolved_identity}:
+            existing = ", ".join(sorted(identities))
+            raise ValueError(
+                "Embedding refresh refused: existing embeddings use "
+                f"{existing}; requested provider resolves to {resolved_identity}.",
+            )
+
+        purged = embedding_store.purge_orphans()
+        all_nodes: list[GraphNode] = []
+        for file_path in graph_store.get_all_files():
+            all_nodes.extend(graph_store.get_nodes_by_file(file_path))
+        embedded = embedding_store.embed_nodes(all_nodes)
+        return {"embedded": embedded, "purged": purged}
+    finally:
+        embedding_store.close()
 
 
 def semantic_search(

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -100,6 +100,8 @@ async def build_or_update_graph_tool(
     base: str = "HEAD~1",
     postprocess: str = "full",
     recurse_submodules: Optional[bool] = None,
+    embedding_provider: Optional[str] = None,
+    embedding_model: Optional[str] = None,
 ) -> dict:
     """Build or incrementally update the code knowledge graph.
 
@@ -122,6 +124,10 @@ async def build_or_update_graph_tool(
                      or "none" (skip all post-processing). Use "minimal" for faster builds.
         recurse_submodules: If True, include files from git submodules.
             When None (default), falls back to CRG_RECURSE_SUBMODULES env var.
+        embedding_provider: Exact provider for an explicit post-build embedding
+            refresh. Must be supplied with embedding_model. Default: disabled.
+        embedding_model: Exact model for an explicit post-build embedding
+            refresh. Must be supplied with embedding_provider. Default: disabled.
     """
     root = _resolve_repo_root(repo_root)
 
@@ -129,6 +135,8 @@ async def build_or_update_graph_tool(
         return with_provenance(build_or_update_graph(
             full_rebuild=full_rebuild, repo_root=root, base=base,
             postprocess=postprocess, recurse_submodules=recurse_submodules,
+            embedding_provider=embedding_provider,
+            embedding_model=embedding_model,
         ), root)
 
     return await asyncio.to_thread(_run)
@@ -140,6 +148,8 @@ async def run_postprocess_tool(
     communities: bool = True,
     fts: bool = True,
     repo_root: Optional[str] = None,
+    embedding_provider: Optional[str] = None,
+    embedding_model: Optional[str] = None,
 ) -> dict:
     """Run post-processing on existing graph (flows, communities, FTS index).
 
@@ -155,12 +165,18 @@ async def run_postprocess_tool(
         communities: Run community detection. Default: True.
         fts: Rebuild FTS index. Default: True.
         repo_root: Repository root path. Auto-detected if omitted.
+        embedding_provider: Exact provider for an explicit embedding refresh.
+            Must be supplied with embedding_model. Default: disabled.
+        embedding_model: Exact model for an explicit embedding refresh.
+            Must be supplied with embedding_provider. Default: disabled.
     """
     root = _resolve_repo_root(repo_root)
 
     def _run() -> dict:
         return with_provenance(run_postprocess(
             flows=flows, communities=communities, fts=fts, repo_root=root,
+            embedding_provider=embedding_provider,
+            embedding_model=embedding_model,
         ), root)
 
     return await asyncio.to_thread(_run)

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import html
 import json
 import logging
 import re
@@ -879,6 +880,85 @@ def _is_test_function(
     if decorators and any(d in _TEST_ANNOTATIONS for d in decorators):
         return True
     return False
+
+
+# Documentation summaries are stored in ``NodeInfo.extra`` so the graph
+# schema remains backward compatible.  A hard cap keeps parser metadata and
+# semantic-search input bounded even when a source file contains a very long
+# API reference as its docstring.
+_MAX_DOCSTRING_CHARS = 400
+_DOC_COMMENT_NODE_TYPES = frozenset({
+    "comment",
+    "block_comment",
+    "line_comment",
+    "doc_comment",
+})
+_DOC_COMMENT_SKIP_TYPES = frozenset({"attribute_item", "decorator"})
+_DOC_COMMENT_WRAPPER_TYPES = frozenset({
+    "export_statement",
+    "template_declaration",
+})
+_CSHARP_SUMMARY_RE = re.compile(
+    r"<summary(?:\s[^>]*)?>(.*?)</summary\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_XML_TAG_RE = re.compile(r"<[^>]+>")
+_DOC_PARAGRAPH_TAG_RE = re.compile(
+    r"</?(?:p|para)(?:\s[^>]*)?>",
+    re.IGNORECASE,
+)
+_DOC_INLINE_TAG_RE = re.compile(
+    r"\{@(?:code|literal|link)\s+([^}]+)\}",
+    re.IGNORECASE,
+)
+_DOC_BRIEF_RE = re.compile(r"^\s*[@\\]brief\s+", re.IGNORECASE)
+
+
+def _clean_docstring_summary(raw: str, language: str) -> str:
+    """Return a whitespace-stable, first-paragraph documentation summary."""
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    if language == "csharp":
+        summary = _CSHARP_SUMMARY_RE.search(text)
+        if summary:
+            text = summary.group(1)
+    if language != "python":
+        text = _DOC_PARAGRAPH_TAG_RE.sub("\n\n", text)
+        text = _DOC_INLINE_TAG_RE.sub(r"\1", text)
+        text = _XML_TAG_RE.sub(" ", text)
+        text = html.unescape(text)
+        text = _DOC_BRIEF_RE.sub("", text)
+
+    lines = [line.strip() for line in text.splitlines()]
+    while lines and not lines[0]:
+        lines.pop(0)
+    paragraph: list[str] = []
+    for line in lines:
+        if not line:
+            break
+        if paragraph and line.startswith(("@param", "@return", "\\param", "\\return")):
+            break
+        paragraph.append(line)
+    return " ".join(" ".join(paragraph).split())[:_MAX_DOCSTRING_CHARS]
+
+
+def _strip_block_doc_comment(text: str) -> str:
+    """Remove a Doxygen/Javadoc-style wrapper and per-line ``*`` prefix."""
+    if text.startswith(("/**", "/*!")):
+        text = text[3:]
+    elif text.startswith("/*"):
+        text = text[2:]
+    if text.endswith("*/"):
+        text = text[:-2]
+
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("*"):
+            stripped = stripped[1:]
+            if stripped.startswith(" "):
+                stripped = stripped[1:]
+        lines.append(stripped)
+    return "\n".join(lines)
 
 
 def _modifier_annotation_names(node) -> list[str]:
@@ -5670,6 +5750,124 @@ class CodeParser:
                         extra={"kafka_type": ann_name},
                     ))
 
+    def _get_docstring_summary(self, node, language: str) -> Optional[str]:
+        """Extract a bounded documentation summary for a definition node."""
+        if language == "python":
+            raw = self._python_docstring_value(node)
+        else:
+            raw = self._preceding_doc_comment(node, language)
+        if not raw:
+            return None
+        return _clean_docstring_summary(raw, language) or None
+
+    @staticmethod
+    def _python_docstring_value(node) -> Optional[str]:
+        """Return Python's actual string value for the first body statement.
+
+        ``ast.literal_eval`` gives us CPython-compatible escape handling and
+        implicit literal concatenation while naturally rejecting f-strings.
+        A bytes literal evaluates successfully but is rejected by the final
+        type check, matching ``__doc__`` semantics.
+        """
+        body = node.child_by_field_name("body")
+        if body is None:
+            return None
+        statement = next(
+            (child for child in body.named_children if child.type != "comment"),
+            None,
+        )
+        if statement is None:
+            return None
+        expression = statement
+        if expression.type == "expression_statement":
+            named = expression.named_children
+            if len(named) != 1:
+                return None
+            expression = named[0]
+        if expression.type not in (
+            "string",
+            "concatenated_string",
+            "parenthesized_expression",
+        ):
+            return None
+        try:
+            value = ast.literal_eval(
+                expression.text.decode("utf-8", errors="strict"),
+            )
+        except (SyntaxError, ValueError, UnicodeDecodeError):
+            return None
+        return value if isinstance(value, str) else None
+
+    @staticmethod
+    def _line_doc_payload(text: str, language: str) -> Optional[str]:
+        """Return one documentation-line payload, or ``None`` if not docs."""
+        stripped = text.strip()
+        if language == "go":
+            if not stripped.startswith("//"):
+                return None
+            return stripped[2:].lstrip()
+        if language == "rust":
+            # Rust ``//!`` is inner module/crate documentation; ``////`` is
+            # an ordinary comment, not an outer item doc comment.
+            if not stripped.startswith("///") or stripped.startswith("////"):
+                return None
+            return stripped[3:].lstrip()
+        if stripped.startswith(("///", "//!")):
+            return stripped[3:].lstrip()
+        return None
+
+    def _preceding_doc_comment(self, node, language: str) -> Optional[str]:
+        """Return documentation directly attached above a definition."""
+        anchor = node
+        while (
+            anchor.parent is not None
+            and anchor.parent.type in _DOC_COMMENT_WRAPPER_TYPES
+        ):
+            anchor = anchor.parent
+
+        siblings: list = []
+        current_line = anchor.start_point[0]
+        sibling = anchor.prev_sibling
+        while sibling is not None:
+            if sibling.end_point[0] < current_line - 1:
+                break
+            if sibling.type in _DOC_COMMENT_SKIP_TYPES:
+                current_line = sibling.start_point[0]
+                sibling = sibling.prev_sibling
+                continue
+            if sibling.type not in _DOC_COMMENT_NODE_TYPES:
+                break
+            siblings.append(sibling)
+            current_line = sibling.start_point[0]
+            sibling = sibling.prev_sibling
+
+        if not siblings:
+            return None
+
+        nearest = siblings[0].text.decode("utf-8", errors="replace").strip()
+        if nearest.startswith("/*"):
+            allowed = ("/**",) if language == "rust" else ("/**", "/*!")
+            if not nearest.startswith(allowed):
+                return None
+            return _strip_block_doc_comment(nearest)
+
+        # Work from the definition upward and stop at the first adjacent
+        # ordinary comment.  This attaches only the nearest documentation
+        # block and avoids hoovering unrelated implementation notes into it.
+        payloads: list[str] = []
+        for comment in siblings:
+            text = comment.text.decode("utf-8", errors="replace")
+            payload = self._line_doc_payload(text, language)
+            if payload is None:
+                break
+            if language == "go" and payload.startswith(("go:", "line ")):
+                continue
+            payloads.append(payload)
+        if not payloads:
+            return None
+        payloads.reverse()
+        return "\n".join(payloads)
+
     def _extract_classes(
         self,
         child,
@@ -5744,6 +5942,10 @@ class CodeParser:
         )
         if class_decorators and "decorators" not in extra:
             extra["decorators"] = class_decorators
+
+        docstring = self._get_docstring_summary(child, language)
+        if docstring:
+            extra["docstring"] = docstring
 
         node = NodeInfo(
             kind="Class",
@@ -5925,6 +6127,10 @@ class CodeParser:
         modifiers_str: Optional[str] = ",".join(deco_list) if deco_list else None
         if deco_list:
             method_extra["decorators"] = list(deco_list)
+
+        docstring = self._get_docstring_summary(child, language)
+        if docstring:
+            method_extra["docstring"] = docstring
 
         node = NodeInfo(
             kind=kind,

--- a/code_review_graph/postprocessing.py
+++ b/code_review_graph/postprocessing.py
@@ -8,6 +8,10 @@ post-processing steps must run to populate derived tables:
 3. Trace execution flows
 4. Detect code communities
 
+An embedding refresh can be added as an explicit fifth step by supplying an
+exact provider and model.  It is default-off because cloud providers transmit
+source-derived text and may incur API cost.
+
 This module extracts that pipeline so every entry point — MCP tool, CLI
 commands, and watch mode — produces identical results.
 """
@@ -23,7 +27,12 @@ from .graph import GraphStore
 logger = logging.getLogger(__name__)
 
 
-def run_post_processing(store: GraphStore) -> dict[str, Any]:
+def run_post_processing(
+    store: GraphStore,
+    *,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
+) -> dict[str, Any]:
     """Run all post-build steps on a populated graph.
 
     Each step is non-fatal: failures are logged and collected as warnings
@@ -43,6 +52,13 @@ def run_post_processing(store: GraphStore) -> dict[str, Any]:
     _rebuild_fts_index(store, result, warnings)
     _trace_flows(store, result, warnings)
     _detect_communities(store, result, warnings)
+    _refresh_embeddings(
+        store,
+        result,
+        warnings,
+        provider=embedding_provider,
+        model=embedding_model,
+    )
 
     if warnings:
         result["warnings"] = warnings
@@ -132,3 +148,34 @@ def _detect_communities(
     except (sqlite3.OperationalError, ImportError) as e:
         logger.warning("Community detection failed: %s", e)
         warnings.append(f"Community detection failed: {type(e).__name__}: {e}")
+
+
+def _refresh_embeddings(
+    store: GraphStore,
+    result: dict[str, Any],
+    warnings: list[str],
+    *,
+    provider: str | None,
+    model: str | None,
+) -> None:
+    """Run an explicitly requested embedding refresh without failing a build."""
+    if provider is None and model is None:
+        return
+    if not provider or not model:
+        warning = "Embedding refresh requires both an explicit provider and model."
+        logger.warning(warning)
+        warnings.append(warning)
+        return
+
+    try:
+        from .embeddings import refresh_embeddings
+
+        refreshed = refresh_embeddings(store, provider=provider, model=model)
+        if refreshed is not None:
+            result["embeddings_refreshed"] = refreshed["embedded"]
+            result["embeddings_purged"] = refreshed["purged"]
+    except Exception as exc:
+        logger.warning("Embedding refresh failed: %s", exc)
+        warnings.append(
+            f"Embedding refresh failed: {type(exc).__name__}: {exc}",
+        )

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -13,12 +13,44 @@ from ._common import _get_store
 logger = logging.getLogger(__name__)
 
 
+def _run_embedding_refresh(
+    store: Any,
+    result: dict[str, Any],
+    warnings: list[str],
+    *,
+    provider: str | None,
+    model: str | None,
+) -> None:
+    """Run a provider-scoped embedding refresh only when explicitly requested."""
+    if provider is None and model is None:
+        return
+    if not provider or not model:
+        warning = "Embedding refresh requires both an explicit provider and model."
+        logger.warning(warning)
+        warnings.append(warning)
+        return
+    try:
+        from code_review_graph.embeddings import refresh_embeddings
+
+        refreshed = refresh_embeddings(store, provider=provider, model=model)
+        if refreshed is not None:
+            result["embeddings_refreshed"] = refreshed["embedded"]
+            result["embeddings_purged"] = refreshed["purged"]
+    except Exception as exc:
+        logger.warning("Embedding refresh failed: %s", exc)
+        warnings.append(
+            f"Embedding refresh failed: {type(exc).__name__}: {exc}",
+        )
+
+
 def _run_postprocess(
     store: Any,
     build_result: dict[str, Any],
     postprocess: str,
     full_rebuild: bool = False,
     changed_files: list[str] | None = None,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
 ) -> list[str]:
     """Run post-build steps based on *postprocess* level.
 
@@ -36,6 +68,13 @@ def _run_postprocess(
     build_result["postprocess_level"] = postprocess
 
     if postprocess == "none":
+        _run_embedding_refresh(
+            store,
+            build_result,
+            warnings,
+            provider=embedding_provider,
+            model=embedding_model,
+        )
         return warnings
 
     # -- Signatures + FTS (fast, always run unless "none") --
@@ -86,6 +125,13 @@ def _run_postprocess(
     )
 
     if postprocess == "minimal":
+        _run_embedding_refresh(
+            store,
+            build_result,
+            warnings,
+            provider=embedding_provider,
+            model=embedding_model,
+        )
         build_result["postprocess_timing"] = timing
         return warnings
 
@@ -151,6 +197,13 @@ def _run_postprocess(
     timing["summaries_s"] = max(
         0.0,
         round(time.perf_counter() - stage_started, 6),
+    )
+    _run_embedding_refresh(
+        store,
+        build_result,
+        warnings,
+        provider=embedding_provider,
+        model=embedding_model,
     )
     build_result["postprocess_timing"] = timing
 
@@ -397,6 +450,8 @@ def build_or_update_graph(
     base: str = "HEAD~1",
     postprocess: str = "full",
     recurse_submodules: bool | None = None,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
 ) -> dict[str, Any]:
     """Build or incrementally update the code knowledge graph.
 
@@ -413,6 +468,12 @@ def build_or_update_graph(
             via ``git ls-files --recurse-submodules``. When None
             (default), falls back to the CRG_RECURSE_SUBMODULES
             environment variable. Default: disabled.
+        embedding_provider: Exact provider to use for an explicitly requested
+            post-build refresh. Must be supplied together with
+            ``embedding_model``; omitted by default so builds never transmit
+            source-derived text or load an embedding model unexpectedly.
+        embedding_model: Exact model for an explicitly requested post-build
+            embedding refresh. Must be supplied with ``embedding_provider``.
 
     Returns:
         Summary with files_parsed/updated, node/edge counts, and errors.
@@ -462,6 +523,8 @@ def build_or_update_graph(
             postprocess,
             full_rebuild=full_rebuild,
             changed_files=changed,
+            embedding_provider=embedding_provider,
+            embedding_model=embedding_model,
         )
         if warnings:
             build_result["warnings"] = warnings
@@ -475,6 +538,8 @@ def run_postprocess(
     communities: bool = True,
     fts: bool = True,
     repo_root: str | None = None,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
 ) -> dict[str, Any]:
     """Run post-processing steps on an existing graph.
 
@@ -487,6 +552,10 @@ def run_postprocess(
         communities: Run community detection. Default: True.
         fts: Rebuild FTS index. Default: True.
         repo_root: Repository root path. Auto-detected if omitted.
+        embedding_provider: Exact provider for an explicit refresh. Must be
+            supplied with ``embedding_model``. Default: disabled.
+        embedding_model: Exact model for an explicit refresh. Must be supplied
+            with ``embedding_provider``. Default: disabled.
 
     Returns:
         Summary of what was computed.
@@ -561,6 +630,14 @@ def run_postprocess(
                 store.rollback()
                 logger.warning("Community detection failed: %s", e)
                 warnings.append(f"Community detection failed: {type(e).__name__}: {e}")
+
+        _run_embedding_refresh(
+            store,
+            result,
+            warnings,
+            provider=embedding_provider,
+            model=embedding_model,
+        )
 
         store.set_metadata(
             "last_postprocessed_at",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -312,6 +312,8 @@ code-review-graph update --brief               # Update graph + show risk panel
 code-review-graph update --brief --verify      # ...and cross-check vs tiktoken
 code-review-graph postprocess                  # Re-run flows, communities, FTS
 code-review-graph embed --provider local       # Compute vector embeddings for semantic search
+code-review-graph update --embedding-provider local --embedding-model all-MiniLM-L6-v2
+                                                # Explicitly refresh an existing index (default: off)
 
 # Monitor and inspect
 code-review-graph status                       # Graph statistics

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -89,6 +89,22 @@ Then use `embed_graph_tool` to compute vectors. `semantic_search_nodes_tool` aut
 
 Embedding providers are local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, and MiniMax. Local embeddings use `CRG_EMBEDDING_MODEL`; OpenAI-compatible providers use `CRG_OPENAI_BASE_URL`, `CRG_OPENAI_API_KEY`, and `CRG_OPENAI_MODEL`. Cloud providers are opt-in and print an egress warning unless `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` is set.
 
+Function/class documentation summaries are included in embedding text. For a
+graph created by an older release, run a full build once before re-embedding so
+all files gain that metadata. Embedding refresh after build/update/watch is
+always default-off; opt in with an exact provider and model, for example:
+
+```bash
+code-review-graph build \
+  --embedding-provider local \
+  --embedding-model all-MiniLM-L6-v2
+```
+
+The same two options work with `update`, `postprocess`, and `watch`. They must be
+provided together. A refresh only updates a previously embedded graph, refuses
+to migrate vectors to a different provider/model/endpoint, purges deleted-node
+vectors, and degrades provider or transport failures to graph-build warnings.
+
 ### 7. Detect changes with risk scoring (v2)
 ```
 Ask your MCP client: "Review my recent changes with risk scoring"

--- a/tests/test_docstring_embeddings.py
+++ b/tests/test_docstring_embeddings.py
@@ -1,0 +1,282 @@
+"""Documentation summaries used by semantic embeddings."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from code_review_graph.embeddings import _node_to_text
+from code_review_graph.graph import GraphNode, GraphStore
+from code_review_graph.incremental import full_build, incremental_update
+from code_review_graph.parser import CodeParser
+
+
+def _parsed_node(path: str, source: bytes, name: str):
+    nodes, _ = CodeParser().parse_bytes(Path(path), source)
+    return next(node for node in nodes if node.name == name)
+
+
+class TestDocumentationSummaryExtraction:
+    def test_python_uses_runtime_string_value_and_first_paragraph(self):
+        node = _parsed_node(
+            "module.py",
+            (
+                b"def parse_rates():\n"
+                b'    (r"Parse\\n" " uploaded \\u20ac rate sheets.\\n\\nDetails.")\n'
+                b"    return []\n"
+            ),
+            "parse_rates",
+        )
+
+        assert node.extra["docstring"] == (r"Parse\n uploaded " + "\N{EURO SIGN} rate sheets.")
+
+    def test_python_rejects_bytes_and_fstrings(self):
+        for literal in (b'b"not docs"', b'f"not {1} docs"'):
+            node = _parsed_node(
+                "module.py",
+                b"def f():\n    " + literal + b"\n    return 1\n",
+                "f",
+            )
+            assert "docstring" not in node.extra
+
+    def test_python_class_and_method_docstrings_are_independent(self):
+        nodes, _ = CodeParser().parse_bytes(
+            Path("module.py"),
+            (
+                b"class Parser:\n"
+                b'    """Parses uploaded files."""\n'
+                b"\n"
+                b"    def run(self):\n"
+                b'        """Run one parse."""\n'
+                b"        return None\n"
+            ),
+        )
+        by_name = {node.name: node for node in nodes}
+
+        assert by_name["Parser"].extra["docstring"] == "Parses uploaded files."
+        assert by_name["run"].extra["docstring"] == "Run one parse."
+
+    def test_jsdoc_on_exported_function_and_blank_line_boundary(self):
+        documented = _parsed_node(
+            "module.ts",
+            b"/** Parse uploaded sheets. */\nexport function parse() {}\n",
+            "parse",
+        )
+        detached = _parsed_node(
+            "module.ts",
+            b"/** Module banner. */\n\nexport function parse() {}\n",
+            "parse",
+        )
+
+        assert documented.extra["docstring"] == "Parse uploaded sheets."
+        assert "docstring" not in detached.extra
+
+    def test_plain_javascript_comment_is_not_documentation(self):
+        node = _parsed_node(
+            "module.js",
+            b"// implementation note\nfunction parse() {}\n",
+            "parse",
+        )
+
+        assert "docstring" not in node.extra
+
+    def test_go_plain_comment_block_is_documentation(self):
+        node = _parsed_node(
+            "module.go",
+            (
+                b"package parser\n\n"
+                b"// Parse reads an uploaded sheet\n"
+                b"// and returns normalized rows.\n"
+                b"func Parse() {}\n"
+            ),
+            "Parse",
+        )
+
+        assert node.extra["docstring"] == (
+            "Parse reads an uploaded sheet and returns normalized rows."
+        )
+
+    def test_go_compiler_directive_is_not_embedding_text(self):
+        node = _parsed_node(
+            "module.go",
+            (
+                b"package parser\n\n"
+                b"// Parse reads an uploaded sheet.\n"
+                b"//go:noinline\n"
+                b"func Parse() {}\n"
+            ),
+            "Parse",
+        )
+
+        assert node.extra["docstring"] == "Parse reads an uploaded sheet."
+
+    def test_rust_outer_docs_cross_attributes_but_inner_docs_do_not_attach(self):
+        documented = _parsed_node(
+            "module.rs",
+            b"/// Parse a sheet.\n#[inline]\nfn parse() {}\n",
+            "parse",
+        )
+        inner = _parsed_node(
+            "module.rs",
+            b"//! Module documentation.\nfn parse() {}\n",
+            "parse",
+        )
+
+        assert documented.extra["docstring"] == "Parse a sheet."
+        assert "docstring" not in inner.extra
+
+    def test_javadoc_keeps_only_the_summary_paragraph(self):
+        node = _parsed_node(
+            "Parser.java",
+            (
+                b"class Parser {\n"
+                b"  /**\n"
+                b"   * Parse a rate sheet.\n"
+                b"   *\n"
+                b"   * @param path uploaded file\n"
+                b"   */\n"
+                b"  void parse(String path) {}\n"
+                b"}\n"
+            ),
+            "parse",
+        )
+
+        assert node.extra["docstring"] == "Parse a rate sheet."
+
+    def test_javadoc_html_paragraph_boundary_excludes_details(self):
+        node = _parsed_node(
+            "Parser.java",
+            (
+                b"class Parser {\n"
+                b"  /** Parse a {@code RateSheet}.\n"
+                b"   * <p>Implementation details must not be embedded.\n"
+                b"   */\n"
+                b"  void parse() {}\n"
+                b"}\n"
+            ),
+            "parse",
+        )
+
+        assert node.extra["docstring"] == "Parse a RateSheet."
+
+    def test_csharp_xml_summary_crosses_attribute(self):
+        node = _parsed_node(
+            "Parser.cs",
+            (
+                b"class Parser {\n"
+                b"  /// <summary>\n"
+                b"  /// Parse a rate sheet.\n"
+                b"  /// </summary>\n"
+                b"  [Obsolete]\n"
+                b"  public void Parse() {}\n"
+                b"}\n"
+            ),
+            "Parse",
+        )
+
+        assert node.extra["docstring"] == "Parse a rate sheet."
+
+    def test_doxygen_comment_attaches_to_cpp_template_function(self):
+        node = _parsed_node(
+            "parser.cpp",
+            (
+                b"/** Parse a typed sheet. */\n"
+                b"template <typename T>\n"
+                b"T parse(T value) { return value; }\n"
+            ),
+            "parse",
+        )
+
+        assert node.extra["docstring"] == "Parse a typed sheet."
+
+    def test_doxygen_brief_marker_is_not_embedded_as_prose(self):
+        node = _parsed_node(
+            "parser.cpp",
+            b"/** @brief Parse a typed sheet. */\nint parse() { return 0; }\n",
+            "parse",
+        )
+
+        assert node.extra["docstring"] == "Parse a typed sheet."
+
+    def test_summary_is_bounded_to_four_hundred_characters(self):
+        node = _parsed_node(
+            "module.py",
+            ('def f():\n    """' + ("word " * 200) + '"""\n').encode(),
+            "f",
+        )
+
+        assert len(node.extra["docstring"]) == 400
+
+
+class TestDocumentationEmbeddingText:
+    @staticmethod
+    def _node(extra: dict) -> GraphNode:
+        return GraphNode(
+            id=1,
+            kind="Function",
+            name="parse_rates",
+            qualified_name="module.py::parse_rates",
+            file_path="module.py",
+            line_start=1,
+            line_end=2,
+            language="python",
+            parent_name=None,
+            params=None,
+            return_type=None,
+            is_test=False,
+            file_hash=None,
+            extra=extra,
+        )
+
+    def test_text_includes_normalized_bounded_summary_deterministically(self):
+        summary = "  Parse\n uploaded\t rate sheets.  " + ("x" * 500)
+
+        first = _node_to_text(self._node({"docstring": summary}))
+        second = _node_to_text(self._node({"docstring": summary}))
+
+        assert first == second
+        assert "Parse uploaded rate sheets." in first
+        assert ("x" * 401) not in first
+
+    def test_non_string_legacy_metadata_is_ignored(self):
+        plain = _node_to_text(self._node({}))
+        malformed = _node_to_text(self._node({"docstring": {"unexpected": "shape"}}))
+
+        assert malformed == plain
+
+
+def test_docstring_metadata_survives_full_and_incremental_persistence(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "module.py"
+    source.write_text('def parse():\n    """Old summary."""\n', encoding="utf-8")
+    store = GraphStore(tmp_path / "graph.db")
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+
+    try:
+        with patch(
+            "code_review_graph.incremental.collect_all_files",
+            return_value=["module.py"],
+        ):
+            full_build(repo, store)
+        full_node = next(
+            node for node in store.get_nodes_by_file(str(source)) if node.name == "parse"
+        )
+        assert full_node.extra["docstring"] == "Old summary."
+
+        source.write_text('def parse():\n    """New summary."""\n', encoding="utf-8")
+        incremental_update(repo, store, changed_files=["module.py"])
+        changed_node = next(
+            node for node in store.get_nodes_by_file(str(source)) if node.name == "parse"
+        )
+        assert changed_node.extra["docstring"] == "New summary."
+
+        source.write_text("def parse():\n    return None\n", encoding="utf-8")
+        incremental_update(repo, store, changed_files=["module.py"])
+        removed_node = next(
+            node for node in store.get_nodes_by_file(str(source)) if node.name == "parse"
+        )
+        assert "docstring" not in removed_node.extra
+    finally:
+        store.close()

--- a/tests/test_embedding_refresh.py
+++ b/tests/test_embedding_refresh.py
@@ -1,0 +1,442 @@
+"""Explicit, provider-scoped embedding refresh and orphan cleanup."""
+
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_review_graph.embeddings import EmbeddingStore, embed_all_nodes
+from code_review_graph.graph import GraphStore
+from code_review_graph.parser import NodeInfo
+from code_review_graph.postprocessing import run_post_processing
+from code_review_graph.tools.build import _run_postprocess
+
+
+class _StubProvider:
+    dimension = 2
+
+    def __init__(self, name: str = "local:test-model") -> None:
+        self.name = name
+        self.embedded: list[str] = []
+
+    def embed(self, texts):
+        self.embedded.extend(texts)
+        return [[float(len(text)), 1.0] for text in texts]
+
+    def embed_query(self, text):
+        return [1.0, 0.0]
+
+
+def _graph_with_function(tmp_path):
+    db = tmp_path / "graph.db"
+    store = GraphStore(db)
+    file_path = str(tmp_path / "module.py")
+    store.upsert_node(
+        NodeInfo(
+            kind="File",
+            name=file_path,
+            file_path=file_path,
+            line_start=1,
+            line_end=20,
+            language="python",
+        )
+    )
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name="keep",
+            file_path=file_path,
+            line_start=1,
+            line_end=2,
+            language="python",
+        )
+    )
+    store.commit()
+    return store, file_path
+
+
+class TestOrphanCleanup:
+    def test_purge_removes_only_vectors_without_graph_nodes(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        provider = _StubProvider()
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider):
+            embeddings = EmbeddingStore(graph.db_path, provider="local", model="test-model")
+        embeddings.embed_nodes(graph.get_all_nodes(exclude_files=False))
+        embeddings._conn.execute(
+            "INSERT INTO embeddings (qualified_name, vector, text_hash, provider) "
+            "VALUES (?, ?, ?, ?)",
+            ("deleted.py::ghost", b"\x00" * 8, "old", provider.name),
+        )
+        embeddings._conn.commit()
+
+        try:
+            assert embeddings.purge_orphans() == 1
+            remaining = embeddings._conn.execute(
+                "SELECT qualified_name FROM embeddings ORDER BY qualified_name",
+            ).fetchall()
+            assert [row["qualified_name"] for row in remaining] == [
+                f"{tmp_path / 'module.py'}::keep",
+            ]
+        finally:
+            embeddings.close()
+            graph.close()
+
+    def test_purge_is_safe_without_a_nodes_table(self, tmp_path):
+        with patch("code_review_graph.embeddings.get_provider", return_value=None):
+            embeddings = EmbeddingStore(tmp_path / "standalone.db")
+        try:
+            assert embeddings.purge_orphans() == 0
+        finally:
+            embeddings.close()
+
+    def test_manual_embed_purges_even_when_provider_is_unavailable(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        with patch("code_review_graph.embeddings.get_provider", return_value=None):
+            embeddings = EmbeddingStore(graph.db_path)
+        embeddings._conn.execute(
+            "INSERT INTO embeddings (qualified_name, vector, text_hash, provider) "
+            "VALUES ('deleted.py::ghost', ?, 'old', 'unknown')",
+            (b"\x00" * 8,),
+        )
+        embeddings._conn.commit()
+
+        try:
+            assert embed_all_nodes(graph, embeddings) == 0
+            assert embeddings.count() == 0
+        finally:
+            embeddings.close()
+            graph.close()
+
+
+class TestExplicitRefresh:
+    def test_never_embedded_graph_skips_without_resolving_provider(self, tmp_path):
+        from code_review_graph.embeddings import refresh_embeddings
+
+        graph, _ = _graph_with_function(tmp_path)
+        try:
+            with patch("code_review_graph.embeddings.get_provider") as get_provider:
+                assert (
+                    refresh_embeddings(
+                        graph,
+                        provider="openai",
+                        model="costly-model",
+                    )
+                    is None
+                )
+            get_provider.assert_not_called()
+        finally:
+            graph.close()
+
+    def test_exact_provider_refreshes_changed_nodes_and_purges_orphans(self, tmp_path):
+        from code_review_graph.embeddings import refresh_embeddings
+
+        graph, file_path = _graph_with_function(tmp_path)
+        provider = _StubProvider()
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider):
+            embeddings = EmbeddingStore(graph.db_path, provider="local", model="test-model")
+            embeddings.embed_nodes(graph.get_all_nodes(exclude_files=False))
+            embeddings._conn.execute(
+                "INSERT INTO embeddings (qualified_name, vector, text_hash, provider) "
+                "VALUES ('deleted.py::ghost', ?, 'old', ?)",
+                (b"\x00" * 8, provider.name),
+            )
+            embeddings._conn.commit()
+            embeddings.close()
+
+            graph.upsert_node(
+                NodeInfo(
+                    kind="Function",
+                    name="added",
+                    file_path=file_path,
+                    line_start=4,
+                    line_end=5,
+                    language="python",
+                )
+            )
+            graph.commit()
+            result = refresh_embeddings(
+                graph,
+                provider="local",
+                model="test-model",
+            )
+
+        try:
+            assert result == {"embedded": 1, "purged": 1}
+        finally:
+            graph.close()
+
+    def test_provider_identity_mismatch_refuses_migration(self, tmp_path):
+        from code_review_graph.embeddings import refresh_embeddings
+
+        graph, _ = _graph_with_function(tmp_path)
+        original = _StubProvider("local:original-model")
+        with patch("code_review_graph.embeddings.get_provider", return_value=original):
+            embeddings = EmbeddingStore(graph.db_path)
+            embeddings.embed_nodes(graph.get_all_nodes(exclude_files=False))
+            embeddings.close()
+
+        requested = _StubProvider("local:new-model")
+        try:
+            with patch(
+                "code_review_graph.embeddings.get_provider",
+                return_value=requested,
+            ):
+                with pytest.raises(ValueError, match="existing embeddings use"):
+                    refresh_embeddings(
+                        graph,
+                        provider="local",
+                        model="new-model",
+                    )
+            assert requested.embedded == []
+        finally:
+            graph.close()
+
+    def test_legacy_rows_without_provider_identity_are_refused_precisely(self, tmp_path):
+        from code_review_graph.embeddings import refresh_embeddings
+
+        graph, _ = _graph_with_function(tmp_path)
+        graph._conn.executescript(
+            "CREATE TABLE embeddings ("
+            "qualified_name TEXT PRIMARY KEY, vector BLOB NOT NULL, "
+            "text_hash TEXT NOT NULL"
+            ");"
+        )
+        graph._conn.execute(
+            "INSERT INTO embeddings (qualified_name, vector, text_hash) "
+            "VALUES (?, ?, ?)",
+            (f"{tmp_path / 'module.py'}::keep", b"\x00" * 8, "old"),
+        )
+        graph.commit()
+
+        try:
+            with patch("code_review_graph.embeddings.get_provider") as get_provider:
+                with pytest.raises(ValueError, match="provider identity"):
+                    refresh_embeddings(
+                        graph,
+                        provider="local",
+                        model="test-model",
+                    )
+            get_provider.assert_not_called()
+        finally:
+            graph.close()
+
+
+class TestRefreshWiring:
+    def test_shared_postprocessing_is_default_off(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        try:
+            with patch(
+                "code_review_graph.embeddings.refresh_embeddings",
+            ) as refresh:
+                run_post_processing(graph)
+            refresh.assert_not_called()
+        finally:
+            graph.close()
+
+    def test_shared_postprocessing_refresh_is_explicit_and_fail_soft(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        try:
+            with patch(
+                "code_review_graph.embeddings.refresh_embeddings",
+                return_value={"embedded": 3, "purged": 2},
+            ) as refresh:
+                result = run_post_processing(
+                    graph,
+                    embedding_provider="local",
+                    embedding_model="test-model",
+                )
+            refresh.assert_called_once_with(
+                graph,
+                provider="local",
+                model="test-model",
+            )
+            assert result["embeddings_refreshed"] == 3
+            assert result["embeddings_purged"] == 2
+
+            with patch(
+                "code_review_graph.embeddings.refresh_embeddings",
+                side_effect=RuntimeError("provider unavailable offline"),
+            ):
+                failed = run_post_processing(
+                    graph,
+                    embedding_provider="local",
+                    embedding_model="test-model",
+                )
+            assert any("provider unavailable offline" in warning for warning in failed["warnings"])
+        finally:
+            graph.close()
+
+    def test_build_postprocess_is_default_off_and_explicit_at_every_level(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        try:
+            with patch(
+                "code_review_graph.embeddings.refresh_embeddings",
+                return_value={"embedded": 1, "purged": 1},
+            ) as refresh:
+                default_result: dict = {}
+                _run_postprocess(graph, default_result, "none")
+                refresh.assert_not_called()
+
+                explicit_result: dict = {}
+                _run_postprocess(
+                    graph,
+                    explicit_result,
+                    "none",
+                    embedding_provider="local",
+                    embedding_model="test-model",
+                )
+            refresh.assert_called_once_with(
+                graph,
+                provider="local",
+                model="test-model",
+            )
+            assert explicit_result["embeddings_refreshed"] == 1
+            assert explicit_result["embeddings_purged"] == 1
+        finally:
+            graph.close()
+
+    def test_partial_provider_scope_warns_without_attempting_refresh(self, tmp_path):
+        graph, _ = _graph_with_function(tmp_path)
+        try:
+            with patch(
+                "code_review_graph.embeddings.refresh_embeddings",
+            ) as refresh:
+                result = run_post_processing(
+                    graph,
+                    embedding_provider="local",
+                )
+            refresh.assert_not_called()
+            assert any("provider and model" in warning.lower() for warning in result["warnings"])
+        finally:
+            graph.close()
+
+    def test_missing_cloud_credentials_are_a_warning_not_a_build_failure(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        graph, _ = _graph_with_function(tmp_path)
+        with patch("code_review_graph.embeddings.get_provider", return_value=None):
+            embeddings = EmbeddingStore(graph.db_path)
+        embeddings._conn.execute(
+            "INSERT INTO embeddings (qualified_name, vector, text_hash, provider) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                f"{tmp_path / 'module.py'}::keep",
+                b"\x00" * 8,
+                "old",
+                "openai:test-model@https://api.example.test/v1",
+            ),
+        )
+        embeddings._conn.commit()
+        embeddings.close()
+        for variable in (
+            "CRG_OPENAI_API_KEY",
+            "CRG_OPENAI_BASE_URL",
+            "CRG_OPENAI_MODEL",
+        ):
+            monkeypatch.delenv(variable, raising=False)
+
+        try:
+            result = run_post_processing(
+                graph,
+                embedding_provider="openai",
+                embedding_model="test-model",
+            )
+            assert result["signatures_computed"] == 2
+            assert any(
+                "Missing required environment" in warning
+                for warning in result["warnings"]
+            )
+        finally:
+            graph.close()
+
+    def test_mcp_build_and_postprocess_forward_exact_scope(self):
+        from code_review_graph import main as crg_main
+
+        build_tool = getattr(
+            crg_main.build_or_update_graph_tool,
+            "fn",
+            crg_main.build_or_update_graph_tool,
+        )
+        postprocess_tool = getattr(
+            crg_main.run_postprocess_tool,
+            "fn",
+            crg_main.run_postprocess_tool,
+        )
+        with (
+            patch.object(
+                crg_main,
+                "with_provenance",
+                side_effect=lambda result, _root: result,
+            ),
+            patch.object(
+                crg_main,
+                "build_or_update_graph",
+                return_value={"status": "ok"},
+            ) as build,
+            patch.object(
+                crg_main,
+                "run_postprocess",
+                return_value={"status": "ok"},
+            ) as postprocess,
+        ):
+            asyncio.run(
+                build_tool(
+                    repo_root="/repo",
+                    embedding_provider="local",
+                    embedding_model="test-model",
+                )
+            )
+            asyncio.run(
+                postprocess_tool(
+                    repo_root="/repo",
+                    embedding_provider="local",
+                    embedding_model="test-model",
+                )
+            )
+
+        assert build.call_args.kwargs["embedding_provider"] == "local"
+        assert build.call_args.kwargs["embedding_model"] == "test-model"
+        assert postprocess.call_args.kwargs["embedding_provider"] == "local"
+        assert postprocess.call_args.kwargs["embedding_model"] == "test-model"
+
+    def test_cli_build_forwards_exact_scope(self):
+        from code_review_graph import cli
+
+        argv = [
+            "code-review-graph",
+            "build",
+            "--repo",
+            "repo-root",
+            "--embedding-provider",
+            "local",
+            "--embedding-model",
+            "test-model",
+        ]
+        result = {"files_parsed": 1, "total_nodes": 2, "total_edges": 1}
+        with (
+            patch.object(sys, "argv", argv),
+            patch(
+                "code_review_graph.graph.GraphStore",
+            ) as graph_store,
+            patch(
+                "code_review_graph.incremental.get_db_path",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "code_review_graph.tools.build.build_or_update_graph",
+                return_value=result,
+            ) as build,
+        ):
+            graph_store.return_value = MagicMock()
+            cli.main()
+
+        build.assert_called_once_with(
+            full_rebuild=True,
+            repo_root="repo-root",
+            postprocess="full",
+            embedding_provider="local",
+            embedding_model="test-model",
+        )


### PR DESCRIPTION
## Summary

This is the current-main replacement for the compatible parts of #602 and #599. It preserves Stefan Hudici's authorship with a `Co-authored-by` trailer.

### Adopted from #602

- store first-paragraph function/class documentation in the existing `extra` JSON field (no schema migration)
- include the summary deterministically in semantic embedding text
- support Python docstrings, JSDoc/Javadoc/Doxygen, C# XML docs, Rust outer docs, and Go doc comments

The port additionally fixes Python escape/concatenation semantics with `ast.literal_eval`, strips documentation markup, handles exported/template-wrapped declarations and Go directives, enforces a 400-character bound both at parse and provider-input time, and verifies full-build plus incremental persistence/removal.

### Adopted and safety-adjusted from #599

- purge embeddings for deleted or renamed graph nodes
- keep hash-incremental refresh and exact provider identity checks
- surface refresh/purge counts without failing graph builds

The source branch's default refresh wiring was intentionally not carried over. Build, update, postprocess, and watch remain default-off. Refresh occurs only when that specific invocation supplies both an exact provider and model. A never-embedded graph returns before provider resolution; an existing index must match the resolved provider/model/endpoint exactly; mixed, legacy, or mismatched identities are refused; missing credentials, offline model availability, and transport errors become build warnings. Manual `embed` also purges orphans, even when the local provider is unavailable.

## Verification

Exact base: `4f9f035b49515fa79e4c084aafb10828d607ba7b`

- focused parser/embedding/tool/CLI/MCP tests: **411 passed, 1 skipped**
- complete non-daemon suite after final rebase: **1684 passed, 1 skipped, 2 xpassed**
- Ruff: clean
- mypy (63 source files): clean
- Bandit: zero findings
- `git diff --check`: clean

The native macOS daemon/watcher test file remains excluded locally because the unchanged baseline crashes in the platform FSEvents layer; GitHub CI will run the repository's normal cross-platform matrix.