### PR TITLE
fix: serialize lazy local embedding initialization (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Fixed
 
+- Serialized first-use local embedding dependency imports and model construction
+  across MCP worker threads. POSIX startup remains lazy, failed loads are not
+  cached, and Windows retains its main-thread prewarm (#610, replacing PR #611).
 - Incremental Git change discovery now reads NUL-delimited byte output, so
   Unicode, whitespace, newline, and literal arrow paths are preserved while
   rename/copy records keep destination-only semantics (PR #618).

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -17,6 +17,7 @@ import re
 import sqlite3
 import struct
 import sys
+import threading
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -66,7 +67,10 @@ class EmbeddingProvider(ABC):
 LOCAL_DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
 
-# Process-wide cache of loaded sentence-transformer models, keyed by model name.
+# Process-wide cache and initialization lock for sentence-transformer models.
+# The dependency import itself touches process-global Torch state, so one lock
+# must cover availability checks, imports, and model construction across every
+# model name. A per-model lock would still allow two first imports to race.
 # Populated by ``prewarm_local_embeddings()`` at server startup (see ``main.main``)
 # and by ``LocalEmbeddingProvider._get_model`` on first lazy load. Sharing the
 # loaded model across ``LocalEmbeddingProvider`` instances avoids re-importing
@@ -75,6 +79,7 @@ LOCAL_DEFAULT_MODEL = "all-MiniLM-L6-v2"
 # tools via ``asyncio.to_thread``; this cache fixes the remaining case where
 # torch DLL / OpenMP init runs inside an executor thread).
 _MODEL_CACHE: dict[str, Any] = {}
+_MODEL_INIT_LOCK = threading.RLock()
 
 
 def prewarm_local_embeddings(model_name: str | None = None) -> None:
@@ -93,19 +98,13 @@ def prewarm_local_embeddings(model_name: str | None = None) -> None:
         model_name: Optional override; falls back to the ``CRG_EMBEDDING_MODEL``
             environment variable and then to ``LOCAL_DEFAULT_MODEL``.
     """
-    try:
-        from sentence_transformers import SentenceTransformer  # noqa: F401
-    except ImportError:
-        return  # cloud-only setup: nothing to pre-warm
-
     resolved = model_name or os.environ.get(
         "CRG_EMBEDDING_MODEL", LOCAL_DEFAULT_MODEL
     )
-    if resolved in _MODEL_CACHE:
-        return
-
     try:
-        _MODEL_CACHE[resolved] = LocalEmbeddingProvider(resolved)._get_model()
+        LocalEmbeddingProvider(resolved)._get_model()
+    except ImportError:
+        return  # cloud-only setup: nothing to pre-warm
     except Exception as exc:  # pragma: no cover — best-effort startup hook
         logger.warning("prewarm_local_embeddings(%s) skipped: %s", resolved, exc)
 
@@ -118,29 +117,45 @@ class LocalEmbeddingProvider(EmbeddingProvider):
         self._model = None  # Lazy-loaded
 
     def _get_model(self):
-        if self._model is None:
-            # Check the process-wide cache first — populated either by a prior
-            # provider instance or by ``prewarm_local_embeddings`` at startup.
+        if self._model is not None:
+            return self._model
+
+        # Fast path for a model fully published by another provider instance.
+        cached = _MODEL_CACHE.get(self._model_name)
+        if cached is not None:
+            self._model = cached
+            return self._model
+
+        with _MODEL_INIT_LOCK:
+            # A competing caller may have initialized this provider or cache
+            # entry while we waited. Recheck both under the process-wide lock.
+            if self._model is not None:
+                return self._model
             cached = _MODEL_CACHE.get(self._model_name)
             if cached is not None:
                 self._model = cached
                 return self._model
+
             try:
                 from sentence_transformers import SentenceTransformer
                 # Check environment variable, default to False to prevent RCE
                 _rce_val = os.environ.get("CRG_ALLOW_REMOTE_CODE", "0")
                 allow_remote_code = _rce_val.lower() in ("1", "true", "yes")
 
-                self._model = SentenceTransformer(
+                model = SentenceTransformer(
                     self._model_name,
                     trust_remote_code=allow_remote_code,
                 )
-                _MODEL_CACHE[self._model_name] = self._model
             except ImportError:
                 raise ImportError(
                     "sentence-transformers not installed. "
                     "Run: pip install code-review-graph[embeddings]"
                 )
+
+            # Publish only a fully constructed model. Failed attempts leave
+            # both the provider and shared cache empty so a waiter can retry.
+            _MODEL_CACHE[self._model_name] = model
+            self._model = model
         return self._model
 
     def embed(self, texts: list[str]) -> list[list[float]]:
@@ -733,11 +748,12 @@ def get_provider(
 
 def _check_available() -> bool:
     """Check whether local embedding support is available."""
-    try:
-        import sentence_transformers  # noqa: F401
-        return True
-    except ImportError:
-        return False
+    with _MODEL_INIT_LOCK:
+        try:
+            import sentence_transformers  # noqa: F401
+            return True
+        except ImportError:
+            return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embedding_initialization.py
+++ b/tests/test_embedding_initialization.py
@@ -1,0 +1,266 @@
+"""Concurrency regression tests for local embedding initialization (#610)."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Callable
+
+import pytest
+
+from code_review_graph import embeddings
+from code_review_graph import main as crg_main
+
+
+@pytest.fixture(autouse=True)
+def _isolate_model_cache():
+    """Keep the process-wide model cache deterministic across tests."""
+    original = dict(embeddings._MODEL_CACHE)
+    embeddings._MODEL_CACHE.clear()
+    yield
+    embeddings._MODEL_CACHE.clear()
+    embeddings._MODEL_CACHE.update(original)
+
+
+def _fake_sentence_transformers(
+    constructor: Callable[..., Any],
+) -> ModuleType:
+    module = ModuleType("sentence_transformers")
+    module.SentenceTransformer = constructor
+    return module
+
+
+def _run_in_thread(
+    target: Callable[[], Any],
+    results: list[Any],
+    errors: list[BaseException],
+) -> threading.Thread:
+    def run() -> None:
+        try:
+            results.append(target())
+        except BaseException as exc:  # noqa: BLE001 - captured for test assertion
+            errors.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    return thread
+
+
+def test_availability_import_and_model_load_do_not_overlap(monkeypatch):
+    """All first-use dependency imports share one process-wide lock."""
+    original_import = builtins.__import__
+    first_import_entered = threading.Event()
+    release_first_import = threading.Event()
+    overlapping_import = threading.Event()
+    state_lock = threading.Lock()
+    active_imports = 0
+    import_calls = 0
+    model = object()
+    fake_module = _fake_sentence_transformers(lambda *_args, **_kwargs: model)
+
+    def tracked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal active_imports, import_calls
+        if name != "sentence_transformers":
+            return original_import(name, globals, locals, fromlist, level)
+
+        with state_lock:
+            import_calls += 1
+            active_imports += 1
+            if active_imports > 1:
+                overlapping_import.set()
+            is_first = import_calls == 1
+        if is_first:
+            first_import_entered.set()
+            release_first_import.wait(timeout=2)
+        with state_lock:
+            active_imports -= 1
+        return fake_module
+
+    monkeypatch.setattr(builtins, "__import__", tracked_import)
+    results: list[Any] = []
+    errors: list[BaseException] = []
+    provider = embeddings.LocalEmbeddingProvider("test-model")
+
+    availability_thread = _run_in_thread(
+        embeddings._check_available, results, errors,
+    )
+    assert first_import_entered.wait(timeout=1)
+    model_thread = _run_in_thread(provider._get_model, results, errors)
+
+    overlap_seen = overlapping_import.wait(timeout=0.5)
+    release_first_import.set()
+    availability_thread.join(timeout=2)
+    model_thread.join(timeout=2)
+
+    assert not availability_thread.is_alive()
+    assert not model_thread.is_alive()
+    assert errors == []
+    assert overlap_seen is False
+    assert True in results
+    assert model in results
+
+
+def test_concurrent_first_model_calls_wait_construct_once_and_share(monkeypatch):
+    """The losing caller waits and receives the first caller's model."""
+    first_constructor_entered = threading.Event()
+    release_constructor = threading.Event()
+    duplicate_constructor = threading.Event()
+    state_lock = threading.Lock()
+    constructor_calls = 0
+    constructed_models: list[object] = []
+
+    def construct(_name: str, **_kwargs):
+        nonlocal constructor_calls
+        with state_lock:
+            constructor_calls += 1
+            call_number = constructor_calls
+        if call_number == 1:
+            first_constructor_entered.set()
+        else:
+            duplicate_constructor.set()
+        release_constructor.wait(timeout=2)
+        model = object()
+        constructed_models.append(model)
+        return model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        _fake_sentence_transformers(construct),
+    )
+    first = embeddings.LocalEmbeddingProvider("test-model")
+    second = embeddings.LocalEmbeddingProvider("test-model")
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    first_thread = _run_in_thread(first._get_model, results, errors)
+    assert first_constructor_entered.wait(timeout=1)
+    second_thread = _run_in_thread(second._get_model, results, errors)
+
+    duplicate_seen = duplicate_constructor.wait(timeout=0.5)
+    release_constructor.set()
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+    assert duplicate_seen is False
+    assert constructor_calls == 1
+    assert len(constructed_models) == 1
+    assert results == [constructed_models[0], constructed_models[0]]
+    assert embeddings._MODEL_CACHE["test-model"] is constructed_models[0]
+
+
+def test_failed_model_construction_is_not_cached_and_retry_succeeds(monkeypatch):
+    """A failed attempt publishes nothing and the same provider can retry."""
+    attempts = 0
+    recovered_model = object()
+
+    def construct(_name: str, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("model load failed")
+        return recovered_model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        _fake_sentence_transformers(construct),
+    )
+    provider = embeddings.LocalEmbeddingProvider("flaky-model")
+
+    with pytest.raises(RuntimeError, match="model load failed"):
+        provider._get_model()
+
+    assert provider._model is None
+    assert "flaky-model" not in embeddings._MODEL_CACHE
+    assert provider._get_model() is recovered_model
+    assert provider._model is recovered_model
+    assert embeddings._MODEL_CACHE["flaky-model"] is recovered_model
+    assert attempts == 2
+
+
+def test_model_cache_remains_scoped_by_model_name(monkeypatch):
+    """Serializing initialization must not mix distinct model identities."""
+    constructed: dict[str, object] = {}
+
+    def construct(name: str, **_kwargs):
+        model = object()
+        constructed[name] = model
+        return model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        _fake_sentence_transformers(construct),
+    )
+
+    alpha = embeddings.LocalEmbeddingProvider("alpha")._get_model()
+    beta = embeddings.LocalEmbeddingProvider("beta")._get_model()
+    alpha_again = embeddings.LocalEmbeddingProvider("alpha")._get_model()
+
+    assert alpha is constructed["alpha"]
+    assert beta is constructed["beta"]
+    assert alpha is not beta
+    assert alpha_again is alpha
+    assert set(embeddings._MODEL_CACHE) == {"alpha", "beta"}
+
+
+def test_posix_server_start_does_not_prewarm_local_embeddings(monkeypatch, tmp_path):
+    """Unused local embeddings impose no model import/load cost on POSIX."""
+    events: list[str] = []
+    monkeypatch.delenv("CRG_TOOLS", raising=False)
+    monkeypatch.setattr(crg_main, "_default_repo_root", None)
+    monkeypatch.setattr(crg_main.sys, "platform", "linux")
+    monkeypatch.setattr(
+        embeddings,
+        "prewarm_local_embeddings",
+        lambda: events.append("prewarm"),
+    )
+    monkeypatch.setattr(
+        crg_main.mcp,
+        "run",
+        lambda **_kwargs: events.append("run"),
+    )
+
+    crg_main.main(repo_root=str(tmp_path))
+
+    assert events == ["run"]
+
+
+def test_windows_server_still_prewarms_before_mcp_run(monkeypatch, tmp_path):
+    """Windows retains main-thread prewarm for its worker-thread deadlock."""
+    events: list[str] = []
+    policy = object()
+    monkeypatch.delenv("CRG_TOOLS", raising=False)
+    monkeypatch.setattr(crg_main, "_default_repo_root", None)
+    monkeypatch.setattr(crg_main.sys, "platform", "win32")
+    monkeypatch.setattr(
+        crg_main.asyncio,
+        "WindowsSelectorEventLoopPolicy",
+        lambda: policy,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        crg_main.asyncio,
+        "set_event_loop_policy",
+        lambda value: events.append("policy") if value is policy else None,
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "prewarm_local_embeddings",
+        lambda: events.append("prewarm"),
+    )
+    monkeypatch.setattr(
+        crg_main.mcp,
+        "run",
+        lambda **_kwargs: events.append("run"),
+    )
+
+    crg_main.main(repo_root=str(tmp_path))
+
+    assert events == ["policy", "prewarm", "run"]


### PR DESCRIPTION
## Summary

This is a concurrency-safe replacement for source PR #611 and addresses issue #610 without imposing unconditional local-model startup work on macOS or Linux. FRONT-JB's diagnosis and contribution are preserved through the commit's `Co-authored-by` trailer.

## Root cause

Local provider availability checks and `LocalEmbeddingProvider._get_model()` could both import `sentence_transformers` / Torch from independent MCP executor threads. The process-wide model cache also used an unsynchronized check-then-construct path. Concurrent first calls could therefore overlap the process-global Torch import, construct the same model twice, or leave callers observing a failed partial initialization.

## Change

- add one process-wide `threading.RLock` shared by dependency availability imports and first model construction
- double-check provider and model-cache state after acquiring the lock
- publish a model to the instance and shared cache only after construction succeeds
- leave failed attempts uncached so a waiter or later call can retry
- preserve cache identity by model name
- retain the existing Windows main-thread prewarm
- retain lazy POSIX startup, so unused embeddings do not import Torch or load/download a model

## Source PR #611 disposition

Adopted:
- the reproduced POSIX concurrent-first-import defect
- the requirement that Torch/sentence-transformers initialization cannot race across MCP workers
- contributor attribution

Not adopted:
- unconditional prewarm on every platform. That moves model import/load cost to every server startup even when embeddings are unused, and can trigger local model resolution/download work before explicit use.

The replacement serializes first use instead; Windows keeps prewarm because its separate worker-thread DLL/OpenMP deadlock requires main-thread initialization.

## Verification

Exact base: `d7e0fd8db6d8d567cd026e6987040a754e85db11`

- regression tests were written first and failed on overlapping imports plus duplicate construction
- focused initialization/embedding/MCP tests: **137 passed**
- complete non-daemon suite: **1662 passed, 1 skipped, 2 xpassed**
- Ruff: clean
- mypy: clean across 63 source files
- Bandit: zero findings
- `git diff --check`: clean

The unchanged native macOS daemon/FSEvents test file is excluded locally; the repository's dedicated Windows daemon/file-handle CI job remains the platform-native verification gate.
