### PR TITLE
feat(platform): validate IBM Bob in real clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   repeated implementation blocks. Nested/aliased `use` trees, `Self` and
   turbofish calls, and bounded cached Cargo path/workspace dependency resolution
   now retain their original graph targets (replacing PR #526).
+- Added IBM Bob Shell and Bob IDE MCP installation using their distinct,
+  documented configuration paths and command-based STDIO schema (PR #540).
 - Added an explicit local JSON visualization export. The output is written
   atomically inside the ignored graph data directory and is documented as
   potentially containing absolute paths and code-structure metadata (PR #449).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ code-review-graph build            # parse your codebase
 One command sets up everything. `install` detects which AI coding tools you have, writes the correct MCP configuration for each one, installs platform-native hooks/skills where supported, and injects graph-aware instructions into your platform rules. It auto-detects whether you installed via `uvx` or `pip`/`pipx` and generates the right config. Restart your editor/tool after installing.
 
 <p align="center">
-  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, and GitHub Copilot" width="85%" />
+  <img src="diagrams/diagram8_supported_platforms.png" alt="One Install, Every Platform: auto-detects Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, IBM Bob, and GitHub Copilot" width="85%" />
 </p>
 
 To target a specific platform:
@@ -68,6 +68,8 @@ code-review-graph install --platform gemini-cli   # configure only Gemini CLI
 code-review-graph install --platform kiro         # configure only Kiro
 code-review-graph install --platform copilot      # configure only GitHub Copilot (VS Code)
 code-review-graph install --platform copilot-cli  # configure only GitHub Copilot CLI
+code-review-graph install --platform bob-shell    # configure only IBM Bob Shell
+code-review-graph install --platform bob-ide      # configure only IBM Bob IDE
 code-review-graph install --platform codebuddy    # configure only CodeBuddy Code
 ```
 
@@ -677,5 +679,5 @@ MIT. See [LICENSE](LICENSE).
 <br>
 <a href="https://code-review-graph.com">code-review-graph.com</a><br><br>
 <code>pip install code-review-graph && code-review-graph install</code><br>
-<sub>Works with Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, GitHub Copilot, and GitHub Copilot CLI</sub>
+<sub>Works with Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, IBM Bob Shell, IBM Bob IDE, GitHub Copilot, and GitHub Copilot CLI</sub>
 </p>

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_CHOICES = [
     "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
     "continue", "opencode", "antigravity", "gemini-cli", "qwen", "kiro", "qoder",
-    "copilot", "copilot-cli", "codebuddy", "all",
+    "copilot", "copilot-cli", "bob-shell", "bob-ide", "codebuddy", "all",
 ]
 
 

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -154,6 +154,27 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "format": "object",
         "needs_type": True,
     },
+    # IBM Bob keeps Shell and IDE global configuration in distinct files;
+    # both use mcpServers entries without a synthetic "type": "stdio" field.
+    # https://bob.ibm.com/docs/shell/configuration/mcp/mcp-bobshell
+    # https://bob.ibm.com/docs/ide/configuration/mcp/mcp-in-bob
+    "bob-shell": {
+        "name": "Bob Shell",
+        "config_path": lambda root: Path.home() / ".bob" / "mcp_settings.json",
+        "key": "mcpServers",
+        "detect": lambda: bool(shutil.which("bob"))
+        or (Path.home() / ".bob" / "mcp_settings.json").exists(),
+        "format": "object",
+        "needs_type": False,
+    },
+    "bob-ide": {
+        "name": "Bob IDE",
+        "config_path": lambda root: root / ".bob" / "mcp.json",
+        "key": "mcpServers",
+        "detect": lambda: (Path.home() / ".bob" / "mcp.json").exists(),
+        "format": "object",
+        "needs_type": False,
+    },
     "codebuddy": {
         "name": "CodeBuddy Code",
         "config_path": lambda root: root / ".mcp.json",
@@ -430,6 +451,11 @@ def install_platform_configs(
         # Workspace-level Kiro detection
         if "kiro" not in platforms_to_install and (repo_root / ".kiro").is_dir():
             platforms_to_install["kiro"] = PLATFORMS["kiro"]
+        # Bob IDE and Bob Shell both use the workspace .bob directory. Treat
+        # an existing directory as an explicit project-level Bob signal, but
+        # never create it in unrelated repositories during an "all" install.
+        if "bob-ide" not in platforms_to_install and (repo_root / ".bob").is_dir():
+            platforms_to_install["bob-ide"] = PLATFORMS["bob-ide"]
 
         # Claude Code and CodeBuddy intentionally share the official project
         # .mcp.json/mcpServers contract. Process that exact pair once, but do

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,6 +19,8 @@ code-review-graph install --platform codex
 code-review-graph install --platform cursor
 code-review-graph install --platform claude-code
 code-review-graph install --platform codebuddy
+code-review-graph install --platform bob-shell
+code-review-graph install --platform bob-ide
 ```
 
 ### Supported Platforms
@@ -40,6 +42,15 @@ code-review-graph install --platform codebuddy
 | **Qoder** | `.qoder/mcp.json` |
 | **GitHub Copilot** | `.vscode/mcp.json` |
 | **GitHub Copilot CLI** | `~/.copilot/mcp-config.json` |
+| **IBM Bob Shell** | `~/.bob/mcp_settings.json` |
+| **IBM Bob IDE** | `.bob/mcp.json` |
+
+The IBM Bob paths and command-based STDIO entries follow the official
+[Bob Shell MCP](https://bob.ibm.com/docs/shell/configuration/mcp/mcp-bobshell)
+and [Bob IDE MCP](https://bob.ibm.com/docs/ide/configuration/mcp/mcp-in-bob)
+contracts. `install --platform all` configures Bob only when its executable,
+global MCP file, or workspace `.bob` directory already provides a detection
+signal.
 
 The CodeBuddy project layout follows its official documentation for
 [MCP configuration](https://www.codebuddy.ai/docs/cli/mcp),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@
 │  ├── Codex                └── incremental update             │
 │  ├── Claude Code, CodeBuddy Code                             │
 │  ├── Cursor, Windsurf, Zed, Continue                         │
-│  └── Gemini CLI, Qwen, Qoder, Copilot, OpenCode              │
+│  └── Gemini CLI, Qwen, Qoder, IBM Bob, Copilot, OpenCode     │
 │          │                        │                          │
 │          ▼                        ▼                          │
 │  ┌────────────────────────────────────────────┐              │

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -98,6 +98,16 @@ def test_handle_init_cursor_installs_cursor_hooks(monkeypatch, tmp_path, capsys)
     assert "Installed Cursor hooks" in out
 
 
+def test_platform_choices_use_current_bob_product_names():
+    choices = __import__(
+        "code_review_graph.cli", fromlist=["_PLATFORM_CHOICES"]
+    )._PLATFORM_CHOICES
+
+    assert "bob-shell" in choices
+    assert "bob-ide" in choices
+    assert "bob-cli" not in choices
+
+
 def test_handle_init_codebuddy_installs_only_codebuddy_native_files(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1560,6 +1560,121 @@ class TestKiroPlatform:
         assert not config_path.exists()
 
 
+class TestBobPlatforms:
+    """Tests for IBM Bob Shell and Bob IDE MCP configuration."""
+
+    def test_bob_platform_entries_follow_current_ibm_contracts(self, tmp_path):
+        bob_shell = PLATFORMS["bob-shell"]
+        bob_ide = PLATFORMS["bob-ide"]
+
+        with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+            assert bob_shell["config_path"](tmp_path) == tmp_path / ".bob" / "mcp_settings.json"
+        assert bob_shell["name"] == "Bob Shell"
+        assert bob_ide["name"] == "Bob IDE"
+        assert bob_ide["config_path"](tmp_path) == tmp_path / ".bob" / "mcp.json"
+        for platform_spec in (bob_shell, bob_ide):
+            assert platform_spec["key"] == "mcpServers"
+            assert platform_spec["format"] == "object"
+            assert platform_spec["needs_type"] is False
+
+    def test_install_bob_shell_uses_global_settings_without_stdio_type(self, tmp_path):
+        fake_home = tmp_path / "home"
+        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+            configured = install_platform_configs(tmp_path, target="bob-shell")
+
+        config_path = fake_home / ".bob" / "mcp_settings.json"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        entry = data["mcpServers"]["code-review-graph"]
+        assert configured == ["Bob Shell"]
+        assert "type" not in entry
+        assert entry["cwd"] == str(tmp_path)
+        assert "serve" in entry["args"]
+
+    def test_install_bob_ide_uses_project_settings_without_stdio_type(self, tmp_path):
+        configured = install_platform_configs(tmp_path, target="bob-ide")
+
+        config_path = tmp_path / ".bob" / "mcp.json"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        entry = data["mcpServers"]["code-review-graph"]
+        assert configured == ["Bob IDE"]
+        assert "type" not in entry
+        assert entry["cwd"] == str(tmp_path)
+        assert "serve" in entry["args"]
+
+    @pytest.mark.parametrize("target", ["bob-shell", "bob-ide"])
+    def test_bob_install_preserves_existing_servers_and_is_idempotent(self, tmp_path, target):
+        fake_home = tmp_path / "home"
+        config_path = (
+            fake_home / ".bob" / "mcp_settings.json"
+            if target == "bob-shell"
+            else tmp_path / ".bob" / "mcp.json"
+        )
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            json.dumps({"mcpServers": {"existing": {"command": "existing"}}}),
+            encoding="utf-8",
+        )
+
+        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+            install_platform_configs(tmp_path, target=target)
+            first = config_path.read_text(encoding="utf-8")
+            install_platform_configs(tmp_path, target=target)
+
+        assert config_path.read_text(encoding="utf-8") == first
+        data = json.loads(first)
+        assert data["mcpServers"]["existing"] == {"command": "existing"}
+        assert list(data["mcpServers"]).count("code-review-graph") == 1
+
+    def test_all_detects_bob_ide_from_workspace_directory(self, tmp_path):
+        (tmp_path / ".bob").mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+
+        assert "Bob IDE" in configured
+        data = json.loads((tmp_path / ".bob" / "mcp.json").read_text(encoding="utf-8"))
+        assert "type" not in data["mcpServers"]["code-review-graph"]
+
+    def test_all_detects_bob_shell_from_executable(self, tmp_path):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        def find_executable(name):
+            return "/usr/local/bin/bob" if name == "bob" else None
+
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.shutil.which", side_effect=find_executable),
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+
+        assert "Bob Shell" in configured
+        data = json.loads(
+            (fake_home / ".bob" / "mcp_settings.json").read_text(encoding="utf-8")
+        )
+        assert "type" not in data["mcpServers"]["code-review-graph"]
+
+    def test_all_does_not_create_bob_files_without_detection_signal(self, tmp_path):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+
+        assert "Bob Shell" not in configured
+        assert "Bob IDE" not in configured
+        assert not (fake_home / ".bob" / "mcp_settings.json").exists()
+        assert not (tmp_path / ".bob" / "mcp.json").exists()
+
+
 class TestCopilotPlatform:
     """Tests for GitHub Copilot platform support."""
 


### PR DESCRIPTION
## Latest refresh — 18 July 2026

- rebased patch-identically onto main 0a3bd6c; current head 9f07ae4
- all 15 hosted checks passed after this rebase
- Bob Shell and Bob IDE are not installed here; this stays draft and is not mergeable by policy## Status

**Draft — do not merge until the real-client checks below pass.**

This re-stages the safe IBM Bob portion of PR #540 after it was reverted from `main` because only automated configuration tests had been run. The original contributor remains credited.

## Change

- install the MCP server for Bob Shell at its documented user configuration path
- install the MCP server for Bob IDE at its documented project configuration path
- use command-based STDIO entries
- preserve unrelated configuration during install, reinstall, and uninstall
- document both clients

## Automated validation

- IBM Bob install/skills tests: **189 passed**
- complete non-daemon suite: **1,913 passed, 1 skipped, 2 expected deselections, 2 xpassed**
- both multiprocessing parity checks: **2 passed**
- Ruff and `git diff --check`: clean

## Required real-client validation

Do not mark this ready or merge it until all items below are recorded with the released applications:

- [ ] Bob Shell discovers the generated MCP server without configuration errors
- [ ] Bob Shell invokes a code-review-graph tool successfully
- [ ] Bob IDE discovers the project MCP server without configuration errors
- [ ] Bob IDE invokes a code-review-graph tool successfully
- [ ] reinstall/upgrade preserves unrelated Bob MCP entries in both clients
- [ ] uninstall removes only code-review-graph and both clients still load their remaining MCP configuration

Carries the safe intent of PR #540 with `mohan-kumar-m2` preserved as co-author.