### PR TITLE
fix(security): resolve open CodeQL alerts

### DIFF
--- a/scripts/diagnose_pypi_connectivity.py
+++ b/scripts/diagnose_pypi_connectivity.py
@@ -10,12 +10,9 @@ Run: python3 scripts/diagnose_pypi_connectivity.py
 """
 from __future__ import annotations
 
-import json
-import os
 import socket
 import ssl
 import sys
-import time
 import urllib.error
 import urllib.request
 
@@ -29,13 +26,17 @@ def main() -> int:
     print("PyPI check: FAILED (pip/pipx may be unable to download build deps like hatchling).")
     print("Workaround: from the repo root, with https://github.com/astral-sh/uv installed:")
     print('  uv tool install . --force')
-    print("Or run pipx from macOS Terminal.app (outside the IDE) if the failure is terminal-specific.")
+    print(
+        "Or run pipx from macOS Terminal.app (outside the IDE) "
+        "if the failure is terminal-specific."
+    )
     return 1
 
 
 def _try_tls_pypi() -> bool:
     try:
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         with socket.create_connection(("pypi.org", 443), timeout=15) as sock:
             with ctx.wrap_socket(sock, server_hostname="pypi.org") as tsock:
                 return bool(tsock.version())

--- a/tests/test_diagnose_pypi_connectivity.py
+++ b/tests/test_diagnose_pypi_connectivity.py
@@ -1,0 +1,37 @@
+"""Tests for the standalone PyPI connectivity diagnostic."""
+
+import ssl
+from contextlib import nullcontext
+
+from scripts import diagnose_pypi_connectivity
+
+
+class _FakeTLSConnection:
+    def version(self) -> str:
+        return "TLSv1.2"
+
+
+class _FakeTLSContext:
+    def __init__(self) -> None:
+        self.minimum_version = ssl.TLSVersion.TLSv1
+
+    def wrap_socket(self, _socket, *, server_hostname: str):
+        assert server_hostname == "pypi.org"
+        return nullcontext(_FakeTLSConnection())
+
+
+def test_direct_tls_probe_requires_tls_1_2_or_newer(monkeypatch):
+    context = _FakeTLSContext()
+    monkeypatch.setattr(
+        diagnose_pypi_connectivity.ssl,
+        "create_default_context",
+        lambda: context,
+    )
+    monkeypatch.setattr(
+        diagnose_pypi_connectivity.socket,
+        "create_connection",
+        lambda *_args, **_kwargs: nullcontext(object()),
+    )
+
+    assert diagnose_pypi_connectivity._try_tls_pypi() is True
+    assert context.minimum_version is ssl.TLSVersion.TLSv1_2

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,14 +1,52 @@
 """Tests for graph visualization export."""
 
 import json
-import re
 import shutil
 import subprocess
+from html.parser import HTMLParser
 
 import pytest
 
 from code_review_graph.graph import GraphStore
 from code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+class _ScriptExtractor(HTMLParser):
+    """Collect external script URLs and inline script bodies from HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.sources: list[str] = []
+        self.inline_scripts: list[str] = []
+        self._inline_chunks: list[str] | None = None
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        if tag != "script":
+            return
+        source = dict(attrs).get("src")
+        if source is not None:
+            self.sources.append(source)
+            self._inline_chunks = None
+        else:
+            self._inline_chunks = []
+
+    def handle_data(self, data: str) -> None:
+        if self._inline_chunks is not None:
+            self._inline_chunks.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._inline_chunks is not None:
+            self.inline_scripts.append("".join(self._inline_chunks))
+            self._inline_chunks = None
+
+
+def _extract_scripts(content: str) -> tuple[list[str], list[str]]:
+    parser = _ScriptExtractor()
+    parser.feed(content)
+    parser.close()
+    return parser.sources, parser.inline_scripts
 
 
 @pytest.fixture
@@ -177,11 +215,24 @@ def test_generate_html(store_with_data, tmp_path):
     generate_html(store_with_data, output_path)
     assert output_path.exists()
     content = output_path.read_text()
-    assert "d3js.org" in content or "d3.v7" in content
+    script_sources, _inline_scripts = _extract_scripts(content)
+    assert script_sources == ["https://d3js.org/d3.v7.min.js"]
     assert "auth.py" in content
     assert "AuthService" in content
     assert "<!DOCTYPE html>" in content
     assert "</html>" in content
+
+
+def test_script_extraction_handles_case_insensitive_html_tags():
+    content = (
+        '<SCRIPT SRC="https://d3js.org/d3.v7.min.js"></SCRIPT>'
+        "<SCRIPT>const responsive = 1 < 2;</SCRIPT>"
+    )
+
+    script_sources, inline_scripts = _extract_scripts(content)
+
+    assert script_sources == ["https://d3js.org/d3.v7.min.js"]
+    assert inline_scripts == ["const responsive = 1 < 2;"]
 
 
 def test_cpp_include_resolution(tmp_path):
@@ -399,7 +450,7 @@ def _assert_responsive_graph_script(content):
     node = shutil.which("node")
     if node is None:
         pytest.skip("Node.js is required for generated JavaScript syntax validation")
-    inline_scripts = re.findall(r"<script(?:\s[^>]*)?>(.*?)</script>", content, re.DOTALL)
+    _script_sources, inline_scripts = _extract_scripts(content)
     assert inline_scripts
     for script in inline_scripts:
         if not script.strip():


### PR DESCRIPTION
## Summary

Fixes the three open high-severity CodeQL alerts on `main`:

- require TLS 1.2 or newer in the direct PyPI diagnostic probe
- replace the test-only URL substring check with exact parsed `<script src>` validation
- replace the test-only HTML filtering regular expression with `HTMLParser`

The visualization production output is unchanged; the two HTML changes remove vulnerable checking patterns from the tests while making the assertions more exact. The TLS change is covered by a regression that inspects the configured minimum protocol version.

## Validation

- focused security/visualization tests: **28 passed**
- complete non-daemon suite: **1,904 passed, 1 skipped, 2 expected deselections, 2 xpassed**
- both multiprocessing parity checks: **2 passed**
- Ruff and `git diff --check`: clean

No external application or manual client validation is required for these three static-analysis fixes. After merge, the next CodeQL run should close alerts #1, #2, and #3 automatically.
