### PR TITLE
fix(platform): validate Copilot and Antigravity ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   repeated implementation blocks. Nested/aliased `use` trees, `Self` and
   turbofish calls, and bounded cached Cargo path/workspace dependency resolution
   now retain their original graph targets (replacing PR #526).
+- Added workspace-scoped Antigravity agent skills under
+  `.agents/skills/<skill>/SKILL.md`, using the current documented discovery
+  path and preserving unrelated user skills (safe port from PR #531).
 - Added an explicit local JSON visualization export. The output is written
   atomically inside the ignored graph data directory and is documented as
   potentially containing absolute paths and code-structure metadata (PR #449).
@@ -54,6 +57,9 @@
   enclosing-class, import, qualified-name, or namespace evidence. This keeps
   incremental work bounded to changed files and leaves unrelated globally
   unique `Class::method` names unresolved (safe subset of PR #568).
+- GitHub Copilot auto-detection now requires an installed Copilot VS Code
+  extension, while Copilot CLI output uses its documented `mcpServers`
+  container, local server type, and tool allowlist (safe port from PR #129).
 - Incremental Git change discovery now reads NUL-delimited byte output, so
   Unicode, whitespace, newline, and literal arrow paths are preserved while
   rename/copy records keep destination-only semantics (PR #618).

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -251,6 +251,7 @@ def _handle_init(args: argparse.Namespace) -> None:
         generate_skills,
         inject_claude_md,
         inject_platform_instructions,
+        install_antigravity_skills,
         install_codebuddy_hooks,
         install_codebuddy_skills,
         install_codex_hooks,
@@ -273,6 +274,11 @@ def _handle_init(args: argparse.Namespace) -> None:
         if target in ("gemini-cli", "all"):
             gemini_skills_dir = install_gemini_cli_skills(repo_root)
             print(f"Installed Gemini CLI skills in {gemini_skills_dir}")
+
+        # Antigravity discovers workspace skills under .agents/skills/.
+        if target in ("antigravity", "all"):
+            antigravity_skills_dir = install_antigravity_skills(repo_root)
+            print(f"Installed Antigravity skills in {antigravity_skills_dir}")
 
         # CodeBuddy discovers project skills under .codebuddy/skills/.
         if target in ("codebuddy", "all"):

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -35,15 +35,86 @@ def _zed_settings_path() -> Path:
 def _copilot_vscode_detected() -> bool:
     """Return whether a GitHub Copilot extension is installed for VS Code."""
     home = Path.home()
-    for extensions_dir in (
+    extension_dirs = [
         home / ".vscode" / "extensions",
         home / ".vscode-insiders" / "extensions",
-    ):
+    ]
+
+    system = platform.system()
+    if system == "Darwin":
+        for applications_dir in (Path("/Applications"), home / "Applications"):
+            for app_name in (
+                "Visual Studio Code.app",
+                "Visual Studio Code - Insiders.app",
+            ):
+                extension_dirs.append(
+                    applications_dir
+                    / app_name
+                    / "Contents"
+                    / "Resources"
+                    / "app"
+                    / "extensions"
+                )
+    elif system == "Windows":
+        for env_name in ("LOCALAPPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)"):
+            if install_root := os.environ.get(env_name):
+                for app_name in ("Microsoft VS Code", "Microsoft VS Code Insiders"):
+                    extension_dirs.append(
+                        Path(install_root)
+                        / app_name
+                        / "resources"
+                        / "app"
+                        / "extensions"
+                    )
+    elif system == "Linux":
+        extension_dirs.extend(
+            [
+                Path("/usr/share/code/resources/app/extensions"),
+                Path("/usr/share/code-insiders/resources/app/extensions"),
+                Path("/usr/lib/code/resources/app/extensions"),
+                Path("/opt/visual-studio-code/resources/app/extensions"),
+                Path("/snap/code/current/usr/share/code/resources/app/extensions"),
+            ]
+        )
+
+    for command in ("code", "code-insiders"):
+        if executable := shutil.which(command):
+            try:
+                parents = Path(executable).resolve().parents[:6]
+            except OSError:
+                continue
+            for parent in parents:
+                extension_dirs.extend(
+                    [
+                        parent / "extensions",
+                        parent / "resources" / "app" / "extensions",
+                        parent / "Resources" / "app" / "extensions",
+                    ]
+                )
+
+    for extensions_dir in dict.fromkeys(extension_dirs):
         try:
-            if any(path.name.startswith("github.copilot-") for path in extensions_dir.iterdir()):
-                return True
+            extension_paths = list(extensions_dir.iterdir())
         except OSError:
             continue
+        for extension_path in extension_paths:
+            name = extension_path.name.lower()
+            if name.startswith("github.copilot-"):
+                return True
+            if "copilot" not in name:
+                continue
+            try:
+                manifest = json.loads(
+                    (extension_path / "package.json").read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (
+                str(manifest.get("publisher", "")).lower() == "github"
+                and str(manifest.get("name", "")).lower()
+                in {"copilot", "copilot-chat"}
+            ):
+                return True
     return False
 
 

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -32,6 +32,21 @@ def _zed_settings_path() -> Path:
     return Path.home() / ".config" / "zed" / "settings.json"
 
 
+def _copilot_vscode_detected() -> bool:
+    """Return whether a GitHub Copilot extension is installed for VS Code."""
+    home = Path.home()
+    for extensions_dir in (
+        home / ".vscode" / "extensions",
+        home / ".vscode-insiders" / "extensions",
+    ):
+        try:
+            if any(path.name.startswith("github.copilot-") for path in extensions_dir.iterdir()):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _opencode_config_path(repo_root: Path) -> Path:
     """Return OpenCode's existing project config, preferring JSONC."""
     for name in ("opencode.jsonc", "opencode.json"):
@@ -142,17 +157,19 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "name": "GitHub Copilot",
         "config_path": lambda root: root / ".vscode" / "mcp.json",
         "key": "servers",
-        "detect": lambda: (Path.home() / ".vscode").exists(),
+        "detect": _copilot_vscode_detected,
         "format": "object",
         "needs_type": True,
     },
     "copilot-cli": {
         "name": "GitHub Copilot CLI",
         "config_path": lambda root: Path.home() / ".copilot" / "mcp-config.json",
-        "key": "servers",
+        "key": "mcpServers",
         "detect": lambda: (Path.home() / ".copilot").exists(),
         "format": "object",
         "needs_type": True,
+        "server_type": "local",
+        "entry_fields": {"tools": ["*"]},
     },
     "codebuddy": {
         "name": "CodeBuddy Code",
@@ -262,7 +279,8 @@ def _build_server_entry(
     if repo_root is not None:
         entry["cwd"] = str(repo_root)
     if plat["needs_type"]:
-        entry["type"] = "stdio"
+        entry["type"] = plat.get("server_type", "stdio")
+    entry.update(plat.get("entry_fields", {}))
     return entry
 
 
@@ -1322,6 +1340,29 @@ def install_gemini_cli_skills(repo_root: Path) -> Path:
         )
         skill_path.write_text(content, encoding="utf-8")
         logger.info("Wrote Gemini CLI skill: %s", skill_path)
+
+    return skills_root
+
+
+def install_antigravity_skills(repo_root: Path) -> Path:
+    """Install workspace-scoped Antigravity skills in .agents/skills/."""
+    skills_root = repo_root / ".agents" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    for filename, skill in _SKILLS.items():
+        slug = filename.rsplit(".", 1)[0]
+        skill_dir = skills_root / slug
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path = skill_dir / "SKILL.md"
+        content = (
+            "---\n"
+            f"name: {slug}\n"
+            f"description: {skill['description']}\n"
+            "---\n\n"
+            f"{skill['body']}\n"
+        )
+        skill_path.write_text(content, encoding="utf-8")
+        logger.info("Wrote Antigravity skill: %s", skill_path)
 
     return skills_root
 

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -1059,7 +1059,7 @@ def _process_repo(
             dry_run=dry_run,
         )
 
-    for root_name in (".claude", ".gemini", ".codebuddy"):
+    for root_name in (".claude", ".gemini", ".codebuddy", ".agents"):
         for slug in _generated_skill_slugs():
             _remove_skill_file(
                 repo_root / root_name / "skills" / slug / "SKILL.md",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,7 +33,7 @@ code-review-graph install --platform codebuddy
 | **Zed** | `.zed/settings.json` |
 | **Continue** | `.continue/config.json` |
 | **OpenCode** | `opencode.jsonc` (preferred) or `opencode.json` |
-| **Antigravity** | `~/.gemini/antigravity/mcp_config.json` |
+| **Antigravity** | `~/.gemini/antigravity/mcp_config.json` + `.agents/skills/<name>/SKILL.md` |
 | **Gemini CLI** | `.gemini/settings.json` |
 | **Qwen Code** | `~/.qwen/settings.json` |
 | **Kiro** | `.kiro/settings/mcp.json` |
@@ -47,6 +47,12 @@ The CodeBuddy project layout follows its official documentation for
 [hooks](https://www.codebuddy.ai/docs/cli/hooks). The shared `.mcp.json` is
 merged with JSONC awareness, while hook commands resolve the repository at
 runtime so committed settings do not contain one developer's checkout path.
+
+Antigravity workspace skills use its documented
+[`.agents/skills` location](https://antigravity.google/docs/skills?app=antigravity-ide).
+Copilot CLI uses the documented `mcpServers` schema in
+[`~/.copilot/mcp-config.json`](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers);
+the VS Code integration remains workspace-scoped in `.vscode/mcp.json`.
 
 ## Core Workflow
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -98,6 +98,56 @@ def test_handle_init_cursor_installs_cursor_hooks(monkeypatch, tmp_path, capsys)
     assert "Installed Cursor hooks" in out
 
 
+def test_handle_init_antigravity_installs_only_workspace_skills(
+    monkeypatch, tmp_path, capsys
+):
+    import code_review_graph.skills as skills_module
+
+    monkeypatch.setattr(
+        "code_review_graph.incremental.find_repo_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.ensure_repo_gitignore_excludes_crg",
+        lambda repo_root: "created",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.skills.install_platform_configs",
+        lambda repo_root, target, dry_run=False: ["Antigravity"],
+    )
+
+    called = {"claude": False, "gemini": False, "antigravity": False}
+
+    def _generate_skills(repo_root):
+        called["claude"] = True
+        return repo_root / ".claude" / "skills"
+
+    def _install_gemini_cli_skills(repo_root):
+        called["gemini"] = True
+        return repo_root / ".gemini" / "skills"
+
+    def _install_antigravity_skills(repo_root):
+        called["antigravity"] = True
+        return repo_root / ".agents" / "skills"
+
+    monkeypatch.setattr(skills_module, "generate_skills", _generate_skills)
+    monkeypatch.setattr(
+        skills_module, "install_gemini_cli_skills", _install_gemini_cli_skills
+    )
+    monkeypatch.setattr(
+        skills_module,
+        "install_antigravity_skills",
+        _install_antigravity_skills,
+        raising=False,
+    )
+
+    _handle_init(_args(tmp_path, "antigravity"))
+    out = capsys.readouterr().out
+
+    assert called == {"claude": False, "gemini": False, "antigravity": True}
+    assert "Installed Antigravity skills" in out
+
+
 def test_handle_init_codebuddy_installs_only_codebuddy_native_files(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1196,7 +1196,8 @@ class TestInstallPlatformConfigs:
                 "gemini-cli": {**PLATFORMS["gemini-cli"], "detect": lambda: False},
             },
         ):
-            configured = install_platform_configs(tmp_path, target="all")
+            with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+                configured = install_platform_configs(tmp_path, target="all")
         assert "Codex" in configured
         assert "Claude Code" in configured
         assert "OpenCode" in configured
@@ -2216,7 +2217,8 @@ class TestInstallSkillsRespectTargetPlatform:
             no_instructions=True,
         )
         with patch("builtins.input", return_value="n"):
-            crg_cli._handle_init(args)
+            with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+                crg_cli._handle_init(args)
         return (tmp_path / ".claude" / "skills").is_dir()
 
     def test_cursor_install_does_not_create_claude_skills(self, tmp_path):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -30,6 +30,7 @@ from code_review_graph.skills import (
     generate_skills,
     inject_claude_md,
     inject_platform_instructions,
+    install_antigravity_skills,
     install_codex_hooks,
     install_cursor_hooks,
     install_gemini_cli_hooks,
@@ -1301,6 +1302,34 @@ class TestGeminiCLIInstall:
         assert "description:" in text
 
 
+class TestAntigravitySkillsInstall:
+    def test_writes_workspace_scoped_skill_directories(self, tmp_path):
+        skills_root = install_antigravity_skills(tmp_path)
+
+        assert skills_root == tmp_path / ".agents" / "skills"
+        skill_path = skills_root / "explore-codebase" / "SKILL.md"
+        assert skill_path.exists()
+        text = skill_path.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert "name: explore-codebase" in text
+        assert "description:" in text
+
+    def test_is_idempotent_and_preserves_unrelated_skills(self, tmp_path):
+        unrelated = tmp_path / ".agents" / "skills" / "user-skill" / "SKILL.md"
+        unrelated.parent.mkdir(parents=True)
+        unrelated.write_text("user content\n", encoding="utf-8")
+
+        first_root = install_antigravity_skills(tmp_path)
+        first = (first_root / "review-changes" / "SKILL.md").read_text(encoding="utf-8")
+        second_root = install_antigravity_skills(tmp_path)
+
+        assert second_root == first_root
+        assert (second_root / "review-changes" / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == first
+        assert unrelated.read_text(encoding="utf-8") == "user content\n"
+
+
 class TestCursorHooksConfig:
     """Tests for generate_cursor_hooks_config()."""
 
@@ -1643,14 +1672,27 @@ class TestCopilotPlatform:
         assert not (tmp_path / "QODER.md").exists()
 
     def test_copilot_included_in_all_when_detected(self, tmp_path):
-        """install_platform_configs with target='all' includes Copilot when ~/.vscode exists."""
+        """Auto-detection requires the Copilot extension, not only VS Code."""
         fake_home = tmp_path / "fakehome"
-        (fake_home / ".vscode").mkdir(parents=True)
+        (fake_home / ".vscode" / "extensions" / "github.copilot-1.2.3").mkdir(
+            parents=True
+        )
         with patch("code_review_graph.skills.Path.home", return_value=fake_home):
             configured = install_platform_configs(tmp_path, target="all")
         assert "GitHub Copilot" in configured
         config_path = tmp_path / ".vscode" / "mcp.json"
         assert config_path.exists()
+
+    def test_copilot_not_detected_from_vscode_alone(self, tmp_path):
+        """An unrelated VS Code install must not trigger Copilot configuration."""
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".vscode" / "extensions" / "ms-python.python-1.0.0").mkdir(
+            parents=True
+        )
+        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+            configured = install_platform_configs(tmp_path, target="all")
+        assert "GitHub Copilot" not in configured
+        assert not (tmp_path / ".vscode" / "mcp.json").exists()
 
 
 class TestCopilotCLIPlatform:
@@ -1661,12 +1703,12 @@ class TestCopilotCLIPlatform:
         assert "copilot-cli" in PLATFORMS
         copilot_cli = PLATFORMS["copilot-cli"]
         assert copilot_cli["name"] == "GitHub Copilot CLI"
-        assert copilot_cli["key"] == "servers"
+        assert copilot_cli["key"] == "mcpServers"
         assert copilot_cli["format"] == "object"
         assert copilot_cli["needs_type"] is True
 
     def test_install_copilot_cli_config(self, tmp_path):
-        """install_platform_configs creates ~/.copilot/mcp-config.json with 'servers' key."""
+        """Install writes the documented Copilot CLI MCP schema."""
         fake_home = tmp_path / "fakehome"
         (fake_home / ".copilot").mkdir(parents=True)
         config_path = fake_home / ".copilot" / "mcp-config.json"
@@ -1684,10 +1726,11 @@ class TestCopilotCLIPlatform:
         assert "GitHub Copilot CLI" in configured
         assert config_path.exists()
         data = json.loads(config_path.read_text())
-        assert "code-review-graph" in data["servers"]
-        entry = data["servers"]["code-review-graph"]
-        assert entry["type"] == "stdio"
+        assert "code-review-graph" in data["mcpServers"]
+        entry = data["mcpServers"]["code-review-graph"]
+        assert entry["type"] == "local"
         assert "serve" in entry["args"]
+        assert entry["tools"] == ["*"]
 
     def test_install_copilot_cli_preserves_existing_servers(self, tmp_path):
         """Existing server entries are preserved when adding code-review-graph."""
@@ -1695,7 +1738,7 @@ class TestCopilotCLIPlatform:
         config_path = fake_home / ".copilot" / "mcp-config.json"
         config_path.parent.mkdir(parents=True)
         config_path.write_text(
-            json.dumps({"servers": {"other-server": {"command": "other"}}}),
+            json.dumps({"mcpServers": {"other-server": {"command": "other"}}}),
             encoding="utf-8",
         )
         with patch.dict(
@@ -1710,8 +1753,8 @@ class TestCopilotCLIPlatform:
         ):
             install_platform_configs(tmp_path, target="copilot-cli")
         data = json.loads(config_path.read_text())
-        assert "other-server" in data["servers"]
-        assert "code-review-graph" in data["servers"]
+        assert "other-server" in data["mcpServers"]
+        assert "code-review-graph" in data["mcpServers"]
 
     def test_copilot_cli_writes_only_copilot_instructions(self, tmp_path):
         """Copilot CLI injection writes its GitHub instruction file."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover - Python 3.10 backport
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
+    _copilot_vscode_detected,
     _cursor_hook_scripts,
     _detect_serve_command,
     _in_poetry_project,
@@ -1678,11 +1679,38 @@ class TestCopilotPlatform:
         (fake_home / ".vscode" / "extensions" / "github.copilot-1.2.3").mkdir(
             parents=True
         )
-        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.platform.system", return_value="Unknown"),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
             configured = install_platform_configs(tmp_path, target="all")
         assert "GitHub Copilot" in configured
         config_path = tmp_path / ".vscode" / "mcp.json"
         assert config_path.exists()
+
+    def test_copilot_detects_vscode_bundled_extension(self, tmp_path):
+        """Current VS Code bundles Copilot under its application extensions."""
+        fake_home = tmp_path / "fakehome"
+        app_root = tmp_path / "vscode" / "resources" / "app"
+        code_cli = app_root / "bin" / "code"
+        code_cli.parent.mkdir(parents=True)
+        code_cli.write_text("", encoding="utf-8")
+        manifest = app_root / "extensions" / "copilot" / "package.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps({"publisher": "GitHub", "name": "copilot-chat"}),
+            encoding="utf-8",
+        )
+
+        def _which(command):
+            return str(code_cli) if command == "code" else None
+
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.shutil.which", side_effect=_which),
+        ):
+            assert _copilot_vscode_detected() is True
 
     def test_copilot_not_detected_from_vscode_alone(self, tmp_path):
         """An unrelated VS Code install must not trigger Copilot configuration."""
@@ -1690,7 +1718,11 @@ class TestCopilotPlatform:
         (fake_home / ".vscode" / "extensions" / "ms-python.python-1.0.0").mkdir(
             parents=True
         )
-        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.platform.system", return_value="Unknown"),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
             configured = install_platform_configs(tmp_path, target="all")
         assert "GitHub Copilot" not in configured
         assert not (tmp_path / ".vscode" / "mcp.json").exists()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -325,6 +325,7 @@ def test_shared_skill_directories_keep_user_files_and_unrelated_skills(
         fake_repo / ".claude" / "skills",
         fake_repo / ".gemini" / "skills",
         fake_repo / ".codebuddy" / "skills",
+        fake_repo / ".agents" / "skills",
     ]
     generated_slug = next(iter(skills._SKILLS)).removesuffix(".md")
     for root in generated_roots:


### PR DESCRIPTION
## Latest refresh — 18 July 2026

- rebased onto main `0a3bd6c`; current head `5496791`
- fixed all-platform test isolation so tests do not touch the real user home
- all 15 hosted checks passed on the current head
- released VS Code and GitHub Copilot CLI validation passed; only Antigravity remains

## Status

**Draft — do not merge until the released Antigravity checks below pass.**

This completes the focused maintainer ports promised when source PRs #129 and #531 were closed. Contributor attribution is preserved.

## Change

- detect the actual GitHub Copilot VS Code extension instead of any VS Code installation
- detect the Copilot extension bundled inside released VS Code builds
- write the released Copilot CLI `mcpServers` contract with `type: local` and `tools: ["*"]`
- install Antigravity workspace skills only at `.agents/skills/<skill>/SKILL.md`; do not carry the source PR's obsolete hooks
- preserve unrelated servers and skills on install/reinstall
- remove only generated code-review-graph entries and Antigravity skills on uninstall

## Automated validation

- source contract regressions: **3 failed before, then passed after the port**
- Antigravity uninstall regression: **failed before, then passed after the fix**
- focused install/skills/uninstall suite: **224 passed**
- complete non-daemon suite: **1,967 passed, 1 skipped, 2 expected deselections, 2 xpassed**
- both multiprocessing parity checks: **2 passed**
- independent maintainer critical-path check: **7 passed**
- Ruff and `git diff --check`: clean
- current GitHub head: **15/15 checks passed**

## Real-client result

PASSED — GitHub Copilot:

- released VS Code 1.127.0 with bundled `GitHub.copilot-chat` 0.55.0 was detected
- VS Code resolved the generated workspace `.vscode/mcp.json` without a configuration parse error
- official GitHub Copilot CLI 1.0.71 loaded `~/.copilot/mcp-config.json` from the user source
- Copilot CLI connected to the code-review-graph MCP server and successfully called `list_graph_stats_tool`; the real result returned `total_nodes: 4334`
- reinstall left both seeded Copilot config files byte-for-byte unchanged and preserved their unrelated servers/settings
- uninstall reported zero errors, removed only `code-review-graph` from both configs, and preserved the unrelated servers/settings
- released VS Code reopened the remaining post-uninstall config and registered the unrelated MCP server; no code-review-graph server remained
- the disposable VS Code instance was closed after validation

## Required real-client validation

Do not mark this ready or merge it until all items below are recorded with released clients.

### GitHub Copilot

- [x] released VS Code with the actual GitHub Copilot extension triggers the intended auto-detection and loads the generated workspace MCP server without configuration errors
- [x] released GitHub Copilot CLI loads `~/.copilot/mcp-config.json` and invokes a code-review-graph tool successfully
- [x] reinstall preserves unrelated Copilot MCP entries
- [x] uninstall removes only code-review-graph and both clients still load their remaining configuration

### Google Antigravity

- [ ] the released Antigravity app opens the workspace and discovers a generated `.agents` skill
- [ ] Antigravity uses a generated skill and invokes a code-review-graph MCP tool successfully
- [ ] reinstall preserves an unrelated workspace skill
- [ ] uninstall removes only generated code-review-graph skills and Antigravity still loads the remaining workspace

Carries PR #129 with `npkriami18` credited and PR #531 with `0deep` credited.
