### PR TITLE
fix(parser): end-to-end dead-guard fix with consumer filtering (#576)

### DIFF
--- a/code_review_graph/analysis.py
+++ b/code_review_graph/analysis.py
@@ -22,6 +22,8 @@ def find_hub_nodes(store: GraphStore, top_n: int = 10) -> list[dict]:
     in_degree: dict[str, int] = Counter()
     out_degree: dict[str, int] = Counter()
     for e in edges:
+        if not e.is_live():
+            continue
         out_degree[e.source_qualified] += 1
         in_degree[e.target_qualified] += 1
 
@@ -129,6 +131,8 @@ def find_knowledge_gaps(store: GraphStore) -> dict[str, list[dict]]:
     degree: dict[str, int] = Counter()
     tested_nodes: set[str] = set()
     for e in edges:
+        if not e.is_live():
+            continue
         degree[e.source_qualified] += 1
         degree[e.target_qualified] += 1
         if e.kind == "TESTED_BY":
@@ -228,9 +232,11 @@ def find_surprising_connections(
 
     node_map = {n.qualified_name: n for n in nodes}
 
-    # Build degree map
+    # Build degree map (skip dead edges)
     degree: dict[str, int] = Counter()
     for e in edges:
+        if not e.is_live():
+            continue
         degree[e.source_qualified] += 1
         degree[e.target_qualified] += 1
 
@@ -243,6 +249,8 @@ def find_surprising_connections(
 
     scored_edges = []
     for e in edges:
+        if not e.is_live():
+            continue
         src = node_map.get(e.source_qualified)
         tgt = node_map.get(e.target_qualified)
         if not src or not tgt:
@@ -285,12 +293,12 @@ def find_surprising_connections(
             reasons.append("peripheral-to-hub")
 
         # Cross-file-type: test <-> non-test (+0.15)
-        if src.is_test != tgt.is_test and e.kind == "CALLS":
+        if src.is_test != tgt.is_test and e.kind == "CALLS" and e.is_live():
             score += 0.15
             reasons.append("cross-test-boundary")
 
         # Non-standard edge kind (+0.15)
-        if e.kind == "CALLS" and src.kind == "Type":
+        if e.kind == "CALLS" and e.is_live() and src.kind == "Type":
             score += 0.15
             reasons.append("unusual-edge-kind")
 

--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -238,7 +238,7 @@ def compute_risk_score(store: GraphStore, node: GraphNode) -> float:
 
     # --- Community crossing (cap 0.15) ---
     callers = store.get_edges_by_target(node.qualified_name)
-    caller_edges = [e for e in callers if e.kind == "CALLS"]
+    caller_edges = [e for e in callers if e.kind == "CALLS" and e.is_live()]
 
     cross_community = 0
     node_cid = store.get_node_community_id(node.id)
@@ -356,7 +356,9 @@ def analyze_changes(
         # parser, so a changed production function finds its tests by source.
         # See: #515
         tested = store.get_edges_by_source(node.qualified_name)
-        if not any(e.kind == "TESTED_BY" for e in tested):
+        if not any(
+            e.kind == "TESTED_BY" and e.is_live() for e in tested
+        ):
             test_gaps.append({
                 "name": _sanitize_name(node.name),
                 "qualified_name": _sanitize_name(node.qualified_name),

--- a/code_review_graph/enrich.py
+++ b/code_review_graph/enrich.py
@@ -133,7 +133,7 @@ def _format_node_context(
     callers: list[str] = []
     seen: set[str] = set()
     for e in store.get_edges_by_target(qn):
-        if e.kind == "CALLS" and len(callers) < 5:
+        if e.kind == "CALLS" and e.is_live() and len(callers) < 5:
             c = store.get_node(e.source_qualified)
             if c and c.name not in seen:
                 seen.add(c.name)
@@ -145,7 +145,7 @@ def _format_node_context(
     callees: list[str] = []
     seen.clear()
     for e in store.get_edges_by_source(qn):
-        if e.kind == "CALLS" and len(callees) < 5:
+        if e.kind == "CALLS" and e.is_live() and len(callees) < 5:
             c = store.get_node(e.target_qualified)
             if c and c.name not in seen:
                 seen.add(c.name)

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -109,6 +109,20 @@ class GraphEdge:
     confidence: float = 1.0
     confidence_tier: str = "EXTRACTED"
 
+    def is_live(self) -> bool:
+        """Return False if this edge sits inside statically-dead code.
+
+        Before the dead-guard fix, the parser emitted CALLS edges inside
+        ``if False:`` / ``if TYPE_CHECKING:`` with
+        ``extra["reachable"] == False``.  After the fix, dead edges are
+        never emitted at all.  This predicate handles both cases so
+        consumers work against old and new graphs.
+        """
+        extra = self.extra or {}
+        if isinstance(extra, str):
+            extra = json.loads(extra)
+        return extra.get("reachable", True)
+
 
 @dataclass
 class FlowAdjacency:
@@ -428,7 +442,8 @@ class GraphStore:
         for qn in input_qns:
             for row in conn.execute(
                 "SELECT target_qualified FROM edges "
-                "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
+                "WHERE source_qualified = ? AND kind = 'TESTED_BY' "
+                "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0",
                 (qn,),
             ).fetchall():
                 tgt = row["target_qualified"]
@@ -442,7 +457,8 @@ class GraphStore:
         bare = qualified_name.rsplit("::", 1)[-1] if "::" in qualified_name else qualified_name
         for row in conn.execute(
             "SELECT target_qualified FROM edges "
-            "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
+            "WHERE source_qualified = ? AND kind = 'TESTED_BY' "
+            "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0",
             (bare,),
         ).fetchall():
             tgt = row["target_qualified"]
@@ -459,7 +475,8 @@ class GraphStore:
             for qn in frontier:
                 for row in conn.execute(
                     "SELECT target_qualified FROM edges "
-                    "WHERE source_qualified = ? AND kind = 'CALLS'",
+                    "WHERE source_qualified = ? AND kind = 'CALLS' "
+                    "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0",
                     (qn,),
                 ).fetchall():
                     next_frontier.add(row["target_qualified"])
@@ -703,11 +720,15 @@ class GraphStore:
             FROM impacted i
             JOIN edges e ON e.source_qualified = i.node_qn
             WHERE i.depth < ?
+              AND (e.kind != 'CALLS'
+                   OR COALESCE(json_extract(e.extra, '$.reachable'), 1) != 0)
             UNION
             SELECT e.source_qualified, i.depth + 1
             FROM impacted i
             JOIN edges e ON e.target_qualified = i.node_qn
             WHERE i.depth < ?
+              AND (e.kind != 'CALLS'
+                   OR COALESCE(json_extract(e.extra, '$.reachable'), 1) != 0)
         )
         SELECT DISTINCT node_qn, MIN(depth) AS min_depth
         FROM impacted
@@ -1119,13 +1140,15 @@ class GraphStore:
         if include_file_sources:
             rows = self._conn.execute(
                 "SELECT DISTINCT target_qualified FROM edges "
-                "WHERE kind = 'CALLS'"
+                "WHERE kind = 'CALLS' "
+                "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0"
             ).fetchall()
         else:
             rows = self._conn.execute(
                 "SELECT DISTINCT e.target_qualified FROM edges e "
                 "LEFT JOIN nodes n ON n.qualified_name = e.source_qualified "
                 "WHERE e.kind = 'CALLS' "
+                "AND COALESCE(json_extract(e.extra, '$.reachable'), 1) != 0 "
                 "AND (n.kind IS NULL OR n.kind != 'File')"
             ).fetchall()
         return {r["target_qualified"] for r in rows}
@@ -1225,7 +1248,10 @@ class GraphStore:
             ).fetchall()
             for r in rows:
                 edge = self._row_to_edge(r)
-                if edge.target_qualified in qualified_names:
+                if (
+                    edge.target_qualified in qualified_names
+                    and edge.is_live()
+                ):
                     results.append(edge)
         return results
 
@@ -1266,10 +1292,15 @@ class GraphStore:
         calls_out: dict[str, list[str]] = {}
         has_tested_by: set[str] = set()
         for row in self._conn.execute(
-            "SELECT kind, source_qualified, target_qualified FROM edges "
+            "SELECT kind, source_qualified, target_qualified, extra FROM edges "
             "WHERE kind IN ('CALLS', 'TESTED_BY')"
         ):
             kind, src, tgt = row["kind"], row["source_qualified"], row["target_qualified"]
+            extra = row["extra"] or {}
+            if isinstance(extra, str):
+                extra = json.loads(extra)
+            if not extra.get("reachable", True):
+                continue
             if kind == "CALLS":
                 calls_out.setdefault(src, []).append(tgt)
             else:  # TESTED_BY: source is the production node being tested. See: #515
@@ -1290,7 +1321,11 @@ class GraphStore:
             if self._nxg_cache is not None:
                 return self._nxg_cache
             g: nx.DiGraph = nx.DiGraph()
-            rows = self._conn.execute("SELECT * FROM edges").fetchall()
+            rows = self._conn.execute(
+                "SELECT * FROM edges "
+                "WHERE kind != 'CALLS' "
+                "OR COALESCE(json_extract(extra, '$.reachable'), 1) != 0"
+            ).fetchall()
             for r in rows:
                 g.add_edge(r["source_qualified"], r["target_qualified"], kind=r["kind"])
             self._nxg_cache = g

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -877,6 +877,35 @@ def file_hash(path: Path) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Parser helpers
+# ---------------------------------------------------------------------------
+
+
+def _node_is_in_child(node, child_node) -> bool:
+    """Return True if *node* is a descendant of *child_node*.
+
+    Used by ``_is_in_static_dead_guard`` to distinguish the consequence
+    (true-branch) of an ``if`` statement from the alternative (else/elif)
+    without walking the full ancestor chain twice.
+
+    Comparison uses byte ranges because the tree-sitter Python bindings
+    create fresh ``Node`` objects on every ``child_by_field_name`` call,
+    so ``is`` identity does not work even when both sides refer to the
+    same tree node.
+    """
+    sb, eb = child_node.start_byte, child_node.end_byte
+    cursor = node
+    while cursor is not None:
+        if (
+            cursor.start_byte == sb
+            and cursor.end_byte == eb
+        ):
+            return True
+        cursor = cursor.parent
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------
 
@@ -5090,51 +5119,88 @@ class CodeParser:
             ))
 
     @staticmethod
-    def _is_in_static_dead_guard(node) -> bool:
+    def _is_in_static_dead_guard(
+        node,
+        import_map: Optional[dict[str, str]] = None,
+    ) -> bool:
         """Walk ancestors to detect statically-dead guards.
 
-        Returns True when ``node`` sits inside an ``if_statement`` whose
-        condition is ``False`` (the literal), the integer ``0``, or
-        ``TYPE_CHECKING`` (the ``typing`` sentinel).  This covers the
-        most common Python idioms for compile-time-only code:
+        Returns True when *node* sits inside the **consequence** (true
+        branch) of an ``if_statement`` whose condition is statically
+        ``False`` (the literal), the integer ``0``, or the
+        ``typing.TYPE_CHECKING`` sentinel.  This covers the most common
+        Python idioms for compile-time-only code::
 
-            if False:
+            if False:          # consequence is dead
                 ...
-            if 0:
+            if 0:              # consequence is dead
                 ...
-            if TYPE_CHECKING:
+            if TYPE_CHECKING:  # consequence is dead
                 ...
 
-        The walk stops at function/class/module boundaries so a dead
-        guard in an outer scope does not leak into nested definitions.
+        Branch semantics:
+
+        * A call in the **else/elif** branch of ``if False:`` is **live**
+          (the else branch runs when the condition is false).
+        * A nested function/class defined under ``if False:`` is still
+          importable — the definition node lives at module scope — so
+          calls *inside* that nested function are not marked dead.
+
+        ``TYPE_CHECKING`` is only treated as the typing sentinel when it
+        is imported via ``from typing import TYPE_CHECKING``.  Aliased
+        imports (``as TC``) and attribute access
+        (``typing.TYPE_CHECKING``) are not yet handled — those are
+        follow-up enhancements.  A local variable coincidentally named
+        ``TYPE_CHECKING`` is not a dead guard.
         """
+        typing_names: set[str] = set()
+        if import_map:
+            for local, qualified in import_map.items():
+                if (
+                    qualified == "typing"
+                    and local == "TYPE_CHECKING"
+                ):
+                    typing_names.add(local)
+
         cursor = node.parent
         while cursor is not None:
             ntype = cursor.type
             # Stop at scope boundaries -- a dead guard in an outer
             # function does not make an inner function's calls dead.
             if ntype in (
-                "function_definition", "class_definition", "module",
+                "function_definition", "class_definition",
+                "async_function_definition", "lambda", "module",
             ):
                 break
             if ntype == "if_statement":
                 cond = cursor.child_by_field_name("condition")
-                if cond is not None:
+                consequence = cursor.child_by_field_name("consequence")
+                if cond is not None and consequence is not None:
+                    is_dead_cond = False
                     # ``if False:``
                     if cond.type == "false":
-                        return True
+                        is_dead_cond = True
                     # ``if 0:``
-                    if (
+                    elif (
                         cond.type == "integer"
                         and cond.text == b"0"
                     ):
-                        return True
+                        is_dead_cond = True
                     # ``if TYPE_CHECKING:``
-                    if (
+                    elif (
                         cond.type == "identifier"
-                        and cond.text == b"TYPE_CHECKING"
+                        and cond.text in {
+                            n.encode() for n in typing_names
+                        }
                     ):
-                        return True
+                        is_dead_cond = True
+
+                    if is_dead_cond:
+                        # Only the consequence (true branch) is dead.
+                        # If node is in the alternative (else/elif),
+                        # it is live -- keep walking up.
+                        if _node_is_in_child(node, consequence):
+                            return True
             cursor = cursor.parent
         return False
 
@@ -5270,11 +5336,11 @@ class CodeParser:
                     call_name, file_path, language,
                     import_map or {}, defined_names or set(),
                 )
-            # Tag calls inside statically-dead guards (if False: /
-            # if TYPE_CHECKING:) so downstream consumers can filter
-            # them out.  Live edges omit the key (absent = live).
-            if self._is_in_static_dead_guard(child):
-                call_extra["reachable"] = False
+            # Skip calls inside statically-dead guards entirely.
+            # Dead edges would confuse every downstream consumer
+            # (callers, impact, flows, dead-code detection).
+            if self._is_in_static_dead_guard(child, import_map):
+                return False
 
             edges.append(EdgeInfo(
                 kind="CALLS",

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5089,6 +5089,47 @@ class CodeParser:
                 line=child.start_point[0] + 1,
             ))
 
+    @staticmethod
+    def _is_in_static_dead_guard(node) -> bool:
+        """Walk ancestors to detect statically-dead guards.
+
+        Returns True when ``node`` sits inside an ``if_statement`` whose
+        condition is ``False`` (the literal) or ``TYPE_CHECKING`` (the
+        ``typing`` sentinel).  This covers the two most common Python
+        idioms for compile-time-only code:
+
+            if False:
+                ...
+            if TYPE_CHECKING:
+                ...
+
+        The walk stops at function/class/module boundaries so a dead
+        guard in an outer scope does not leak into nested definitions.
+        """
+        cursor = node.parent
+        while cursor is not None:
+            ntype = cursor.type
+            # Stop at scope boundaries -- a dead guard in an outer
+            # function does not make an inner function's calls dead.
+            if ntype in (
+                "function_definition", "class_definition", "module",
+            ):
+                break
+            if ntype == "if_statement":
+                cond = cursor.child_by_field_name("condition")
+                if cond is not None:
+                    # ``if False:``
+                    if cond.type == "false":
+                        return True
+                    # ``if TYPE_CHECKING:``
+                    if (
+                        cond.type == "identifier"
+                        and cond.text == b"TYPE_CHECKING"
+                    ):
+                        return True
+            cursor = cursor.parent
+        return False
+
     def _extract_calls(
         self,
         child,
@@ -5221,6 +5262,12 @@ class CodeParser:
                     call_name, file_path, language,
                     import_map or {}, defined_names or set(),
                 )
+            # Tag calls inside statically-dead guards (if False: /
+            # if TYPE_CHECKING:) so downstream consumers can filter
+            # them out.  Live edges omit the key (absent = live).
+            if self._is_in_static_dead_guard(child):
+                call_extra["reachable"] = False
+
             edges.append(EdgeInfo(
                 kind="CALLS",
                 source=caller,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5094,11 +5094,13 @@ class CodeParser:
         """Walk ancestors to detect statically-dead guards.
 
         Returns True when ``node`` sits inside an ``if_statement`` whose
-        condition is ``False`` (the literal) or ``TYPE_CHECKING`` (the
-        ``typing`` sentinel).  This covers the two most common Python
-        idioms for compile-time-only code:
+        condition is ``False`` (the literal), the integer ``0``, or
+        ``TYPE_CHECKING`` (the ``typing`` sentinel).  This covers the
+        most common Python idioms for compile-time-only code:
 
             if False:
+                ...
+            if 0:
                 ...
             if TYPE_CHECKING:
                 ...
@@ -5120,6 +5122,12 @@ class CodeParser:
                 if cond is not None:
                     # ``if False:``
                     if cond.type == "false":
+                        return True
+                    # ``if 0:``
+                    if (
+                        cond.type == "integer"
+                        and cond.text == b"0"
+                    ):
                         return True
                     # ``if TYPE_CHECKING:``
                     if (

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -111,7 +111,7 @@ def rename_preview(
     # --- Call sites (CALLS edges targeting this node) ---
     call_edges = store.get_edges_by_target(node.qualified_name)
     for edge in call_edges:
-        if edge.kind == "CALLS":
+        if edge.kind == "CALLS" and edge.is_live():
             edits.append({
                 "file": edge.file_path,
                 "line": edge.line,
@@ -124,6 +124,8 @@ def rename_preview(
     bare_edges = store.search_edges_by_target_name(old_name, kind="CALLS")
     seen = {(e["file"], e["line"]) for e in edits}
     for edge in bare_edges:
+        if not edge.is_live():
+            continue
         key = (edge.file_path, edge.line)
         if key not in seen:
             edits.append({
@@ -471,13 +473,13 @@ def find_dead_code(
         incoming = store.get_edges_by_target(node.qualified_name)
         # Also check class-qualified edges (e.g. "ClassName::method") which
         # lack the file-path prefix used in node.qualified_name.
-        if not any(e.kind == "CALLS" for e in incoming) and node.parent_name:
+        if not any(e.kind == "CALLS" and e.is_live() for e in incoming) and node.parent_name:
             class_qn = f"{node.parent_name}::{node.name}"
             incoming = incoming + store.get_edges_by_target(class_qn)
         # Also check bare-name and partially-qualified edges.
         # CALLS targets may be bare ("funcName"), class-qualified
         # ("Class::method"), or workspace-qualified ("pkg/dir::funcName").
-        if not any(e.kind == "CALLS" for e in incoming):
+        if not any(e.kind == "CALLS" and e.is_live() for e in incoming):
             bare = store.search_edges_by_target_name(node.name, kind="CALLS")
             # Also search for partially-qualified targets ending with ::name
             suffix_rows = conn.execute(
@@ -497,7 +499,7 @@ def find_dead_code(
         # edge -- look outgoing, not incoming. See: #515
         outgoing_tb = [
             e for e in store.get_edges_by_source(node.qualified_name)
-            if e.kind == "TESTED_BY"
+            if e.kind == "TESTED_BY" and e.is_live()
         ]
         if not outgoing_tb and node.parent_name:
             # Class-qualified source (e.g. "ClassName::method") which lacks the
@@ -505,13 +507,14 @@ def find_dead_code(
             class_qn = f"{node.parent_name}::{node.name}"
             outgoing_tb += [
                 e for e in store.get_edges_by_source(class_qn)
-                if e.kind == "TESTED_BY"
+                if e.kind == "TESTED_BY" and e.is_live()
             ]
         if not outgoing_tb:
             # Bare-name source fallback: unresolved TESTED_BY edges may store the
             # production function by its plain name (e.g. "authenticate").
             bare_rows = conn.execute(
-                "SELECT * FROM edges WHERE kind = 'TESTED_BY' AND source_qualified = ?",
+                "SELECT * FROM edges WHERE kind = 'TESTED_BY' AND source_qualified = ? "
+                "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0",
                 (node.name,),
             ).fetchall()
             outgoing_tb += [
@@ -522,7 +525,7 @@ def find_dead_code(
         if node.kind == "Class" and not any(e.kind == "INHERITS" for e in incoming):
             bare_inh = store.search_edges_by_target_name(node.name, kind="INHERITS")
             incoming = incoming + bare_inh
-        has_callers = any(e.kind == "CALLS" for e in incoming)
+        has_callers = any(e.kind == "CALLS" and e.is_live() for e in incoming)
         has_test_refs = bool(outgoing_tb)
         has_importers = any(e.kind == "IMPORTS_FROM" for e in incoming)
         has_references = any(e.kind == "REFERENCES" for e in incoming)
@@ -539,7 +542,8 @@ def find_dead_code(
             bare_prefix = node.name + "."
             member_calls = conn.execute(
                 "SELECT COUNT(*) FROM edges WHERE kind = 'CALLS'"
-                " AND (target_qualified LIKE ? OR target_qualified LIKE ?)",
+                " AND (target_qualified LIKE ? OR target_qualified LIKE ?)"
+                " AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0",
                 (f"%{member_prefix}%", f"%{bare_prefix}%"),
             ).fetchone()[0]
             if member_calls > 0:
@@ -567,6 +571,7 @@ def find_dead_code(
                             if conn.execute(
                                 "SELECT 1 FROM edges "
                                 "WHERE target_qualified = ? AND kind = 'CALLS' "
+                                "AND COALESCE(json_extract(extra, '$.reachable'), 1) != 0 "
                                 "LIMIT 1",
                                 (base_method_qn,),
                             ).fetchone():
@@ -652,7 +657,7 @@ def suggest_refactorings(store: GraphStore) -> list[dict[str, Any]]:
 
             incoming_calls = [
                 e for e in store.get_edges_by_target(fnode.qualified_name)
-                if e.kind == "CALLS"
+                if e.kind == "CALLS" and e.is_live()
             ]
             if not incoming_calls:
                 continue

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -227,7 +227,7 @@ def query_graph(
         if pattern == "callers_of":
             seen_sources: set[str] = set()
             for e in store.get_edges_by_target(qn):
-                if e.kind == "CALLS":
+                if e.kind == "CALLS" and e.is_live():
                     if e.source_qualified not in seen_sources:
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
@@ -239,6 +239,8 @@ def query_graph(
             # (e.g. "file.ts::generateTestCode"). Search by plain name too.
             if node:
                 for e in store.search_edges_by_target_name(node.name):
+                    if not e.is_live():
+                        continue
                     if e.source_qualified not in seen_sources:
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
@@ -249,7 +251,7 @@ def query_graph(
         elif pattern == "callees_of":
             seen_targets: set[str] = set()
             for e in store.get_edges_by_source(qn):
-                if e.kind == "CALLS":
+                if e.kind == "CALLS" and e.is_live():
                     if e.target_qualified not in seen_targets:
                         seen_targets.add(e.target_qualified)
                         callee = store.get_node(e.target_qualified)
@@ -693,10 +695,14 @@ def traverse_graph_func(
                 current_qn
             )
             for e in out_edges:
+                if not e.is_live():
+                    continue
                 tgt = e.target_qualified
                 if tgt not in visited:
                     queue.append((tgt, cur_depth + 1))
             for e in in_edges:
+                if not e.is_live():
+                    continue
                 src = e.source_qualified
                 if src not in visited:
                     queue.append((src, cur_depth + 1))

--- a/tests/fixtures/sample_dead_guard.py
+++ b/tests/fixtures/sample_dead_guard.py
@@ -1,7 +1,7 @@
 """Fixture for testing dead-guard detection on CALLS edges.
 
-Contains calls under ``if False:``, ``if TYPE_CHECKING:``, and a live
-call as a control.  The parser should tag the first two with
+Contains calls under ``if False:``, ``if 0:``, ``if TYPE_CHECKING:``,
+and a live call as a control.  The parser should tag the dead ones with
 ``extra["reachable"] == False`` and leave the live call without the key.
 """
 
@@ -22,6 +22,9 @@ def caller():
 
     if False:
         dead_false_call()  # noqa: F821
+
+    if 0:
+        dead_zero_call()  # noqa: F821
 
     if TYPE_CHECKING:
         dead_tc_call()  # noqa: F821

--- a/tests/fixtures/sample_dead_guard.py
+++ b/tests/fixtures/sample_dead_guard.py
@@ -1,0 +1,27 @@
+"""Fixture for testing dead-guard detection on CALLS edges.
+
+Contains calls under ``if False:``, ``if TYPE_CHECKING:``, and a live
+call as a control.  The parser should tag the first two with
+``extra["reachable"] == False`` and leave the live call without the key.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os.path import join as pjoin  # noqa: F401
+
+
+def live_helper():
+    pass
+
+
+def caller():
+    live_helper()
+
+    if False:
+        dead_false_call()  # noqa: F821
+
+    if TYPE_CHECKING:
+        dead_tc_call()  # noqa: F821

--- a/tests/fixtures/sample_dead_guard.py
+++ b/tests/fixtures/sample_dead_guard.py
@@ -1,8 +1,14 @@
 """Fixture for testing dead-guard detection on CALLS edges.
 
 Contains calls under ``if False:``, ``if 0:``, ``if TYPE_CHECKING:``,
-and a live call as a control.  The parser should tag the dead ones with
-``extra["reachable"] == False`` and leave the live call without the key.
+and live calls as controls.  The parser should:
+
+* **omit** CALLS edges inside the consequence (true branch) of a dead
+  guard -- those edges are never emitted at all.
+* **keep** CALLS edges inside the else/elif branch of a dead guard --
+  those branches execute when the condition is false.
+* treat ``TYPE_CHECKING`` as the typing sentinel only when it is
+  imported from ``typing``.
 """
 
 from __future__ import annotations
@@ -18,13 +24,35 @@ def live_helper():
 
 
 def caller():
-    live_helper()
+    live_helper()                    # live -- no guard
 
     if False:
-        dead_false_call()  # noqa: F821
+        dead_false_call()            # noqa: F821 -- dead consequence
 
     if 0:
-        dead_zero_call()  # noqa: F821
+        dead_zero_call()             # noqa: F821 -- dead consequence
 
     if TYPE_CHECKING:
-        dead_tc_call()  # noqa: F821
+        dead_tc_call()               # noqa: F821 -- dead consequence
+
+
+def else_branch():
+    """Calls in the else branch of ``if False:`` are LIVE."""
+    if False:
+        dead_in_if()                 # noqa: F821 -- dead consequence
+    else:
+        live_in_else()               # live -- else branch of if False
+
+
+def elif_chain():
+    """Calls in elif branches of ``if False:`` are LIVE."""
+    if False:
+        dead_elif_consequence()      # noqa: F821 -- dead
+    elif some_condition():
+        live_elif_call()             # live -- elif branch
+    else:
+        live_final_else()            # live -- else branch
+
+
+def some_condition() -> bool:
+    return True

--- a/tests/fixtures/sample_type_checking_false_positive.py
+++ b/tests/fixtures/sample_type_checking_false_positive.py
@@ -1,0 +1,14 @@
+"""False-positive control: a local ``TYPE_CHECKING`` variable that is NOT
+imported from ``typing`` must not mark calls as dead.
+
+See: #576, #580.
+"""
+
+
+TYPE_CHECKING = False  # noqa: N816 -- local, not from typing
+
+
+def live_under_local_tc():
+    """This call should be LIVE -- TYPE_CHECKING is a local variable."""
+    if TYPE_CHECKING:
+        should_be_live()             # noqa: F821

--- a/tests/test_mcp_stdio_zombie.py
+++ b/tests/test_mcp_stdio_zombie.py
@@ -1,0 +1,310 @@
+"""Regression tests for MCP stdio zombie / FD-inheritance issues.
+
+The MCP server communicates over stdio (stdin pipe).  When the host
+disconnects (closes its end of the pipe), the server must exit cleanly
+without leaving orphaned worker, fork-server, or zombie processes.
+
+These tests verify:
+1. ``_select_executor_kind()`` respects ``CRG_PARSE_EXECUTOR`` overrides
+   and auto-switches to threads on Windows when stdin is not a TTY.
+2. An end-to-end subprocess test that spawns the real MCP server with
+   pipe stdin, triggers a parse, closes the parent side of stdin, and
+   asserts the server exits within a short timeout with no zombies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from code_review_graph.incremental import _select_executor_kind
+
+# ---------------------------------------------------------------------------
+# Unit tests for _select_executor_kind
+# ---------------------------------------------------------------------------
+
+class TestSelectExecutorKind:
+    """Verify the executor selection logic and CRG_PARSE_EXECUTOR overrides."""
+
+    def test_default_returns_process(self, monkeypatch):
+        """Without any override, the default is 'process' on non-Windows."""
+        monkeypatch.delenv("CRG_PARSE_EXECUTOR", raising=False)
+        result = _select_executor_kind()
+        if sys.platform == "win32" and not sys.stdin.isatty():
+            assert result == "thread"
+        else:
+            assert result == "process"
+
+    def test_explicit_process_override(self, monkeypatch):
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "process")
+        assert _select_executor_kind() == "process"
+
+    def test_explicit_thread_override(self, monkeypatch):
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "thread")
+        assert _select_executor_kind() == "thread"
+
+    def test_override_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "THREAD")
+        assert _select_executor_kind() == "thread"
+
+    def test_override_with_whitespace(self, monkeypatch):
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "  process  ")
+        assert _select_executor_kind() == "process"
+
+    def test_empty_string_ignored(self, monkeypatch):
+        """An empty CRG_PARSE_EXECUTOR should fall through to platform logic."""
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "")
+        result = _select_executor_kind()
+        assert result in ("process", "thread")
+
+    def test_invalid_value_ignored(self, monkeypatch):
+        """An unrecognized value falls through to platform logic."""
+        monkeypatch.setenv("CRG_PARSE_EXECUTOR", "fork")
+        result = _select_executor_kind()
+        assert result in ("process", "thread")
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only logic")
+    def test_windows_stdio_auto_switches_to_thread(self, monkeypatch):
+        """On Windows with non-TTY stdin (MCP stdio), auto-select thread."""
+        monkeypatch.delenv("CRG_PARSE_EXECUTOR", raising=False)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        assert _select_executor_kind() == "thread"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only logic")
+    def test_windows_tty_keeps_process(self, monkeypatch):
+        """On Windows with a real TTY, keep the process executor."""
+        monkeypatch.delenv("CRG_PARSE_EXECUTOR", raising=False)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        assert _select_executor_kind() == "process"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression: MCP server exits cleanly on stdin close
+# ---------------------------------------------------------------------------
+
+def _descendants(pids: set[int]) -> set[int]:
+    """Return all descendant PIDs of the given set (recursive)."""
+    all_desc: set[int] = set()
+    frontier = set(pids)
+    while frontier:
+        next_frontier: set[int] = set()
+        for pid in frontier:
+            try:
+                children = subprocess.check_output(
+                    ["pgrep", "-P", str(pid)],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                for line in children.splitlines():
+                    child = int(line)
+                    if child not in all_desc:
+                        all_desc.add(child)
+                        next_frontier.add(child)
+            except (subprocess.CalledProcessError, ValueError):
+                pass
+        frontier = next_frontier
+    return all_desc
+
+
+def _any_alive(pids: set[int]) -> list[int]:
+    """Return PIDs that are still alive (kill -0 succeeds)."""
+    alive = []
+    for pid in pids:
+        try:
+            os.kill(pid, 0)
+            alive.append(pid)
+        except OSError:
+            pass
+    return alive
+
+
+class TestMcpStdioZombieRegression:
+    """End-to-end: server must exit cleanly when the host closes stdin."""
+
+    TIMEOUT_S = 15  # generous for CI; real exit is < 2s
+
+    def _find_server_script(self) -> str:
+        """Locate the MCP server entry point for subprocess invocation."""
+        # The package is installed; use `code-review-graph serve` via the
+        # console_scripts entry point, or fall back to `python -m`.
+        return sys.executable
+
+    def test_server_exits_on_stdin_close(self, tmp_path):
+        """Spawn MCP server with pipe stdin, close parent side, assert exit.
+
+        Steps:
+        1. Start ``code-review-graph serve`` with stdin=PIPE so the server
+           reads from a pipe (not a TTY).
+        2. Send a minimal JSON-RPC initialize message to trigger the
+           server's read loop.
+        3. Close the parent's write end of stdin to simulate a host
+           disconnect.
+        4. Wait up to TIMEOUT_S for the server to exit.
+        5. Assert the exit code is 0 or the process was terminated cleanly.
+        6. Assert no child/zombie processes remain.
+        """
+        env = os.environ.copy()
+        env["CRG_PARSE_EXECUTOR"] = "thread"  # avoid fork issues in test
+        env.pop("CRG_TOOLS", None)
+
+        proc = subprocess.Popen(
+            [self._find_server_script(), "-m", "code_review_graph.cli", "serve"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=str(tmp_path),
+        )
+
+        try:
+            # Record children before we do anything.
+            initial_children = _descendants({proc.pid})
+
+            # Send a minimal JSON-RPC initialize request so the server
+            # enters its read loop (it blocks on stdin.readline()).
+            init_msg = json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0.1"},
+                    "protocolVersion": "2024-11-05",
+                },
+            }) + "\n"
+            try:
+                proc.stdin.write(init_msg.encode())
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                # Server may have already exited (fast path).
+                pass
+
+            # Give the server a moment to process the initialize.
+            time.sleep(0.5)
+
+            # Close stdin to simulate host disconnect.
+            try:
+                proc.stdin.close()
+            except OSError:
+                pass
+
+            # Wait for the server to exit.
+            try:
+                proc.wait(timeout=self.TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+                pytest.fail(
+                    f"MCP server did not exit within {self.TIMEOUT_S}s "
+                    f"after stdin was closed (pid={proc.pid})"
+                )
+
+            # Collect any new children that appeared during the run.
+            time.sleep(1.0)
+            final_children = _descendants({proc.pid})
+            new_children = final_children - initial_children
+            alive_orphans = _any_alive(new_children)
+
+            assert not alive_orphans, (
+                f"Orphan child processes still alive after server exit: "
+                f"{alive_orphans} (server pid={proc.pid})"
+            )
+
+        finally:
+            # Belt-and-suspenders cleanup.
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=3)
+
+    def test_server_exits_on_stdin_close_with_parse(self, tmp_path):
+        """Same as above but triggers a real parse before disconnecting.
+
+        This exercises the process/thread executor path and verifies that
+        worker processes are properly cleaned up when stdin closes mid-parse.
+        """
+        # Create a tiny repo so the server has something to parse.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "hello.py").write_text("def hello():\n    return 42\n")
+
+        env = os.environ.copy()
+        env["CRG_PARSE_EXECUTOR"] = "thread"
+        env.pop("CRG_TOOLS", None)
+
+        proc = subprocess.Popen(
+            [self._find_server_script(), "-m", "code_review_graph.cli", "serve",
+             "--repo", str(tmp_path)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=str(tmp_path),
+        )
+
+        try:
+            initial_children = _descendants({proc.pid})
+
+            # Send initialize.
+            init_msg = json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0.1"},
+                    "protocolVersion": "2024-11-05",
+                },
+            }) + "\n"
+            try:
+                proc.stdin.write(init_msg.encode())
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                pass
+
+            # Send a tools/call to trigger a build (uses the executor).
+            build_msg = json.dumps({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "build_or_update_graph_tool",
+                    "arguments": {"repo_root": str(tmp_path)},
+                },
+            }) + "\n"
+            try:
+                proc.stdin.write(build_msg.encode())
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                pass
+
+            # Give the parse some time to start.
+            time.sleep(1.0)
+
+            # Close stdin mid-parse.
+            try:
+                proc.stdin.close()
+            except OSError:
+                pass
+
+            try:
+                proc.wait(timeout=self.TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+                pytest.fail(
+                    f"MCP server did not exit within {self.TIMEOUT_S}s "
+                    f"after stdin close during parse (pid={proc.pid})"
+                )
+
+            time.sleep(1.0)
+            final_children = _descendants({proc.pid})
+            new_children = final_children - initial_children
+            alive_orphans = _any_alive(new_children)
+
+            assert not alive_orphans, (
+                f"Orphan child processes still alive after mid-parse "
+                f"stdin close: {alive_orphans} (server pid={proc.pid})"
+            )
+
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=3)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1149,34 +1149,65 @@ class TestCodeParser:
         assert "test_something" in test_names
         assert "helper" not in test_names
 
-    def test_dead_guard_reachable_flag(self):
-        """CALLS edges inside ``if False:`` / ``if 0:`` /
-        ``if TYPE_CHECKING:`` are tagged with
-        ``extra["reachable"] == False``; live calls omit the key
-        entirely.  See: #576."""
+    def test_dead_guard_omits_dead_edges(self):
+        """CALLS edges inside the consequence (true branch) of
+        ``if False:`` / ``if 0:`` / ``if TYPE_CHECKING:`` are never
+        emitted.  Live calls and calls in else/elif branches are kept.
+        See: #576, #580."""
         nodes, edges = self.parser.parse_file(
             FIXTURES / "sample_dead_guard.py",
         )
         calls = [e for e in edges if e.kind == "CALLS"]
 
+        # Live control: emitted normally
         live = [e for e in calls if "live_helper" in e.target]
+        assert len(live) == 1
+
+        # Dead consequence calls are NOT emitted at all
         dead_false = [e for e in calls if "dead_false_call" in e.target]
         dead_zero = [e for e in calls if "dead_zero_call" in e.target]
         dead_tc = [e for e in calls if "dead_tc_call" in e.target]
+        assert dead_false == []
+        assert dead_zero == []
+        assert dead_tc == []
 
-        # Control: live call has no reachable key
+        # Dead consequence inside else_branch function is NOT emitted
+        dead_in_if = [e for e in calls if "dead_in_if" in e.target]
+        assert dead_in_if == []
+
+        # else branch of ``if False:`` is LIVE
+        live_else = [e for e in calls if "live_in_else" in e.target]
+        assert len(live_else) == 1
+
+        # elif branches of ``if False:`` are LIVE
+        live_elif = [e for e in calls if "live_elif_call" in e.target]
+        assert len(live_elif) == 1
+
+        # final else of elif chain is LIVE
+        live_final = [e for e in calls if "live_final_else" in e.target]
+        assert len(live_final) == 1
+
+        # Dead consequence of elif chain is NOT emitted
+        dead_elif_cons = [
+            e for e in calls if "dead_elif_consequence" in e.target
+        ]
+        assert dead_elif_cons == []
+
+        # Total: 5 live edges (live_helper, live_in_else,
+        # some_condition, live_elif_call, live_final_else)
+        assert len(calls) == 5
+
+    def test_type_checking_false_positive(self):
+        """A local variable named ``TYPE_CHECKING`` that is NOT imported
+        from ``typing`` must not mark calls as dead.  See: #576."""
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_type_checking_false_positive.py",
+        )
+        calls = [e for e in edges if e.kind == "CALLS"]
+        # Exactly one CALLS edge should exist (should_be_live)
+        assert len(calls) == 1
+        live = [e for e in calls if "should_be_live" in e.target]
         assert len(live) == 1
-        assert "reachable" not in live[0].extra
-
-        # Dead calls carry the flag
-        assert len(dead_false) == 1
-        assert dead_false[0].extra.get("reachable") is False
-
-        assert len(dead_zero) == 1
-        assert dead_zero[0].extra.get("reachable") is False
-
-        assert len(dead_tc) == 1
-        assert dead_tc[0].extra.get("reachable") is False
 
 
 class TestValueReferences:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1149,6 +1149,30 @@ class TestCodeParser:
         assert "test_something" in test_names
         assert "helper" not in test_names
 
+    def test_dead_guard_reachable_flag(self):
+        """CALLS edges inside ``if False:`` / ``if TYPE_CHECKING:`` are
+        tagged with ``extra["reachable"] == False``; live calls omit the
+        key entirely.  See: #576."""
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.py",
+        )
+        calls = [e for e in edges if e.kind == "CALLS"]
+
+        live = [e for e in calls if "live_helper" in e.target]
+        dead_false = [e for e in calls if "dead_false_call" in e.target]
+        dead_tc = [e for e in calls if "dead_tc_call" in e.target]
+
+        # Control: live call has no reachable key
+        assert len(live) == 1
+        assert "reachable" not in live[0].extra
+
+        # Dead calls carry the flag
+        assert len(dead_false) == 1
+        assert dead_false[0].extra.get("reachable") is False
+
+        assert len(dead_tc) == 1
+        assert dead_tc[0].extra.get("reachable") is False
+
 
 class TestValueReferences:
     """Tests for REFERENCES edge extraction from function-as-value patterns."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1150,9 +1150,10 @@ class TestCodeParser:
         assert "helper" not in test_names
 
     def test_dead_guard_reachable_flag(self):
-        """CALLS edges inside ``if False:`` / ``if TYPE_CHECKING:`` are
-        tagged with ``extra["reachable"] == False``; live calls omit the
-        key entirely.  See: #576."""
+        """CALLS edges inside ``if False:`` / ``if 0:`` /
+        ``if TYPE_CHECKING:`` are tagged with
+        ``extra["reachable"] == False``; live calls omit the key
+        entirely.  See: #576."""
         nodes, edges = self.parser.parse_file(
             FIXTURES / "sample_dead_guard.py",
         )
@@ -1160,6 +1161,7 @@ class TestCodeParser:
 
         live = [e for e in calls if "live_helper" in e.target]
         dead_false = [e for e in calls if "dead_false_call" in e.target]
+        dead_zero = [e for e in calls if "dead_zero_call" in e.target]
         dead_tc = [e for e in calls if "dead_tc_call" in e.target]
 
         # Control: live call has no reachable key
@@ -1169,6 +1171,9 @@ class TestCodeParser:
         # Dead calls carry the flag
         assert len(dead_false) == 1
         assert dead_false[0].extra.get("reachable") is False
+
+        assert len(dead_zero) == 1
+        assert dead_zero[0].extra.get("reachable") is False
 
         assert len(dead_tc) == 1
         assert dead_tc[0].extra.get("reachable") is False


### PR DESCRIPTION
## Summary

Fix #576 end-to-end. PR #580 tagged CALLS edges with `extra.reachable=False` but no consumer checked it — every caller, impact, flow, and dead-code path still traversed dead edges as live.

This fix takes the opposite approach: **dead CALLS edges are never emitted at all**. All downstream consumers also gained `is_live()` filtering for backward compatibility with old graphs.

## What Changed

### Parser (parser.py)

**Branch semantics fix** — only the consequence (true branch) of a dead guard is dead; else/elif branches are live:

```python
# BEFORE (PR #580): entire if_statement treated as dead
# AFTER: only consequence branch is dead
if False:
    dead_call()      # NOT emitted
else:
    live_call()      # emitted
```

**TYPE_CHECKING import verification** — only treat `TYPE_CHECKING` as the typing sentinel when `import_map` confirms it was imported from `typing`. A coincidentally-named local variable is not a dead guard.

**Byte-range comparison** — tree-sitter Python bindings create fresh `Node` objects per `child_by_field_name` call, so `is` identity comparison failed. Switched to byte-range matching in `_node_is_in_child()`.

**Scope boundaries** — added `lambda` and `async_function_definition` to the scope-boundary list so nested definitions under dead guards don't propagate dead status.

### Graph (graph.py)

- `GraphEdge.is_live()` — backward-compat predicate with `None`/`str`/`dict` defense for `extra`
- SQL filters use `COALESCE(json_extract(extra, '$.reachable'), 1) != 0` to handle new graphs (no `reachable` key) and old graphs (`reachable: False`)
- Filters added to: `get_all_call_targets` (2 queries), `_build_networkx_graph`, `get_impact_radius_sql` CTE, `get_edges_among`, `get_transitive_tests` (CALLS + 3 TESTED_BY queries), `load_flow_adjacency` (unified CALLS+TESTED_BY)

### Consumers (6 files)

Every consumer that traverses CALLS or TESTED_BY edges now filters via `is_live()`:

| File | Functions |
|------|-----------|
| analysis.py | `find_hub_nodes`, `find_knowledge_gaps`, `find_surprising_connections` (degree + edge loop), `find_bridge_nodes` (NetworkX) |
| changes.py | `compute_risk_score`, `analyze_changes` (TESTED_BY) |
| enrich.py | `_format_node_context` (callers + callees) |
| refactor.py | `rename_preview` (calls + bare-name fallback), `find_dead_code` (TESTED_BY × 3 + polymorphic SQL + member SQL), `suggest_refactorings` |
| tools/query.py | `query_graph` (callers_of calls + fallback, callees_of), `traverse_graph_func` (BFS/DFS) |

### Tests

- `test_dead_guard_omits_dead_edges` — verifies dead consequences are omitted, else/elif calls are live, total count = 5
- `test_type_checking_false_positive` — local `TYPE_CHECKING` variable (not from typing) must not suppress calls, total count = 1

## End-to-End Verification

Built a real graph from fixtures and verified at store level:

```
=== get_all_call_targets: 5 targets ===
  live_elif_call / live_final_else / live_in_else / live_helper / some_condition
  Leaked dead targets: NONE

=== is_live() backward compat ===
  reachable=False  -> False  (correct)
  no key           -> True   (correct)
  JSON string      -> False  (correct)
  None             -> True   (correct)

=== SQL filter ===
  Old dead edge (reachable=False): No (correctly filtered)
  New live edge (no key): Yes (correctly included)

ALL CHECKS PASSED
```

## Known Limitations (Follow-up)

1. **`typing.TYPE_CHECKING` attribute access** — `if typing.TYPE_CHECKING:` (attribute node) is not recognized. Needs attribute-node handling in `_is_in_static_dead_guard`.
2. **TYPE_CHECKING alias** — `from typing import TYPE_CHECKING as TC` is not recognized. Needs alias resolution from `import_map`.
3. **Cross-language** — dead-guard detection is Python-focused. `if (false) { ... }` in JavaScript is not handled (intentional scope for this PR).

## Review Process

This PR went through 9 rounds of automated architecture review (deepseek-v4-flash via code-forge with code-review-graph context injection). Rounds 1–8 found and fixed real bugs; round 9 returned zero new findings.

Key bugs caught during review:
- The original SQL filter used `IS NOT 0`, which silently excluded all CALLS edges on new graphs (no `reachable` key yields NULL, and `NULL IS NOT 0` is falsy). Fixed by switching to `COALESCE(..., 1) != 0`.
- `import typing` was incorrectly treated as a dead guard — when a file does `import typing` (the module itself), the local name `typing` was added to the sentinel set, causing any `if typing:` block to suppress calls. Fixed by requiring `local == "TYPE_CHECKING"` in addition to `qualified == "typing"`.
- `GraphEdge.is_live()` crashed on old databases where `extra` is stored as a JSON string or NULL. Added `None` and `isinstance(str)` guards.
- `async_function_definition` was missing from the scope-boundary list, so async functions nested under dead guards could have their calls incorrectly marked dead.
- The `search_edges_by_target_name` fallback path in both `query_graph` and `rename_preview` was not filtering dead edges from old graphs.
- TESTED_BY edges in `get_transitive_tests`, `find_dead_code`, and `analyze_changes` were not filtered, allowing dead test coverage to appear real.