### PR TITLE
docs: sync release-facing version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: tirth8205/code-review-graph@v2.3.6
+      - uses: tirth8205/code-review-graph@v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Features
 
-## v2.3.6 (Current)
+## v2.3.7 (Current)
 - **Framework-aware PHP parsing**: traits, enums, object creation, and base clauses are indexed; Composer PSR-4 resolution is longest-prefix, multi-directory, cached, and repository-bounded; Blade references ignore comments/escaped directives; Laravel Route and Eloquent edges require explicit framework/import/receiver evidence.
 - **Custom languages without forking**: drop a `.code-review-graph/languages.toml` into your repo to index any grammar shipped by tree-sitter-language-pack — extension map plus node-type lists, validated and capped, with built-in languages always winning. See [CUSTOM_LANGUAGES.md](CUSTOM_LANGUAGES.md).
 - **GitHub Action for risk-scored PR reviews**: composite `action.yml` builds/restores the graph from CI cache, runs `detect-changes` against the PR base, and upserts a sticky comment with risk table, affected flows, test gaps, and the Token Savings line. Optional `fail-on-risk` merge gate. Dogfooded on this repo via `.github/workflows/pr-review.yml`. See [GITHUB_ACTION.md](GITHUB_ACTION.md).

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: tirth8205/code-review-graph@v2.3.6
+      - uses: tirth8205/code-review-graph@v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -53,7 +53,7 @@ uses Node 24-based GitHub actions, including `actions/setup-python@v6`,
 To turn the review into a merge gate:
 
 ```yaml
-      - uses: tirth8205/code-review-graph@v2.3.6
+      - uses: tirth8205/code-review-graph@v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-risk: high

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -1,4 +1,4 @@
-# LLM-OPTIMIZED REFERENCE -- code-review-graph v2.3.6
+# LLM-OPTIMIZED REFERENCE -- code-review-graph v2.3.7
 
 AI coding agents: Read ONLY the exact `<section>` you need. Never load the whole file.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Shipped
 
-### v2.3.6
+### v2.3.7
 - **Custom languages without forking**: `.code-review-graph/languages.toml` maps extensions and node types to any tree-sitter-language-pack grammar (`docs/CUSTOM_LANGUAGES.md`)
 - **GitHub Action** for risk-scored PR review comments: graph built/restored on the CI runner, sticky comment upserted per push, optional `fail-on-risk` merge gate; dogfooded via `.github/workflows/pr-review.yml` (`docs/GITHUB_ACTION.md`)
 - **`agent_baseline` benchmark**: graph queries vs a realistic grep-and-read-top-k agent baseline, wired into all six pinned eval configs

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Code Review Graph — User Guide
 
-**Applies to:** v2.3.6
+**Applies to:** v2.3.7
 
 ## Installation
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -3,6 +3,11 @@
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
 ROOT = Path(__file__).parents[1]
 README_FILES = (
     "README.md",
@@ -26,6 +31,19 @@ USER_DOC_FILES = README_FILES + (
     "docs/LLM-OPTIMIZED-REFERENCE.md",
     "docs/TROUBLESHOOTING.md",
 )
+RELEASE_VERSION_DOC_FILES = (
+    "README.md",
+    "docs/FEATURES.md",
+    "docs/GITHUB_ACTION.md",
+    "docs/LLM-OPTIMIZED-REFERENCE.md",
+    "docs/ROADMAP.md",
+    "docs/USAGE.md",
+)
+
+
+def current_project_version() -> str:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return pyproject["project"]["version"]
 
 
 def test_pip_extra_examples_use_cross_shell_double_quotes():
@@ -61,6 +79,18 @@ def test_github_action_references_use_current_supported_majors():
                     f"{path.relative_to(ROOT)} uses actions/{action}@v{actual}; "
                     f"expected v{expected}"
                 )
+
+
+def test_release_facing_docs_match_project_version():
+    version = current_project_version()
+    previous_minor = re.escape("2.3.6")
+
+    for doc_name in RELEASE_VERSION_DOC_FILES:
+        content = (ROOT / doc_name).read_text(encoding="utf-8")
+        assert version in content, f"{doc_name} does not mention current version {version}"
+        assert re.search(rf"\bv{previous_minor}\b|\b{previous_minor}\b", content) is None, (
+            f"{doc_name} still references previous release version 2.3.6"
+        )
 
 
 def test_codebuddy_install_docs_cover_project_artifacts():


### PR DESCRIPTION
## Summary
- Update release-facing documentation references from v2.3.6 to v2.3.7 now that the package metadata, changelog, and tag are on 2.3.7.
- Add a documentation regression test that reads pyproject.toml and checks the main release-facing docs mention the current project version.

## Verification
- uv run pytest tests/test_documentation.py -q
- uv run --extra dev ruff check tests/test_documentation.py