### PR TITLE
fix(search): preserve cross-repository result visibility

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -940,8 +940,10 @@ def cross_repo_search_tool(
 ) -> dict:
     """Search for code entities across all registered repositories.
 
-    Runs hybrid search on each registered repo's graph database and merges
-    the results by score. Register repos first with the CLI 'register' command.
+    Runs hybrid search on each registered repo's graph database and interleaves
+    results by repository-local rank. Equal ranks follow registry order, and up
+    to ``limit`` results per searched repo may be returned. Register repos first
+    with the CLI 'register' command.
 
     Args:
         query: Search string to match against node names.

--- a/code_review_graph/tools/registry_tools.py
+++ b/code_review_graph/tools/registry_tools.py
@@ -79,10 +79,10 @@ def cross_repo_search_func(
                 "results": [],
             }
 
-        all_results: list[dict[str, Any]] = []
+        ranked_results: list[tuple[int, int, dict[str, Any]]] = []
         searched_repos: list[str] = []
 
-        for repo_entry in repos:
+        for repo_index, repo_entry in enumerate(repos):
             repo_path = Path(repo_entry["path"])
             db_path = get_db_path(repo_path)
             if not db_path.exists():
@@ -95,10 +95,10 @@ def cross_repo_search_func(
                         store, query, kind=kind, limit=limit
                     )
                     alias = repo_entry.get("alias", repo_path.name)
-                    for r in results:
+                    for local_rank, r in enumerate(results):
                         r["repo"] = alias
                         r["repo_path"] = str(repo_path)
-                    all_results.extend(results)
+                        ranked_results.append((local_rank, repo_index, r))
                     searched_repos.append(alias)
                 finally:
                     store.close()
@@ -107,10 +107,10 @@ def cross_repo_search_func(
                     "Search failed for %s: %s", repo_path, exc
                 )
 
-        # Sort all results by score descending
-        all_results.sort(
-            key=lambda r: r.get("score", 0), reverse=True
-        )
+        # Scores from different search paths are not comparable across repos.
+        # Merge by each repo's local rank and use registry order as a stable tie-breaker.
+        ranked_results.sort(key=lambda item: (item[0], item[1]))
+        all_results = [result for _, _, result in ranked_results]
 
         return {
             "status": "ok",
@@ -118,7 +118,7 @@ def cross_repo_search_func(
                 f"Found {len(all_results)} result(s) across "
                 f"{len(searched_repos)} repo(s) for '{query}'"
             ),
-            "results": all_results[:limit],
+            "results": all_results,
             "repos_searched": searched_repos,
         }
     except Exception as exc:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -239,6 +239,65 @@ class TestCrossRepoSearch:
         import shutil
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
+    def test_cross_repo_search_merges_by_local_rank(self, tmp_path):
+        """Cross-repo results use local rank instead of incomparable raw scores."""
+        from code_review_graph.tools import cross_repo_search_func
+
+        android_repo = tmp_path / "android"
+        ios_repo = tmp_path / "ios"
+        android_repo.mkdir()
+        ios_repo.mkdir()
+        android_db = tmp_path / "android.db"
+        ios_db = tmp_path / "ios.db"
+        android_db.touch()
+        ios_db.touch()
+
+        android_results = [
+            {"name": "Splash", "score": 0.032},
+            {"name": "SplashWelcomeScreen", "score": 0.016},
+        ]
+        ios_results = [
+            {"name": "SplashViewController", "score": 3.0},
+            {"name": "SplashScreen", "score": 2.0},
+        ]
+
+        with (
+            patch("code_review_graph.registry.Registry") as mock_registry_cls,
+            patch(
+                "code_review_graph.tools.registry_tools.get_db_path",
+                side_effect=[android_db, ios_db],
+            ),
+            patch("code_review_graph.tools.registry_tools.GraphStore") as mock_store_cls,
+            patch(
+                "code_review_graph.tools.registry_tools.hybrid_search",
+                side_effect=[android_results, ios_results],
+            ) as mock_search,
+        ):
+            mock_registry_cls.return_value.list_repos.return_value = [
+                {"path": str(android_repo), "alias": "android"},
+                {"path": str(ios_repo), "alias": "ios"},
+            ]
+            mock_store_cls.side_effect = [MagicMock(), MagicMock()]
+
+            result = cross_repo_search_func(query="splash", limit=2)
+
+        assert result["status"] == "ok"
+        assert [item["repo"] for item in result["results"]] == [
+            "android",
+            "ios",
+            "android",
+            "ios",
+        ]
+        assert [item["score"] for item in result["results"]] == [0.032, 3.0, 0.016, 2.0]
+        assert [item["repo_path"] for item in result["results"]] == [
+            str(android_repo),
+            str(ios_repo),
+            str(android_repo),
+            str(ios_repo),
+        ]
+        assert result["summary"] == "Found 4 result(s) across 2 repo(s) for 'splash'"
+        assert [call.kwargs["limit"] for call in mock_search.call_args_list] == [2, 2]
+
 
 class TestSetDataDir:
     """Tests for set_data_dir and get_data_dir_for_repo methods."""


### PR DESCRIPTION
## Linked issue

Closes #619

## What & why

`cross_repo_search_tool` merged raw scores from repository-local search paths that use different scales. A repository using keyword fallback could therefore outrank every FTS/RRF result, and the final global slice could hide another repository entirely.

This change interleaves results by each repository's local rank, uses registry order as a deterministic tie-breaker, and returns the complete set already bounded by the per-repository `limit`. Original scores and repository provenance are preserved. The public tool description now documents the ordering and response cardinality.

The related camelCase tokenization and multi-word query behavior remain out of scope.

## How it was tested

```bash
uv run pytest tests/test_registry.py -q
uv run pytest tests/ --tb=short -q
uv run ruff check code_review_graph/ tests/test_registry.py
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

- Registry tests: 27 passed
- Full suite: 1962 passed, 5 skipped, 2 xpassed
- Ruff: passed
- Mypy: no issues in 66 source files

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Public tool documentation updated for the behavior change
