### PR TITLE
fix(parser): distinguish C++ overload identities

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -323,6 +323,13 @@ class GraphStore:
         row = self._conn.execute("SELECT value FROM metadata WHERE key=?", (key,)).fetchone()
         return row["value"] if row else None
 
+    def has_nodes_for_language(self, language: str) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM nodes WHERE language = ? LIMIT 1",
+            (language,),
+        ).fetchone()
+        return row is not None
+
     def commit(self) -> None:
         self._conn.commit()
 
@@ -472,13 +479,25 @@ class GraphStore:
                 "indirect": indirect,
             }
 
+        def _has_unresolved_metadata(raw_extra: str | None) -> bool:
+            try:
+                edge_extra = json.loads(raw_extra or "{}")
+            except (TypeError, json.JSONDecodeError):
+                return False
+            return isinstance(edge_extra, dict) and (
+                "ambiguous_targets" in edge_extra
+                or "unresolved_targets" in edge_extra
+            )
+
         # Direct TESTED_BY (source=production, target=test). See: #515
         for qn in input_qns:
             for row in conn.execute(
-                "SELECT target_qualified FROM edges "
+                "SELECT target_qualified, extra FROM edges "
                 "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                 (qn,),
             ).fetchall():
+                if _has_unresolved_metadata(row["extra"]):
+                    continue
                 tgt = row["target_qualified"]
                 if tgt not in seen:
                     seen.add(tgt)
@@ -522,10 +541,12 @@ class GraphStore:
             )
 
         for row in conn.execute(
-            "SELECT target_qualified, file_path FROM edges "
+            "SELECT target_qualified, file_path, extra FROM edges "
             "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
             (bare,),
         ).fetchall():
+            if _has_unresolved_metadata(row["extra"]):
+                continue
             if _candidate_for_context(bare, row["file_path"]) != qualified_name:
                 continue
             tgt = row["target_qualified"]
@@ -541,10 +562,12 @@ class GraphStore:
             next_frontier: set[str] = set()
             for qn in frontier:
                 for row in conn.execute(
-                    "SELECT target_qualified FROM edges "
+                    "SELECT target_qualified, extra FROM edges "
                     "WHERE source_qualified = ? AND kind = 'CALLS'",
                     (qn,),
                 ).fetchall():
+                    if _has_unresolved_metadata(row["extra"]):
+                        continue
                     next_frontier.add(row["target_qualified"])
             if len(next_frontier) > max_frontier:
                 next_frontier = set(list(next_frontier)[:max_frontier])
@@ -555,10 +578,12 @@ class GraphStore:
                 if "::" not in callee:
                     continue
                 for row in conn.execute(
-                    "SELECT target_qualified FROM edges "
+                    "SELECT target_qualified, extra FROM edges "
                     "WHERE source_qualified = ? AND kind = 'TESTED_BY'",
                     (callee,),
                 ).fetchall():
+                    if _has_unresolved_metadata(row["extra"]):
+                        continue
                     tgt = row["target_qualified"]
                     if tgt not in seen:
                         seen.add(tgt)
@@ -596,6 +621,213 @@ class GraphStore:
         """
         return self._resolve_bare_endpoints("CALLS", "target_qualified")
 
+    def resolve_cpp_scoped_call_targets(self) -> int:
+        """Resolve cross-file C++ ``Scope::call`` targets by stable scope identity.
+
+        An explicit C++ scope is stronger evidence than a globally unique bare
+        name. Resolve it when exactly one signature-bearing node matches; keep
+        overload sets explicit and bounded when more than one node matches.
+        """
+        rows = self._conn.execute(
+            "SELECT e.id, e.source_qualified, e.target_qualified, e.file_path, "
+            "e.line, e.extra, s.parent_name, t.id target_id "
+            "FROM edges e "
+            "JOIN nodes s ON s.qualified_name = e.source_qualified "
+            "LEFT JOIN nodes t ON t.qualified_name = e.target_qualified "
+            "WHERE e.kind = 'CALLS' AND s.language = 'cpp' "
+            "AND ((t.id IS NULL AND e.target_qualified LIKE '%::%') "
+            "OR e.extra LIKE '%\"cpp_scoped_target\"%')",
+        ).fetchall()
+        if not rows:
+            return 0
+
+        candidates_by_name: dict[str, list[sqlite3.Row]] = {}
+        for candidate in self._conn.execute(
+            "SELECT name, qualified_name, parent_name FROM nodes "
+            "WHERE language = 'cpp' AND kind IN ('Function', 'Test') "
+            "ORDER BY qualified_name",
+        ).fetchall():
+            candidates_by_name.setdefault(candidate["name"], []).append(candidate)
+
+        resolved = 0
+        changed = False
+
+        def sync_tested_by(
+            call_edge: sqlite3.Row,
+            original_target: str,
+            source_qualified: str,
+            desired_extra: dict,
+            serialized_extra: str,
+        ) -> bool:
+            """Keep parser-generated TESTED_BY mirrors aligned with CALLS."""
+            changed_mirror = False
+            mirrors = self._conn.execute(
+                "SELECT id, source_qualified, extra FROM edges "
+                "WHERE kind = 'TESTED_BY' AND target_qualified = ? "
+                "AND file_path = ? AND line = ?",
+                (
+                    call_edge["source_qualified"],
+                    call_edge["file_path"],
+                    call_edge["line"],
+                ),
+            ).fetchall()
+            for mirror in mirrors:
+                try:
+                    mirror_extra = json.loads(mirror["extra"] or "{}")
+                except (TypeError, json.JSONDecodeError):
+                    mirror_extra = {}
+                mirror_original = (
+                    mirror_extra.get("cpp_scoped_target")
+                    if isinstance(mirror_extra, dict)
+                    else None
+                )
+                if (
+                    mirror["source_qualified"]
+                    not in (call_edge["target_qualified"], original_target)
+                    and mirror_original != original_target
+                ):
+                    continue
+                if (
+                    mirror["source_qualified"] == source_qualified
+                    and mirror_extra == desired_extra
+                ):
+                    continue
+                self._conn.execute(
+                    "UPDATE edges SET source_qualified = ?, extra = ? WHERE id = ?",
+                    (source_qualified, serialized_extra, mirror["id"]),
+                )
+                changed_mirror = True
+            return changed_mirror
+
+        for edge in rows:
+            try:
+                extra = json.loads(edge["extra"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                extra = {}
+            if not isinstance(extra, dict):
+                extra = {}
+            previous_extra = dict(extra)
+
+            original_target = extra.get("cpp_scoped_target")
+            target = (
+                original_target
+                if isinstance(original_target, str)
+                else edge["target_qualified"]
+            )
+            global_scope = target.startswith("::")
+            normalized = target.lstrip(":")
+            if "::" not in normalized:
+                continue
+            explicit_scope, bare_name = normalized.rsplit("::", 1)
+            explicit_scope = explicit_scope.replace("::", ".")
+
+            preferred_scopes: list[str] = []
+            source_scope = edge["parent_name"]
+            if not global_scope:
+                while source_scope:
+                    preferred_scopes.append(f"{source_scope}.{explicit_scope}")
+                    source_scope = (
+                        source_scope.rsplit(".", 1)[0]
+                        if "." in source_scope
+                        else None
+                    )
+            preferred_scopes.append(explicit_scope)
+
+            candidates: list[str] = []
+            for preferred_scope in preferred_scopes:
+                candidates = [
+                    candidate["qualified_name"]
+                    for candidate in candidates_by_name.get(bare_name, [])
+                    if candidate["parent_name"] == preferred_scope
+                ]
+                if candidates:
+                    break
+
+            if len(candidates) == 1:
+                extra["cpp_scoped_target"] = target
+                for key in (
+                    "ambiguous_targets",
+                    "ambiguous_target_count",
+                    "ambiguous_targets_truncated",
+                    "unresolved_targets",
+                    "unresolved_target_count",
+                    "unresolved_targets_truncated",
+                ):
+                    extra.pop(key, None)
+                serialized_extra = json.dumps(extra, sort_keys=True)
+                call_changed = (
+                    edge["target_qualified"] != candidates[0]
+                    or previous_extra != extra
+                )
+                if call_changed:
+                    self._conn.execute(
+                        "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
+                        (candidates[0], serialized_extra, edge["id"]),
+                    )
+                    resolved += 1
+                mirror_changed = sync_tested_by(
+                    edge, target, candidates[0], extra, serialized_extra,
+                )
+                changed = changed or call_changed or mirror_changed
+            elif len(candidates) > 1:
+                for key in (
+                    "unresolved_targets",
+                    "unresolved_target_count",
+                    "unresolved_targets_truncated",
+                ):
+                    extra.pop(key, None)
+                extra.update({
+                    "cpp_scoped_target": target,
+                    "ambiguous_targets": candidates[:20],
+                    "ambiguous_target_count": len(candidates),
+                    "ambiguous_targets_truncated": len(candidates) > 20,
+                })
+                serialized_extra = json.dumps(extra, sort_keys=True)
+                call_changed = (
+                    edge["target_qualified"] != target
+                    or previous_extra != extra
+                )
+                if call_changed:
+                    self._conn.execute(
+                        "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
+                        (target, serialized_extra, edge["id"]),
+                    )
+                mirror_changed = sync_tested_by(
+                    edge, target, target, extra, serialized_extra,
+                )
+                changed = changed or call_changed or mirror_changed
+            else:
+                extra["cpp_scoped_target"] = target
+                for key in (
+                    "ambiguous_targets",
+                    "ambiguous_target_count",
+                    "ambiguous_targets_truncated",
+                ):
+                    extra.pop(key, None)
+                extra.update({
+                    "unresolved_targets": [],
+                    "unresolved_target_count": 0,
+                    "unresolved_targets_truncated": False,
+                })
+                serialized_extra = json.dumps(extra, sort_keys=True)
+                call_changed = (
+                    edge["target_qualified"] != target
+                    or previous_extra != extra
+                )
+                if call_changed:
+                    self._conn.execute(
+                        "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
+                        (target, serialized_extra, edge["id"]),
+                    )
+                mirror_changed = sync_tested_by(
+                    edge, target, target, extra, serialized_extra,
+                )
+                changed = changed or call_changed or mirror_changed
+
+        if changed:
+            self._conn.commit()
+        return resolved
+
     def resolve_bare_tested_by_sources(self) -> int:
         """Resolve bare TESTED_BY sources backed by graph evidence.
 
@@ -612,14 +844,14 @@ class GraphStore:
         """Resolve a bare edge endpoint only when one candidate has evidence."""
         if endpoint == "target_qualified":
             select_sql = (
-                "SELECT id, source_qualified, target_qualified, file_path "
+                "SELECT id, source_qualified, target_qualified, file_path, extra "
                 "FROM edges WHERE kind = ? "
                 "AND target_qualified NOT LIKE '%::%'"
             )
             update_sql = "UPDATE edges SET target_qualified = ? WHERE id = ?"
         elif endpoint == "source_qualified":
             select_sql = (
-                "SELECT id, source_qualified, target_qualified, file_path "
+                "SELECT id, source_qualified, target_qualified, file_path, extra "
                 "FROM edges WHERE kind = ? "
                 "AND source_qualified NOT LIKE '%::%'"
             )
@@ -655,6 +887,16 @@ class GraphStore:
 
         resolved = 0
         for edge in bare_edges:
+            try:
+                edge_extra = json.loads(edge["extra"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                edge_extra = {}
+            if isinstance(edge_extra, dict) and (
+                "ambiguous_targets" in edge_extra
+                or "unresolved_targets" in edge_extra
+            ):
+                continue
+
             bare_name = edge[endpoint]
             candidates = node_lookup.get(bare_name, [])
             if not candidates:
@@ -736,6 +978,62 @@ class GraphStore:
         params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()
         return [self._row_to_node(r) for r in rows]
+
+    def count_search_nodes(self, query: str) -> int:
+        """Count nodes using the same FTS-first semantics as ``search_nodes``."""
+        words = query.split()
+        if not words:
+            return 0
+
+        try:
+            if len(words) == 1:
+                fts_query = '"' + query.replace('"', '""') + '"'
+            else:
+                fts_query = " AND ".join(
+                    '"' + word.replace('"', '""') + '"' for word in words
+                )
+            count = self._conn.execute(
+                "SELECT COUNT(*) FROM nodes_fts f "
+                "JOIN nodes n ON f.rowid = n.id "
+                "WHERE nodes_fts MATCH ?",
+                (fts_query,),
+            ).fetchone()[0]
+            if count:
+                return int(count)
+        except Exception:  # nosec B110 - FTS5 may not exist on older schemas
+            pass
+
+        conditions: list[str] = []
+        params: list[str] = []
+        for word in words:
+            value = word.lower()
+            conditions.append(
+                "(LOWER(name) LIKE ? OR LOWER(qualified_name) LIKE ?)"
+            )
+            params.extend([f"%{value}%", f"%{value}%"])
+        where = " AND ".join(conditions)
+        sql = f"SELECT COUNT(*) FROM nodes WHERE {where}"  # nosec B608
+        return int(self._conn.execute(sql, params).fetchone()[0])
+
+    def count_nodes_by_name(
+        self,
+        name: str,
+        language: str | None = None,
+        kinds: tuple[str, ...] = (),
+    ) -> int:
+        """Count exact-name nodes with optional language and kind filters."""
+        conditions = ["name = ?"]
+        params: list[Any] = [name]
+        if language is not None:
+            conditions.append("language = ?")
+            params.append(language)
+        if kinds:
+            placeholders = ", ".join("?" for _ in kinds)
+            conditions.append(f"kind IN ({placeholders})")
+            params.extend(kinds)
+        where = " AND ".join(conditions)
+        sql = f"SELECT COUNT(*) FROM nodes WHERE {where}"  # nosec B608
+        return int(self._conn.execute(sql, params).fetchone()[0])
 
     # --- Impact / Graph traversal ---
 
@@ -1556,9 +1854,10 @@ class GraphStore:
     def _make_qualified(self, node: NodeInfo) -> str:
         if node.kind == "File":
             return node.file_path
+        identity_name = node.identity_name or node.name
         if node.parent_name:
-            return f"{node.file_path}::{node.parent_name}.{node.name}"
-        return f"{node.file_path}::{node.name}"
+            return f"{node.file_path}::{node.parent_name}.{identity_name}"
+        return f"{node.file_path}::{identity_name}"
 
     def _row_to_node(self, row: sqlite3.Row) -> GraphNode:
         return GraphNode(
@@ -1624,10 +1923,28 @@ def node_to_dict(n: GraphNode) -> dict:
 
 
 def edge_to_dict(e: GraphEdge) -> dict:
-    return {
+    result: dict = {
         "id": e.id, "kind": e.kind,
         "source": _sanitize_name(e.source_qualified),
         "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
         "confidence": e.confidence, "confidence_tier": e.confidence_tier,
     }
+    for key in ("ambiguous_targets", "unresolved_targets"):
+        targets = e.extra.get(key)
+        if isinstance(targets, list):
+            result[key] = [
+                _sanitize_name(target)
+                for target in targets[:20]
+                if isinstance(target, str)
+            ]
+            resolution = key.removesuffix("_targets")
+            count = e.extra.get(f"{resolution}_target_count")
+            if not isinstance(count, int):
+                count = len(targets)
+            result[f"{resolution}_target_count"] = count
+            result[f"{resolution}_targets_truncated"] = bool(
+                e.extra.get(f"{resolution}_targets_truncated")
+                or count > len(result[key])
+            )
+    return result

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -66,6 +66,9 @@ def _make_executor(max_workers: int):
 
 logger = logging.getLogger(__name__)
 
+CPP_IDENTITY_VERSION = "1"
+_CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
+
 
 def _run_rescript_resolver(store: GraphStore) -> Optional[dict]:
     """Run the ReScript cross-module resolver, swallowing any failure so
@@ -926,6 +929,7 @@ def full_build(
     total_nodes = 0
     total_edges = 0
     errors = []
+    cpp_errors: set[str] = set()
     file_count = len(files)
 
     use_serial = os.environ.get("CRG_SERIAL_PARSE", "") == "1"
@@ -943,9 +947,13 @@ def full_build(
                 total_edges += len(edges)
             except (OSError, PermissionError) as e:
                 errors.append({"file": rel_path, "error": str(e)})
+                if parser.detect_language(full_path) == "cpp":
+                    cpp_errors.add(str(rel_path))
             except Exception as e:
                 logger.warning("Error parsing %s: %s", rel_path, e)
                 errors.append({"file": rel_path, "error": str(e)})
+                if parser.detect_language(full_path) == "cpp":
+                    cpp_errors.add(str(rel_path))
             if i % 50 == 0 or i == file_count:
                 logger.info("Progress: %d/%d files parsed", i, file_count)
     else:
@@ -963,6 +971,8 @@ def full_build(
                 if error:
                     logger.warning("Error parsing %s: %s", rel_path, error)
                     errors.append({"file": rel_path, "error": error})
+                    if parser.detect_language(repo_root / rel_path) == "cpp":
+                        cpp_errors.add(str(rel_path))
                     continue
                 full_path = repo_root / rel_path
                 store.store_file_nodes_edges(
@@ -978,6 +988,8 @@ def full_build(
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
+    if not cpp_errors:
+        store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
@@ -1009,6 +1021,29 @@ def incremental_update(
     """Incremental update: re-parse changed + dependent files only."""
     parser = CodeParser(repo_root)
     ignore_patterns = _load_ignore_patterns(repo_root)
+
+    if (
+        store.get_metadata(_CPP_IDENTITY_METADATA_KEY) != CPP_IDENTITY_VERSION
+        and store.has_nodes_for_language("cpp")
+    ):
+        logger.info(
+            "C++ identity format changed; rebuilding the graph before incremental update",
+        )
+        rebuilt = full_build(repo_root, store)
+        return {
+            "files_updated": rebuilt["files_parsed"],
+            "total_nodes": rebuilt["total_nodes"],
+            "total_edges": rebuilt["total_edges"],
+            "changed_files": list(changed_files or []),
+            "dependent_files": [],
+            "errors": rebuilt["errors"],
+            "identity_rebuild": True,
+            "rescript_resolution": rebuilt["rescript_resolution"],
+            "spring_resolution": rebuilt["spring_resolution"],
+            "event_resolution": rebuilt["event_resolution"],
+            "temporal_resolution": rebuilt["temporal_resolution"],
+            "hcl_resolution": rebuilt["hcl_resolution"],
+        }
 
     # Determine changed files
     if changed_files is None:
@@ -1112,6 +1147,7 @@ def incremental_update(
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "incremental")
+    store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
     _store_vcs_metadata(repo_root, store)
     store.commit()
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9290,8 +9290,6 @@ class CodeParser:
         # Recurse into class body
         if language == "julia":
             recursive_class = self._julia_scope_join(enclosing_class, name)
-        elif language == "cpp":
-            recursive_class = name
         else:
             recursive_class = name
         self._extract_from_tree(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -521,6 +521,7 @@ class NodeInfo:
     modifiers: Optional[str] = None
     is_test: bool = False
     extra: dict = field(default_factory=dict)
+    identity_name: Optional[str] = None
 
 
 @dataclass
@@ -2384,7 +2385,7 @@ class CodeParser:
         test_qnames = set()
         for n in nodes:
             if n.is_test:
-                qn = self._qualify(n.name, n.file_path, n.parent_name)
+                qn = self._node_qualified(n)
                 test_qnames.add(qn)
         if test_qnames:
             for edge in list(edges):
@@ -2395,6 +2396,7 @@ class CodeParser:
                         target=edge.source,
                         file_path=edge.file_path,
                         line=edge.line,
+                        extra=edge.extra.copy(),
                     ))
 
         return nodes, edges
@@ -4005,14 +4007,49 @@ class CodeParser:
                 nodes, edges, file_path,
             )
 
-        # Build symbol table: bare_name -> qualified_name
-        symbols: dict[str, str] = {}
+        is_cpp = any(node.language == "cpp" for node in nodes)
+
+        def cpp_resolution_extra(
+            extra: dict,
+            resolution: str,
+            candidates: list[str],
+        ) -> dict:
+            limit = 20
+            return {
+                **extra,
+                f"{resolution}_targets": candidates[:limit],
+                f"{resolution}_target_count": len(candidates),
+                f"{resolution}_targets_truncated": len(candidates) > limit,
+            }
+
+        # Build symbol table: bare_name -> qualified names. Most languages
+        # retain their established first-definition behavior; C++ needs all
+        # candidates so an overloaded call is never silently bound to one.
+        symbols: dict[str, list[tuple[str, Optional[str]]]] = {}
+        callable_symbols: dict[str, list[tuple[str, Optional[str]]]] = {}
+        source_scopes: dict[str, Optional[str]] = {}
         for node in nodes:
             if node.kind in ("Function", "Class", "Type", "Test"):
                 bare = node.name
-                qualified = self._qualify(bare, file_path, node.parent_name)
-                if bare not in symbols:
-                    symbols[bare] = qualified
+                qualified = self._node_qualified(node)
+                entry = (qualified, node.parent_name)
+                if entry not in symbols.setdefault(bare, []):
+                    symbols[bare].append(entry)
+                if (
+                    node.kind in ("Function", "Test")
+                    and entry not in callable_symbols.setdefault(bare, [])
+                ):
+                    callable_symbols[bare].append(entry)
+                source_scopes[qualified] = node.parent_name
+
+        def candidate_entries(
+            target: str,
+            edge_kind: str,
+        ) -> list[tuple[str, Optional[str]]]:
+            entries = symbols.get(target, [])
+            if is_cpp and edge_kind == "CALLS":
+                return callable_symbols.get(target) or entries
+            return entries
 
         resolved: list[EdgeInfo] = []
         for edge in edges:
@@ -4022,17 +4059,163 @@ class CodeParser:
             ):
                 resolved.append(edge)
                 continue
-            has_receiver = bool(edge.extra.get("receiver"))
+            receiver = edge.extra.get("receiver")
+            has_receiver = bool(receiver)
+            cpp_lexical_receiver = is_cpp and receiver == "this"
+            if (
+                is_cpp
+                and has_receiver
+                and not cpp_lexical_receiver
+                and edge.kind in ("CALLS", "REFERENCES")
+                and "::" not in edge.target
+            ):
+                receiver_candidates = [
+                    qualified
+                    for qualified, _ in candidate_entries(edge.target, edge.kind)
+                ]
+                edge = EdgeInfo(
+                    kind=edge.kind,
+                    source=edge.source,
+                    target=edge.target,
+                    file_path=edge.file_path,
+                    line=edge.line,
+                    extra=cpp_resolution_extra(
+                        edge.extra,
+                        "unresolved",
+                        receiver_candidates,
+                    ),
+                )
+                resolved.append(edge)
+                continue
+            if (
+                is_cpp
+                and edge.kind in ("CALLS", "REFERENCES")
+                and "::" in edge.target
+                and not edge.target.startswith(f"{file_path}::")
+            ):
+                explicit_scope, bare_target = edge.target.rsplit("::", 1)
+                global_scope = edge.target.startswith("::")
+                explicit_scope = explicit_scope.lstrip(":").replace("::", ".")
+                scoped_entries = candidate_entries(bare_target, edge.kind)
+                if explicit_scope:
+                    explicit_preferred_scopes: list[str] = []
+                    source_scope = source_scopes.get(edge.source)
+                    if not global_scope:
+                        while source_scope:
+                            explicit_preferred_scopes.append(
+                                f"{source_scope}.{explicit_scope}",
+                            )
+                            source_scope = (
+                                source_scope.rsplit(".", 1)[0]
+                                if "." in source_scope
+                                else None
+                            )
+                    explicit_preferred_scopes.append(explicit_scope)
+                    matching_entries = []
+                    for preferred_scope in explicit_preferred_scopes:
+                        matching_entries = [
+                            (qualified, parent_scope)
+                            for qualified, parent_scope in scoped_entries
+                            if parent_scope == preferred_scope
+                        ]
+                        if matching_entries:
+                            break
+                else:
+                    matching_entries = [
+                        (qualified, parent_scope)
+                        for qualified, parent_scope in scoped_entries
+                        if parent_scope is None
+                    ]
+                scoped_candidates = [
+                    qualified for qualified, _ in matching_entries
+                ]
+                if scoped_candidates:
+                    if len(scoped_candidates) > 1:
+                        edge = EdgeInfo(
+                            kind=edge.kind,
+                            source=edge.source,
+                            target=edge.target,
+                            file_path=edge.file_path,
+                            line=edge.line,
+                            extra=cpp_resolution_extra(
+                                edge.extra,
+                                "ambiguous",
+                                scoped_candidates,
+                            ),
+                        )
+                    else:
+                        edge = EdgeInfo(
+                            kind=edge.kind,
+                            source=edge.source,
+                            target=scoped_candidates[0],
+                            file_path=edge.file_path,
+                            line=edge.line,
+                            extra=edge.extra,
+                        )
+                    resolved.append(edge)
+                    continue
             if (
                 edge.kind in ("CALLS", "REFERENCES")
                 and "::" not in edge.target
-                and not has_receiver
+                and (not has_receiver or cpp_lexical_receiver)
             ):
-                if edge.target in symbols:
+                entries = candidate_entries(edge.target, edge.kind)
+                candidates = [qualified for qualified, _ in entries]
+                if is_cpp and entries:
+                    source_scope = source_scopes.get(edge.source)
+                    preferred_scopes: list[Optional[str]] = []
+                    while source_scope:
+                        preferred_scopes.append(source_scope)
+                        source_scope = (
+                            source_scope.rsplit(".", 1)[0]
+                            if "." in source_scope
+                            else None
+                        )
+                    preferred_scopes.append(None)
+                    candidates = []
+                    for preferred_scope in preferred_scopes:
+                        candidates = [
+                            qualified
+                            for qualified, parent_scope in entries
+                            if parent_scope == preferred_scope
+                        ]
+                        if candidates:
+                            break
+                    if not candidates:
+                        edge = EdgeInfo(
+                            kind=edge.kind,
+                            source=edge.source,
+                            target=edge.target,
+                            file_path=edge.file_path,
+                            line=edge.line,
+                            extra=cpp_resolution_extra(
+                                edge.extra,
+                                "unresolved",
+                                [qualified for qualified, _ in entries],
+                            ),
+                        )
+                        resolved.append(edge)
+                        continue
+                if candidates:
+                    if is_cpp and len(candidates) > 1:
+                        edge = EdgeInfo(
+                            kind=edge.kind,
+                            source=edge.source,
+                            target=edge.target,
+                            file_path=edge.file_path,
+                            line=edge.line,
+                            extra=cpp_resolution_extra(
+                                edge.extra,
+                                "ambiguous",
+                                candidates,
+                            ),
+                        )
+                        resolved.append(edge)
+                        continue
                     edge = EdgeInfo(
                         kind=edge.kind,
                         source=edge.source,
-                        target=symbols[edge.target],
+                        target=candidates[0],
                         file_path=edge.file_path,
                         line=edge.line,
                         extra=edge.extra,
@@ -8980,6 +9163,8 @@ class CodeParser:
         if not name:
             return False
 
+        class_parent = enclosing_class
+
         # Swift: detect the actual type keyword (class/struct/enum/actor/extension)
         # and store it in extra["swift_kind"] for richer downstream analysis.
         # Tree-sitter maps struct/enum/actor/extension all to class_declaration;
@@ -9056,7 +9241,7 @@ class CodeParser:
             line_start=child.start_point[0] + 1,
             line_end=child.end_point[0] + 1,
             language=language,
-            parent_name=enclosing_class,
+            parent_name=class_parent,
             modifiers=class_modifiers,
             extra=extra,
         )
@@ -9071,7 +9256,7 @@ class CodeParser:
         edges.append(EdgeInfo(
             kind="CONTAINS",
             source=class_container,
-            target=self._qualify(name, file_path, enclosing_class),
+            target=self._qualify(name, file_path, class_parent),
             file_path=file_path,
             line=child.start_point[0] + 1,
         ))
@@ -9082,7 +9267,7 @@ class CodeParser:
             edges.append(EdgeInfo(
                 kind="INHERITS",
                 source=self._qualify(
-                    name, file_path, enclosing_class,
+                    name, file_path, class_parent,
                 ),
                 target=base,
                 file_path=file_path,
@@ -9103,11 +9288,12 @@ class CodeParser:
             self._emit_kafka_edges_from_class(child, name, file_path, edges)
 
         # Recurse into class body
-        recursive_class = (
-            self._julia_scope_join(enclosing_class, name)
-            if language == "julia"
-            else name
-        )
+        if language == "julia":
+            recursive_class = self._julia_scope_join(enclosing_class, name)
+        elif language == "cpp":
+            recursive_class = name
+        else:
+            recursive_class = name
         self._extract_from_tree(
             child, source, language, file_path, nodes, edges,
             enclosing_class=recursive_class, enclosing_func=None,
@@ -9204,8 +9390,27 @@ class CodeParser:
             )
             container_scope = lexical_parent
 
-        qualified = self._qualify(name, file_path, parent_name)
+        identity_name = name
         params = self._get_params(child, language, source)
+        if language == "cpp":
+            explicit_scope, identity_name, cpp_params = self._cpp_function_identity(
+                child, name, source,
+            )
+            lexical_namespace = self._cpp_lexical_namespace(child)
+            lexical_classes = self._cpp_lexical_class_names(child)
+            lexical_class_scope = ".".join(lexical_classes) or None
+            parent_name = self._cpp_scope_join(
+                lexical_namespace,
+                explicit_scope or lexical_class_scope or enclosing_class,
+            )
+            if lexical_classes:
+                container_scope = ".".join(lexical_classes[-2:])
+            elif enclosing_class:
+                container_scope = enclosing_class
+            if cpp_params is not None:
+                params = cpp_params
+
+        qualified = self._qualify(identity_name, file_path, parent_name)
         ret_type = self._get_return_type(child, language, source)
 
         # Java: detect Temporal method-level annotations and Kafka listeners
@@ -9312,6 +9517,7 @@ class CodeParser:
             modifiers=modifiers_str,
             is_test=is_test,
             extra=method_extra,
+            identity_name=identity_name,
         )
         nodes.append(node)
 
@@ -9360,11 +9566,11 @@ class CodeParser:
 
         # Recurse to find calls inside the function
         recursive_class = (
-            parent_name if language == "julia" else enclosing_class
+            parent_name if language in ("julia", "cpp") else enclosing_class
         )
         self._extract_from_tree(
             child, source, language, file_path, nodes, edges,
-            enclosing_class=recursive_class, enclosing_func=name,
+            enclosing_class=recursive_class, enclosing_func=identity_name,
             import_map=import_map, defined_names=defined_names,
             _depth=_depth + 1,
         )
@@ -9516,7 +9722,10 @@ class CodeParser:
             # uses this evidence during parsing, and the Spring DI resolver
             # consumes the same metadata for Java injected fields.
             call_extra: dict = {}
-            if language in self._TYPED_CALL_LANGUAGES or language == "rust":
+            if (
+                language in self._TYPED_CALL_LANGUAGES
+                or language in ("cpp", "rust")
+            ):
                 receiver, method_name = self._get_member_call_receiver_method(
                     child, language,
                 )
@@ -9575,7 +9784,11 @@ class CodeParser:
             # The spring_resolver post-pass will do the correct cross-type lookup.
             receiver_name = call_extra.get("receiver")
             if receiver_name in ("self", "cls", "this") and enclosing_class:
-                target = self._qualify(call_name, file_path, enclosing_class)
+                target = (
+                    call_name
+                    if language == "cpp"
+                    else self._qualify(call_name, file_path, enclosing_class)
+                )
             elif (
                 language == "rust"
                 and call_name.startswith("Self::")
@@ -9620,6 +9833,19 @@ class CodeParser:
             if callee is None or callee.type != "field_expression":
                 return None, None
             receiver = callee.child_by_field_name("value")
+            method = callee.child_by_field_name("field")
+            if receiver is None or method is None:
+                return None, None
+            return (
+                receiver.text.decode("utf-8", errors="replace"),
+                method.text.decode("utf-8", errors="replace"),
+            )
+
+        if language == "cpp" and node.type == "call_expression":
+            callee = node.child_by_field_name("function")
+            if callee is None or callee.type != "field_expression":
+                return None, None
+            receiver = callee.child_by_field_name("argument")
             method = callee.child_by_field_name("field")
             if receiver is None or method is None:
                 return None, None
@@ -12667,6 +12893,8 @@ class CodeParser:
             if resolved_rust:
                 return resolved_rust
         if call_name in defined_names:
+            if language == "cpp":
+                return call_name
             return self._qualify(call_name, file_path, None)
         if call_name in import_map:
             if language == "julia":
@@ -12817,6 +13045,14 @@ class CodeParser:
             return f"{file_path}::{enclosing_class}.{name}"
         return f"{file_path}::{name}"
 
+    def _node_qualified(self, node: NodeInfo) -> str:
+        """Return the parser identity for a node without changing display name."""
+        return self._qualify(
+            node.identity_name or node.name,
+            node.file_path,
+            node.parent_name,
+        )
+
     def _get_name(self, node, language: str, kind: str) -> Optional[str]:
         """Extract the name from a class/function definition node."""
         # Dart: function_signature has a return-type node before the identifier;
@@ -12863,6 +13099,12 @@ class CodeParser:
                 if child.type == "identifier":
                     return child.text.decode("utf-8", errors="replace")
             return None
+
+        if language == "cpp" and kind == "function":
+            declarator = node.child_by_field_name("declarator")
+            cpp_name = self._cpp_callable_name(declarator)
+            if cpp_name:
+                return cpp_name
 
         # For C/C++/Objective-C: function names are inside
         # function_declarator / pointer_declarator. Check these first to
@@ -13116,6 +13358,226 @@ class CodeParser:
                                 )
             # First parameter_list is always the receiver; stop searching.
             return None
+        return None
+
+    @staticmethod
+    def _cpp_scope_join(
+        outer: Optional[str],
+        inner: Optional[str],
+    ) -> Optional[str]:
+        if outer and inner:
+            return f"{outer}.{inner}"
+        return outer or inner
+
+    def _cpp_lexical_namespace(self, node) -> Optional[str]:
+        """Return the dotted namespace path containing a C++ AST node."""
+        namespaces: list[str] = []
+        ancestor = node.parent
+        while ancestor is not None:
+            if ancestor.type == "namespace_definition":
+                name_node = ancestor.child_by_field_name("name")
+                namespace = (
+                    name_node.text.decode("utf-8", errors="replace")
+                    if name_node is not None
+                    else "(anonymous)"
+                )
+                namespaces.append(re.sub(r"\s*::\s*", ".", namespace))
+            ancestor = ancestor.parent
+        namespaces.reverse()
+        return ".".join(namespaces) or None
+
+    def _cpp_lexical_class_names(self, node) -> list[str]:
+        """Return containing C++ class names from outermost to innermost."""
+        classes: list[str] = []
+        ancestor = node.parent
+        class_types = self._class_types.get("cpp", [])
+        while ancestor is not None:
+            if ancestor.type in class_types:
+                name = self._get_name(ancestor, "cpp", "class")
+                if name:
+                    classes.append(name)
+            ancestor = ancestor.parent
+        classes.reverse()
+        return classes
+
+    def _cpp_function_identity(
+        self,
+        node,
+        name: str,
+        source: bytes,
+    ) -> tuple[Optional[str], str, Optional[str]]:
+        """Return explicit scope, signature identity, and raw C++ parameters."""
+        declarator_root = node.child_by_field_name("declarator")
+        declarator = self._cpp_find_function_declarator(declarator_root)
+        if declarator is None:
+            return None, name, None
+
+        callable_name = self._cpp_callable_name(declarator_root) or name
+        callable_node = declarator.child_by_field_name("declarator")
+        if declarator_root is not None and declarator_root.type == "qualified_identifier":
+            callable_node = declarator_root
+        elif callable_node is not None and callable_node.type != "qualified_identifier":
+            callable_node = self._cpp_find_qualified_identifier(callable_node)
+        explicit_scope: Optional[str] = None
+        if callable_node is not None and callable_node.type == "qualified_identifier":
+            callable_text = callable_node.text.decode(
+                "utf-8", errors="replace",
+            )
+            if "::" in callable_text:
+                scope_text = callable_text.rsplit("::", 1)[0].lstrip(":").strip()
+                explicit_scope = re.sub(
+                    r"\s*::\s*", ".", scope_text,
+                )
+
+        parameters = declarator.child_by_field_name("parameters")
+        if parameters is None:
+            return explicit_scope, name, None
+
+        parameter_types = [
+            self._cpp_parameter_type(parameter, source)
+            for parameter in parameters.named_children
+            if parameter.type != "comment"
+        ]
+        parameter_types = [value for value in parameter_types if value]
+        if any(child.type == "..." for child in parameters.children):
+            parameter_types.append("...")
+        if parameter_types == ["void"]:
+            parameter_types = []
+        qualifiers = [
+            child.text.decode("utf-8", errors="replace").strip()
+            for child in declarator.children
+            if child.type in ("type_qualifier", "ref_qualifier")
+        ]
+        qualifier_suffix = f" {' '.join(qualifiers)}" if qualifiers else ""
+        raw_params = parameters.text.decode("utf-8", errors="replace")
+        return (
+            explicit_scope,
+            f"{callable_name}({','.join(parameter_types)}){qualifier_suffix}",
+            raw_params,
+        )
+
+    def _cpp_find_function_declarator(self, declarator):
+        """Find the callable declarator through reference/pointer wrappers."""
+        if declarator is None:
+            return None
+        if declarator.type in ("function_declarator", "abstract_function_declarator"):
+            return declarator
+        for child in declarator.named_children:
+            if child.type in ("parameter_list", "template_argument_list"):
+                continue
+            found = self._cpp_find_function_declarator(child)
+            if found is not None:
+                return found
+        return None
+
+    def _cpp_find_qualified_identifier(self, declarator):
+        """Find the callable's qualified identifier outside its parameters."""
+        if declarator is None:
+            return None
+        if declarator.type == "qualified_identifier":
+            return declarator
+        for child in declarator.named_children:
+            if child.type in ("parameter_list", "template_argument_list"):
+                continue
+            found = self._cpp_find_qualified_identifier(child)
+            if found is not None:
+                return found
+        return None
+
+    def _cpp_callable_name(self, declarator) -> Optional[str]:
+        """Return a C++ callable name without confusing it with its return type."""
+        if declarator is None:
+            return None
+
+        operator_cast = self._cpp_find_declarator_kind(declarator, "operator_cast")
+        if operator_cast is not None:
+            function_declarator = self._cpp_find_function_declarator(operator_cast)
+            if function_declarator is not None:
+                prefix_end = function_declarator.start_byte - operator_cast.start_byte
+                name = operator_cast.text[:prefix_end].decode(
+                    "utf-8", errors="replace",
+                )
+                name = re.sub(r"\s+", " ", name).strip()
+                return re.sub(r"\s*([*&])\s*", r"\1", name)
+
+        def leaf_name(current):
+            for child in reversed(current.named_children):
+                if child.type in ("parameter_list", "template_argument_list"):
+                    continue
+                if child.type in (
+                    "identifier",
+                    "field_identifier",
+                    "destructor_name",
+                    "operator_name",
+                ):
+                    return child.text.decode("utf-8", errors="replace")
+                found = leaf_name(child)
+                if found:
+                    return found
+            return None
+
+        return leaf_name(declarator)
+
+    def _cpp_find_declarator_kind(self, declarator, kind: str):
+        """Find one declarator node kind while ignoring parameter declarations."""
+        if declarator is None:
+            return None
+        if declarator.type == kind:
+            return declarator
+        for child in declarator.named_children:
+            if child.type in ("parameter_list", "template_argument_list"):
+                continue
+            found = self._cpp_find_declarator_kind(child, kind)
+            if found is not None:
+                return found
+        return None
+
+    def _cpp_parameter_type(self, parameter, source: bytes) -> str:
+        """Normalize one C++ parameter to its type-only identity fragment."""
+        end_byte = parameter.end_byte
+        for child in parameter.children:
+            if child.type == "=":
+                end_byte = child.start_byte
+                break
+
+        declarator = parameter.child_by_field_name("declarator")
+        name_node = self._cpp_declarator_name(declarator)
+        if name_node is not None and name_node.start_byte < end_byte:
+            raw = (
+                source[parameter.start_byte:name_node.start_byte]
+                + source[name_node.end_byte:end_byte]
+            ).decode("utf-8", errors="replace")
+        else:
+            raw = source[parameter.start_byte:end_byte].decode(
+                "utf-8", errors="replace",
+            )
+
+        raw = re.sub(r"/\*.*?\*/|//[^\r\n]*", " ", raw, flags=re.DOTALL)
+        raw = re.sub(r"\[\[.*?\]\]", " ", raw, flags=re.DOTALL)
+        normalized = re.sub(r"\s+", " ", raw).strip()
+        normalized = re.sub(r"\s*::\s*", "::", normalized)
+        normalized = re.sub(r"\s*([<>,*&()\[\]])\s*", r"\1", normalized)
+        return normalized
+
+    def _cpp_declarator_name(self, declarator):
+        """Find the declared identifier while avoiding nested parameter types."""
+        if declarator is None:
+            return None
+        if declarator.type in ("identifier", "field_identifier"):
+            return declarator
+
+        nested = declarator.child_by_field_name("declarator")
+        if nested is not None and nested != declarator:
+            found = self._cpp_declarator_name(nested)
+            if found is not None:
+                return found
+
+        for child in declarator.named_children:
+            if child.type in ("parameter_list", "template_argument_list"):
+                continue
+            found = self._cpp_declarator_name(child)
+            if found is not None:
+                return found
         return None
 
     def _get_params(self, node, language: str, source: bytes) -> Optional[str]:
@@ -13789,7 +14251,11 @@ class CodeParser:
             return first.text.decode("utf-8", errors="replace")
 
         # Scoped call (e.g., Rust path::func())
-        if first.type in ("scoped_identifier", "qualified_name"):
+        if first.type in (
+            "scoped_identifier",
+            "qualified_identifier",
+            "qualified_name",
+        ):
             return first.text.decode("utf-8", errors="replace")
 
         # R namespace-qualified call: dplyr::filter()

--- a/code_review_graph/postprocessing.py
+++ b/code_review_graph/postprocessing.py
@@ -75,7 +75,7 @@ def _resolve_bare_endpoints(
     result: dict[str, Any],
     warnings: list[str],
 ) -> None:
-    """Qualify bare CALLS/TESTED_BY endpoints before derived graph steps."""
+    """Resolve bare and C++ scoped call targets before derived graph steps."""
     try:
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
@@ -84,9 +84,9 @@ def _resolve_bare_endpoints(
             store.resolve_cpp_scoped_call_targets()
         )
     except sqlite3.OperationalError as e:
-        logger.warning("Bare-endpoint resolution failed: %s", e)
+        logger.warning("Call-target resolution failed: %s", e)
         warnings.append(
-            f"Bare-endpoint resolution failed: {type(e).__name__}: {e}"
+            f"Call-target resolution failed: {type(e).__name__}: {e}"
         )
 
 

--- a/code_review_graph/postprocessing.py
+++ b/code_review_graph/postprocessing.py
@@ -80,6 +80,9 @@ def _resolve_bare_endpoints(
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
         result["bare_edges_resolved"] = resolved
+        result["cpp_scoped_edges_resolved"] = (
+            store.resolve_cpp_scoped_call_targets()
+        )
     except sqlite3.OperationalError as e:
         logger.warning("Bare-endpoint resolution failed: %s", e)
         warnings.append(

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -77,7 +77,7 @@ def _run_postprocess(
         )
         return warnings
 
-    # Resolve only same-file/import-backed targets before derived graph steps.
+    # Resolve bare and C++ scoped call targets before derived graph steps.
     try:
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
@@ -86,9 +86,9 @@ def _run_postprocess(
             store.resolve_cpp_scoped_call_targets()
         )
     except sqlite3.OperationalError as e:
-        logger.warning("Bare-endpoint resolution failed: %s", e)
+        logger.warning("Call-target resolution failed: %s", e)
         warnings.append(
-            f"Bare-endpoint resolution failed: {type(e).__name__}: {e}"
+            f"Call-target resolution failed: {type(e).__name__}: {e}"
         )
 
     # -- Signatures + FTS (fast, always run unless "none") --
@@ -587,9 +587,9 @@ def run_postprocess(
                 store.resolve_cpp_scoped_call_targets()
             )
         except sqlite3.OperationalError as e:
-            logger.warning("Bare-endpoint resolution failed: %s", e)
+            logger.warning("Call-target resolution failed: %s", e)
             warnings.append(
-                f"Bare-endpoint resolution failed: {type(e).__name__}: {e}"
+                f"Call-target resolution failed: {type(e).__name__}: {e}"
             )
 
         try:

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -82,6 +82,9 @@ def _run_postprocess(
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
         build_result["bare_edges_resolved"] = resolved
+        build_result["cpp_scoped_edges_resolved"] = (
+            store.resolve_cpp_scoped_call_targets()
+        )
     except sqlite3.OperationalError as e:
         logger.warning("Bare-endpoint resolution failed: %s", e)
         warnings.append(
@@ -580,6 +583,9 @@ def run_postprocess(
             resolved = store.resolve_bare_call_targets()
             resolved += store.resolve_bare_tested_by_sources()
             result["bare_edges_resolved"] = resolved
+            result["cpp_scoped_edges_resolved"] = (
+                store.resolve_cpp_scoped_call_targets()
+            )
         except sqlite3.OperationalError as e:
             logger.warning("Bare-endpoint resolution failed: %s", e)
             warnings.append(

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -316,17 +316,24 @@ def query_graph(
                     node = candidates[0]
                     target = node.qualified_name
                 elif len(candidates) > 1:
+                    candidate_count = (
+                        len(candidates)
+                        if java_candidates is not None
+                        else store.count_search_nodes(target)
+                    )
                     ranked = _rank_disambiguation_candidates(candidates, target)
                     return {
                         "status": "ambiguous",
                         "summary": (
-                            f"'{target}' matches {len(candidates)} node(s). "
+                            f"'{target}' matches {candidate_count} node(s). "
                             "Re-run with a qualified_name from disambiguation."
                         ),
                         # Preserve the established key while adding the clearer
                         # agent-facing name introduced by #458.
                         "candidates": ranked,
                         "disambiguation": ranked,
+                        "candidate_count": candidate_count,
+                        "candidates_truncated": candidate_count > len(candidates),
                         "hint": (
                             "Use a qualified_name from disambiguation as the "
                             "target parameter."
@@ -354,7 +361,27 @@ def query_graph(
             # (e.g. "generateTestCode") while qn is fully qualified
             # (e.g. "file.ts::generateTestCode"). Search by plain name too.
             if node:
+                cpp_overload_count = (
+                    store.count_nodes_by_name(
+                        node.name,
+                        language="cpp",
+                        kinds=("Function", "Test"),
+                    )
+                    if node.language == "cpp"
+                    else 0
+                )
                 for e in store.iter_edges_by_target_name(node.name):
+                    # A C++ overload set deliberately keeps the target bare.
+                    # Its candidates support disambiguation, but do not prove
+                    # that any one exact overload was called.
+                    if (
+                        "ambiguous_targets" in e.extra
+                        or "unresolved_targets" in e.extra
+                        or (node.language == "cpp" and e.extra.get("receiver"))
+                    ):
+                        continue
+                    if cpp_overload_count > 1:
+                        continue
                     if e.source_qualified not in seen_sources:
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
@@ -370,12 +397,46 @@ def query_graph(
                         callee = store.get_node(e.target_qualified)
                         if callee:
                             add_result(node_to_dict(callee), e)
-                        elif "::" not in e.target_qualified:
-                            add_result({
+                        elif (
+                            isinstance(e.extra.get("ambiguous_targets"), list)
+                            or isinstance(e.extra.get("unresolved_targets"), list)
+                            or "::" not in e.target_qualified
+                            or (node is not None and node.language == "cpp")
+                        ):
+                            unresolved = (
+                                e.extra.get("ambiguous_targets")
+                                or e.extra.get("unresolved_targets")
+                            )
+                            result: dict[str, Any] = {
                                 "kind": "Function",
                                 "name": e.target_qualified,
                                 "qualified_name": e.target_qualified,
-                            }, e)
+                            }
+                            if isinstance(unresolved, list):
+                                resolution = (
+                                    "ambiguous"
+                                    if e.extra.get("ambiguous_targets")
+                                    else "unresolved"
+                                )
+                                result["resolution"] = resolution
+                                result["candidates"] = [
+                                    _sanitize_name(candidate)
+                                    for candidate in unresolved[:20]
+                                    if isinstance(candidate, str)
+                                ]
+                                candidate_count = e.extra.get(
+                                    f"{resolution}_target_count",
+                                )
+                                if not isinstance(candidate_count, int):
+                                    candidate_count = len(unresolved)
+                                result["candidate_count"] = candidate_count
+                                result["candidates_truncated"] = bool(
+                                    e.extra.get(
+                                        f"{resolution}_targets_truncated",
+                                    )
+                                    or candidate_count > len(result["candidates"])
+                                )
+                            add_result(result, e)
 
         elif pattern == "imports_of":
             for e in store.iter_edges_by_source(qn):
@@ -448,8 +509,19 @@ def query_graph(
                     seen.add(test_qn)
             # Also search by naming convention
             name = node.name if node else target
-            test_nodes = store.search_nodes(f"test_{name}", limit=10)
-            test_nodes += store.search_nodes(f"Test{name}", limit=10)
+            cpp_overload_set = bool(
+                node
+                and node.language == "cpp"
+                and store.count_nodes_by_name(
+                    node.name,
+                    language="cpp",
+                    kinds=("Function", "Test"),
+                ) > 1
+            )
+            test_nodes = []
+            if not cpp_overload_set:
+                test_nodes = store.search_nodes(f"test_{name}", limit=10)
+                test_nodes += store.search_nodes(f"Test{name}", limit=10)
             for t in test_nodes:
                 if t.qualified_name not in seen and t.is_test:
                     result = node_to_dict(t)

--- a/tests/test_cpp_overload_identity.py
+++ b/tests/test_cpp_overload_identity.py
@@ -1,0 +1,1220 @@
+"""Regression coverage for stable C++ overload identities (#622)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import CPP_IDENTITY_VERSION, incremental_update
+from code_review_graph.parser import CodeParser, EdgeInfo, NodeInfo
+from code_review_graph.tools.query import query_graph
+
+
+def _index_source(tmp_path: Path, source: str) -> tuple[Path, GraphStore]:
+    source_path = tmp_path / "IWorkspace.cpp"
+    source_path.write_text(source, encoding="utf-8")
+
+    nodes, edges = CodeParser().parse_file(source_path)
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir(exist_ok=True)
+    store = GraphStore(graph_dir / "graph.db")
+    store.store_file_nodes_edges(str(source_path), nodes, edges)
+    return source_path, store
+
+
+def test_cpp_overloads_keep_distinct_scoped_signature_identities(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """void markChanged() {}
+void IWorkspace::deleteDataFile(
+    DataFile* file,
+    bool refresh,
+    bool preservePlot)
+{
+    markChanged();
+}
+void IWorkspace::deleteDataFile(DataFile* file, bool refresh) {}
+""",
+    )
+    prefix = str(source_path)
+    three_arg = f"{prefix}::IWorkspace.deleteDataFile(DataFile*,bool,bool)"
+    two_arg = f"{prefix}::IWorkspace.deleteDataFile(DataFile*,bool)"
+    changed = f"{prefix}::markChanged()"
+
+    try:
+        overloads = [
+            node
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.name == "deleteDataFile"
+        ]
+        assert {node.qualified_name for node in overloads} == {three_arg, two_arg}
+        assert {node.parent_name for node in overloads} == {"IWorkspace"}
+        assert store.get_node(three_arg).line_start == 2
+        assert store.get_node(three_arg).line_end == 8
+    finally:
+        store.close()
+
+    callers = query_graph("callers_of", changed, repo_root=str(tmp_path))
+    assert callers["status"] == "ok"
+    assert [result["qualified_name"] for result in callers["results"]] == [three_arg]
+
+
+def test_cpp_signature_normalizes_parameter_types_not_names_or_defaults(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """void Widget::update(
+    const std::vector<int>& values,
+    DataFile * file,
+    bool refresh = true) {}
+void commented(int /* identity-neutral */ value) {}
+void unnamed(int /* identity-neutral */) {}
+void attributed([[maybe_unused]] int value) {}
+""",
+    )
+
+    try:
+        functions = [
+            node
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.kind == "Function"
+        ]
+        assert {node.qualified_name for node in functions} == {
+            f"{source_path}::Widget.update(const std::vector<int>&,DataFile*,bool)",
+            f"{source_path}::commented(int)",
+            f"{source_path}::unnamed(int)",
+            f"{source_path}::attributed(int)",
+        }
+    finally:
+        store.close()
+
+
+def test_ambiguous_cpp_call_records_candidates_without_claiming_an_overload(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """void process(int value) {}
+void process(double value) {}
+void caller() { process(1); }
+""",
+    )
+    prefix = str(source_path)
+    int_overload = f"{prefix}::process(int)"
+    double_overload = f"{prefix}::process(double)"
+    caller = f"{prefix}::caller()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert len(call_edges) == 1
+        assert call_edges[0].target_qualified == "process"
+        assert set(call_edges[0].extra["ambiguous_targets"]) == {
+            int_overload,
+            double_overload,
+        }
+    finally:
+        store.close()
+
+    ambiguous = query_graph("callers_of", "process", repo_root=str(tmp_path))
+    assert ambiguous["status"] == "ambiguous"
+    assert {
+        candidate["qualified_name"] for candidate in ambiguous["disambiguation"]
+    } == {int_overload, double_overload}
+
+    exact = query_graph("callers_of", int_overload, repo_root=str(tmp_path))
+    assert exact["status"] == "ok"
+    assert exact["results"] == []
+
+    callees = query_graph("callees_of", caller, repo_root=str(tmp_path))
+    assert callees["status"] == "ok"
+    assert callees["results"] == [{
+        "kind": "Function",
+        "name": "process",
+        "qualified_name": "process",
+        "resolution": "ambiguous",
+        "candidates": [int_overload, double_overload],
+        "candidate_count": 2,
+        "candidates_truncated": False,
+    }]
+    assert callees["edges"][0]["ambiguous_targets"] == [
+        int_overload,
+        double_overload,
+    ]
+    assert callees["edges"][0]["ambiguous_target_count"] == 2
+    assert callees["edges"][0]["ambiguous_targets_truncated"] is False
+
+
+def test_cpp_call_resolution_prefers_the_lexical_class_scope(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct A {
+    void process() {}
+    void caller() { process(); }
+};
+struct B { void process() {} };
+""",
+    )
+    prefix = str(source_path)
+    caller = f"{prefix}::A.caller()"
+    target = f"{prefix}::A.process()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert [(edge.target_qualified, edge.extra) for edge in call_edges] == [
+            (target, {}),
+        ]
+    finally:
+        store.close()
+
+
+def test_cpp_member_call_does_not_bind_to_the_enclosing_class(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct B { void process() {} };
+struct A {
+    void process() {}
+    void caller(B& b) { b.process(); }
+};
+""",
+    )
+    prefix = str(source_path)
+    caller = f"{prefix}::A.caller(B&)"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert len(call_edges) == 1
+        assert call_edges[0].target_qualified == "process"
+        assert call_edges[0].extra["receiver"] == "b"
+        assert set(call_edges[0].extra["unresolved_targets"]) == {
+            f"{prefix}::A.process()",
+            f"{prefix}::B.process()",
+        }
+        assert call_edges[0].extra["unresolved_target_count"] == 2
+        assert call_edges[0].extra["unresolved_targets_truncated"] is False
+    finally:
+        store.close()
+
+
+def test_cpp_this_call_resolves_to_signature_identity(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct A {
+    void process() {}
+    void caller() { this->process(); }
+};
+""",
+    )
+    caller = f"{source_path}::A.caller()"
+    target = f"{source_path}::A.process()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert [(edge.target_qualified, edge.extra) for edge in call_edges] == [
+            (target, {"receiver": "this"}),
+        ]
+        assert store.get_node(target) is not None
+    finally:
+        store.close()
+
+
+def test_cpp_overloaded_this_call_stays_ambiguous_within_its_class(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct B { void process(int value) {} };
+struct A {
+    void process(int value) {}
+    void process(double value) {}
+    void caller() { this->process(1); }
+};
+""",
+    )
+    caller = f"{source_path}::A.caller()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert len(call_edges) == 1
+        assert call_edges[0].target_qualified == "process"
+        assert set(call_edges[0].extra["ambiguous_targets"]) == {
+            f"{source_path}::A.process(int)",
+            f"{source_path}::A.process(double)",
+        }
+        assert call_edges[0].extra["ambiguous_target_count"] == 2
+        assert call_edges[0].extra["ambiguous_targets_truncated"] is False
+        assert call_edges[0].extra["receiver"] == "this"
+    finally:
+        store.close()
+
+
+def test_cpp_call_resolution_walks_enclosing_namespace_scopes(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """namespace N {
+void helper() {}
+namespace M { void caller() { helper(); } }
+struct A { void caller() { helper(); } };
+}
+""",
+    )
+    prefix = str(source_path)
+    target = f"{prefix}::N.helper()"
+
+    try:
+        for caller in (f"{prefix}::N.M.caller()", f"{prefix}::N.A.caller()"):
+            call_edges = [
+                edge
+                for edge in store.get_edges_by_source(caller)
+                if edge.kind == "CALLS"
+            ]
+            assert [(edge.target_qualified, edge.extra) for edge in call_edges] == [
+                (target, {}),
+            ]
+    finally:
+        store.close()
+
+
+def test_cpp_explicit_scope_prefers_the_callers_lexical_namespace(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct A { static void run() {} };
+namespace N {
+struct A { static void run() {} };
+void caller() { A::run(); }
+}
+""",
+    )
+    caller = f"{source_path}::N.caller()"
+    target = f"{source_path}::N.A.run()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert [(edge.target_qualified, edge.extra) for edge in call_edges] == [
+            (target, {}),
+        ]
+    finally:
+        store.close()
+
+
+def test_cpp_callable_candidate_wins_over_same_named_class(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct process {};
+void process(int value) {}
+void caller() { process(1); }
+""",
+    )
+    caller = f"{source_path}::caller()"
+    target = f"{source_path}::process(int)"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert [(edge.target_qualified, edge.extra) for edge in call_edges] == [
+            (target, {}),
+        ]
+    finally:
+        store.close()
+
+
+def test_cpp_candidate_metadata_is_bounded_and_reports_truncation(tmp_path: Path):
+    overloads = "\n".join(
+        f"void process(Type{index} value) {{}}" for index in range(25)
+    )
+    source_path, store = _index_source(
+        tmp_path,
+        f"{overloads}\nvoid caller() {{ process(1); }}\n",
+    )
+    caller = f"{source_path}::caller()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert len(call_edges) == 1
+        assert len(call_edges[0].extra["ambiguous_targets"]) == 20
+        assert call_edges[0].extra["ambiguous_target_count"] == 25
+        assert call_edges[0].extra["ambiguous_targets_truncated"] is True
+    finally:
+        store.close()
+
+    callees = query_graph("callees_of", caller, repo_root=str(tmp_path))
+    assert len(callees["results"][0]["candidates"]) == 20
+    assert callees["results"][0]["candidate_count"] == 25
+    assert callees["results"][0]["candidates_truncated"] is True
+    assert callees["edges"][0]["ambiguous_target_count"] == 25
+    assert callees["edges"][0]["ambiguous_targets_truncated"] is True
+
+    ambiguous = query_graph("callers_of", "process", repo_root=str(tmp_path))
+    assert ambiguous["status"] == "ambiguous"
+    assert len(ambiguous["disambiguation"]) == 20
+    assert ambiguous["candidate_count"] == 25
+    assert ambiguous["candidates_truncated"] is True
+    assert "matches 25 node(s)" in ambiguous["summary"]
+
+
+def test_cpp_explicit_scope_calls_resolve_or_preserve_ambiguity(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct A {
+    static void unique() {}
+    static void overloaded(int value) {}
+    static void overloaded(double value) {}
+};
+namespace N { void helper() {} }
+void caller() { A::unique(); A::overloaded(1); N::helper(); }
+""",
+    )
+    caller = f"{source_path}::caller()"
+
+    try:
+        call_edges = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        assert {
+            edge.target_qualified
+            for edge in call_edges
+            if not edge.extra.get("ambiguous_targets")
+        } == {
+            f"{source_path}::A.unique()",
+            f"{source_path}::N.helper()",
+        }
+        ambiguous_edges = [
+            edge for edge in call_edges if edge.extra.get("ambiguous_targets")
+        ]
+        assert len(ambiguous_edges) == 1
+        assert ambiguous_edges[0].target_qualified == "A::overloaded"
+        assert set(ambiguous_edges[0].extra["ambiguous_targets"]) == {
+            f"{source_path}::A.overloaded(int)",
+            f"{source_path}::A.overloaded(double)",
+        }
+    finally:
+        store.close()
+
+    callees = query_graph("callees_of", caller, repo_root=str(tmp_path))
+    ambiguous_result = next(
+        result
+        for result in callees["results"]
+        if result.get("resolution") == "ambiguous"
+    )
+    assert ambiguous_result["qualified_name"] == "A::overloaded"
+    assert ambiguous_result["candidate_count"] == 2
+    assert ambiguous_result["candidates_truncated"] is False
+
+
+def test_cpp_identity_includes_member_qualifiers_and_variadic_marker(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct Widget {
+    void update() {}
+    void update() const {}
+    void visit() & {}
+    void visit() && {}
+};
+void logValues(int value, ...) {}
+""",
+    )
+
+    try:
+        identities = {
+            node.qualified_name
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.kind == "Function"
+        }
+        assert identities == {
+            f"{source_path}::Widget.update()",
+            f"{source_path}::Widget.update() const",
+            f"{source_path}::Widget.visit() &",
+            f"{source_path}::Widget.visit() &&",
+            f"{source_path}::logValues(int,...)",
+        }
+    finally:
+        store.close()
+
+
+def test_cpp_identity_includes_lexical_namespace_scope(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """namespace Alpha {
+void process(int value) {}
+struct Widget : Base { void read() const {} };
+}
+namespace Beta { void process(int value) {} }
+""",
+    )
+
+    try:
+        identities = {
+            node.qualified_name
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.kind == "Function"
+        }
+        assert identities == {
+            f"{source_path}::Alpha.process(int)",
+            f"{source_path}::Alpha.Widget.read() const",
+            f"{source_path}::Beta.process(int)",
+        }
+        class_qn = f"{source_path}::Widget"
+        widget = store.get_node(class_qn)
+        assert widget is not None
+        assert widget.parent_name is None
+        assert any(
+            edge.kind == "CONTAINS" and edge.target_qualified == class_qn
+            for edge in store.get_edges_by_source(str(source_path))
+        )
+        assert any(
+            edge.kind == "INHERITS" and edge.target_qualified == "Base"
+            for edge in store.get_edges_by_source(class_qn)
+        )
+        assert any(
+            edge.kind == "CONTAINS"
+            and edge.target_qualified == f"{source_path}::Alpha.Widget.read() const"
+            for edge in store.get_edges_by_source(class_qn)
+        )
+    finally:
+        store.close()
+
+
+def test_cpp_nested_class_keys_stay_legacy_while_function_scope_is_complete(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct Outer {
+    struct Inner {
+        struct Deep : Base { void run() {} };
+    };
+};
+""",
+    )
+    prefix = str(source_path)
+    outer = f"{prefix}::Outer"
+    inner = f"{prefix}::Outer.Inner"
+    deep = f"{prefix}::Inner.Deep"
+    run = f"{prefix}::Outer.Inner.Deep.run()"
+
+    try:
+        class_ids = {
+            node.qualified_name
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.kind == "Class"
+        }
+        assert class_ids == {outer, inner, deep}
+        assert store.get_node(run) is not None
+        assert any(
+            edge.kind == "INHERITS" and edge.target_qualified == "Base"
+            for edge in store.get_edges_by_source(deep)
+        )
+        assert any(
+            edge.kind == "CONTAINS" and edge.target_qualified == run
+            for edge in store.get_edges_by_source(deep)
+        )
+    finally:
+        store.close()
+
+
+def test_reindex_replaces_legacy_unsuffixed_cpp_identity(tmp_path: Path):
+    source_path = tmp_path / "IWorkspace.cpp"
+    source_path.write_text(
+        "void IWorkspace::deleteDataFile(DataFile* file, bool refresh) {}\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    legacy_qn = f"{source_path}::IWorkspace.deleteDataFile"
+
+    try:
+        store.upsert_node(
+            NodeInfo(
+                kind="Function",
+                name="deleteDataFile",
+                file_path=str(source_path),
+                line_start=1,
+                line_end=1,
+                language="cpp",
+                parent_name="IWorkspace",
+            )
+        )
+        store.commit()
+        assert store.get_node(legacy_qn) is not None
+
+        nodes, edges = CodeParser().parse_file(source_path)
+        store.store_file_nodes_edges(str(source_path), nodes, edges)
+
+        assert store.get_node(legacy_qn) is None
+        assert store.get_node(
+            f"{source_path}::IWorkspace.deleteDataFile(DataFile*,bool)"
+        ) is not None
+    finally:
+        store.close()
+
+
+def test_incremental_upgrade_rebuilds_cpp_identities_and_removes_stale_edges(
+    tmp_path: Path,
+):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    callee_path.write_text("void run(int value) {}\n", encoding="utf-8")
+    caller_path.write_text("void caller() { run(1); }\n", encoding="utf-8")
+    store = GraphStore(tmp_path / "graph.db")
+    legacy_callee = f"{callee_path}::run"
+    legacy_caller = f"{caller_path}::caller"
+
+    try:
+        for path, name in ((callee_path, "run"), (caller_path, "caller")):
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name=name,
+                file_path=str(path),
+                line_start=1,
+                line_end=1,
+                language="cpp",
+            ))
+        store.upsert_edge(EdgeInfo(
+            kind="CALLS",
+            source=legacy_caller,
+            target=legacy_callee,
+            file_path=str(caller_path),
+            line=1,
+        ))
+        store.commit()
+
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=["callee.cpp", "caller.cpp"],
+        ):
+            result = incremental_update(tmp_path, store, changed_files=[])
+
+        assert result["identity_rebuild"] is True
+        assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
+        assert store.get_node(legacy_callee) is None
+        assert store.get_node(f"{callee_path}::run(int)") is not None
+        assert all(
+            edge.target_qualified != legacy_callee
+            for edge in store.get_edges_by_source(f"{caller_path}::caller()")
+        )
+    finally:
+        store.close()
+
+
+def test_cross_file_bare_call_is_not_claimed_by_each_exact_overload(
+    tmp_path: Path,
+):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    callee_path.write_text(
+        "void process(int value) {}\nvoid process(double value) {}\n",
+        encoding="utf-8",
+    )
+    caller_path.write_text(
+        "void caller() { process(1); }\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+
+    try:
+        parser = CodeParser()
+        for path in (callee_path, caller_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+        bare_edges = [
+            edge
+            for edge in store.get_edges_by_source(f"{caller_path}::caller()")
+            if edge.kind == "CALLS"
+        ]
+        assert [(edge.target_qualified, edge.extra) for edge in bare_edges] == [
+            ("process", {}),
+        ]
+    finally:
+        store.close()
+
+    for overload in ("process(int)", "process(double)"):
+        callers = query_graph(
+            "callers_of",
+            f"{callee_path}::{overload}",
+            repo_root=str(tmp_path),
+        )
+        assert callers["status"] == "ok"
+        assert callers["results"] == []
+
+
+def test_failed_cpp_identity_upgrade_remains_pending_and_retries(tmp_path: Path):
+    source_path = tmp_path / "run.cpp"
+    source_path.write_text("void run(int value) {}\n", encoding="utf-8")
+    legacy_qn = f"{source_path}::run"
+    store = GraphStore(tmp_path / "graph.db")
+
+    try:
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="run",
+            file_path=str(source_path),
+            line_start=1,
+            line_end=1,
+            language="cpp",
+        ))
+        store.commit()
+
+        with (
+            patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["run.cpp"],
+            ),
+            patch(
+                "code_review_graph.incremental.CodeParser.parse_bytes",
+                side_effect=RuntimeError("simulated parse failure"),
+            ),
+        ):
+            failed = incremental_update(tmp_path, store, changed_files=[])
+
+        assert failed["identity_rebuild"] is True
+        assert failed["errors"]
+        assert store.get_metadata("cpp_identity_version") is None
+        assert store.get_node(legacy_qn) is not None
+
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=["run.cpp"],
+        ):
+            retried = incremental_update(tmp_path, store, changed_files=[])
+
+        assert retried["identity_rebuild"] is True
+        assert retried["errors"] == []
+        assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
+        assert store.get_node(legacy_qn) is None
+        assert store.get_node(f"{source_path}::run(int)") is not None
+    finally:
+        store.close()
+
+
+def test_cpp_reference_return_and_operator_overloads_keep_callable_identity(
+    tmp_path: Path,
+):
+    source_path, store = _index_source(
+        tmp_path,
+        """struct A {
+    A& operator=(const A& other) { return *this; }
+    operator bool() const { return true; }
+};
+A& clone(int value) { static A result; return result; }
+A& clone(double value) { static A result; return result; }
+""",
+    )
+
+    try:
+        functions = {
+            node.qualified_name
+            for node in store.get_nodes_by_file(str(source_path))
+            if node.kind == "Function"
+        }
+        assert functions == {
+            f"{source_path}::A.operator=(const A&)",
+            f"{source_path}::A.operator bool() const",
+            f"{source_path}::clone(int)",
+            f"{source_path}::clone(double)",
+        }
+    finally:
+        store.close()
+
+
+def test_cpp_leading_global_scope_is_normalized(tmp_path: Path):
+    source_path, store = _index_source(
+        tmp_path,
+        """namespace N { struct A { static void run(); }; }
+void ::N::A::run() {}
+""",
+    )
+
+    try:
+        run = store.get_node(f"{source_path}::N.A.run()")
+        assert run is not None
+        assert run.parent_name == "N.A"
+        assert store.get_node(f"{source_path}::.N.A.run()") is None
+    finally:
+        store.close()
+
+
+def test_cross_file_receiver_call_without_type_evidence_stays_unresolved(
+    tmp_path: Path,
+):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    callee_path.write_text(
+        "struct A { void process() {} };\n",
+        encoding="utf-8",
+    )
+    caller_path.write_text(
+        "struct B; void test_receiver(B& b) { b.process(); }\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+
+    target = f"{callee_path}::A.process()"
+    caller = f"{caller_path}::test_receiver(B&)"
+    try:
+        parser = CodeParser()
+        for path in (callee_path, caller_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+        store.upsert_edge(EdgeInfo(
+            kind="IMPORTS_FROM",
+            source=str(caller_path),
+            target=str(callee_path),
+            file_path=str(caller_path),
+            line=1,
+        ))
+        store.commit()
+
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == "process"
+        assert call.extra["receiver"] == "b"
+        assert call.extra["unresolved_targets"] == []
+        assert call.extra["unresolved_target_count"] == 0
+        assert store.resolve_bare_call_targets() == 0
+        assert store.resolve_bare_tested_by_sources() == 0
+        call_after_postprocess = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call_after_postprocess.target_qualified == "process"
+        tested_by = [
+            edge
+            for edge in store.get_edges_by_target(caller)
+            if edge.kind == "TESTED_BY"
+        ]
+        assert len(tested_by) == 1
+        assert tested_by[0].source_qualified == "process"
+        assert tested_by[0].extra["unresolved_targets"] == []
+        assert store.get_transitive_tests(target, max_depth=0) == []
+    finally:
+        store.close()
+
+    callers = query_graph("callers_of", target, repo_root=str(tmp_path))
+    assert callers["status"] == "ok"
+    assert callers["results"] == []
+
+
+def test_cross_file_scoped_calls_resolve_or_keep_bounded_overload_candidates(
+    tmp_path: Path,
+):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    callee_path.write_text(
+        """void A::unique() {}
+void A::run(int value) {}
+void A::run(double value) {}
+""",
+        encoding="utf-8",
+    )
+    caller_path.write_text(
+        "void test_run() { A::unique(); A::run(1); }\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    caller = f"{caller_path}::test_run()"
+
+    try:
+        parser = CodeParser()
+        for path in (callee_path, caller_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 1
+        assert store.resolve_cpp_scoped_call_targets() == 0
+        calls = [
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        ]
+        unique = next(edge for edge in calls if edge.target_qualified.endswith("unique()"))
+        assert unique.target_qualified == f"{callee_path}::A.unique()"
+
+        overloaded = next(edge for edge in calls if edge.target_qualified == "A::run")
+        assert set(overloaded.extra["ambiguous_targets"]) == {
+            f"{callee_path}::A.run(int)",
+            f"{callee_path}::A.run(double)",
+        }
+        assert overloaded.extra["ambiguous_target_count"] == 2
+        assert overloaded.extra["ambiguous_targets_truncated"] is False
+
+        tested_by = {
+            edge.source_qualified: edge
+            for edge in store.get_edges_by_target(caller)
+            if edge.kind == "TESTED_BY"
+        }
+        unique_target = f"{callee_path}::A.unique()"
+        assert tested_by[unique_target].extra["cpp_scoped_target"] == "A::unique"
+        assert tested_by["A::run"].extra == overloaded.extra
+        assert [
+            match["qualified_name"]
+            for match in store.get_transitive_tests(unique_target, max_depth=0)
+        ] == [caller]
+        assert store.get_transitive_tests(
+            f"{callee_path}::A.run(int)", max_depth=0,
+        ) == []
+    finally:
+        store.close()
+
+    tests_for_unique = query_graph(
+        "tests_for", unique_target, repo_root=str(tmp_path),
+    )
+    assert [
+        result["qualified_name"] for result in tests_for_unique["results"]
+    ] == [caller]
+    tests_for_overload = query_graph(
+        "tests_for", f"{callee_path}::A.run(int)", repo_root=str(tmp_path),
+    )
+    assert tests_for_overload["results"] == []
+
+
+def test_ambiguous_scoped_calls_do_not_create_indirect_test_coverage(
+    tmp_path: Path,
+):
+    callee_path = tmp_path / "callee.cpp"
+    production_path = tmp_path / "production.cpp"
+    test_path = tmp_path / "scenario_test.cpp"
+    callee_path.write_text(
+        "void A::run(int value) {}\nvoid A::run(double value) {}\n",
+        encoding="utf-8",
+    )
+    production_path.write_text(
+        "void production() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    test_path.write_text(
+        "void test_scenario() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    production = f"{production_path}::production()"
+
+    try:
+        parser = CodeParser()
+        for path in (callee_path, production_path, test_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 0
+        assert store.get_transitive_tests(production) == []
+    finally:
+        store.close()
+
+    tests_for_production = query_graph(
+        "tests_for", production, repo_root=str(tmp_path),
+    )
+    assert tests_for_production["results"] == []
+
+
+def test_deleted_scoped_candidate_becomes_explicitly_unresolved(tmp_path: Path):
+    callee_path = tmp_path / "callee.cpp"
+    production_path = tmp_path / "production.cpp"
+    test_path = tmp_path / "scenario_test.cpp"
+    callee_path.write_text("void A::run(int value) {}\n", encoding="utf-8")
+    production_path.write_text(
+        "void production() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    test_path.write_text(
+        "void test_scenario() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    parser = CodeParser()
+    production = f"{production_path}::production()"
+    test = f"{test_path}::test_scenario()"
+
+    try:
+        for path in (callee_path, production_path, test_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 2
+        assert [
+            match["qualified_name"]
+            for match in store.get_transitive_tests(production)
+        ] == [test]
+
+        callee_path.write_text("// A::run was removed\n", encoding="utf-8")
+        nodes, edges = parser.parse_file(callee_path)
+        store.store_file_nodes_edges(str(callee_path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 0
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(production)
+            if edge.kind == "CALLS"
+        )
+        tested_by = next(
+            edge
+            for edge in store.get_edges_by_target(test)
+            if edge.kind == "TESTED_BY"
+        )
+        assert call.target_qualified == "A::run"
+        assert call.extra["unresolved_targets"] == []
+        assert call.extra["unresolved_target_count"] == 0
+        assert tested_by.source_qualified == "A::run"
+        assert tested_by.extra == call.extra
+        assert store.get_transitive_tests(production) == []
+    finally:
+        store.close()
+
+    tests_for_production = query_graph(
+        "tests_for", production, repo_root=str(tmp_path),
+    )
+    assert tests_for_production["results"] == []
+
+
+def test_missing_scoped_candidate_rechecks_when_definition_appears(tmp_path: Path):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    caller_path.write_text(
+        "void caller() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    store = GraphStore(tmp_path / "graph.db")
+    parser = CodeParser()
+    caller = f"{caller_path}::caller()"
+
+    try:
+        nodes, edges = parser.parse_file(caller_path)
+        store.store_file_nodes_edges(str(caller_path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 0
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == "A::run"
+        assert call.extra["cpp_scoped_target"] == "A::run"
+        assert call.extra["unresolved_targets"] == []
+        assert store.resolve_cpp_scoped_call_targets() == 0
+
+        callee_path.write_text("void A::run(int value) {}\n", encoding="utf-8")
+        nodes, edges = parser.parse_file(callee_path)
+        store.store_file_nodes_edges(str(callee_path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 1
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == f"{callee_path}::A.run(int)"
+        assert "unresolved_targets" not in call.extra
+    finally:
+        store.close()
+
+
+def test_cross_file_scoped_resolution_rechecks_candidate_changes(tmp_path: Path):
+    callee_path = tmp_path / "callee.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    callee_path.write_text("void A::run(int value) {}\n", encoding="utf-8")
+    caller_path.write_text(
+        "void test_caller() { A::run(1); }\n",
+        encoding="utf-8",
+    )
+    store = GraphStore(tmp_path / "graph.db")
+    parser = CodeParser()
+    caller = f"{caller_path}::test_caller()"
+
+    try:
+        for path in (callee_path, caller_path):
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(str(path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 1
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == f"{callee_path}::A.run(int)"
+        assert call.extra["cpp_scoped_target"] == "A::run"
+        tested_by = next(
+            edge
+            for edge in store.get_edges_by_target(caller)
+            if edge.kind == "TESTED_BY"
+        )
+        assert tested_by.source_qualified == f"{callee_path}::A.run(int)"
+        assert tested_by.extra == call.extra
+
+        callee_path.write_text(
+            "void A::run(int value) {}\nvoid A::run(double value) {}\n",
+            encoding="utf-8",
+        )
+        nodes, edges = parser.parse_file(callee_path)
+        store.store_file_nodes_edges(str(callee_path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 0
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == "A::run"
+        assert call.extra["ambiguous_target_count"] == 2
+        tested_by = next(
+            edge
+            for edge in store.get_edges_by_target(caller)
+            if edge.kind == "TESTED_BY"
+        )
+        assert tested_by.source_qualified == "A::run"
+        assert tested_by.extra == call.extra
+
+        callee_path.write_text(
+            "void A::run(double value) {}\n",
+            encoding="utf-8",
+        )
+        nodes, edges = parser.parse_file(callee_path)
+        store.store_file_nodes_edges(str(callee_path), nodes, edges)
+
+        assert store.resolve_cpp_scoped_call_targets() == 1
+        call = next(
+            edge
+            for edge in store.get_edges_by_source(caller)
+            if edge.kind == "CALLS"
+        )
+        assert call.target_qualified == f"{callee_path}::A.run(double)"
+        assert call.extra["cpp_scoped_target"] == "A::run"
+        assert "ambiguous_targets" not in call.extra
+        assert "ambiguous_target_count" not in call.extra
+        assert "ambiguous_targets_truncated" not in call.extra
+        tested_by = next(
+            edge
+            for edge in store.get_edges_by_target(caller)
+            if edge.kind == "TESTED_BY"
+        )
+        assert tested_by.source_qualified == f"{callee_path}::A.run(double)"
+        assert tested_by.extra == call.extra
+    finally:
+        store.close()
+
+
+def test_non_cpp_failure_does_not_repeat_cpp_identity_migration(tmp_path: Path):
+    cpp_path = tmp_path / "run.cpp"
+    python_path = tmp_path / "broken.py"
+    cpp_path.write_text("void run(int value) {}\n", encoding="utf-8")
+    python_path.write_text("def broken(): pass\n", encoding="utf-8")
+    store = GraphStore(tmp_path / "graph.db")
+    original_parse_bytes = CodeParser.parse_bytes
+
+    def parse_with_python_failure(parser, path, source):
+        if Path(path).suffix == ".py":
+            raise RuntimeError("simulated non-C++ parse failure")
+        return original_parse_bytes(parser, path, source)
+
+    try:
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="run",
+            file_path=str(cpp_path),
+            line_start=1,
+            line_end=1,
+            language="cpp",
+        ))
+        store.commit()
+
+        with (
+            patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["run.cpp", "broken.py"],
+            ),
+            patch.object(CodeParser, "parse_bytes", new=parse_with_python_failure),
+        ):
+            migrated = incremental_update(tmp_path, store, changed_files=[])
+
+        assert migrated["identity_rebuild"] is True
+        assert migrated["errors"] == [
+            {"file": "broken.py", "error": "simulated non-C++ parse failure"},
+        ]
+        assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
+        assert store.get_node(f"{cpp_path}::run(int)") is not None
+
+        no_retry = incremental_update(tmp_path, store, changed_files=[])
+        assert no_retry.get("identity_rebuild") is None
+    finally:
+        store.close()
+
+
+def test_non_cpp_scoped_unresolved_callee_query_behavior_stays_unchanged(
+    tmp_path: Path,
+):
+    source_path = tmp_path / "lib.rs"
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    store = GraphStore(graph_dir / "graph.db")
+    caller = f"{source_path}::caller"
+
+    try:
+        store.upsert_node(NodeInfo(
+            kind="Function",
+            name="caller",
+            file_path=str(source_path),
+            line_start=1,
+            line_end=1,
+            language="rust",
+        ))
+        store.upsert_edge(EdgeInfo(
+            kind="CALLS",
+            source=caller,
+            target="external::missing",
+            file_path=str(source_path),
+            line=1,
+        ))
+        store.commit()
+    finally:
+        store.close()
+
+    result = query_graph("callees_of", caller, repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert result["results"] == []

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -418,5 +418,5 @@ class TestResolveBareEndpointsStep:
             result = run_post_processing(self.store)
 
         assert "bare_edges_resolved" not in result
-        assert any("Bare-endpoint resolution" in w for w in result["warnings"])
+        assert any("Call-target resolution" in w for w in result["warnings"])
         assert "communities_detected" in result


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #622

## What & why

C++ overloads previously shared the same `qualified_name`, so later graph upserts could replace an earlier overload and `callers_of` could report the wrong source range.

This change:

- gives C++ functions stable scoped identities that include normalized parameter types and member qualifiers while preserving their public display names and existing class keys;
- carries the same overload identity into call sources and resolves receiver/scoped targets only when the graph has enough evidence;
- records bounded candidate metadata when an overload is ambiguous or unresolved instead of selecting the first match;
- keeps `CALLS`, generated `TESTED_BY`, query fallback, and transitive coverage behavior consistent as candidates move between missing, unique, ambiguous, and deleted states;
- adds a versioned incremental migration so existing C++ graph identities are rebuilt safely without repeating the migration for unrelated parse failures.

Full compile-time C++ overload resolution is intentionally out of scope. Calls that cannot be proven remain explicit and honest.

## How it was tested

```bash
UV_CACHE_DIR=/private/tmp/contribution-uv-cache uv run --frozen pytest tests/test_cpp_overload_identity.py -q
# 29 passed

UV_CACHE_DIR=/private/tmp/contribution-uv-cache uv run --frozen pytest tests/ --tb=short -q
# 1990 passed, 5 skipped, 2 xpassed

UV_CACHE_DIR=/private/tmp/contribution-uv-cache uv run --frozen ruff check code_review_graph/ tests/test_cpp_overload_identity.py
# All checks passed

UV_CACHE_DIR=/private/tmp/contribution-uv-cache uv run --frozen --with mypy --default-index https://mirrors.aliyun.com/pypi/simple mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
# Success: no issues found in 66 source files
```

Independent review also reproduced the full missing -> unique -> ambiguous -> unique -> missing state machine, confirmed exact-overload coverage suppression, and observed zero mutating SQLite statements on an unchanged second resolver pass.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (docstrings)
