### PR TITLE
fix(platform): fix copilot-cli MCP config key and instructions path (#616)

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -149,7 +149,7 @@ PLATFORMS: dict[str, dict[str, Any]] = {
     "copilot-cli": {
         "name": "GitHub Copilot CLI",
         "config_path": lambda root: Path.home() / ".copilot" / "mcp-config.json",
-        "key": "servers",
+        "key": "mcpServers",
         "detect": lambda: (Path.home() / ".copilot").exists(),
         "format": "object",
         "needs_type": True,
@@ -1116,6 +1116,7 @@ cover what you need.
 # different from the default _CLAUDE_MD_SECTION.
 _PLATFORM_INSTRUCTION_CUSTOM_SECTIONS: dict[str, tuple[str, str]] = {
     ".github/code-review-graph.instruction.md": (_CLAUDE_MD_SECTION_MARKER, _COPILOT_SECTION),
+    ".github/instructions/code-review-graph.instructions.md": (_CLAUDE_MD_SECTION_MARKER, _COPILOT_SECTION),
 }
 
 
@@ -1162,7 +1163,8 @@ _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     ".windsurfrules": ("windsurf",),
     "QODER.md": ("qoder",),
     ".kiro/steering/code-review-graph.md": ("kiro",),
-    ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
+    ".github/code-review-graph.instruction.md": ("copilot",),
+    ".github/instructions/code-review-graph.instructions.md": ("copilot-cli",),
     "CODEBUDDY.md": ("codebuddy",),
 }
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -677,6 +677,7 @@ class TestInjectPlatformInstructionsFiltering:
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
+            ".github/instructions/code-review-graph.instructions.md",
             "CODEBUDDY.md",
         }
 
@@ -686,6 +687,7 @@ class TestInjectPlatformInstructionsFiltering:
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
             ".github/code-review-graph.instruction.md",
+            ".github/instructions/code-review-graph.instructions.md",
             "CODEBUDDY.md",
         }
 
@@ -1661,12 +1663,12 @@ class TestCopilotCLIPlatform:
         assert "copilot-cli" in PLATFORMS
         copilot_cli = PLATFORMS["copilot-cli"]
         assert copilot_cli["name"] == "GitHub Copilot CLI"
-        assert copilot_cli["key"] == "servers"
+        assert copilot_cli["key"] == "mcpServers"
         assert copilot_cli["format"] == "object"
         assert copilot_cli["needs_type"] is True
 
     def test_install_copilot_cli_config(self, tmp_path):
-        """install_platform_configs creates ~/.copilot/mcp-config.json with 'servers' key."""
+        """install_platform_configs creates ~/.copilot/mcp-config.json with 'mcpServers' key."""
         fake_home = tmp_path / "fakehome"
         (fake_home / ".copilot").mkdir(parents=True)
         config_path = fake_home / ".copilot" / "mcp-config.json"
@@ -1684,18 +1686,18 @@ class TestCopilotCLIPlatform:
         assert "GitHub Copilot CLI" in configured
         assert config_path.exists()
         data = json.loads(config_path.read_text())
-        assert "code-review-graph" in data["servers"]
-        entry = data["servers"]["code-review-graph"]
+        assert "code-review-graph" in data["mcpServers"]
+        entry = data["mcpServers"]["code-review-graph"]
         assert entry["type"] == "stdio"
         assert "serve" in entry["args"]
 
     def test_install_copilot_cli_preserves_existing_servers(self, tmp_path):
-        """Existing server entries are preserved when adding code-review-graph."""
+        """Existing mcpServers entries are preserved when adding code-review-graph."""
         fake_home = tmp_path / "fakehome"
         config_path = fake_home / ".copilot" / "mcp-config.json"
         config_path.parent.mkdir(parents=True)
         config_path.write_text(
-            json.dumps({"servers": {"other-server": {"command": "other"}}}),
+            json.dumps({"mcpServers": {"other-server": {"command": "other"}}}),
             encoding="utf-8",
         )
         with patch.dict(
@@ -1710,14 +1712,14 @@ class TestCopilotCLIPlatform:
         ):
             install_platform_configs(tmp_path, target="copilot-cli")
         data = json.loads(config_path.read_text())
-        assert "other-server" in data["servers"]
-        assert "code-review-graph" in data["servers"]
+        assert "other-server" in data["mcpServers"]
+        assert "code-review-graph" in data["mcpServers"]
 
     def test_copilot_cli_writes_only_copilot_instructions(self, tmp_path):
-        """Copilot CLI injection writes its GitHub instruction file."""
+        """Copilot CLI injection writes to .github/instructions/code-review-graph.instructions.md."""
         updated = inject_platform_instructions(tmp_path, target="copilot-cli")
-        assert ".github/code-review-graph.instruction.md" in updated
-        instructions = tmp_path / ".github" / "code-review-graph.instruction.md"
+        assert ".github/instructions/code-review-graph.instructions.md" in updated
+        instructions = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
         assert instructions.exists()
         content = instructions.read_text()
         assert _CLAUDE_MD_SECTION_MARKER in content


### PR DESCRIPTION
Fixes #616.

## Summary

- **Bug 1**: `install --platform copilot-cli` was writing the MCP server entry under `"servers"` in `~/.copilot/mcp-config.json`. Copilot CLI only parses `"mcpServers"`, so the server was silently ignored. Fixed by changing the platform key from `"servers"` to `"mcpServers"`.

- **Bug 2**: Graph instructions were written to `.github/code-review-graph.instruction.md` (shared with the `copilot` VS Code target). Copilot CLI only auto-loads files matching `.github/instructions/**/*.instructions.md`. Fixed by splitting the entry so `copilot-cli` writes to `.github/instructions/code-review-graph.instructions.md` while `copilot` keeps its existing path.

## Repro (before fix)

```bash
mkdir -p /tmp/fakehome/.copilot
HOME=/tmp/fakehome uvx code-review-graph install --platform copilot-cli -y
cat /tmp/fakehome/.copilot/mcp-config.json
# → { "servers": { ... } }   ← wrong key, Copilot CLI ignores it
```

## Smoke test (after fix)

Verified with the real Copilot CLI harness via `--additional-mcp-config`:

```
code-review-graph-*  — ~25 tools for codebase analysis (connected)
```

Copilot CLI also spontaneously led its tool summary with the graph tools, confirming the instruction file was loaded.

## Test plan

- [x] `uv run pytest tests/test_skills.py` — all 177 tests pass (updated assertions for new key and path)
- [x] Full suite: 1961 passed, 5 skipped
- [x] Manual repro with isolated `HOME` confirms `mcpServers` key and correct instruction file path
- [x] Live Copilot CLI smoke test confirms server connects and instructions load

🤖 Generated with [Claude Code](https://claude.com/claude-code)