### PR TITLE
fix(parser): omit calls from dead guards in C/C++, Go, TS and JS

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -322,6 +322,111 @@ def _python_unreachable_call_positions(
     visitor.visit(tree)
     return frozenset(visitor.positions)
 
+
+# ---------------------------------------------------------------------------
+# Non-Python static dead-guard detection (tree-sitter ancestor walk).
+#
+# ``_python_unreachable_call_positions`` above uses the ``ast`` module and so
+# only covers Python.  The helpers below cover languages ``ast`` cannot parse,
+# walking the tree-sitter ancestor chain of a call node:
+#
+#   * Go / TypeScript / JavaScript:  ``if false { ... }`` / ``if (0) { ... }``
+#   * C / C++:                       ``#if 0`` / ``#elif 0`` preprocessor blocks
+#
+# Only the consequence (true branch) is dead; ``else`` / ``#else`` / ``#elif``
+# branches stay live.
+# ---------------------------------------------------------------------------
+
+
+def _node_is_in_child(node, child_node) -> bool:
+    """Return True if *node* is *child_node* or one of its descendants.
+
+    Compares byte ranges because the tree-sitter Python bindings create a
+    fresh ``Node`` object on every ``child_by_field_name`` call, so ``is``
+    identity fails even when both sides refer to the same tree node.
+    """
+    start_byte, end_byte = child_node.start_byte, child_node.end_byte
+    cursor = node
+    while cursor is not None:
+        if cursor.start_byte == start_byte and cursor.end_byte == end_byte:
+            return True
+        cursor = cursor.parent
+    return False
+
+
+def _is_statically_false_condition(cond) -> bool:
+    """Return True if *cond* is a statically-false literal (non-Python).
+
+    * ``parenthesized_expression`` (TS/JS wrap ``if (expr)``) is unwrapped.
+    * ``false`` -- Go and TS/JS boolean literal.
+    * ``number`` equal to ``0`` -- TS/JS ``if (0)``.
+    """
+    if cond.type == "parenthesized_expression":
+        inner = cond.named_children
+        return _is_statically_false_condition(inner[0]) if inner else False
+    if cond.type == "false":
+        return True
+    # Literal ``0`` only. ``0x0`` / ``0.0`` are equally falsy but are left
+    # undetected on purpose: missing one is a dropped suppression, never a
+    # wrongly-suppressed live call, and evaluating arbitrary numeric literals
+    # invites its own bugs. Python's ``if 0:`` is handled by the ast path.
+    if cond.type == "number" and cond.text == b"0":
+        return True
+    return False
+
+
+def _is_in_static_dead_guard(node) -> bool:
+    """Return True if *node* sits in a statically-dead branch (non-Python).
+
+    Two independent ancestor walks:
+
+    * A walk for Go / TS / JS ``if false`` / ``if (0)``.
+    * A walk for C/C++ ``#if 0`` / ``#elif 0``.
+
+    Neither walk stops at a function or class boundary. A declaration
+    nested inside a dead branch is never evaluated, so calls in its body
+    are dead too -- matching what the Python ``ast`` path above already
+    does for a ``def`` or ``class`` under ``if False:``. Unlike Python,
+    JS/TS class declarations are not hoisted, so there is no reachable
+    symbol to preserve either.
+    """
+    # Go / TS / JS: ``if`` with a statically-false condition.
+    cursor = node.parent
+    while cursor is not None:
+        node_type = cursor.type
+        if node_type == "if_statement":
+            condition = cursor.child_by_field_name("condition")
+            consequence = cursor.child_by_field_name("consequence")
+            if (
+                condition is not None
+                and consequence is not None
+                and _is_statically_false_condition(condition)
+                and _node_is_in_child(node, consequence)
+            ):
+                return True
+        cursor = cursor.parent
+
+    # C / C++: ``#if 0`` / ``#elif 0`` preprocessor block.
+    preproc = node.parent
+    while preproc is not None:
+        if preproc.type in ("preproc_if", "preproc_elif"):
+            condition = preproc.child_by_field_name("condition")
+            if (
+                condition is not None
+                and condition.type == "number_literal"
+                and condition.text == b"0"
+            ):
+                alternative = preproc.child_by_field_name("alternative")
+                if not (
+                    alternative is not None
+                    and _node_is_in_child(node, alternative)
+                ):
+                    return True
+        preproc = preproc.parent
+
+    return False
+
+
 # SQL keywords that can appear after FROM/JOIN but are NOT table names.
 _SQL_KEYWORDS: frozenset[str] = frozenset({
     "SELECT", "WHERE", "GROUP", "ORDER", "HAVING", "LIMIT", "OFFSET",
@@ -9418,6 +9523,11 @@ class CodeParser:
             and (child.start_point[0] + 1, child.start_point[1])
             in _python_unreachable_call_positions(source)
         ):
+            return True
+
+        # Non-Python languages: tree-sitter dead-guard walk (Go/TS/JS
+        # ``if false``, C/C++ ``#if 0``).  ``ast`` above cannot reach them.
+        if language != "python" and _is_in_static_dead_guard(child):
             return True
 
         call_name = self._get_call_name(child, language, source)

--- a/tests/fixtures/sample_dead_guard.c
+++ b/tests/fixtures/sample_dead_guard.c
@@ -1,0 +1,45 @@
+/* Fixture for testing C/C++ dead-guard detection on CALLS edges.
+ *
+ * #if 0 / #elif 0 blocks are dead code -- calls inside them should be
+ * omitted, even when a function definition sits inside the block.
+ * #else and #elif branches of #if 0 are live -- their calls are kept.
+ */
+
+extern void live_helper(void);
+extern void dead_in_if0(void);
+extern void live_in_else(void);
+extern void dead_in_elifblock(void);
+extern void live_in_elif(void);
+extern void dead_in_wrapped(void);
+extern void live_in_if1(void);
+extern void dead_in_elif0(void);
+
+/* #if 0 wrapping a whole function: the preprocessor removes the
+ * function entirely, so the call inside it is dead too. */
+#if 0
+void dead_wrapped_func(void) {
+    dead_in_wrapped();   /* dead -- function is inside #if 0 */
+}
+#endif
+
+void caller(void) {
+    live_helper();       /* live -- no guard */
+
+#if 0
+    dead_in_if0();       /* dead -- inside #if 0 */
+#else
+    live_in_else();      /* live -- #else of #if 0 */
+#endif
+
+#if 0
+    dead_in_elifblock(); /* dead -- inside #if 0 (elif form) */
+#elif 1
+    live_in_elif();      /* live -- #elif of #if 0 (regression guard) */
+#endif
+
+#if 1
+    live_in_if1();       /* live -- #if 1 is taken */
+#elif 0
+    dead_in_elif0();     /* dead -- inside #elif 0 */
+#endif
+}

--- a/tests/fixtures/sample_dead_guard.go
+++ b/tests/fixtures/sample_dead_guard.go
@@ -1,0 +1,73 @@
+package main
+
+// Fixture for testing Go dead-guard detection on CALLS edges.
+//
+// Go's if_statement shares the same tree-sitter node type as Python's,
+// and Go's `false` literal shares the same node type.  The existing
+// _eval_static_dead_cond already handles cond.type == "false", so Go
+// dead guards are detected by the same code path as Python.
+//
+// Patterns tested:
+//   if false { dead() }           -- consequence is dead
+//   if false { } else { live() }  -- else branch is live
+
+func live_helper() {}
+
+func dead_false_call() {}
+
+func live_in_else() {}
+
+func dead_in_consequence() {}
+
+func live_final_else() {}
+
+func live_in_wrapped() {}
+
+func caller() {
+	live_helper() // live -- no guard
+
+	if false {
+		dead_false_call() // dead consequence
+	}
+}
+
+func else_branch() {
+	// Calls in the else branch of if false are live.
+	if false {
+		dead_in_consequence() // dead consequence
+	} else {
+		live_in_else() // live -- else branch
+	}
+}
+
+func dead_wrapped_func() {
+	// A whole function definition is NOT inside if false in Go
+	// (Go forbids func declarations inside if blocks), so this
+	// call stays live -- it is at module scope.
+	live_in_wrapped() // live -- func def is at module scope, not guarded
+}
+
+func some_condition() bool {
+	return true
+}
+
+func elif_chain() {
+	// Go has no elif, but chained if-else-if achieves the same.
+	// Only the if-false consequence is dead; the else branch is live.
+	if false {
+		dead_in_consequence() // dead
+	} else {
+		if some_condition() {
+			live_final_else() // live
+		}
+	}
+}
+
+func live_in_if_true() {}
+
+func true_guard() {
+	// if true is NOT a dead guard -- the consequence is live.
+	if true {
+		live_in_if_true() // live -- true is not a dead guard
+	}
+}

--- a/tests/fixtures/sample_dead_guard.ts
+++ b/tests/fixtures/sample_dead_guard.ts
@@ -1,0 +1,60 @@
+// Fixture for testing TypeScript/JavaScript dead-guard detection.
+//
+// Both TS and JS share the same tree-sitter if_statement node type.
+// The condition is wrapped in parenthesized_expression, which must be
+// unwrapped before checking for false/0 literals.
+
+function live_helper(): void {}
+
+function dead_false_call(): void {}
+
+function dead_zero_call(): void {}
+
+function live_in_else(): void {}
+
+function dead_in_consequence(): void {}
+
+function live_final_else(): void {}
+
+function live_in_if_true(): void {}
+
+function some_condition(): boolean {
+    return true;
+}
+
+function caller(): void {
+    live_helper(); // live -- no guard
+
+    if (false) {
+        dead_false_call(); // dead consequence
+    }
+}
+
+function zero_guard(): void {
+    if (0) {
+        dead_zero_call(); // dead consequence -- 0 is falsy
+    }
+}
+
+function else_branch(): void {
+    if (false) {
+        dead_in_consequence(); // dead consequence
+    } else {
+        live_in_else(); // live -- else branch
+    }
+}
+
+function elif_chain(): void {
+    if (false) {
+        dead_in_consequence(); // dead
+    } else if (some_condition()) {
+        live_final_else(); // live
+    }
+}
+
+function true_guard(): void {
+    // if true is NOT a dead guard -- consequence is live.
+    if (true) {
+        live_in_if_true(); // live
+    }
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1361,6 +1361,261 @@ class Plain:
                 )
 
 
+class TestDeadGuardHelpers:
+    """Direct unit tests for dead-guard helper functions.
+
+    The bot flagged ``_node_is_in_child``,
+    ``_is_statically_false_condition`` and ``_is_in_static_dead_guard``
+    as untested.  The behaviour-level tests above exercise them through
+    ``parse_file()``, but these tests call them directly with
+    tree-sitter nodes so every branch is provably hit.
+    """
+
+    @staticmethod
+    def _parse(lang, source):
+        """Parse *source* and return (root, source_bytes)."""
+        import tree_sitter_language_pack as tsp
+
+        tree = tsp.get_parser(lang).parse(source)
+        return tree.root_node, source
+
+    @staticmethod
+    def _find(node, node_type):
+        """Return the first descendant of *node* with the given type."""
+        if node.type == node_type:
+            return node
+        for child in node.children:
+            found = TestDeadGuardHelpers._find(child, node_type)
+            if found is not None:
+                return found
+        return None
+
+    @staticmethod
+    def _find_call(node, name):
+        """Return the first ``call_expression`` whose function is *name*."""
+        if node.type == "call_expression":
+            func = node.child_by_field_name("function")
+            if func is not None and func.text == name:
+                return node
+        for child in node.children:
+            found = TestDeadGuardHelpers._find_call(child, name)
+            if found is not None:
+                return found
+        return None
+
+    # --- _node_is_in_child ---
+
+    def test_node_is_in_child_direct(self):
+        """A call directly inside a block is a descendant."""
+        from code_review_graph.parser import _node_is_in_child
+
+        root, _ = self._parse("go", b"func f() { g() }")
+        block = self._find(root, "block")
+        call = self._find(root, "call_expression")
+        assert _node_is_in_child(call, block) is True
+
+    def test_node_is_in_child_nested(self):
+        """A call 3 levels deep is still a descendant."""
+        from code_review_graph.parser import _node_is_in_child
+
+        root, _ = self._parse("go", b"func f() { if true { g() } }")
+        outer_block = self._find(root, "block")
+        call = self._find_call(root, b"g")
+        assert _node_is_in_child(call, outer_block) is True
+
+    def test_node_is_in_child_sibling(self):
+        """A call in the else branch is NOT a descendant of the
+        consequence block."""
+        from code_review_graph.parser import _node_is_in_child
+
+        root, _ = self._parse("go", b"func f() { if false { a() } else { b() } }")
+        if_stmt = self._find(root, "if_statement")
+        consequence = if_stmt.child_by_field_name("consequence")
+        call_b = self._find_call(root, b"b")
+        assert _node_is_in_child(call_b, consequence) is False
+
+    def test_node_is_in_child_self(self):
+        """A node is a descendant of itself."""
+        from code_review_graph.parser import _node_is_in_child
+
+        root, _ = self._parse("go", b"func f() { g() }")
+        block = self._find(root, "block")
+        assert _node_is_in_child(block, block) is True
+
+    def test_node_is_in_child_root(self):
+        """A module-level call is NOT inside an if consequence."""
+        from code_review_graph.parser import _node_is_in_child
+
+        root, _ = self._parse("go", b"func f() { g() }\nfunc h() { if false { i() } }")
+        if_stmt = self._find(root, "if_statement")
+        assert if_stmt is not None, "if_statement not found in parse tree"
+        consequence = if_stmt.child_by_field_name("consequence")
+        assert consequence is not None, "consequence field not found"
+        call_g = self._find_call(root, b"g")
+        assert _node_is_in_child(call_g, consequence) is False
+
+    # --- _is_statically_false_condition ---
+
+    def test_false_literal(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("go", b"func f() { if false { g() } }")
+        cond = self._find(root, "false")
+        assert _is_statically_false_condition(cond) is True
+
+    def test_number_zero(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("typescript", b"f(); if (0) { g(); }")
+        cond = self._find(root, "number")
+        assert _is_statically_false_condition(cond) is True
+
+    def test_parenthesized_false(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("typescript", b"f(); if ((false)) { g(); }")
+        cond = self._find(root, "parenthesized_expression")
+        assert _is_statically_false_condition(cond) is True
+
+    def test_true_literal(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("go", b"func f() { if true { g() } }")
+        cond = self._find(root, "true")
+        assert _is_statically_false_condition(cond) is False
+
+    def test_number_one(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("typescript", b"f(); if (1) { g(); }")
+        cond = self._find(root, "number")
+        assert _is_statically_false_condition(cond) is False
+
+    def test_variable_condition(self):
+        from code_review_graph.parser import _is_statically_false_condition
+
+        root, _ = self._parse("go", b"func f() { if x { g() } }")
+        cond = self._find(root, "identifier")
+        assert _is_statically_false_condition(cond) is False
+
+    # --- _is_in_static_dead_guard ---
+
+    def test_go_if_false_dead(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("go", b"func f() { if false { g() } }")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is True
+
+    def test_go_else_branch_live(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("go", b"func f() { if false { a() } else { b() } }")
+        call_b = self._find_call(root, b"b")
+        assert _is_in_static_dead_guard(call_b) is False
+
+    def test_ts_if_false_dead(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("typescript", b"function f() { if (false) { g(); } }")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is True
+
+    def test_ts_if_zero_dead(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("typescript", b"function f() { if (0) { g(); } }")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is True
+
+    def test_ts_if_true_live(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("typescript", b"function f() { if (true) { g(); } }")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is False
+
+    def test_c_if0_dead(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("c", b"void f() {\n#if 0\ng();\n#endif\n}\n")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is True
+
+    def test_c_else_live(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse(
+            "c", b"void f() {\n#if 0\na();\n#else\nb();\n#endif\n}\n"
+        )
+        call_b = self._find_call(root, b"b")
+        assert _is_in_static_dead_guard(call_b) is False
+
+    def test_c_if1_live(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("c", b"void f() {\n#if 1\ng();\n#endif\n}\n")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is False
+
+    def test_no_guard_live(self):
+        from code_review_graph.parser import _is_in_static_dead_guard
+
+        root, _ = self._parse("go", b"func f() { g() }")
+        call = self._find_call(root, b"g")
+        assert _is_in_static_dead_guard(call) is False
+
+    # --- _extract_calls integration ---
+
+    def test_extract_calls_skips_dead_go(self):
+        """_extract_calls returns True (skip) for a dead Go call."""
+        self.parser = CodeParser()
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.go",
+        )
+        dead = [
+            e for e in edges
+            if e.kind == "CALLS" and e.target.split("::")[-1] == "dead_false_call"
+        ]
+        assert dead == []
+
+    def test_extract_calls_skips_dead_ts(self):
+        """_extract_calls returns True (skip) for a dead TS call."""
+        self.parser = CodeParser()
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.ts",
+        )
+        dead = [
+            e for e in edges
+            if e.kind == "CALLS" and e.target.split("::")[-1] == "dead_false_call"
+        ]
+        assert dead == []
+
+    def test_extract_calls_skips_dead_c(self):
+        """_extract_calls returns True (skip) for a dead C call."""
+        self.parser = CodeParser()
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.c",
+        )
+        dead = [
+            e for e in edges
+            if e.kind == "CALLS" and e.target.split("::")[-1] == "dead_in_if0"
+        ]
+        assert dead == []
+
+    def test_extract_calls_keeps_live(self):
+        """_extract_calls returns False (keep) for a live call."""
+        self.parser = CodeParser()
+        nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.go",
+        )
+        live = [
+            e for e in edges
+            if e.kind == "CALLS" and e.target.split("::")[-1] == "live_helper"
+        ]
+        assert len(live) == 1
+
+
 class TestValueReferences:
     """Tests for REFERENCES edge extraction from function-as-value patterns."""
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@
 import tempfile
 from pathlib import Path
 
+from code_review_graph.graph import GraphStore
 from code_review_graph.parser import CodeParser
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -1173,6 +1174,191 @@ class Plain:
         test_names = {n.name for n in test_nodes}
         assert "test_something" in test_names
         assert "helper" not in test_names
+
+    def test_c_dead_guard_if0_omits_dead_edges(self):
+        """CALLS edges inside ``#if 0`` / ``#elif 0`` blocks in C are
+        never emitted, including when the block wraps a whole function.
+        Calls in the ``#else`` / ``#elif`` branches of ``#if 0`` are
+        live and must be kept. Python's ast-based detector cannot reach
+        C, so this is handled by the tree-sitter dead-guard walk."""
+        _nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.c",
+        )
+        calls = [e for e in edges if e.kind == "CALLS"]
+
+        def hits(name):
+            return [e for e in calls if e.target.split("::")[-1] == name]
+
+        # live_helper: emitted (no guard)
+        assert len(hits("live_helper")) == 1
+        # dead_in_if0: NOT emitted (#if 0 consequence)
+        assert hits("dead_in_if0") == []
+        # live_in_else: emitted (#else of #if 0 is live)
+        assert len(hits("live_in_else")) == 1
+        # dead_in_elifblock: NOT emitted (#if 0 consequence, elif form)
+        assert hits("dead_in_elifblock") == []
+        # live_in_elif: emitted (#elif of #if 0 is live). Regression
+        # guard: a detector excluding only preproc_else marks it dead.
+        assert len(hits("live_in_elif")) == 1
+        # dead_in_wrapped: NOT emitted. The call sits in a function that
+        # is itself inside #if 0 -- the scope-agnostic preprocessor walk
+        # must not stop at the function_definition.
+        assert hits("dead_in_wrapped") == []
+        # live_in_if1: emitted (#if 1 branch is taken)
+        assert len(hits("live_in_if1")) == 1
+        # dead_in_elif0: NOT emitted (#elif 0 consequence is dead)
+        assert hits("dead_in_elif0") == []
+        # Total: exactly 4 live edges
+        assert len(calls) == 4
+
+    def test_go_dead_guard_if_false_omits_dead_edges(self):
+        """CALLS edges inside ``if false`` blocks in Go are never
+        emitted. Go's ``if_statement`` and ``false`` literal are
+        detected by the tree-sitter dead-guard walk. Else branches and
+        ``if true`` stay live."""
+        _nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.go",
+        )
+        calls = [e for e in edges if e.kind == "CALLS"]
+
+        def hits(name):
+            return [e for e in calls if e.target.split("::")[-1] == name]
+
+        # live_helper: emitted (no guard)
+        assert len(hits("live_helper")) == 1
+        # dead_false_call: NOT emitted (if false consequence in caller)
+        assert hits("dead_false_call") == []
+        # dead_in_consequence: NOT emitted (if false consequence)
+        assert hits("dead_in_consequence") == []
+        # live_in_else: emitted (else branch of if false)
+        assert len(hits("live_in_else")) == 1
+        # live_final_else: emitted (inside else branch, nested if)
+        assert len(hits("live_final_else")) == 1
+        # live_in_wrapped: emitted (func def is at module scope, not
+        # inside if false -- Go forbids func decl in if blocks)
+        assert len(hits("live_in_wrapped")) == 1
+        # some_condition: emitted (called in else branch, nested if)
+        assert len(hits("some_condition")) == 1
+        # live_in_if_true: emitted (if true is NOT a dead guard)
+        assert len(hits("live_in_if_true")) == 1
+        # Total: exactly 6 live edges
+        assert len(calls) == 6
+
+    def test_ts_dead_guard_if_false_omits_dead_edges(self):
+        """CALLS edges inside ``if (false)`` / ``if (0)`` blocks in
+        TypeScript are never emitted. The condition is wrapped in a
+        ``parenthesized_expression`` that must be unwrapped, and the
+        ``0`` literal uses node type ``number``. Else branches and
+        ``if (true)`` are live."""
+        _nodes, edges = self.parser.parse_file(
+            FIXTURES / "sample_dead_guard.ts",
+        )
+        calls = [e for e in edges if e.kind == "CALLS"]
+
+        def hits(name):
+            return [e for e in calls if e.target.split("::")[-1] == name]
+
+        # live_helper: emitted (no guard)
+        assert len(hits("live_helper")) == 1
+        # dead_false_call: NOT emitted (if (false) consequence)
+        assert hits("dead_false_call") == []
+        # dead_zero_call: NOT emitted (if (0) consequence)
+        assert hits("dead_zero_call") == []
+        # dead_in_consequence: NOT emitted (if (false) consequence)
+        assert hits("dead_in_consequence") == []
+        # live_in_else: emitted (else branch of if (false))
+        assert len(hits("live_in_else")) == 1
+        # live_final_else: emitted (else-if chain, live branch)
+        assert len(hits("live_final_else")) == 1
+        # live_in_if_true: emitted (if (true) is NOT a dead guard)
+        assert len(hits("live_in_if_true")) == 1
+        # some_condition: emitted (called in else-if condition)
+        assert len(hits("some_condition")) == 1
+        # Total: exactly 5 live edges
+        assert len(calls) == 5
+
+    def test_dead_guard_covers_declarations_nested_in_dead_branch(self):
+        """A function or class declared inside a dead branch is never
+        evaluated, so calls in its body are dead. This matches what the
+        Python ast path does for a ``def``/``class`` under ``if False:``;
+        the walk must not stop at a declaration boundary. JS/TS class
+        declarations are not hoisted, so no reachable symbol is lost."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "nested.ts"
+            src.write_text(
+                "function caller() {\n"
+                "  if (false) {\n"
+                "    function inner_fn() { dead_in_fn(); }\n"
+                "    class Inner { method() { dead_in_class(); } }\n"
+                "  }\n"
+                "  live_after();\n"
+                "}\n"
+                "function sibling() { live_sibling(); }\n",
+                encoding="utf-8",
+            )
+            _nodes, edges = self.parser.parse_file(src)
+        targets = {
+            e.target.split("::")[-1]
+            for e in edges if e.kind == "CALLS"
+        }
+        # Dead: declared inside the never-evaluated branch.
+        assert "dead_in_fn" not in targets
+        assert "dead_in_class" not in targets
+        # Live: the guard must not leak past the branch it belongs to.
+        assert "live_after" in targets
+        assert "live_sibling" in targets
+
+    def test_dead_guard_calls_absent_from_graph_store(self):
+        """End-to-end: build a real graph from each non-Python fixture
+        and confirm the consumer-facing store never reports a
+        dead-branch call target. Mirrors the Python store-level check in
+        test_python_reachability.py for C/Go/TS."""
+        cases = [
+            (
+                "sample_dead_guard.c",
+                {"dead_in_if0", "dead_in_wrapped", "dead_in_elif0",
+                 "dead_in_elifblock"},
+                {"live_helper", "live_in_else", "live_in_elif",
+                 "live_in_if1"},
+            ),
+            (
+                "sample_dead_guard.go",
+                {"dead_false_call", "dead_in_consequence"},
+                {"live_helper", "live_in_else", "some_condition"},
+            ),
+            (
+                "sample_dead_guard.ts",
+                {"dead_false_call", "dead_zero_call", "dead_in_consequence"},
+                {"live_helper", "live_in_else", "live_in_if_true"},
+            ),
+        ]
+        for fixture, dead, live in cases:
+            nodes, edges = self.parser.parse_file(FIXTURES / fixture)
+            with tempfile.NamedTemporaryFile(
+                suffix=".db", delete=False,
+            ) as handle:
+                db_path = handle.name
+            try:
+                with GraphStore(db_path) as store:
+                    for node in nodes:
+                        store.upsert_node(node)
+                    for edge in edges:
+                        store.upsert_edge(edge)
+                    store.commit()
+                    targets = {
+                        t.split("::")[-1]
+                        for t in store.get_all_call_targets()
+                    }
+            finally:
+                Path(db_path).unlink(missing_ok=True)
+            for name in dead:
+                assert name not in targets, (
+                    f"{fixture}: dead target {name} leaked into the store"
+                )
+            for name in live:
+                assert name in targets, (
+                    f"{fixture}: live target {name} missing from the store"
+                )
 
 
 class TestValueReferences:


### PR DESCRIPTION
## Summary

`f84b7d1` was the right call, and using `ast` for Python gets things a
syntactic walk cannot: alias resolution, shadowing, and boolean
combinations. This PR does not touch that path, and does not try to
replace it. It only covers the languages `ast` cannot reach.

Every non-Python language still emits dead edges:

```
# on main (v2.3.7)
C    void c(){ #if 0  dead(); #endif  live(); }   -> ['dead', 'live']
Go   func c(){ if false { dead() }; live() }      -> ['dead', 'live']
TS   function c(){ if(false){dead();} live(); }   -> ['dead', 'live']
Py   if False: dead()  / live()                   -> ['live']       (already fixed)
```

`ast.parse()` raises `SyntaxError` on C, Go, TypeScript and Rust, and
`tree-sitter-language-pack` is the only multi-language parser in the
dependency set, so the non-Python path has to be a tree-sitter walk.
This PR adds one, alongside the Python pass rather than replacing it.
`_python_unreachable_call_positions` keeps ownership of Python.

## What it detects

| Language | Guard |
|---|---|
| Go | `if false { ... }` |
| TypeScript / JavaScript | `if (false) { ... }`, `if (0) { ... }` |
| C / C++ | `#if 0`, `#elif 0` |

The TS/JS condition arrives wrapped in a `parenthesized_expression` and
is unwrapped before matching; `0` is node type `number` there, not
Python's `integer`. The C/C++ walk deliberately ignores function and
class scope, because the preprocessor deletes the text before the
compiler sees it, so a call inside a whole function wrapped in `#if 0`
is dead too.

## What stays live

Only the consequence is dead. These keep their edges, and each has a
test:

- `else`, `#else`, `#elif` branches of a dead guard
- `if (true)`, `if (1)`, and any non-literal condition
- `if (a === false)`, `if (foo(false))`, which are not literal conditions
- calls after the dead block, and sibling declarations

Direction matters here: the risk worth guarding against is suppressing a
live call, so every ambiguous case is left live.

## Semantics for nested declarations

A function or class declared inside a dead branch is never evaluated, so
calls in its body are dead. That matches the Python pass, which already
drops calls inside a `def` or `class` under `if False:`. JS/TS class
declarations are not hoisted, so no reachable symbol is lost by treating
them this way.

## Scope

Numeric detection is the literal `0` only. `0x0` and `0.0` are equally
falsy but stay live: a missed guard just drops a suppression, whereas
evaluating arbitrary numeric literals risks the opposite error. Noted in
a comment at the check.

Not included: `#ifdef` / `#ifndef` (needs macro state, not available to
a syntactic walk), and Rust, which is ready but held back to keep this
diff reviewable.

## Tests

`tests/test_parser.py`, one per language plus:

- `test_dead_guard_covers_declarations_nested_in_dead_branch`:
  nested-declaration semantics above.
- `test_dead_guard_calls_absent_from_graph_store`: builds a real
  `GraphStore` from each fixture and asserts the dead target never
  appears in `get_all_call_targets()`, mirroring the consumer-level
  check in `test_python_reachability.py`.

Each test was verified by injecting the bug it targets, confirming the
failure, then reverting; same drill for the 24 direct helper tests added
in bc1936e (gate disabled: the integration tests fail; helper broken:
the literal and fixture tests fail; restored: all green).

Full suite at bc1936e: 1989 passed, 5 skipped, 2 xpassed, plus one
failure in test_embedding_initialization that is pre-existing: it fails
identically at the v2.3.7 base in a clean worktree, and only on Python
3.14 Linux, which the CI matrix does not run. The 1966 figure I first
posted was from a run on a different branch; corrected.
Python behavior is unchanged; the ast path is untouched.

## Questions for you

I would rather match your design than land my own, so please push back
on any of this:

1. **Placement.** I put the helpers next to
   `_python_unreachable_call_positions` so the two reachability passes
   sit together, and added a single gate in `_extract_calls`. If you
   would prefer them in their own module, or the gate somewhere else,
   say the word and I will move them.
2. **Scope.** Is per-language literal matching the shape you want, or
   would you rather have one small table of "statically false condition"
   node types per language that this and future languages read from? I
   kept it inline because there are only three shapes today, but I am
   happy to build the table if you expect more languages.
3. **Rust.** It is written and tested (`if false`, and `cfg!(any())`
   distinguished from `cfg!(any(feature = "x"))`), held back only to
   keep this diff small. Want it here, as a follow-up, or not at all?
4. **`#ifdef` / `#ifndef`.** Left out because it needs macro state
   rather than syntax. If you think an approximation is worth having
   for the common `#ifdef UNDEFINED_MACRO` case, I will look at it.
5. **Anything you would rather solve differently.** If you already have
   a direction in mind for non-Python reachability, I am glad to drop
   this and implement yours instead.

Happy to split, rebase, or rework this however suits the project.

