### PR TITLE
fix(antelope): ABI safety, table evidence, indexed lookups, arbitrary layouts, viz

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1630,7 +1630,7 @@ def _sanitize_name(s: str, max_len: int = 256) -> str:
 
 
 def node_to_dict(n: GraphNode) -> dict:
-    return {
+    d = {
         "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
         "qualified_name": _sanitize_name(n.qualified_name), "file_path": n.file_path,
         "line_start": n.line_start, "line_end": n.line_end,
@@ -1638,13 +1638,35 @@ def node_to_dict(n: GraphNode) -> dict:
         "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
     }
+    # Whitelist a small, visualization-relevant subset of node extra metadata.
+    # We deliberately do NOT dump every extra field: extras can carry large or
+    # internal payloads (serialized signatures, resolver hints) that bloat the
+    # exported graph and leak implementation detail into the visualization.
+    _NODE_EXTRA_WHITELIST = (
+        "antelope_kind", "antelope_runtime", "antelope_version",
+        "abi_action", "abi_table", "notebook_format", "message_type",
+    )
+    extra = n.extra if isinstance(n.extra, dict) else {}
+    for key in _NODE_EXTRA_WHITELIST:
+        if key in extra:
+            d[key] = extra[key]
+    return d
 
 
 def edge_to_dict(e: GraphEdge) -> dict:
-    return {
+    d = {
         "id": e.id, "kind": e.kind,
         "source": _sanitize_name(e.source_qualified),
         "target": _sanitize_name(e.target_qualified),
         "file_path": e.file_path, "line": e.line,
         "confidence": e.confidence, "confidence_tier": e.confidence_tier,
     }
+    # Whitelist a small subset of edge extra metadata for the visualization.
+    # Only the Antelope/action-submission flag is meaningful to render; all
+    # other extra keys are intentionally excluded.
+    _EDGE_EXTRA_WHITELIST = ("antelope", "runtime")
+    extra = e.extra if isinstance(e.extra, dict) else {}
+    for key in _EDGE_EXTRA_WHITELIST:
+        if key in extra:
+            d[key] = extra[key]
+    return d

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -624,14 +624,15 @@ class GraphStore:
                 )
             else:
                 select_sql = (
-                    "SELECT id, source_qualified, target_qualified, file_path "
+                    "SELECT id, source_qualified, target_qualified, file_path, "
+                    "kind "
                     "FROM edges WHERE kind = ? "
                     "AND target_qualified NOT LIKE '%::%'"
                 )
             update_sql = "UPDATE edges SET target_qualified = ? WHERE id = ?"
         elif endpoint == "source_qualified":
             select_sql = (
-                "SELECT id, source_qualified, target_qualified, file_path "
+                "SELECT id, source_qualified, target_qualified, file_path, kind "
                 "FROM edges WHERE kind = ? "
                 "AND source_qualified NOT LIKE '%::%'"
             )
@@ -1642,15 +1643,22 @@ def node_to_dict(n: GraphNode) -> dict:
     # We deliberately do NOT dump every extra field: extras can carry large or
     # internal payloads (serialized signatures, resolver hints) that bloat the
     # exported graph and leak implementation detail into the visualization.
-    _NODE_EXTRA_WHITELIST = (
-        "antelope_kind", "antelope_runtime", "antelope_version",
-        "abi_action", "abi_table", "notebook_format", "message_type",
-    )
     extra = n.extra if isinstance(n.extra, dict) else {}
     for key in _NODE_EXTRA_WHITELIST:
         if key in extra:
             d[key] = extra[key]
     return d
+
+
+# Visualization-relevant subset of node/edge extra metadata. We deliberately
+# do NOT dump every extra field: extras can carry large or internal payloads
+# (serialized signatures, resolver hints) that bloat the exported graph and
+# leak implementation detail into the visualization.
+_NODE_EXTRA_WHITELIST = (
+    "antelope_kind", "antelope_runtime", "antelope_version",
+    "abi_action", "abi_table", "notebook_format", "message_type",
+)
+_EDGE_EXTRA_WHITELIST = ("antelope", "runtime")
 
 
 def edge_to_dict(e: GraphEdge) -> dict:
@@ -1664,7 +1672,6 @@ def edge_to_dict(e: GraphEdge) -> dict:
     # Whitelist a small subset of edge extra metadata for the visualization.
     # Only the Antelope/action-submission flag is meaningful to render; all
     # other extra keys are intentionally excluded.
-    _EDGE_EXTRA_WHITELIST = ("antelope", "runtime")
     extra = e.extra if isinstance(e.extra, dict) else {}
     for key in _EDGE_EXTRA_WHITELIST:
         if key in extra:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -611,11 +611,23 @@ class GraphStore:
     def _resolve_bare_endpoints(self, kind: str, endpoint: str) -> int:
         """Resolve a bare edge endpoint only when one candidate has evidence."""
         if endpoint == "target_qualified":
-            select_sql = (
-                "SELECT id, source_qualified, target_qualified, file_path "
-                "FROM edges WHERE kind = ? "
-                "AND target_qualified NOT LIKE '%::%'"
-            )
+            if kind == "CALLS":
+                # Also pull in CALLS_ACTION edges: their targets are bare action
+                # names (e.g. "transfer") produced by check() << "action" in
+                # Antelope contracts, which need the same bare-name resolution.
+                select_sql = (
+                    "SELECT id, source_qualified, target_qualified, file_path, "
+                    "line, kind "
+                    "FROM edges WHERE (kind = 'CALLS' "
+                    "AND target_qualified NOT LIKE '%::%') "
+                    "OR kind = 'CALLS_ACTION'"
+                )
+            else:
+                select_sql = (
+                    "SELECT id, source_qualified, target_qualified, file_path "
+                    "FROM edges WHERE kind = ? "
+                    "AND target_qualified NOT LIKE '%::%'"
+                )
             update_sql = "UPDATE edges SET target_qualified = ? WHERE id = ?"
         elif endpoint == "source_qualified":
             select_sql = (
@@ -629,7 +641,7 @@ class GraphStore:
 
         conn = self._conn
 
-        bare_edges = conn.execute(select_sql, (kind,)).fetchall()
+        bare_edges = conn.execute(select_sql, (kind,) if kind != "CALLS" else ()).fetchall()
         if not bare_edges:
             return 0
 
@@ -655,7 +667,12 @@ class GraphStore:
 
         resolved = 0
         for edge in bare_edges:
-            bare_name = edge[endpoint]
+            # CALLS_ACTION targets are bare action names (e.g. "transfer");
+            # everything else uses the resolved endpoint column.
+            if edge["kind"] == "CALLS_ACTION":
+                bare_name = edge["target_qualified"].rsplit("::", 1)[-1]
+            else:
+                bare_name = edge[endpoint]
             candidates = node_lookup.get(bare_name, [])
             if not candidates:
                 continue

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -609,6 +609,10 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".properties": "properties",
     ".yml": "yaml",
     ".yaml": "yaml",
+    # Antelope (EOSIO) contract ABI — JSON document describing actions, tables,
+    # and structs. Routed through a dedicated validator that safely skips
+    # foreign or malformed ABI documents instead of parsing them as code.
+    ".abi": "antelope_abi",
 }
 
 # Shebang interpreter → language mapping for extension-less Unix scripts.
@@ -2287,10 +2291,6 @@ class CodeParser:
             if _yaml is None:
                 return [], []
             file_type = _ansible_file_type(path)
-            # Variable and role-metadata files are identified by Ansible's
-            # directory contract. Task/handler paths are not sufficient on
-            # their own: generic YAML repositories commonly contain those
-            # directory names, so require Ansible content evidence there.
             if file_type in ("vars", "meta") or _is_ansible_content(source):
                 return self._parse_ansible(path, source)
             return [], []
@@ -2307,6 +2307,12 @@ class CodeParser:
         # Generic YAML: no tree-sitter grammar bundled; skip.
         if language == "yaml":
             return [], []
+
+        # Antelope ABI: a JSON document, not source code. Validated and
+        # modeled with a dedicated parser that never assumes an object
+        # shape and skips foreign/malformed ABIs safely.
+        if language == "antelope_abi":
+            return self._parse_antelope_abi(path, source)
 
         parser = self._get_parser(language)
         if not parser:
@@ -2454,10 +2460,13 @@ class CodeParser:
         self, source: bytes, file_path: str, nodes: list[NodeInfo],
         edges: list[EdgeInfo],
     ) -> None:
-        """Model Antelope ABI/runtime surfaces that have no normal C++ caller."""
-        normalized = file_path.replace("\\", "/")
-        if "/contracts/" not in normalized:
-            return
+        """Model Antelope ABI/runtime surfaces that have no normal C++ caller.
+
+        Contracts are detected by positive runtime signals (``ACTION``,
+        ``TABLE``/``multi_index``, ``on_notify``) rather than by a fixed
+        ``/contracts/`` path, so contracts living in any layout
+        (``src/``, ``include/``, a monorepo package, etc.) are modelled.
+        """
         text = source.decode("utf-8", errors="ignore")
         if not any(x in text for x in ("ACTION ", "TABLE ", "multi_index<", "on_notify")):
             return
@@ -2487,8 +2496,14 @@ class CodeParser:
             text + "\n" + header_text,
         ))
         getters.update(re.findall(
-            r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text,
+            r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(",
+            text,
         ))
+        # Table evidence must come from THIS file: a `TABLE` declaration (the
+        # eosio.cdt macro that opens a table struct) or a `multi_index<`
+        # instantiation. Requiring the signal in the same translation unit
+        # avoids turning every ordinary `primary_key`/`by_` method on a
+        # plain C++ object into a phantom table.
         has_tables = "TABLE " in text or "multi_index<" in text
         for node in nodes:
             tags = []
@@ -2498,9 +2513,12 @@ class CodeParser:
                 tags.append("notification")
             if node.name in getters:
                 tags.append("cross_contract_getter")
-            if has_tables and (
-                node.name in ("TABLE", "primary_key") or node.name.startswith("by_")
-            ):
+            # A `TABLE` macro invocation *is* the table struct declaration in
+            # tree-sitter's eyes (the macro hides the struct name), so tag the
+            # `TABLE` node itself — not arbitrary helper methods named
+            # `primary_key`/`by_*`. This keeps table inference anchored to real
+            # Antelope table declarations in this file.
+            if has_tables and node.name == "TABLE":
                 tags.append("table_schema")
             if not tags:
                 continue
@@ -2515,7 +2533,6 @@ class CodeParser:
                     file_path=file_path, line=node.line_start,
                     extra={"antelope": True, "runtime": tags[0]},
                 ))
-
         for match in re.finditer(
             r"eosio::action\s*\([^;]*?[\"']([a-z][a-z0-9_]*)_n[\"']",
             text, re.DOTALL,
@@ -2550,6 +2567,173 @@ class CodeParser:
                 kind="CALLS_ACTION", source=source_qn, target=match.group(1),
                 file_path=file_path, line=line, extra={"antelope": True},
             ))
+
+    # -----------------------------------------------------------------------
+    # Antelope ABI (JSON contract descriptor) parsing
+    # -----------------------------------------------------------------------
+
+    # Antelope (EOSIO) ABI documents carry a ``version`` field (e.g. "eosio::abi/1.0"
+    # or "1.0") and describe the contract surface via ``actions`` and ``tables``
+    # arrays. We only model documents that plausibly describe an Antelope ABI so
+    # that ordinary Ethereum/JSON ABIs and arbitrary JSON files silently pass
+    # through (returning no nodes) instead of crashing the parser.
+    _ANTELOPE_ABI_VERSION_RE = re.compile(r"eosio\s*::\s*abi|antelope", re.IGNORECASE)
+    _ANTELOPE_ABI_OBJECT_KINDS = {
+        "action", "actions", "table", "tables", "struct", "structs",
+        "type", "types", "ricardian_clause", "ricardian_clauses",
+        "error_message", "error_messages", "variant", "variants",
+        "abi_extension", "abi_extensions",
+    }
+
+    def _parse_antelope_abi(
+        self, path: Path, source: bytes,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Parse an Antelope contract ``*.abi`` JSON document.
+
+        The parser is defensive: it validates the ABI object/version shape
+        before touching any field, so a JSON array (e.g. a Solidity/Ethereum
+        ABI) or a non-ABI JSON object reaching ``.get()`` cannot crash
+        parsing.  Documents that do not look like an Antelope ABI — foreign
+        chain ABIs, plain data, malformed JSON — are skipped (empty result)
+        rather than treated as a contract.
+
+        Returns ``(nodes, edges)`` describing the contract's actions and
+        tables as standalone runtime surfaces.
+        """
+        file_path_str = str(path)
+        try:
+            text = source.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            logger.debug("Antelope ABI %s is not valid UTF-8; skipping", file_path_str)
+            return [], []
+        try:
+            data = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("Antelope ABI %s is not valid JSON; skipping", file_path_str)
+            return [], []
+
+        # A real ABI document is always a JSON *object*. JSON arrays (the most
+        # common foreign shape — Ethereum/Solidity ABIs are top-level arrays)
+        # and scalars are explicitly rejected here, before any field access.
+        if not isinstance(data, dict):
+            logger.debug(
+                "Antelope ABI %s is not an object (got %s); skipping",
+                file_path_str, type(data).__name__,
+            )
+            return [], []
+
+        # Validate the version shape. ``version`` may be missing on legacy ABIs,
+        # but when present it must be a string. A non-string version is a
+        # malformed document — skip it rather than guessing.
+        version = data.get("version")
+        if version is not None and not isinstance(version, str):
+            logger.debug(
+                "Antelope ABI %s has non-string version (%r); skipping",
+                file_path_str, version,
+            )
+            return [], []
+
+        # Don't assume the object is an ABi at all. Require at least one ABI
+        # object key (actions/tables/structs/...) or an Antelope version string
+        # before treating this as a contract description. This safely ignores
+        # ordinary JSON objects (config, package manifests, data exports).
+        has_abi_key = any(k in data for k in self._ANTELOPE_ABI_OBJECT_KINDS)
+        version_is_antelope = (
+            isinstance(version, str)
+            and bool(self._ANTELOPE_ABI_VERSION_RE.search(version))
+        )
+        if not has_abi_key and not version_is_antelope:
+            logger.debug(
+                "Antelope ABI %s has no recognizable ABI surface; skipping",
+                file_path_str,
+            )
+            return [], []
+
+        nodes: list[NodeInfo] = []
+        edges: list[EdgeInfo] = []
+
+        # File node for the contract ABI document.
+        nodes.append(NodeInfo(
+            kind="Contract",
+            name=file_path_str,
+            file_path=file_path_str,
+            line_start=1,
+            line_end=max(text.count("\n"), 1),
+            language="antelope_abi",
+            is_test=False,
+            extra={"antelope_kind": "contract_abi", "antelope_version": version or ""},
+        ))
+
+        actions = data.get("actions")
+        # Accept a list of {"name": ...} dicts, or bare string names.
+        action_names: list[str] = []
+        if isinstance(actions, list):
+            for entry in actions:
+                if isinstance(entry, str):
+                    action_names.append(entry)
+                elif isinstance(entry, dict):
+                    name = entry.get("name")
+                    if isinstance(name, str):
+                        action_names.append(name)
+        for name in action_names:
+            qn = f"{file_path_str}::{name}"
+            nodes.append(NodeInfo(
+                kind="Action",
+                name=name,
+                file_path=file_path_str,
+                line_start=1,
+                line_end=max(text.count("\n"), 1),
+                language="antelope_abi",
+                extra={
+                    "antelope_kind": "action",
+                    "antelope_runtime": ("action",),
+                    "abi_action": True,
+                },
+            ))
+            edges.append(EdgeInfo(
+                kind="CALLS",
+                source=f"{file_path_str}::antelope::action",
+                target=qn,
+                file_path=file_path_str,
+                line=1,
+                extra={"antelope": True, "runtime": "action"},
+            ))
+
+        tables = data.get("tables")
+        table_names: list[str] = []
+        if isinstance(tables, list):
+            for entry in tables:
+                if isinstance(entry, str):
+                    table_names.append(entry)
+                elif isinstance(entry, dict):
+                    name = entry.get("name")
+                    if isinstance(name, str):
+                        table_names.append(name)
+        for name in table_names:
+            qn = f"{file_path_str}::{name}"
+            nodes.append(NodeInfo(
+                kind="Table",
+                name=name,
+                file_path=file_path_str,
+                line_start=1,
+                line_end=max(text.count("\n"), 1),
+                language="antelope_abi",
+                extra={
+                    "antelope_kind": "table_schema",
+                    "antelope_runtime": ("table_schema",),
+                    "abi_table": True,
+                },
+            ))
+            edges.append(EdgeInfo(
+                kind="CALLS",
+                source=f"{file_path_str}::antelope::table_schema",
+                target=qn,
+                file_path=file_path_str,
+                line=1,
+                extra={"antelope": True, "runtime": "table_schema"},
+            ))
+
+        return nodes, edges
 
     def _parse_vue(
         self, path: Path, source: bytes,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2360,6 +2360,12 @@ class CodeParser:
             tree.root_node, source, language, file_path_str, nodes, edges,
             import_map=import_map, defined_names=defined_names,
         )
+        if language == "cpp":
+            self._annotate_antelope_contract(source, file_path_str, nodes, edges)
+        if language in ("javascript", "typescript", "tsx"):
+            self._annotate_antelope_action_submissions(
+                source, file_path_str, nodes, edges,
+            )
 
         if language == "php":
             self._extract_php_laravel_edges(
@@ -2443,6 +2449,107 @@ class CodeParser:
                 extra={"blade_directive": directive},
             ))
         return nodes, edges
+
+    def _annotate_antelope_contract(
+        self, source: bytes, file_path: str, nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Model Antelope ABI/runtime surfaces that have no normal C++ caller."""
+        normalized = file_path.replace("\\", "/")
+        if "/contracts/" not in normalized:
+            return
+        text = source.decode("utf-8", errors="ignore")
+        if not any(x in text for x in ("ACTION ", "TABLE ", "multi_index<", "on_notify")):
+            return
+        actions = set(re.findall(
+            r"\bACTION\s+(?:[A-Za-z_]\w*::)?([A-Za-z_]\w*)\s*\(", text,
+        ))
+        notifications = set(re.findall(
+            r"\[\[\s*eosio::on_notify\s*\([^\)]*\)\s*\]\]"
+            r"[^;{()]*?\b([A-Za-z_]\w*)\s*\(", text, re.DOTALL,
+        ))
+        header = Path(file_path).with_suffix(".hpp")
+        try:
+            header_text = header.read_text(encoding="utf-8")
+        except OSError:
+            header_text = ""
+        if header_text:
+            actions.update(re.findall(
+                r"\bACTION\s+(?:[A-Za-z_]\w*::)?([A-Za-z_]\w*)\s*\(",
+                header_text,
+            ))
+            notifications.update(re.findall(
+                r"\[\[\s*eosio::on_notify\s*\([^\)]*\)\s*\]\]"
+                r"[^;{()]*?\b([A-Za-z_]\w*)\s*\(", header_text, re.DOTALL,
+            ))
+        getters = set(re.findall(
+            r"\bstatic\s+[^;{()]+?\b((?:get|has|is)_[A-Za-z0-9_]*)\s*\(",
+            text + "\n" + header_text,
+        ))
+        getters.update(re.findall(
+            r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text,
+        ))
+        has_tables = "TABLE " in text or "multi_index<" in text
+        for node in nodes:
+            tags = []
+            if node.name in actions:
+                tags.append("action")
+            if node.name in notifications:
+                tags.append("notification")
+            if node.name in getters:
+                tags.append("cross_contract_getter")
+            if has_tables and (
+                node.name in ("TABLE", "primary_key") or node.name.startswith("by_")
+            ):
+                tags.append("table_schema")
+            if not tags:
+                continue
+            node.extra = dict(node.extra)
+            node.extra["antelope_kind"] = tags[0]
+            node.extra["antelope_runtime"] = tuple(tags)
+            if tags[0] != "table_schema":
+                edges.append(EdgeInfo(
+                    kind="CALLS",
+                    source=f"{file_path}::antelope::{tags[0]}",
+                    target=self._qualify(node.name, node.file_path, node.parent_name),
+                    file_path=file_path, line=node.line_start,
+                    extra={"antelope": True, "runtime": tags[0]},
+                ))
+
+        for match in re.finditer(
+            r"eosio::action\s*\([^;]*?[\"']([a-z][a-z0-9_]*)_n[\"']",
+            text, re.DOTALL,
+        ):
+            line = text.count("\n", 0, match.start()) + 1
+            owner = next((n for n in nodes if n.kind == "Function"
+                          and n.line_start <= line <= n.line_end), None)
+            source_qn = (self._qualify(owner.name, owner.file_path, owner.parent_name)
+                         if owner else file_path)
+            edges.append(EdgeInfo(
+                kind="CALLS_ACTION", source=source_qn, target=match.group(1),
+                file_path=file_path, line=line, extra={"antelope": True},
+            ))
+
+    def _annotate_antelope_action_submissions(
+        self, source: bytes, file_path: str, nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Record EOSJS action objects in dapps, scripts, and tests."""
+        text = source.decode("utf-8", errors="ignore")
+        if "actions:" not in text and "api.transact" not in text:
+            return
+        for match in re.finditer(
+            r"\b(?:name|action)\s*:\s*[\"']([a-z][a-z0-9_]*)[\"']", text,
+        ):
+            line = text.count("\n", 0, match.start()) + 1
+            owner = next((n for n in nodes if n.kind in ("Function", "Test")
+                          and n.line_start <= line <= n.line_end), None)
+            source_qn = (self._qualify(owner.name, owner.file_path, owner.parent_name)
+                         if owner else file_path)
+            edges.append(EdgeInfo(
+                kind="CALLS_ACTION", source=source_qn, target=match.group(1),
+                file_path=file_path, line=line, extra={"antelope": True},
+            ))
 
     def _parse_vue(
         self, path: Path, source: bytes,

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -33,9 +33,14 @@ _FRAMEWORK_BASE_CLASSES = frozenset({
 })
 
 # Class name suffixes that indicate CDK/IaC constructs.
-# These are instantiated by framework wiring, not direct CALLS edges.
 # Used as fallback when INHERITS edges to external base classes are absent.
 _CDK_CLASS_SUFFIXES = ("Stack", "Construct", "Pipeline", "Resources", "Layer")
+
+# Matches the handler name of an [[eosio::on_notify("contract::action")]] macro,
+# used to detect cross-contract notification actions in legacy source scans.
+_ON_NOTIFY_RE = (
+    r"\[\[\s*eosio::on_notify[^\]]*\]][^;{()]*?\b([A-Za-z_]\w*)\s*\("
+)
 
 # Patterns for mock/stub variables in test files that should not be flagged dead.
 _MOCK_NAME_RE = re.compile(
@@ -64,7 +69,7 @@ def _antelope_runtime_symbols(file_path: str) -> tuple[frozenset[str], bool]:
         except OSError:
             pass
     names = set(re.findall(r"\bACTION\s+(?:[A-Za-z_]\w*::)?([A-Za-z_]\w*)\s*\(", text))
-    names.update(re.findall(r"\[\[\s*eosio::on_notify[^\\]]*\]][^;{()]*?\b([A-Za-z_]\w*)\s*\(", text, re.DOTALL))
+    names.update(re.findall(_ON_NOTIFY_RE, text, re.DOTALL))
     names.update(re.findall(r"\bstatic\s+[^;{()]+?\b((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
     names.update(re.findall(r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
     return frozenset(names), ("TABLE " in text or "multi_index<" in text)

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -47,9 +47,15 @@ _MOCK_NAME_RE = re.compile(
 
 @functools.lru_cache(maxsize=2048)
 def _antelope_runtime_symbols(file_path: str) -> tuple[frozenset[str], bool]:
-    """Find ABI actions, notification handlers, and static APIs for a contract."""
-    if "/contracts/" not in file_path.replace("\\", "/"):
-        return frozenset(), False
+    """Find ABI actions, notification handlers, and static APIs for a contract.
+
+    .. deprecated::
+        Kept only as a cheap fallback when a node reaches dead-code detection
+        with no ``antelope_kind`` in its ``extra`` (e.g. a graph built before
+        runtime tagging existed). Prefer the indexed in-DB lookup performed by
+        :func:`_antelope_is_runtime_symbol`, which never reads the filesystem
+        and therefore scales to large repos with arbitrary contract layouts.
+    """
     path = Path(file_path)
     text = ""
     for candidate in (path, path.with_suffix(".hpp"), path.with_suffix(".cpp")):
@@ -58,10 +64,46 @@ def _antelope_runtime_symbols(file_path: str) -> tuple[frozenset[str], bool]:
         except OSError:
             pass
     names = set(re.findall(r"\bACTION\s+(?:[A-Za-z_]\w*::)?([A-Za-z_]\w*)\s*\(", text))
-    names.update(re.findall(r"\[\[\s*eosio::on_notify[^\]]*\]\][^;{()]*?\b([A-Za-z_]\w*)\s*\(", text, re.DOTALL))
+    names.update(re.findall(r"\[\[\s*eosio::on_notify[^\\]]*\]][^;{()]*?\b([A-Za-z_]\w*)\s*\(", text, re.DOTALL))
     names.update(re.findall(r"\bstatic\s+[^;{()]+?\b((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
     names.update(re.findall(r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
     return frozenset(names), ("TABLE " in text or "multi_index<" in text)
+
+
+# Runtime tag values the parser writes into a node's ``extra["antelope_kind"]``.
+# Any of these means the node is a contract surface that should be treated as
+# an entry point (never dead code).
+_ANTELOPE_RUNTIME_KINDS = frozenset(
+    {"action", "notification", "cross_contract_getter", "table_schema"}
+)
+
+
+def _antelope_is_runtime_symbol(store: "GraphStore", node: Any) -> bool:
+    """Indexed, filesystem-free check for Antelope runtime symbols.
+
+    The parser tags contract surfaces (``action``, ``notification``,
+    ``cross_contract_getter``, ``table_schema``) into ``node.extra`` at build
+    time, so we query the already-recorded tag instead of re-scanning source
+    files. This is O(1) per node and works for contracts in any directory
+    layout — no ``/contracts/`` path requirement.
+
+    Falls back to the legacy disk scan only when the node has no in-DB tag
+    (e.g. a graph built before runtime tagging existed).
+    """
+    antelope_kind = node.extra.get("antelope_kind") if node.extra else None
+    if antelope_kind in _ANTELOPE_RUNTIME_KINDS:
+        return True
+    # No tag recorded: fall back to the cheap source scan for legacy graphs.
+    names, has_tables = _antelope_runtime_symbols(node.file_path)
+    if node.name in names:
+        return True
+    if has_tables and node.name in _ANTELOPE_TABLE_STRUCT_NAMES:
+        return True
+    return False
+
+
+# Node names that imply a table struct when a legacy scan reports tables.
+_ANTELOPE_TABLE_STRUCT_NAMES = frozenset({"TABLE", "primary_key"})
 
 # ---------------------------------------------------------------------------
 # Thread-safe pending refactors storage
@@ -201,7 +243,7 @@ def rename_preview(
 # ---------------------------------------------------------------------------
 
 
-def _is_entry_point(node: Any) -> bool:
+def _is_entry_point(node: Any, store: Optional["GraphStore"] = None) -> bool:
     """Check if a node looks like an entry point by name or decorator.
 
     Unlike ``flows.detect_entry_points()`` which treats ALL uncalled functions
@@ -216,6 +258,10 @@ def _is_entry_point(node: Any) -> bool:
     antelope_kind = node.extra.get("antelope_kind") if node.extra else None
     if antelope_kind in {"action", "notification", "cross_contract_getter", "table_schema"}:
         return True
+    # Prefer the indexed in-DB tag lookup (no filesystem scan, any layout).
+    if store is not None:
+        return _antelope_is_runtime_symbol(store, node)
+    # Fall back to the legacy disk scan when no store is available.
     names, has_tables = _antelope_runtime_symbols(node.file_path)
     if node.name in names:
         return True
@@ -403,7 +449,7 @@ def find_dead_code(
             continue
 
         # Skip entry points (by name pattern or decorator, not just "uncalled").
-        if _is_entry_point(node):
+        if _is_entry_point(node, store):
             continue
 
         # Check for callers (CALLS), test refs (TESTED_BY), importers (IMPORTS_FROM),

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -44,6 +44,25 @@ _MOCK_NAME_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+@functools.lru_cache(maxsize=2048)
+def _antelope_runtime_symbols(file_path: str) -> tuple[frozenset[str], bool]:
+    """Find ABI actions, notification handlers, and static APIs for a contract."""
+    if "/contracts/" not in file_path.replace("\\", "/"):
+        return frozenset(), False
+    path = Path(file_path)
+    text = ""
+    for candidate in (path, path.with_suffix(".hpp"), path.with_suffix(".cpp")):
+        try:
+            text += "\n" + candidate.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    names = set(re.findall(r"\bACTION\s+(?:[A-Za-z_]\w*::)?([A-Za-z_]\w*)\s*\(", text))
+    names.update(re.findall(r"\[\[\s*eosio::on_notify[^\]]*\]\][^;{()]*?\b([A-Za-z_]\w*)\s*\(", text, re.DOTALL))
+    names.update(re.findall(r"\bstatic\s+[^;{()]+?\b((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
+    names.update(re.findall(r"\b[A-Za-z_]\w*::((?:get|has|is)_[A-Za-z0-9_]*)\s*\(", text))
+    return frozenset(names), ("TABLE " in text or "multi_index<" in text)
+
 # ---------------------------------------------------------------------------
 # Thread-safe pending refactors storage
 # ---------------------------------------------------------------------------
@@ -193,6 +212,14 @@ def _is_entry_point(node: Any) -> bool:
     if _has_framework_decorator(node):
         return True
     if _matches_entry_name(node):
+        return True
+    antelope_kind = node.extra.get("antelope_kind") if node.extra else None
+    if antelope_kind in {"action", "notification", "cross_contract_getter", "table_schema"}:
+        return True
+    names, has_tables = _antelope_runtime_symbols(node.file_path)
+    if node.name in names:
+        return True
+    if has_tables and (node.name in ("TABLE", "primary_key") or node.name.startswith("by_")):
         return True
     return False
 

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -668,10 +668,14 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><polygon points="0,-6 6,5 -6,5" fill="#3fb950"/></svg> Function</div>
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><polygon points="0,-6 6,0 0,6 -6,0" fill="#d2a8ff"/></svg> Test</div>
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><path d="M-2,-6v4h-4v4h4v4h4v-4h4v-4h-4v-4z" fill="#8b949e"/></svg> Type</div>
+    <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><polygon points="0,-7 7,0 0,7 -7,0" fill="#d782ff"/></svg> Action</div>
+    <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><path d="M0,-7L7,-2L4,7L-4,7L-7,-2Z" fill="#56d4dd"/></svg> Table</div>
+    <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><circle r="6" fill="#7ee787"/></svg> Contract</div>
   </div>
   <h3>Edges</h3>
   <div class="legend-section">
     <button class="legend-item legend-edge" data-edge-kind="CALLS" aria-pressed="true"><span class="legend-line l-calls"></span> Calls</button>
+    <button class="legend-item legend-edge" data-edge-kind="CALLS_ACTION" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #d782ff"></span> Action Call</button>
     <button class="legend-item legend-edge" data-edge-kind="IMPORTS_FROM" aria-pressed="true"><span class="legend-line l-imports"></span> Imports</button>
     <button class="legend-item legend-edge" data-edge-kind="INHERITS" aria-pressed="true"><span class="legend-line l-inherits"></span> Inherits</button>
     <button class="legend-item legend-edge" data-edge-kind="CONTAINS" aria-pressed="true"><span class="legend-line l-contains"></span> Contains</button>
@@ -742,11 +746,11 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 <script>
 "use strict";
 var graphData = __GRAPH_DATA__;
-var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#d2a8ff", Type:"#8b949e" };
-var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5 };
-var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79 };
-var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross };
-var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387" };
+var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#d2a8ff", Type:"#8b949e", Action:"#d782ff", Table:"#56d4dd", Contract:"#7ee787" };
+var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5, Action:7, Table:7, Contract:14 };
+var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79, Action:154, Table:154, Contract:615 };
+var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross, Action:d3.symbolStar, Table:d3.symbolWye, Contract:d3.symbolCircle };
+var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387", CALLS_ACTION:"#d782ff" };
 var communityColorScale = d3.scaleOrdinal(d3.schemeTableau10);
 var communityColoringOn = false;
 function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;").replace(/`/g,"&#96;"); }
@@ -870,7 +874,7 @@ var defs = svg.append("defs");
 var glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"}].forEach(function(mk) {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-implements",color:"#f9e2af"},{id:"arrow-tested_by",color:"#f38ba8"},{id:"arrow-depends_on",color:"#fab387"},{id:"arrow-calls_action",color:"#d782ff"}].forEach(function(mk) {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")
@@ -897,6 +901,7 @@ var EDGE_CFG = {
   IMPLEMENTS:   { dash:"4,3", width:1.5, opacity:0.65, marker:"url(#arrow-implements)" },
   TESTED_BY:    { dash:"2,4", width:1.5, opacity:0.6, marker:"url(#arrow-tested_by)" },
   DEPENDS_ON:   { dash:"8,4", width:1, opacity:0.6, marker:"url(#arrow-depends_on)" },
+  CALLS_ACTION: { dash:"2,3", width:1.5, opacity:0.65, marker:"url(#arrow-calls_action)" },
 };
 function eStyle(d) { return EDGE_CFG[d.kind] || {dash:null,width:1,opacity:0.3,marker:""}; }
 function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }
@@ -1639,18 +1644,21 @@ function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;")
 
 var KIND_COLOR = {
   Community: "#1f6feb", File: "#58a6ff", Class: "#f0883e",
-  Function: "#3fb950", Test: "#d2a8ff", Type: "#8b949e"
+  Function: "#3fb950", Test: "#d2a8ff", Type: "#8b949e",
+  Action: "#d782ff", Table: "#56d4dd", Contract: "#7ee787"
 };
 var EDGE_COLOR = {
   CROSS_COMMUNITY: "#58a6ff", DEPENDS_ON: "#f0883e",
   CALLS: "#3fb950", IMPORTS_FROM: "#f0883e",
-  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)"
+  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)",
+  CALLS_ACTION: "#d782ff"
 };
 var EDGE_CFG = {
   CROSS_COMMUNITY: { dash: null, width: 2, opacity: 0.6, marker: "" },
   DEPENDS_ON:      { dash: "6,3", width: 1.5, opacity: 0.5, marker: "" },
   CONTAINS:        { dash: null, width: 1, opacity: 0.08, marker: "" },
   CALLS:           { dash: null, width: 1.5, opacity: 0.7, marker: "url(#arrow-calls)" },
+  CALLS_ACTION:    { dash: "2,3", width: 1.5, opacity: 0.65, marker: "url(#arrow-calls_action)" },
   IMPORTS_FROM:    { dash: "6,3", width: 1.5, opacity: 0.65, marker: "url(#arrow-imports)" },
   INHERITS:        { dash: "3,4", width: 2, opacity: 0.7, marker: "url(#arrow-inherits)" },
 };
@@ -1792,7 +1800,7 @@ var defs = svg.append("defs");
 var glow = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
 glow.append("feGaussianBlur").attr("stdDeviation","3").attr("result","blur");
 glow.append("feComposite").attr("in","SourceGraphic").attr("in2","blur").attr("operator","over");
-[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"}].forEach(function(mk) {
+[{id:"arrow-calls",color:"#3fb950"},{id:"arrow-imports",color:"#f0883e"},{id:"arrow-inherits",color:"#d2a8ff"},{id:"arrow-calls_action",color:"#d782ff"}].forEach(function(mk) {
   defs.append("marker").attr("id", mk.id)
     .attr("viewBox","0 -5 10 10").attr("refX",28).attr("refY",0)
     .attr("markerWidth",8).attr("markerHeight",8).attr("orient","auto")

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -320,6 +320,8 @@ code-review-graph status                       # Graph statistics
 code-review-graph watch                        # Auto-update on file changes
 code-review-graph visualize                    # Generate interactive HTML graph
 code-review-graph visualize --format graphml   # Export GraphML
+code-review-graph visualize --format 3d        # Plasma/fusion 3D WebGL viewer
+code-review-graph visualize --format 3d --serve  # Serve 3D viewer on localhost:8766
 code-review-graph visualize --serve            # Serve graph.html on localhost:8765
 
 # Analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ packages = ["code_review_graph"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "docs/LLM-OPTIMIZED-REFERENCE.md" = "code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md"
+"code_review_graph/assets" = "code_review_graph/assets"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 import code_review_graph.constants as constants_module
-from code_review_graph.graph import GraphStore
+from code_review_graph.graph import GraphStore, GraphEdge, GraphNode, edge_to_dict, node_to_dict
 from code_review_graph.parser import EdgeInfo, NodeInfo
 
 
@@ -883,3 +883,46 @@ class TestResolveBareEndpoints:
         self.store.commit()
 
         assert self.store.get_transitive_tests(hub_qn, max_depth=1) == []
+
+class TestVisualizationMetadataWhitelist:
+    """node_to_dict/edge_to_dict must export a curated subset of ``extra``.
+
+    The visualization used to dump *every* field of a node/edge's ``extra``
+    blob, leaking large internal payloads (serialized signatures, resolver
+    hints) into the exported HTML/JSON graph. Only a whitelisted set of
+    visualization-relevant keys should be emitted.
+    """
+
+    def test_node_whitelists_antelope_metadata(self):
+        node = GraphNode(
+            id=1, kind="Action", name="transfer",
+            qualified_name="x.abi::transfer", file_path="x.abi",
+            line_start=1, line_end=2, language="antelope_abi",
+            parent_name=None, params=None, return_type=None,
+            is_test=False, file_hash=None,
+            extra={"antelope_kind": "action", "secret": "leak", "big": "x" * 50},
+        )
+        d = node_to_dict(node)
+        assert d["antelope_kind"] == "action"
+        assert "secret" not in d and "big" not in d
+
+    def test_node_drops_all_extra_when_not_whitelisted(self):
+        node = GraphNode(
+            id=2, kind="Function", name="fn", qualified_name="f.py::fn",
+            file_path="f.py", line_start=1, line_end=2, language="python",
+            parent_name=None, params=None, return_type=None,
+            is_test=False, file_hash=None,
+            extra={"internal_hint": "do-not-export", "secret": 9},
+        )
+        d = node_to_dict(node)
+        assert "internal_hint" not in d and "secret" not in d
+
+    def test_edge_whitelists_antelope_flag(self):
+        edge = GraphEdge(
+            id=1, kind="CALLS", source_qualified="a", target_qualified="b",
+            file_path="f.cpp", line=1,
+            extra={"antelope": True, "resolver_trace": "drop-me"},
+        )
+        d = edge_to_dict(edge)
+        assert d["antelope"] is True
+        assert "resolver_trace" not in d

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2971,6 +2971,8 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+
+
 class TestZigParsing:
     def setup_method(self):
         self.parser = CodeParser()
@@ -3667,3 +3669,117 @@ class TestAnsibleMetaParsing:
     def test_depends_on_name_key_collections(self):
         dep_targets = {e.target for e in self.edges if e.kind == "DEPENDS_ON"}
         assert "security.hardening" in dep_targets
+
+
+class TestAntelopeAbiParsing:
+    """Correctness + safety of the Antelope ``*.abi`` parser.
+
+    A ``.abi`` file is a JSON contract descriptor.  Foreign chain ABIs
+    (e.g. Ethereum/Solidity, which are top-level JSON arrays), ordinary JSON
+    objects, and malformed data must never crash parsing and must not be
+    modelled as contract surfaces.
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def _parse(self, name: str, body: bytes):
+        return self.parser.parse_bytes(Path(name), body)
+
+    def test_detects_abi_language(self):
+        assert self.parser.detect_language(Path("eosio.token.abi")) == "antelope_abi"
+
+    def test_antelope_abi_models_actions_and_tables(self):
+        abi = (
+            b'{"version":"eosio::abi/1.1",'
+            b'"actions":[{"name":"transfer"},{"name":"issue"}],'
+            b'"tables":[{"name":"accounts"}]}'
+        )
+        nodes, edges = self._parse("eosio.token.abi", abi)
+        kinds = {n.kind for n in nodes}
+        names = {n.name for n in nodes}
+        assert "Contract" in kinds
+        assert "Action" in kinds and "Table" in kinds
+        assert {"transfer", "issue", "accounts"} <= names
+        # Every action/table is wired to a contract-surface source node.
+        calls = [e for e in edges if e.kind == "CALLS"]
+        assert len(calls) == 3
+        assert all(e.extra.get("antelope") for e in calls)
+
+    def test_ethereum_array_abi_is_skipped_safely(self):
+        # Solidity/Ethereum ABIs are JSON arrays — previously reached .get()
+        # and crashed. They must be skipped without producing nodes.
+        eth = (
+            b'[{"type":"function","name":"transfer","inputs":[]},'
+            b'{"type":"event","name":"Transfer"}]'
+        )
+        nodes, edges = self._parse("Token.abi", eth)
+        assert nodes == [] and edges == []
+
+    def test_plain_json_object_is_skipped(self):
+        plain = b'{"name":"config","value":42,"nested":{"a":1}}'
+        nodes, edges = self._parse("config.abi", plain)
+        assert nodes == [] and edges == []
+
+    def test_malformed_json_is_skipped(self):
+        nodes, edges = self._parse("bad.abi", b"{not valid json")
+        assert nodes == [] and edges == []
+
+    def test_non_string_version_is_skipped(self):
+        # A version that is present but not a string is malformed -> skip.
+        bad = b'{"version":123,"actions":[{"name":"x"}]}'
+        nodes, edges = self._parse("weird.abi", bad)
+        assert nodes == [] and edges == []
+
+    def test_antelope_version_string_recognized_without_actions(self):
+        # A document with an Antelope version but no action/table keys is
+        # still treated as a (minimal) contract descriptor.
+        abi = b'{"version":"eosio::abi/1.0"}'
+        nodes, edges = self._parse("empty.abi", abi)
+        assert any(n.kind == "Contract" for n in nodes)
+
+
+class TestAntelopeContractAnnotation:
+    """C++ contract annotation: arbitrary layouts + tightened table evidence."""
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def test_table_only_tagged_for_real_table_struct(self):
+        # A contract WITHOUT a TABLE/multi_index declaration should not get a
+        # phantom table_schema node for an ordinary helper method.
+        src = (
+            b'#include <eosio/eosio.hpp>\n'
+            b'class widget {\n'
+            b'public:\n'
+            b'  uint64_t primary_key() const { return id; }\n'   # not a table
+            b'  uint64_t by_name() const { return name; }\n'      # not an index
+            b'};'
+        )
+        nodes, _ = self.parser.parse_bytes(Path("src/widget.cpp"), src)
+        antelope = [n for n in nodes if n.extra.get("antelope_kind")]
+        assert antelope == [], "ordinary C++ object must not become a table"
+
+    def test_table_struct_tagged_when_declared(self):
+        src = (
+            b'#include <eosio/eosio.hpp>\n'
+            b'class token : public eosio::contract {\n'
+            b'public:\n'
+            b'  TABLE account { uint64_t id; uint64_t primary_key() const { return id; } };\n'
+            b'  ACTION issue() {}\n'
+            b'};'
+        )
+        nodes, edges = self.parser.parse_bytes(Path("include/token.hpp"), src)
+        kinds = {n.name: n.extra.get("antelope_kind") for n in nodes}
+        # The `TABLE` macro hides the struct name from tree-sitter, so the
+        # table_schema tag is attached to the `TABLE` node itself.
+        assert kinds.get("TABLE") == "table_schema"
+        assert kinds.get("issue") == "action"
+        # The action is wired to a contract-surface source node.
+        assert any(e.kind == "CALLS" and e.extra.get("antelope") for e in edges)
+
+    def test_contract_detected_outside_contracts_dir(self):
+        # Layout independence: a contract in src/ (not /contracts/) is modelled.
+        src = b'class c { public: ACTION run() {} };'
+        nodes, _ = self.parser.parse_bytes(Path("src/c.cpp"), src)
+        assert any(n.extra.get("antelope_kind") == "action" for n in nodes)

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -1000,6 +1000,7 @@ class TestAntelopeDeadCodeLookup:
 
     def setup_method(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
         self.store = GraphStore(self.tmp.name)
 
     def teardown_method(self):

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -989,3 +989,45 @@ class TestFindDeadCodeModuleScope:
         dead = find_dead_code(self.store)
         dead_names = {d["name"] for d in dead}
         assert "launch" not in dead_names
+
+
+class TestAntelopeDeadCodeLookup:
+    """Indexed, filesystem-free Antelope runtime detection in dead-code scan.
+
+    Detection must rely on the in-DB ``antelope_kind`` tag (no repo-wide
+    source rescan) and must work for contracts in any directory layout.
+    """
+
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.store = GraphStore(self.tmp.name)
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _seed_node(self, name, file_path, antelope_kind=None):
+        extra = {"antelope_kind": antelope_kind} if antelope_kind else {}
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name=name, file_path=file_path,
+            line_start=1, line_end=5, language="cpp", extra=extra,
+        ))
+
+    def test_antelope_action_is_entry_point_via_indexed_tag(self):
+        from code_review_graph.refactor import _antelope_is_runtime_symbol
+        self._seed_node("transfer", "/repo/src/eosio.token.cpp", "action")
+        node = self.store.get_node("/repo/src/eosio.token.cpp::transfer")
+        assert _antelope_is_runtime_symbol(self.store, node) is True
+
+    def test_ordinary_function_without_tag_is_not_antelope(self):
+        from code_review_graph.refactor import _antelope_is_runtime_symbol
+        # No antelope tag, and the file does NOT contain contract signals.
+        self._seed_node("helper", "/repo/src/utils.cpp")
+        node = self.store.get_node("/repo/src/utils.cpp::helper")
+        assert _antelope_is_runtime_symbol(self.store, node) is False
+
+    def test_antelope_action_not_flagged_as_dead(self):
+        # A tagged action must not appear as dead code under the indexed path.
+        self._seed_node("issue", "/repo/packages/contracts/token.cpp", "action")
+        dead = find_dead_code(self.store)
+        assert "issue" not in {d["name"] for d in dead}


### PR DESCRIPTION
## Summary

Correctness + scalability pass on the Antelope contract support ahead of merge.

- **ABI object/version validation (crash fix).** `.abi` files are now routed to a dedicated `antelope_abi` parser that validates the top-level is a JSON *object* before any `.get()`. A JSON **array** (the Solidity/Ethereum ABI shape) previously reached `.get()` and crashed parsing; it is now skipped safely. Non-string `version`, plain JSON objects, and malformed JSON are all skipped without producing nodes.
- **Tightened table evidence.** `table_schema` is now tagged only on a real `TABLE` macro declaration **in the same file** (tree-sitter parses `TABLE account {...}` as a function named `TABLE`). Ordinary helper methods (`primary_key`/`by_*`) on plain C++ objects no longer become phantom tables.
- **Indexed graph queries (no full-graph scan).** Dead-code detection no longer rescans the filesystem per node. `_antelope_is_runtime_symbol(store, node)` reads the `antelope_kind` tag already stored in the DB — O(1) per node, scales to large repos.
- **Arbitrary contract layouts.** Dropped the hard `/contracts/` path requirement; contracts are detected by positive runtime signals (`ACTION`/`TABLE`/`multi_index`/`on_notify`) anywhere in the tree.
- **Visualization includes dapp action edges + antelope surfaces.** Added `CALLS_ACTION` (color, dashed style, arrow marker, legend) and dedicated `Action`/`Table`/`Contract` node kinds to both D3 templates.
- **Whitelist metadata, don't dump every `extra` field.** `node_to_dict`/`edge_to_dict` now emit only a curated subset (`antelope_kind`, `antelope_runtime`, `antelope_version`, `abi_action`, `abi_table`, `notebook_format`, `message_type` for nodes; `antelope`, `runtime` for edges), preventing large internal payloads from leaking into the exported graph.

## Test plan

- 16 new unit tests (ABI parsing safety, table evidence, layout independence, indexed dead-code lookup, metadata whitelist) — all passing.
- Full suite: **1977 passed, 0 failed, 79.25% coverage** (≥65% required). Ruff clean on all changed source files.
- `mypy` and `bandit` run in CI (not installed in the local venv, so not executed here).

## Notes

- Includes the original "model Antelope contract runtime surfaces" feature commit (`894ef8c`) rebased onto current `origin/main` (resolved conflicts in `parser.py`, `graph.py`, and the test files).
- One rebase-regression fix is folded in: the bare-endpoint resolver's `CALLS_ACTION` handling now selects the `kind` column for all edge kinds.