### PR TITLE
fix(install): inject AGENTS.md instructions for Codex platform

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -1156,7 +1156,7 @@ def inject_claude_md(repo_root: Path) -> None:
 # Used to filter writes when the user passes --platform <X>: only files
 # whose owner set includes the target (or "all") are written.
 _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
-    "AGENTS.md": ("cursor", "opencode", "antigravity"),
+    "AGENTS.md": ("cursor", "opencode", "antigravity", "codex"),
     "GEMINI.md": ("antigravity", "gemini-cli"),
     ".cursorrules": ("cursor",),
     ".windsurfrules": ("windsurf",),
@@ -1358,7 +1358,7 @@ def inject_platform_instructions(repo_root: Path, target: str = "all") -> list[s
     - ``"all"`` (default): writes every file — matches pre-filter behavior.
     - ``"claude"``: writes nothing (CLAUDE.md is handled by ``inject_claude_md``).
     - any other platform key (``cursor``, ``windsurf``, ``antigravity``,
-      ``opencode``): writes only the files associated with that platform.
+      ``opencode``, ``codex``): writes only the files associated with that platform.
 
     Returns list of filenames that were created or updated.
     """

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -726,6 +726,16 @@ class TestInjectPlatformInstructionsFiltering:
         updated = inject_platform_instructions(tmp_path, target="opencode")
         assert updated == ["AGENTS.md"]
 
+    def test_codex_writes_only_agents(self, tmp_path):
+        updated = inject_platform_instructions(tmp_path, target="codex")
+        assert updated == ["AGENTS.md"]
+        assert not (tmp_path / "GEMINI.md").exists()
+        assert not (tmp_path / ".cursorrules").exists()
+        assert not (tmp_path / ".windsurfrules").exists()
+        assert not (tmp_path / "QODER.md").exists()
+        content = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+        assert _CLAUDE_MD_SECTION_MARKER in content
+
     def test_qoder_writes_only_qoder_md(self, tmp_path):
         updated = inject_platform_instructions(tmp_path, target="qoder")
         assert updated == ["QODER.md"]


### PR DESCRIPTION
## Summary

`install --platform codex` already configures the Codex MCP server and hooks, but it never injected graph-first instructions into `AGENTS.md`. Codex therefore had the tools available without a stable repo instruction telling the agent when to prefer the graph.

This maps `codex` onto the existing `AGENTS.md` instruction owners (same path as `opencode` / `cursor` / `antigravity`) and adds a regression test.

Fixes https://github.com/tirth8205/code-review-graph/issues/500

## Test plan

- [x] `uv run pytest tests/test_skills.py::TestInjectPlatformInstructionsFiltering::test_codex_writes_only_agents tests/test_skills.py::TestInjectPlatformInstructionsFiltering::test_opencode_writes_only_agents -q`
- [ ] Optional: in a clean temp repo, run `code-review-graph install --platform codex` and confirm `AGENTS.md` contains the graph instruction section


Made with [Cursor](https://cursor.com)