### PR TITLE
perf: reuse parsers across parallel graph builds

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -30,6 +30,12 @@ _MAX_PARSE_WORKERS = int(os.environ.get("CRG_PARSE_WORKERS", str(min(os.cpu_coun
 # transport's file-descriptor lifetime problem.
 _MCP_STDIO_ACTIVE = False
 
+# Each process-pool worker runs this module in its own process, while each
+# thread-pool worker needs isolated parser state.  A thread-local cache covers
+# both cases and avoids rebuilding CodeParser (including its grammar probes and
+# parser caches) for every file in a parallel build.
+_PARSE_WORKER_STATE = threading.local()
+
 
 def _select_executor_kind() -> str:
     """Return 'process' or 'thread' for parallel parsing.
@@ -878,7 +884,7 @@ def find_dependents(
 def _parse_single_file(
     args: tuple[str, str],
 ) -> tuple[str, list, list, str | None, str]:
-    """Parse one file in a worker process.
+    """Parse one file in a process- or thread-pool worker.
 
     Returns ``(rel_path, nodes, edges, error_or_none, file_hash)``.
     Must be a module-level function so ``ProcessPoolExecutor`` can
@@ -889,7 +895,12 @@ def _parse_single_file(
     try:
         raw = abs_path.read_bytes()
         fhash = hashlib.sha256(raw).hexdigest()
-        parser = CodeParser(Path(repo_root_str))
+        parser = getattr(_PARSE_WORKER_STATE, "parser", None)
+        parser_repo_root = getattr(_PARSE_WORKER_STATE, "repo_root", None)
+        if parser is None or parser_repo_root != repo_root_str:
+            parser = CodeParser(Path(repo_root_str))
+            _PARSE_WORKER_STATE.parser = parser
+            _PARSE_WORKER_STATE.repo_root = repo_root_str
         nodes, edges = parser.parse_bytes(abs_path, raw)
         return (rel_path, nodes, edges, None, fhash)
     except Exception as e:

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,7 +1,7 @@
 """Tests for the incremental graph update module."""
 
 import subprocess
-from unittest.mock import MagicMock, patch  # noqa: F401 – patch used in tests
+from unittest.mock import MagicMock, call, patch  # noqa: F401 – used in tests
 
 import code_review_graph.incremental as incremental_module
 from code_review_graph.graph import GraphStore
@@ -759,6 +759,67 @@ class TestParallelParsing:
         assert error is not None
         assert nodes == []
         assert edges == []
+
+    def test_parse_single_file_reuses_parser_in_worker(self, tmp_path):
+        (tmp_path / "first.py").write_text("first = 1\n")
+        (tmp_path / "second.py").write_text("second = 2\n")
+
+        with patch.object(incremental_module, "CodeParser") as parser_cls:
+            parser_cls.return_value.parse_bytes.return_value = ([], [])
+            _parse_single_file(("first.py", str(tmp_path)))
+            _parse_single_file(("second.py", str(tmp_path)))
+
+        parser_cls.assert_called_once_with(tmp_path)
+        assert parser_cls.return_value.parse_bytes.call_count == 2
+
+    def test_parse_single_file_does_not_reuse_parser_across_repos(self, tmp_path):
+        first_repo = tmp_path / "first"
+        second_repo = tmp_path / "second"
+        first_repo.mkdir()
+        second_repo.mkdir()
+        (first_repo / "mod.py").write_text("first = 1\n")
+        (second_repo / "mod.py").write_text("second = 2\n")
+
+        with patch.object(incremental_module, "CodeParser") as parser_cls:
+            parser_cls.return_value.parse_bytes.return_value = ([], [])
+            _parse_single_file(("mod.py", str(first_repo)))
+            _parse_single_file(("mod.py", str(second_repo)))
+
+        assert parser_cls.call_args_list == [
+            call(first_repo),
+            call(second_repo),
+        ]
+
+    def test_parse_single_file_keeps_thread_worker_parsers_isolated(self, tmp_path):
+        files = ["first.py", "second.py"]
+        for filename in files:
+            (tmp_path / filename).write_text(f"name = {filename!r}\n")
+
+        barrier = incremental_module.threading.Barrier(len(files))
+        parser_instances = []
+
+        class BlockingParser:
+            def __init__(self, repo_root):
+                self.repo_root = repo_root
+                parser_instances.append(self)
+
+            def parse_bytes(self, path, raw):
+                barrier.wait(timeout=5)
+                return [], []
+
+        with patch.object(incremental_module, "CodeParser", BlockingParser):
+            with incremental_module.concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(files)
+            ) as executor:
+                results = list(
+                    executor.map(
+                        _parse_single_file,
+                        [(filename, str(tmp_path)) for filename in files],
+                    )
+                )
+
+        assert len(parser_instances) == len(files)
+        assert all(result[3] is None for result in results)
 
     def test_parallel_build_produces_same_results(self, tmp_path):
         """Serial and parallel builds produce identical node/edge counts."""


### PR DESCRIPTION
## Linked issue

Related to #189 and the parser-load hardening merged in #459.

## What & why

Parallel full and incremental builds called `CodeParser(...)` once per file. That discarded the parser instance cache on every task and repeatedly paid language-pack/parser initialization inside each worker. On a mixed-language checkout of this repository, the default 8-process raw build took 36.23 seconds even though serial parsing took 7.71 seconds.

This change keeps one parser per worker and repository in `threading.local()` storage:

- process workers reuse parser state across their assigned files;
- thread workers retain isolated mutable parser state;
- changing repository roots invalidates the worker-local parser;
- executor selection, worker-count policy, error handling, and serial SQLite writes remain unchanged.

The worker-local design also applies to incremental builds because both build paths share `_parse_single_file`.

## Impact and benchmark

Same 215-file mixed-language repository, fresh project-local data directory, `--skip-postprocess`, Python 3.14.2 on a 10-core Apple Silicon host:

| Configuration | Before | After |
|---|---:|---:|
| 8 process workers (default) | 36.23 s | 7.11 s |
| 4 process workers | 5.59 s | 6.32 s |

The default path improves by about 5.1x. The two post-change worker counts produced identical graphs: 4,420 nodes and 34,162 edges. I intentionally left worker-count heuristics unchanged; the measured regression is parser lifecycle, while a global worker cap needs broader repository-size and platform data.

## How it was tested

```bash
uv run pytest tests/test_incremental.py::TestParseExecutorSelection tests/test_incremental.py::TestParallelParsing tests/test_mcp_stdio_shutdown.py -q
# 10 passed

CRG_PARSE_EXECUTOR=thread uv run pytest tests/test_incremental.py::TestParallelParsing::test_parallel_build_produces_same_results -q
CRG_PARSE_EXECUTOR=process uv run pytest tests/test_incremental.py::TestParallelParsing::test_parallel_build_produces_same_results -q
# 1 passed for each executor

uv tool run ruff check code_review_graph/incremental.py tests/test_incremental.py
# All checks passed

uv tool run mypy code_review_graph/incremental.py --ignore-missing-imports --no-strict-optional
# Success: no issues found

uv run pytest -q
# 1963 passed, 5 skipped, 2 xpassed, 1 unrelated failure
```

The full-suite failure is pre-existing on Python 3.14/macOS: `test_windows_server_still_prewarms_before_mcp_run` monkeypatches `asyncio.WindowsSelectorEventLoopPolicy` after setting `sys.platform` to `win32`, which raises inside Python 3.14 asyncio before this code path is reached.

## Checklist

- [x] Tests added for new functionality
- [ ] All tests pass: one unrelated Python 3.14 platform-emulation failure documented above
- [x] Linting passes
- [x] Type checking passes for the changed production module
- [x] Lines are at most 100 characters
- [x] Docstring and implementation comments updated for the worker lifecycle behavior

