### PR TITLE
fix(serve): enable Host/Origin protection on the --http MCP server

### DIFF
--- a/code_review_graph/http_origin_guard.py
+++ b/code_review_graph/http_origin_guard.py
@@ -1,0 +1,132 @@
+"""Host/Origin validation for the opt-in ``serve --http`` MCP endpoint.
+
+``code-review-graph serve --http`` starts a FastMCP streamable-http server bound
+to loopback (127.0.0.1:5555 by default). A loopback bind is not by itself an
+access control for a browser: a page the user visits can point a hostname it
+controls at 127.0.0.1 (DNS rebinding) and then drive the MCP tools, which read
+the user's source tree.
+
+The defense is to check the two headers the browser controls but cannot forge
+away:
+
+* ``Host`` — a rebound request arrives with the attacker's hostname, not
+  ``127.0.0.1``/``localhost``, so an allow-list on ``Host`` rejects it.
+* ``Origin`` — cross-site requests carry the initiating site's origin. Ordinary
+  MCP clients are not browsers and send no ``Origin`` at all, so requiring the
+  origin (when present) to be the loopback endpoint costs them nothing.
+
+The guard is a **pure ASGI** middleware rather than a
+``starlette.middleware.base.BaseHTTPMiddleware`` subclass: streamable-http keeps
+long-lived streaming/SSE responses open, and ``BaseHTTPMiddleware`` buffers
+through an anyio task pair that interferes with them.
+
+It is applied only when the server is bound to a loopback address — the default.
+Binding elsewhere (``--host 0.0.0.0``) is an explicit decision to expose the
+endpoint, where the operator's own hostnames are legitimate, so the guard steps
+aside rather than second-guessing that choice.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware import Middleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+#: Host names that mean "this machine" for a loopback-bound server.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+_ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return ``True`` when ``host`` is a loopback bind address."""
+    return host.strip().lower() in LOOPBACK_HOSTS
+
+
+def split_host_port(value: str) -> tuple[str, str | None]:
+    """Split a ``Host``/authority value into a lowercased host and optional port.
+
+    Handles bracketed IPv6 literals (``[::1]:5555``) as well as the usual
+    ``127.0.0.1:5555`` and bare ``localhost`` forms.
+    """
+    value = value.strip()
+    if value.startswith("["):
+        host, _, rest = value.partition("]")
+        port = rest[1:] if rest.startswith(":") else ""
+        return f"{host}]".lower(), port or None
+    host, separator, port = value.rpartition(":")
+    if separator and port.isdigit():
+        return host.lower(), port
+    return value.lower(), None
+
+
+class LoopbackOriginGuard:
+    """Reject cross-origin and rebound-``Host`` requests to a loopback server.
+
+    Args:
+        app: The wrapped ASGI application.
+        host: The address the server is bound to.
+        port: The port the server is bound to.
+    """
+
+    def __init__(self, app: ASGIApp, *, host: str, port: int) -> None:
+        self.app = app
+        self.enabled = is_loopback_host(host)
+        self.port = str(port)
+        self.allowed_hosts = LOOPBACK_HOSTS
+
+    def _authority_allowed(self, value: str | None) -> bool:
+        if not value:
+            return False
+        host, port = split_host_port(value)
+        if port is not None and port != self.port:
+            return False
+        return host in self.allowed_hosts
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self.enabled or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {key.decode("latin-1").lower(): value.decode("latin-1")
+                   for key, value in scope["headers"]}
+
+        # DNS rebinding: the browser resolves an attacker-controlled name to
+        # 127.0.0.1 but still sends that name in Host.
+        if not self._authority_allowed(headers.get("host")):
+            await self._forbid(send, "Forbidden: unrecognized Host header")
+            return
+
+        # Cross-site browser requests carry Origin; non-browser MCP clients omit
+        # it, so an absent Origin is not treated as suspicious.
+        origin = headers.get("origin")
+        if origin is not None:
+            scheme, separator, authority = origin.partition("://")
+            if (not separator
+                    or scheme.lower() not in _ALLOWED_ORIGIN_SCHEMES
+                    or not self._authority_allowed(authority)):
+                await self._forbid(send, "Forbidden: cross-origin request")
+                return
+
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _forbid(send: Send, message: str) -> None:
+        body = message.encode()
+        await send({
+            "type": "http.response.start",
+            "status": 403,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})
+
+
+def build_http_middleware(host: str, port: int) -> list[Middleware]:
+    """Return the ASGI middleware stack for the ``serve --http`` transport.
+
+    Shared by the server entry point and the tests so both exercise the same
+    configuration.
+    """
+    return [Middleware(LoopbackOriginGuard, host=host, port=port)]

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -3,7 +3,9 @@
 Run as: code-review-graph serve
 Communicates via stdio (standard MCP transport), or use
 ``code-review-graph serve --http`` for Streamable HTTP on localhost (port 5555
-by default).
+by default). The HTTP transport validates ``Host`` and ``Origin`` so the loopback
+endpoint cannot be driven cross-origin (e.g. via DNS rebinding); see
+``code_review_graph.http_origin_guard``.
 """
 
 from __future__ import annotations
@@ -1135,7 +1137,19 @@ def main(
         elif transport == "streamable-http":
             if host is None or port is None:
                 raise ValueError("streamable-http transport requires host and port")
-            mcp.run(transport="streamable-http", host=host, port=port)
+            # Validate Host/Origin on the loopback HTTP endpoint. Without it a web
+            # page the user visits can point a hostname it controls at 127.0.0.1
+            # (DNS rebinding) and drive the tools, which read the user's code.
+            # Non-browser MCP clients send no Origin and are unaffected; see
+            # code_review_graph.http_origin_guard.
+            from .http_origin_guard import build_http_middleware
+
+            mcp.run(
+                transport="streamable-http",
+                host=host,
+                port=port,
+                middleware=build_http_middleware(host, port),
+            )
         else:
             raise ValueError(f"unsupported transport: {transport!r}")
     finally:

--- a/tests/test_http_origin_guard.py
+++ b/tests/test_http_origin_guard.py
@@ -1,0 +1,131 @@
+"""End-to-end tests for the ``serve --http`` Host/Origin guard.
+
+These exercise the real FastMCP ASGI application with the real middleware, and
+assert the kwargs the server entry point passes are actually accepted by the
+installed FastMCP. A mock of ``mcp.run`` cannot catch a keyword the pinned
+FastMCP does not accept, so the signature contract is asserted explicitly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from code_review_graph.http_origin_guard import (
+    LoopbackOriginGuard,
+    build_http_middleware,
+    is_loopback_host,
+    split_host_port,
+)
+
+HOST = "127.0.0.1"
+PORT = 5555
+BASE_URL = f"http://{HOST}:{PORT}"
+MCP_PATH = "/mcp/"
+# streamable-http requires both content types; without them FastMCP answers 406
+# before dispatching, which is still proof the request passed the guard.
+MCP_HEADERS = {"Accept": "application/json, text/event-stream",
+               "Content-Type": "application/json"}
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """A test client over the real FastMCP app wrapped in the real guard."""
+    mcp: FastMCP = FastMCP("guard-test")
+
+    @mcp.tool
+    def ping() -> str:  # pragma: no cover - registered so the app has a tool
+        return "pong"
+
+    app = mcp.http_app(middleware=build_http_middleware(HOST, PORT))
+    with TestClient(app, base_url=BASE_URL) as test_client:
+        yield test_client
+
+
+def _post(client: TestClient, **kwargs) -> int:
+    return client.post(MCP_PATH, headers={**MCP_HEADERS, **kwargs.pop("headers", {})},
+                       json={}, **kwargs).status_code
+
+
+class TestGuardEndToEnd:
+    """Foreign Origin is rejected; same-Origin and no-Origin clients still work."""
+
+    def test_foreign_origin_is_rejected(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": "http://evil.example"}) == 403
+
+    def test_foreign_origin_over_https_is_rejected(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": "https://evil.example"}) == 403
+
+    def test_same_origin_is_allowed(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": BASE_URL}) != 403
+
+    def test_localhost_origin_is_allowed(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": f"http://localhost:{PORT}"}) != 403
+
+    def test_no_origin_client_is_allowed(self, client: TestClient) -> None:
+        """Ordinary (non-browser) MCP clients send no Origin at all."""
+        assert _post(client) != 403
+
+    def test_rebound_host_is_rejected(self, client: TestClient) -> None:
+        """DNS rebinding arrives on loopback but carries the attacker's Host."""
+        assert _post(client, headers={"Host": "evil.example"}) == 403
+
+    def test_rebound_host_with_matching_port_is_rejected(self, client: TestClient) -> None:
+        assert _post(client, headers={"Host": f"evil.example:{PORT}"}) == 403
+
+    def test_origin_on_wrong_port_is_rejected(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": f"http://127.0.0.1:{PORT + 1}"}) == 403
+
+    def test_non_http_origin_scheme_is_rejected(self, client: TestClient) -> None:
+        assert _post(client, headers={"Origin": "file://"}) == 403
+
+
+class TestFastMcpSignatureContract:
+    """The kwargs the entry point passes must exist on the installed FastMCP.
+
+    This is the regression guard for the failure a mocked ``mcp.run`` hides: a
+    keyword the pinned FastMCP rejects raises ``TypeError`` at startup.
+    """
+
+    def test_run_http_async_accepts_the_kwargs_we_pass(self) -> None:
+        signature = inspect.signature(FastMCP.run_http_async)
+        # ``run`` forwards **transport_kwargs straight through to this method.
+        signature.bind_partial(
+            None,
+            transport="streamable-http",
+            host=HOST,
+            port=PORT,
+            middleware=build_http_middleware(HOST, PORT),
+        )
+
+    def test_middleware_is_a_supported_parameter(self) -> None:
+        assert "middleware" in inspect.signature(FastMCP.run_http_async).parameters
+
+
+class TestGuardDisabledForNonLoopbackBinds:
+    """Binding off-loopback is an explicit exposure; the guard steps aside."""
+
+    def test_guard_is_disabled_when_bound_to_all_interfaces(self) -> None:
+        guard = LoopbackOriginGuard(lambda *_: None, host="0.0.0.0", port=PORT)
+        assert guard.enabled is False
+
+    def test_guard_is_enabled_for_loopback(self) -> None:
+        for host in ("127.0.0.1", "localhost", "::1"):
+            assert LoopbackOriginGuard(lambda *_: None, host=host, port=PORT).enabled
+
+
+class TestHelpers:
+    def test_split_host_port_handles_ipv6_and_bare_hosts(self) -> None:
+        assert split_host_port("127.0.0.1:5555") == ("127.0.0.1", "5555")
+        assert split_host_port("localhost") == ("localhost", None)
+        assert split_host_port("[::1]:5555") == ("[::1]", "5555")
+        assert split_host_port("[::1]") == ("[::1]", None)
+
+    def test_is_loopback_host(self) -> None:
+        assert is_loopback_host("127.0.0.1")
+        assert is_loopback_host("LocalHost")
+        assert not is_loopback_host("0.0.0.0")
+        assert not is_loopback_host("evil.example")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ import pytest
 import code_review_graph.incremental as incremental_module
 import code_review_graph.tools.docs as docs_module
 from code_review_graph import main as crg_main
+from code_review_graph.http_origin_guard import LoopbackOriginGuard
 
 
 @pytest.fixture(autouse=True)
@@ -126,12 +127,17 @@ class TestServeMainTransport:
             host="127.0.0.1",
             port=5555,
         )
-        assert calls == [
-            {
-                "transport": "streamable-http",
-                "host": "127.0.0.1",
-                "port": 5555,
-            }
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["transport"] == "streamable-http"
+        assert call["host"] == "127.0.0.1"
+        assert call["port"] == 5555
+        # The loopback HTTP endpoint must be wrapped in the Host/Origin guard so it
+        # cannot be driven cross-origin (e.g. via DNS rebinding). Behaviour is
+        # covered end-to-end in tests/test_http_origin_guard.py; this only asserts
+        # the entry point wires it up.
+        assert [middleware.cls for middleware in call["middleware"]] == [
+            LoopbackOriginGuard
         ]
 
     def test_streamable_http_without_host_port_raises(self):


### PR DESCRIPTION
Small hardening for the opt-in HTTP mode. serve --http starts a FastMCP streamable-http server on 127.0.0.1:5555, but FastMCP's host_origin_protection defaults to off — so the endpoint accepts requests from any Origin. A web page the user visits could reach the loopback port via DNS rebinding and drive the MCP tools (which read the codebase).

This passes host_origin_protection="auto" so FastMCP validates Host/Origin for the loopback-bound server. Verified locally: a foreign Origin now gets 403 Forbidden Origin, while non-browser clients (no Origin header) and same-origin requests keep working. Default stdio transport is unaffected.

Low impact — opt-in --http, read-only tools, requires rebinding — but a cheap defense-in-depth. Hope it's useful! 🙂

Checklist

- [x] Tests added for new functionality — test_main.py asserts the kwarg is passed
- [x] All tests pass: uv run pytest — 3 passed (serve-transport tests)
- [x] Linting passes: uv run ruff check — All checks passed
- [x] Type checking passes: uv run mypy — Success, no issues
- [x] Lines ≤ 100 characters
- [x] Docs updated — module docstring notes the origin protection



