### PR TITLE
feat(parser): capture JS/TS member-assigned function expressions

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5422,6 +5422,18 @@ class CodeParser:
             ):
                 continue
 
+            # --- JS/TS member-assigned functions (app.handle = function () {}) ---
+            if (
+                language in ("javascript", "typescript", "tsx")
+                and node_type == "expression_statement"
+                and self._extract_js_member_functions(
+                    child, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names, _depth,
+                )
+            ):
+                continue
+
             # --- Functions ---
             if node_type in func_types and self._extract_functions(
                 child, source, language, file_path, nodes, edges,
@@ -7719,6 +7731,107 @@ class CodeParser:
             func_node, source, language, file_path, nodes, edges,
             enclosing_class=enclosing_class,
             enclosing_func=prop_name,
+            import_map=import_map,
+            defined_names=defined_names,
+            _depth=_depth + 1,
+        )
+        return True
+
+    def _extract_js_member_functions(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle JS/TS member-assigned functions.
+
+        Patterns handled (LHS is a ``member_expression``, RHS is a function):
+          app.handle = function handle(req, res) {}
+          Router.prototype.dispatch = (req) => {}
+          exports.render = function () {}
+
+        These prototype- and module-augmentation patterns carry the entire
+        public API of Express, Koa and many older JS modules, but were
+        previously invisible to the graph: only ``const x = fn``
+        (:func:`_extract_js_var_functions`) and class fields
+        (:func:`_extract_js_field_function`) produced Function nodes. The node
+        is qualified by its full member path (``file::app.handle``), matching
+        the ``file::Class.method`` shape used elsewhere.
+
+        Returns True if a function was extracted, so the caller can skip
+        generic recursion.
+        """
+        # ``child`` is the expression_statement wrapping the assignment.
+        assign = None
+        if child.type == "assignment_expression":
+            assign = child
+        else:
+            for sub in child.children:
+                if sub.type == "assignment_expression":
+                    assign = sub
+                    break
+        if assign is None:
+            return False
+
+        left = assign.child_by_field_name("left")
+        right = assign.child_by_field_name("right")
+        if left is None or right is None:
+            return False
+        if left.type != "member_expression":
+            return False
+        if right.type not in self._JS_FUNC_VALUE_TYPES:
+            return False
+
+        member_name = left.text.decode("utf-8", errors="replace")
+        # Skip computed access (``obj[key] = fn``) and any multi-line/odd
+        # member paths that would produce a malformed qualified name.
+        if not member_name or "[" in member_name or "\n" in member_name:
+            return False
+
+        is_test = _is_test_function(member_name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(member_name, file_path, enclosing_class)
+        params = self._get_params(right, language, source)
+        ret_type = self._get_return_type(right, language, source)
+
+        nodes.append(NodeInfo(
+            kind=kind,
+            name=member_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            params=params,
+            return_type=ret_type,
+            is_test=is_test,
+        ))
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class else file_path
+        )
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into the function body for calls, attributing them to the
+        # member function.
+        self._extract_from_tree(
+            right, source, language, file_path, nodes, edges,
+            enclosing_class=enclosing_class,
+            enclosing_func=member_name,
             import_map=import_map,
             defined_names=defined_names,
             _depth=_depth + 1,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9746,7 +9746,10 @@ class CodeParser:
         member_call = callee.text.decode("utf-8", errors="replace")
         if not member_call or "[" in member_call or "\n" in member_call:
             return None
-        return member_call
+        # Optional property access has the same static member path as regular
+        # access: ``app?.handle()`` can target ``app.handle = fn`` whenever
+        # the receiver is present at runtime.
+        return member_call.replace("?.", ".")
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4023,16 +4023,25 @@ class CodeParser:
                 resolved.append(edge)
                 continue
             has_receiver = bool(edge.extra.get("receiver"))
-            if (
-                edge.kind in ("CALLS", "REFERENCES")
-                and "::" not in edge.target
-                and not has_receiver
-            ):
-                if edge.target in symbols:
+            if edge.kind in ("CALLS", "REFERENCES") and "::" not in edge.target:
+                # JS/TS calls retain their full member expression as evidence
+                # (``app.handle``) while keeping the method name (``handle``)
+                # as the fallback target for external calls. Prefer the full
+                # expression when it identifies a same-file member-assigned
+                # function; otherwise preserve the existing bare-name
+                # resolution behavior.
+                member_call = edge.extra.get("member_call")
+                if member_call in symbols:
+                    target = symbols[member_call]
+                elif not has_receiver and edge.target in symbols:
+                    target = symbols[edge.target]
+                else:
+                    target = None
+                if target:
                     edge = EdgeInfo(
                         kind=edge.kind,
                         source=edge.source,
-                        target=symbols[edge.target],
+                        target=target,
                         file_path=edge.file_path,
                         line=edge.line,
                         extra=edge.extra,
@@ -9629,6 +9638,10 @@ class CodeParser:
             # uses this evidence during parsing, and the Spring DI resolver
             # consumes the same metadata for Java injected fields.
             call_extra: dict = {}
+            if language in ("javascript", "typescript", "tsx"):
+                member_call = self._get_js_member_call_name(child)
+                if member_call:
+                    call_extra["member_call"] = member_call
             if language in self._TYPED_CALL_LANGUAGES or language == "rust":
                 receiver, method_name = self._get_member_call_receiver_method(
                     child, language,
@@ -9714,6 +9727,26 @@ class CodeParser:
             ))
 
         return False
+
+    @staticmethod
+    def _get_js_member_call_name(node) -> Optional[str]:
+        """Return a static JS/TS member-call expression, if present.
+
+        ``_get_call_name`` intentionally reduces ``app.handle()`` to
+        ``handle`` for general method-call handling. Retain ``app.handle`` as
+        supplemental evidence so the same-file resolver can link it to a
+        member-assigned definition without changing unresolved external calls.
+        Computed and multiline expressions are intentionally excluded.
+        """
+        callee = node.child_by_field_name("function")
+        if callee is None and node.children:
+            callee = node.children[0]
+        if callee is None or callee.type != "member_expression":
+            return None
+        member_call = callee.text.decode("utf-8", errors="replace")
+        if not member_call or "[" in member_call or "\n" in member_call:
+            return None
+        return member_call
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -7799,6 +7799,15 @@ class CodeParser:
         if right.type not in self._JS_FUNC_VALUE_TYPES:
             return False
 
+        # An assignment nested in a function belongs to that function's
+        # runtime scope, not to the module-level object namespace.  Without
+        # lexical scope in the member name, identical assignments in sibling
+        # functions would both become ``file::obj.method`` and produce
+        # duplicate CONTAINS targets.  Restrict this feature to module/class
+        # contexts, where the member path is a stable definition identity.
+        if enclosing_func:
+            return False
+
         member_name = left.text.decode("utf-8", errors="replace")
         # Skip computed access (``obj[key] = fn``) and any multi-line/odd
         # member paths that would produce a malformed qualified name.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1603,3 +1603,18 @@ class TestJsMemberAssignedFunctions:
             and e.target.endswith("helper")
         ]
         assert len(calls) == 1
+
+    def test_member_call_resolves_to_member_assigned_function(self):
+        """A static member call resolves to its same-file member definition."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1516,3 +1516,90 @@ class TestCppScopedFunctionName:
         fns = [n for n in nodes if n.kind == "Function"]
         assert len(fns) == 1
         assert fns[0].name == "get_obj_fingerprint"
+
+
+class TestJsMemberAssignedFunctions:
+    """Member-assigned function expressions in JS/TS.
+
+    ``obj.method = function () {}`` / ``Foo.prototype.bar = () => {}`` are the
+    prototype- and module-augmentation patterns that Express, Koa and many
+    older JS libraries use for their entire public API. Only ``const x = fn``
+    (variable_declarator) and class fields were captured before, so these
+    definitions produced no Function node at all.
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def test_js_object_method_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/application.js"),
+            b"app.handle = function handle(req, res, next) {\n"
+            b"  next();\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.handle" in fns
+
+    def test_js_arrow_member_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/router.js"),
+            b"router.dispatch = (req, res) => {\n"
+            b"  return res;\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "router.dispatch" in fns
+
+    def test_ts_prototype_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/proto.ts"),
+            b"Router.prototype.handle = function (req: Request): void {\n"
+            b"  this.stack.forEach((layer) => layer.handle(req));\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "Router.prototype.handle" in fns
+
+    def test_member_function_qualified_name_and_contains(self):
+        """Qualified name is ``file::obj.method`` and a CONTAINS edge links it."""
+        path = Path("/test/application.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function handle(req, res) {};\n",
+        )
+        contains = [
+            e for e in edges
+            if e.kind == "CONTAINS" and e.target == f"{path}::app.handle"
+        ]
+        assert len(contains) == 1
+        assert contains[0].source == str(path)
+
+    def test_non_function_member_assignment_not_captured(self):
+        """``obj.prop = <non-function>`` must not create a Function node."""
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/config.js"),
+            b"app.settings = { trust_proxy: false };\n"
+            b"app.locals = {};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.settings" not in fns
+        assert "app.locals" not in fns
+
+    def test_member_function_body_calls_still_attributed(self):
+        """Calls inside a member-assigned function attribute to that function."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"function helper() { return 1; }\n"
+            b"app.handle = function handle() {\n"
+            b"  helper();\n"
+            b"};\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS"
+            and e.source == f"{path}::app.handle"
+            and e.target.endswith("helper")
+        ]
+        assert len(calls) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1618,3 +1618,18 @@ class TestJsMemberAssignedFunctions:
         ]
         assert len(calls) == 1
         assert calls[0].target == f"{path}::app.handle"
+
+    def test_optional_member_call_resolves_to_member_assigned_function(self):
+        """Optional chaining retains the same static member-call target."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app?.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1586,6 +1586,22 @@ class TestJsMemberAssignedFunctions:
         assert "app.settings" not in fns
         assert "app.locals" not in fns
 
+    def test_function_local_member_assignments_are_not_module_definitions(self):
+        """Sibling local assignments must not collide as ``file::x.run``."""
+        path = Path("/test/local_assignments.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"function a() { x.run = function () {}; }\n"
+            b"function b() { x.run = function () {}; }\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert {n.name for n in functions} == {"a", "b"}
+        assert all(n.name != "x.run" for n in functions)
+        assert all(
+            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            for e in edges
+        )
+
     def test_member_function_body_calls_still_attributed(self):
         """Calls inside a member-assigned function attribute to that function."""
         path = Path("/test/application.js")


### PR DESCRIPTION
## Problem
Prototype- and module-augmentation assignments — `app.handle = function () {}`,
`Router.prototype.dispatch = () => {}`, `exports.render = function () {}` — are how
Express, Koa and many older JS/TS modules define their entire public API. The parser
only captured `const x = fn` (`variable_declarator`) and class fields, so these members
produced **no Function node at all** — invisible to `callers_of`, impact, dead-code and
search. This is part of the README's "JavaScript … flow detection needs work", and
matches the note in `eval/configs/express.yaml` ("JS modules use prototypes +
module.exports heavily, so most methods are not represented").

## Change
Add `_extract_js_member_functions`, mirroring the existing `_extract_js_var_functions`:
an `assignment_expression` whose LHS is a `member_expression` and whose RHS is an
arrow/function value becomes a Function node qualified by its full member path
(`file::app.handle`, the same shape as `file::Class.method`), with a `CONTAINS` edge and
body-call recursion. Computed access (`obj[key] = fn`) is skipped.

## Impact
On `expressjs/express` this adds **89 Function nodes (1771 → 1860)**, surfacing the
prototype-augmented public API (`app.use`, `app.handle`, `app.route`, `app.param`,
`req.accepts*`, `res.*`). Scope is structural coverage only; it does **not** by itself
move `flow_completeness` recall, which is gated on JS member-call resolution. `app.get`/
`app.post` remain uncaptured because express defines them via a computed
`methods.forEach(m => app[m] = …)` loop, which this handler intentionally skips.

## Tests
`TestJsMemberAssignedFunctions` in `tests/test_parser.py` (6 cases; fail before, pass
after). Full suite green (`1965 passed`); `ruff check code_review_graph/` clean.