### PR TITLE
fix(flows): rematch incremental flows across node replacement

### DIFF
--- a/code_review_graph/communities.py
+++ b/code_review_graph/communities.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import logging
 import random
 import re
+import sqlite3
 from collections import Counter, defaultdict
+from pathlib import Path
 from typing import Any
 
 from .graph import GraphEdge, GraphNode, GraphStore, _sanitize_name
@@ -846,10 +848,111 @@ def detect_communities(
     return results
 
 
+def capture_community_assignments(
+    store: GraphStore,
+    file_paths: list[str],
+) -> dict[str, int]:
+    """Capture ``qualified_name -> community_id`` for nodes in *file_paths*.
+
+    Must run **before** node replacement so assignments can be remapped onto
+    the new node rows after IDs churn (#569).
+    """
+    if not file_paths:
+        return {}
+
+    conn = store._conn
+    mapping: dict[str, int] = {}
+    for i in range(0, len(file_paths), _SQL_BATCH):
+        batch = file_paths[i:i + _SQL_BATCH]
+        placeholders = ",".join("?" * len(batch))
+        rows = conn.execute(
+            f"SELECT qualified_name, community_id FROM nodes "  # nosec B608
+            f"WHERE community_id IS NOT NULL AND file_path IN ({placeholders})",
+            batch,
+        ).fetchall()
+        for qn, cid in rows:
+            if qn and cid is not None:
+                mapping[qn] = int(cid)
+    return mapping
+
+
+def remap_community_assignments(
+    store: GraphStore,
+    community_by_qn: dict[str, int],
+) -> int:
+    """Re-apply captured community IDs onto current nodes by qualified name.
+
+    Returns the number of nodes updated.
+    """
+    if not community_by_qn:
+        return 0
+
+    conn = store._conn
+    updated = 0
+    items = list(community_by_qn.items())
+    if conn.in_transaction:
+        conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for qn, cid in items:
+            cur = conn.execute(
+                "UPDATE nodes SET community_id = ? WHERE qualified_name = ?",
+                (cid, qn),
+            )
+            if cur.rowcount:
+                updated += cur.rowcount
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    return updated
+
+
+def purge_empty_communities(store: GraphStore) -> int:
+    """Delete community rows that no longer have any assigned nodes.
+
+    Also refreshes ``size`` for communities that still have members so
+    incremental deletion stays consistent with a fresh full rebuild.
+    Returns the number of empty community rows removed.
+    """
+    conn = store._conn
+    if conn.in_transaction:
+        conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        # Refresh sizes from live node assignments.
+        conn.execute(
+            "UPDATE communities SET size = ("
+            "SELECT COUNT(*) FROM nodes "
+            "WHERE nodes.community_id = communities.id)"
+        )
+        cur = conn.execute(
+            "DELETE FROM communities WHERE id NOT IN ("
+            "SELECT DISTINCT community_id FROM nodes "
+            "WHERE community_id IS NOT NULL)"
+        )
+        deleted = cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
+        # Drop summary rows for removed communities when the table exists.
+        try:
+            conn.execute(
+                "DELETE FROM community_summaries WHERE community_id NOT IN ("
+                "SELECT id FROM communities)"
+            )
+        except sqlite3.OperationalError:
+            pass
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    return deleted
+
+
 def incremental_detect_communities(
     store: GraphStore,
     changed_files: list[str],
     min_size: int = 2,
+    repo_root: str | Path | None = None,
+    force: bool = False,
 ) -> int:
     """Re-detect communities only if changed files affect existing communities.
 
@@ -861,19 +964,26 @@ def incremental_detect_communities(
         store: The GraphStore instance.
         changed_files: List of file paths that have changed.
         min_size: Minimum number of nodes for a community to be included.
+        repo_root: Optional repo root used to expand relative/absolute paths.
+        force: When True, always re-run detection (used after pre-replacement
+            capture showed communities were affected even if path matching
+            would otherwise miss them).
 
     Returns:
         Number of communities detected, or 0 if skipped.
     """
-    if not changed_files:
+    if not changed_files and not force:
         return 0
 
+    from .flows import expand_changed_file_paths
+
+    expanded = expand_changed_file_paths(store, changed_files, repo_root=repo_root)
     conn = store._conn
 
     # Check if any communities are affected (batch to stay under SQLite limit)
     affected_count = 0
-    for i in range(0, len(changed_files), _SQL_BATCH):
-        batch = changed_files[i:i + _SQL_BATCH]
+    for i in range(0, len(expanded), _SQL_BATCH):
+        batch = expanded[i:i + _SQL_BATCH]
         placeholders = ",".join("?" * len(batch))
         row = conn.execute(
             f"SELECT COUNT(DISTINCT community_id) FROM nodes "  # nosec B608
@@ -882,9 +992,8 @@ def incremental_detect_communities(
         ).fetchone()
         if row:
             affected_count += row[0]
-    affected = (affected_count,) if affected_count else None
 
-    if not affected or affected[0] == 0:
+    if not force and affected_count == 0:
         return 0  # No communities affected, skip
 
     # Re-run full community detection (correct and fast enough)

--- a/code_review_graph/communities.py
+++ b/code_review_graph/communities.py
@@ -891,7 +891,8 @@ def remap_community_assignments(
     updated = 0
     items = list(community_by_qn.items())
     if conn.in_transaction:
-        conn.commit()
+        logger.warning("Rolling back uncommitted transaction before BEGIN IMMEDIATE")
+        conn.rollback()
     conn.execute("BEGIN IMMEDIATE")
     try:
         for qn, cid in items:
@@ -917,7 +918,8 @@ def purge_empty_communities(store: GraphStore) -> int:
     """
     conn = store._conn
     if conn.in_transaction:
-        conn.commit()
+        logger.warning("Rolling back uncommitted transaction before BEGIN IMMEDIATE")
+        conn.rollback()
     conn.execute("BEGIN IMMEDIATE")
     try:
         # Refresh sizes from live node assignments.

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -43,7 +43,9 @@ def expand_changed_file_paths(
     ``git diff --name-only`` yields repo-relative paths, while parsed nodes
     store absolute ``file_path`` values (and tests often use relative paths).
     Matching must accept both without treating ``%`` / ``_`` as wildcards
-    (#569).
+    (#569). When *repo_root* is provided, only exact absolute/relative
+    variants are used — the ``LIKE`` basename fallback is skipped so a
+    root-level ``util.py`` cannot match ``left/util.py``.
     """
     root = Path(repo_root).resolve() if repo_root is not None else None
     variants: list[str] = []
@@ -83,12 +85,12 @@ def expand_changed_file_paths(
     matched_seen = set(variants)
     if variants:
         for i in range(0, len(variants), _SQL_BATCH):
-            batch = variants[i:i + _SQL_BATCH]
-            placeholders = ",".join("?" * len(batch))
+            path_batch = variants[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(path_batch))
             rows = store._conn.execute(
                 f"SELECT DISTINCT file_path FROM nodes "  # nosec B608
                 f"WHERE file_path IN ({placeholders})",
-                batch,
+                path_batch,
             ).fetchall()
             for row in rows:
                 fp = row[0]
@@ -96,27 +98,29 @@ def expand_changed_file_paths(
                     matched.append(fp)
                     matched_seen.add(fp)
 
-    # Relative inputs without a repo root (or mixed stores): match only at a
-    # path-separator boundary. Stored paths are POSIX (#774), so anchor on '/'.
-    # Keep an escaped Windows '\' pattern for any legacy backslash rows.
-    for rel in relative_inputs:
-        escaped = _escape_like_literal(rel)
-        patterns = (
-            escaped,                 # exact relative path
-            f"%/{escaped}",          # POSIX separator anchor
-            f"%\\\\{escaped}",       # legacy Windows separator anchor
-        )
-        for pattern in patterns:
-            rows = store._conn.execute(
-                "SELECT DISTINCT file_path FROM nodes "
-                "WHERE file_path LIKE ? ESCAPE '\\'",
-                (pattern,),
-            ).fetchall()
-            for row in rows:
-                fp = row[0]
-                if fp not in matched_seen:
-                    matched.append(fp)
-                    matched_seen.add(fp)
+    # LIKE fallback is only for relative inputs without a repo root, where we
+    # cannot build exact absolute variants. When repo_root is known, skip it:
+    # otherwise root-level ``util.py`` also matches ``left/util.py`` via
+    # ``%/util.py``, and incremental clears the wrong file's flows.
+    if root is None:
+        for rel in relative_inputs:
+            escaped = _escape_like_literal(rel)
+            patterns = (
+                escaped,                 # exact relative path
+                f"%/{escaped}",          # POSIX separator anchor
+                f"%\\\\{escaped}",       # legacy Windows separator anchor
+            )
+            for pattern in patterns:
+                rows = store._conn.execute(
+                    "SELECT DISTINCT file_path FROM nodes "
+                    "WHERE file_path LIKE ? ESCAPE '\\'",
+                    (pattern,),
+                ).fetchall()
+                for row in rows:
+                    fp = row[0]
+                    if fp not in matched_seen:
+                        matched.append(fp)
+                        matched_seen.add(fp)
     return matched
 
 
@@ -179,32 +183,33 @@ def clear_flows_for_files(store: GraphStore, file_paths: list[str]) -> set[str]:
 
     conn = store._conn
     if conn.in_transaction:
-        conn.commit()
+        logger.warning("Rolling back uncommitted transaction before BEGIN IMMEDIATE")
+        conn.rollback()
     conn.execute("BEGIN IMMEDIATE")
     try:
         for i in range(0, len(flow_ids), _SQL_BATCH):
-            batch = flow_ids[i:i + _SQL_BATCH]
-            placeholders = ",".join("?" * len(batch))
+            flow_batch = flow_ids[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(flow_batch))
             conn.execute(
                 f"DELETE FROM flow_memberships WHERE flow_id IN ({placeholders})",  # nosec B608
-                batch,
+                flow_batch,
             )
             conn.execute(
                 f"DELETE FROM flows WHERE id IN ({placeholders})",  # nosec B608
-                batch,
+                flow_batch,
             )
         # Drop memberships that still point at nodes about to be deleted so
         # replacement cannot leave dangling flow_memberships rows.
         for i in range(0, len(node_ids), _SQL_BATCH):
-            batch = node_ids[i:i + _SQL_BATCH]
-            placeholders = ",".join("?" * len(batch))
+            node_batch = node_ids[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(node_batch))
             conn.execute(
                 f"DELETE FROM flow_memberships WHERE node_id IN ({placeholders})",  # nosec B608
-                batch,
+                node_batch,
             )
             conn.execute(
                 f"DELETE FROM flows WHERE entry_point_id IN ({placeholders})",  # nosec B608
-                batch,
+                node_batch,
             )
         conn.commit()
     except BaseException:
@@ -220,7 +225,8 @@ def purge_orphan_flow_data(store: GraphStore) -> int:
     """
     conn = store._conn
     if conn.in_transaction:
-        conn.commit()
+        logger.warning("Rolling back uncommitted transaction before BEGIN IMMEDIATE")
+        conn.rollback()
     conn.execute("BEGIN IMMEDIATE")
     try:
         cur = conn.execute(
@@ -718,13 +724,13 @@ def incremental_trace_flows(
     affected_ids: list[int] = []
     if expanded:
         for i in range(0, len(expanded), _SQL_BATCH):
-            batch = expanded[i:i + _SQL_BATCH]
-            placeholders = ",".join("?" * len(batch))
+            path_batch = expanded[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(path_batch))
             affected_rows = conn.execute(
                 f"SELECT DISTINCT fm.flow_id FROM flow_memberships fm "  # nosec B608
                 f"JOIN nodes n ON n.id = fm.node_id "
                 f"WHERE n.file_path IN ({placeholders})",
-                batch,
+                path_batch,
             ).fetchall()
             affected_ids.extend(r[0] for r in affected_rows)
         affected_ids = list(dict.fromkeys(affected_ids))
@@ -735,13 +741,13 @@ def incremental_trace_flows(
     entry_point_ids: set[int] = set()
     if affected_ids:
         for i in range(0, len(affected_ids), _SQL_BATCH):
-            batch = affected_ids[i:i + _SQL_BATCH]
-            ep_placeholders = ",".join("?" * len(batch))
+            id_batch = affected_ids[i:i + _SQL_BATCH]
+            ep_placeholders = ",".join("?" * len(id_batch))
             ep_rows = conn.execute(
                 f"SELECT f.entry_point_id, n.qualified_name FROM flows f "  # nosec B608
                 f"LEFT JOIN nodes n ON n.id = f.entry_point_id "
                 f"WHERE f.id IN ({ep_placeholders})",
-                batch,
+                id_batch,
             ).fetchall()
             for row in ep_rows:
                 if row[0] is not None:
@@ -756,7 +762,10 @@ def incremental_trace_flows(
     # orphaned flow_memberships rows pointing at deleted flows.  See #258.
     if affected_ids:
         if conn.in_transaction:
-            conn.commit()
+            logger.warning(
+                "Rolling back uncommitted transaction before BEGIN IMMEDIATE"
+            )
+            conn.rollback()
         conn.execute("BEGIN IMMEDIATE")
         try:
             for fid in affected_ids:

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -12,13 +12,219 @@ import json
 import logging
 import re
 from collections import deque
-from typing import Optional
+from pathlib import Path
+from typing import Iterable, Optional
 
 from .constants import SECURITY_KEYWORDS as _SECURITY_KEYWORDS
 from .graph import FlowAdjacency, GraphNode, GraphStore, _sanitize_name
 from .parser import normalize_file_path
 
 logger = logging.getLogger(__name__)
+
+_SQL_BATCH = 450
+
+
+def _escape_like_literal(value: str) -> str:
+    """Escape ``\\``, ``%``, and ``_`` for use in a SQL LIKE pattern."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+
+
+def expand_changed_file_paths(
+    store: GraphStore,
+    changed_files: Iterable[str],
+    repo_root: str | Path | None = None,
+) -> list[str]:
+    """Expand *changed_files* to every path form present in the graph.
+
+    ``git diff --name-only`` yields repo-relative paths, while parsed nodes
+    store absolute ``file_path`` values (and tests often use relative paths).
+    Matching must accept both without treating ``%`` / ``_`` as wildcards
+    (#569).
+    """
+    root = Path(repo_root).resolve() if repo_root is not None else None
+    variants: list[str] = []
+    seen: set[str] = set()
+    relative_inputs: list[str] = []
+
+    def _add(path: str) -> None:
+        if path and path not in seen:
+            seen.add(path)
+            variants.append(path)
+
+    for raw in changed_files:
+        text = str(raw).replace("\\", "/")
+        _add(text)
+        path = Path(raw)
+        if path.is_absolute():
+            _add(str(path))
+            try:
+                resolved = path.resolve()
+                _add(str(resolved))
+                if root is not None:
+                    _add(str(resolved.relative_to(root)).replace("\\", "/"))
+            except (OSError, ValueError):
+                pass
+        else:
+            relative_inputs.append(text)
+            if root is not None:
+                _add(str(root / path))
+                try:
+                    _add(str((root / path).resolve()))
+                except OSError:
+                    pass
+
+    # Exact hits first.
+    matched: list[str] = list(variants)
+    matched_seen = set(variants)
+    if variants:
+        for i in range(0, len(variants), _SQL_BATCH):
+            batch = variants[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(batch))
+            rows = store._conn.execute(
+                f"SELECT DISTINCT file_path FROM nodes "  # nosec B608
+                f"WHERE file_path IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for row in rows:
+                fp = row[0]
+                if fp not in matched_seen:
+                    matched.append(fp)
+                    matched_seen.add(fp)
+
+    # Relative inputs without a repo root (or mixed stores): match exact
+    # suffixes with escaped LIKE so "_" / "%" in filenames stay literal.
+    for rel in relative_inputs:
+        escaped = _escape_like_literal(rel)
+        patterns = (f"%/{escaped}", f"%\\{escaped}", escaped)
+        for pattern in patterns:
+            rows = store._conn.execute(
+                "SELECT DISTINCT file_path FROM nodes "
+                "WHERE file_path LIKE ? ESCAPE '\\'",
+                (pattern,),
+            ).fetchall()
+            for row in rows:
+                fp = row[0]
+                if fp not in matched_seen:
+                    matched.append(fp)
+                    matched_seen.add(fp)
+    return matched
+
+
+def capture_affected_flow_entry_points(
+    store: GraphStore,
+    file_paths: list[str],
+) -> set[str]:
+    """Return entry-point qualified names for flows touching *file_paths*.
+
+    Must run **before** node replacement: after ``remove_file_data`` the old
+    node IDs are gone and membership JOINs can no longer find those flows.
+    """
+    if not file_paths:
+        return set()
+
+    node_ids = store.get_node_ids_by_files(file_paths)
+    if not node_ids:
+        return set()
+
+    flow_ids = store.get_flow_ids_by_node_ids(node_ids)
+    if not flow_ids:
+        return set()
+
+    conn = store._conn
+    entry_qns: set[str] = set()
+    for i in range(0, len(flow_ids), _SQL_BATCH):
+        batch = flow_ids[i:i + _SQL_BATCH]
+        placeholders = ",".join("?" * len(batch))
+        rows = conn.execute(
+            f"SELECT n.qualified_name FROM flows f "  # nosec B608
+            f"JOIN nodes n ON n.id = f.entry_point_id "
+            f"WHERE f.id IN ({placeholders})",
+            batch,
+        ).fetchall()
+        entry_qns.update(r[0] for r in rows if r[0])
+    return entry_qns
+
+
+def clear_flows_for_files(store: GraphStore, file_paths: list[str]) -> set[str]:
+    """Delete flows that touch *file_paths* before those nodes are replaced.
+
+    Returns the entry-point qualified names that should be re-traced after
+    replacement (stable across node ID churn).
+    """
+    entry_qns = capture_affected_flow_entry_points(store, file_paths)
+    if not file_paths:
+        return entry_qns
+
+    conn = store._conn
+    node_ids = list(store.get_node_ids_by_files(file_paths))
+    flow_ids = store.get_flow_ids_by_node_ids(set(node_ids)) if node_ids else []
+
+    if conn.in_transaction:
+        conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for i in range(0, len(flow_ids), _SQL_BATCH):
+            batch = flow_ids[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(batch))
+            conn.execute(
+                f"DELETE FROM flow_memberships WHERE flow_id IN ({placeholders})",  # nosec B608
+                batch,
+            )
+            conn.execute(
+                f"DELETE FROM flows WHERE id IN ({placeholders})",  # nosec B608
+                batch,
+            )
+        # Drop memberships that still point at nodes about to be deleted so
+        # replacement cannot leave dangling flow_memberships rows.
+        for i in range(0, len(node_ids), _SQL_BATCH):
+            batch = node_ids[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(batch))
+            conn.execute(
+                f"DELETE FROM flow_memberships WHERE node_id IN ({placeholders})",  # nosec B608
+                batch,
+            )
+            conn.execute(
+                f"DELETE FROM flows WHERE entry_point_id IN ({placeholders})",  # nosec B608
+                batch,
+            )
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    return entry_qns
+
+
+def purge_orphan_flow_data(store: GraphStore) -> int:
+    """Remove flow rows/memberships that reference missing nodes.
+
+    Returns the number of orphan memberships deleted.
+    """
+    conn = store._conn
+    if conn.in_transaction:
+        conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        cur = conn.execute(
+            "DELETE FROM flow_memberships WHERE node_id NOT IN (SELECT id FROM nodes)"
+        )
+        deleted = cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
+        conn.execute(
+            "DELETE FROM flows WHERE entry_point_id NOT IN (SELECT id FROM nodes)"
+        )
+        # Flows whose memberships were fully purged.
+        conn.execute(
+            "DELETE FROM flows WHERE id NOT IN ("
+            "SELECT DISTINCT flow_id FROM flow_memberships)"
+        )
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    return deleted
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -460,52 +666,73 @@ def incremental_trace_flows(
     store: GraphStore,
     changed_files: list[str],
     max_depth: int = 15,
+    repo_root: str | Path | None = None,
+    entry_point_qns: Iterable[str] | None = None,
 ) -> int:
     """Re-trace only flows that touch *changed_files*.  Much faster than full trace.
 
-    1. Find flow IDs whose memberships reference nodes in *changed_files*.
-    2. Collect the entry-point node IDs of those flows before deleting them.
-    3. Delete only the affected flows and their memberships.
-    4. Re-detect entry points, keeping those in *changed_files* **or** whose
-       node ID was an entry point of a deleted flow.
-    5. BFS-trace each relevant entry point via :func:`_trace_single_flow`.
-    6. INSERT the new flows (without clearing unrelated flows).
+    1. Expand *changed_files* to absolute/relative forms present in the graph (#569).
+    2. Purge orphan memberships left behind by node ID replacement.
+    3. Find flow IDs whose memberships reference nodes in the expanded paths.
+    4. Collect entry-point node IDs / qualified names before deleting those flows.
+    5. Delete only the affected flows and their memberships.
+    6. Re-detect entry points in expanded paths **or** matching pre-captured
+       entry-point qualified names (stable across node replacement).
+    7. BFS-trace each relevant entry point via :func:`_trace_single_flow`.
+    8. INSERT the new flows (without clearing unrelated flows).
 
     Returns the number of re-traced flows that were stored.
     """
-    if not changed_files:
+    if not changed_files and not entry_point_qns:
         return 0
 
     # Graph identity uses POSIX separators (#774); bridge native-separator
     # caller paths before matching against stored file_path values.
     changed_files = [normalize_file_path(p) for p in changed_files]
     conn = store._conn
-    changed_file_set = set(changed_files)
+    expanded = expand_changed_file_paths(store, changed_files, repo_root=repo_root)
+    changed_file_set = set(expanded)
+    preserved_entry_qns = {qn for qn in (entry_point_qns or []) if qn}
+
+    # Safety net for callers that replace nodes without clear_flows_for_files.
+    purge_orphan_flow_data(store)
 
     # ------------------------------------------------------------------
-    # 1. Find affected flow IDs
+    # 1. Find affected flow IDs (path-expanded)
     # ------------------------------------------------------------------
-    placeholders = ",".join("?" * len(changed_files))
-    affected_rows = conn.execute(
-        f"SELECT DISTINCT fm.flow_id FROM flow_memberships fm "  # nosec B608
-        f"JOIN nodes n ON n.id = fm.node_id "
-        f"WHERE n.file_path IN ({placeholders})",
-        changed_files,
-    ).fetchall()
-    affected_ids = [r[0] for r in affected_rows]
+    affected_ids: list[int] = []
+    if expanded:
+        for i in range(0, len(expanded), _SQL_BATCH):
+            batch = expanded[i:i + _SQL_BATCH]
+            placeholders = ",".join("?" * len(batch))
+            affected_rows = conn.execute(
+                f"SELECT DISTINCT fm.flow_id FROM flow_memberships fm "  # nosec B608
+                f"JOIN nodes n ON n.id = fm.node_id "
+                f"WHERE n.file_path IN ({placeholders})",
+                batch,
+            ).fetchall()
+            affected_ids.extend(r[0] for r in affected_rows)
+        affected_ids = list(dict.fromkeys(affected_ids))
 
     # ------------------------------------------------------------------
-    # 2. Collect old entry-point node IDs before deletion
+    # 2. Collect old entry-point node IDs / QNs before deletion
     # ------------------------------------------------------------------
     entry_point_ids: set[int] = set()
     if affected_ids:
-        ep_placeholders = ",".join("?" * len(affected_ids))
-        ep_rows = conn.execute(
-            f"SELECT entry_point_id FROM flows "  # nosec B608
-            f"WHERE id IN ({ep_placeholders})",
-            affected_ids,
-        ).fetchall()
-        entry_point_ids = {r[0] for r in ep_rows}
+        for i in range(0, len(affected_ids), _SQL_BATCH):
+            batch = affected_ids[i:i + _SQL_BATCH]
+            ep_placeholders = ",".join("?" * len(batch))
+            ep_rows = conn.execute(
+                f"SELECT f.entry_point_id, n.qualified_name FROM flows f "  # nosec B608
+                f"LEFT JOIN nodes n ON n.id = f.entry_point_id "
+                f"WHERE f.id IN ({ep_placeholders})",
+                batch,
+            ).fetchall()
+            for row in ep_rows:
+                if row[0] is not None:
+                    entry_point_ids.add(row[0])
+                if row[1]:
+                    preserved_entry_qns.add(row[1])
 
     # ------------------------------------------------------------------
     # 3. Delete affected flows and their memberships
@@ -533,7 +760,11 @@ def incremental_trace_flows(
     entry_points = detect_entry_points(store)
     relevant_eps = [
         ep for ep in entry_points
-        if ep.file_path in changed_file_set or ep.id in entry_point_ids
+        if (
+            ep.file_path in changed_file_set
+            or ep.id in entry_point_ids
+            or ep.qualified_name in preserved_entry_qns
+        )
     ]
 
     # ------------------------------------------------------------------

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -95,11 +95,17 @@ def expand_changed_file_paths(
                     matched.append(fp)
                     matched_seen.add(fp)
 
-    # Relative inputs without a repo root (or mixed stores): match exact
-    # suffixes with escaped LIKE so "_" / "%" in filenames stay literal.
+    # Relative inputs without a repo root (or mixed stores): match only at a
+    # path-separator boundary. With ESCAPE '\', a literal backslash in the
+    # pattern must itself be escaped as '\\' — otherwise "%\b.py" becomes an
+    # unanchored "%b.py" suffix match and wrongly includes "ab.py".
     for rel in relative_inputs:
         escaped = _escape_like_literal(rel)
-        patterns = (f"%/{escaped}", f"%\\{escaped}", escaped)
+        patterns = (
+            escaped,                 # exact relative path
+            f"%/{escaped}",          # POSIX separator anchor
+            f"%\\\\{escaped}",       # Windows separator anchor (literal '\')
+        )
         for pattern in patterns:
             rows = store._conn.execute(
                 "SELECT DISTINCT file_path FROM nodes "
@@ -114,25 +120,21 @@ def expand_changed_file_paths(
     return matched
 
 
-def capture_affected_flow_entry_points(
+def _flows_touching_files(
     store: GraphStore,
     file_paths: list[str],
-) -> set[str]:
-    """Return entry-point qualified names for flows touching *file_paths*.
-
-    Must run **before** node replacement: after ``remove_file_data`` the old
-    node IDs are gone and membership JOINs can no longer find those flows.
-    """
+) -> tuple[list[int], list[int], set[str]]:
+    """Return ``(node_ids, flow_ids, entry_point_qns)`` for *file_paths*."""
     if not file_paths:
-        return set()
+        return [], [], set()
 
-    node_ids = store.get_node_ids_by_files(file_paths)
+    node_ids = list(store.get_node_ids_by_files(file_paths))
     if not node_ids:
-        return set()
+        return [], [], set()
 
-    flow_ids = store.get_flow_ids_by_node_ids(node_ids)
+    flow_ids = store.get_flow_ids_by_node_ids(set(node_ids))
     if not flow_ids:
-        return set()
+        return node_ids, [], set()
 
     conn = store._conn
     entry_qns: set[str] = set()
@@ -146,6 +148,19 @@ def capture_affected_flow_entry_points(
             batch,
         ).fetchall()
         entry_qns.update(r[0] for r in rows if r[0])
+    return node_ids, flow_ids, entry_qns
+
+
+def capture_affected_flow_entry_points(
+    store: GraphStore,
+    file_paths: list[str],
+) -> set[str]:
+    """Return entry-point qualified names for flows touching *file_paths*.
+
+    Must run **before** node replacement: after ``remove_file_data`` the old
+    node IDs are gone and membership JOINs can no longer find those flows.
+    """
+    _node_ids, _flow_ids, entry_qns = _flows_touching_files(store, file_paths)
     return entry_qns
 
 
@@ -155,14 +170,14 @@ def clear_flows_for_files(store: GraphStore, file_paths: list[str]) -> set[str]:
     Returns the entry-point qualified names that should be re-traced after
     replacement (stable across node ID churn).
     """
-    entry_qns = capture_affected_flow_entry_points(store, file_paths)
     if not file_paths:
+        return set()
+
+    node_ids, flow_ids, entry_qns = _flows_touching_files(store, file_paths)
+    if not node_ids and not flow_ids:
         return entry_qns
 
     conn = store._conn
-    node_ids = list(store.get_node_ids_by_files(file_paths))
-    flow_ids = store.get_flow_ids_by_node_ids(set(node_ids)) if node_ids else []
-
     if conn.in_transaction:
         conn.commit()
     conn.execute("BEGIN IMMEDIATE")

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -51,12 +51,13 @@ def expand_changed_file_paths(
     relative_inputs: list[str] = []
 
     def _add(path: str) -> None:
-        if path and path not in seen:
-            seen.add(path)
-            variants.append(path)
+        normalized = normalize_file_path(path)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            variants.append(normalized)
 
     for raw in changed_files:
-        text = str(raw).replace("\\", "/")
+        text = normalize_file_path(raw)
         _add(text)
         path = Path(raw)
         if path.is_absolute():
@@ -65,7 +66,7 @@ def expand_changed_file_paths(
                 resolved = path.resolve()
                 _add(str(resolved))
                 if root is not None:
-                    _add(str(resolved.relative_to(root)).replace("\\", "/"))
+                    _add(str(resolved.relative_to(root)))
             except (OSError, ValueError):
                 pass
         else:
@@ -77,7 +78,7 @@ def expand_changed_file_paths(
                 except OSError:
                     pass
 
-    # Exact hits first.
+    # Exact hits first (graph identities are POSIX-normalized; see #774).
     matched: list[str] = list(variants)
     matched_seen = set(variants)
     if variants:
@@ -96,15 +97,14 @@ def expand_changed_file_paths(
                     matched_seen.add(fp)
 
     # Relative inputs without a repo root (or mixed stores): match only at a
-    # path-separator boundary. With ESCAPE '\', a literal backslash in the
-    # pattern must itself be escaped as '\\' — otherwise "%\b.py" becomes an
-    # unanchored "%b.py" suffix match and wrongly includes "ab.py".
+    # path-separator boundary. Stored paths are POSIX (#774), so anchor on '/'.
+    # Keep an escaped Windows '\' pattern for any legacy backslash rows.
     for rel in relative_inputs:
         escaped = _escape_like_literal(rel)
         patterns = (
             escaped,                 # exact relative path
             f"%/{escaped}",          # POSIX separator anchor
-            f"%\\\\{escaped}",       # Windows separator anchor (literal '\')
+            f"%\\\\{escaped}",       # legacy Windows separator anchor
         )
         for pattern in patterns:
             rows = store._conn.execute(

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1840,11 +1840,22 @@ class GraphStore:
         return result
 
     def get_files_matching(self, pattern: str) -> list[str]:
-        """Return distinct ``file_path`` values matching a LIKE suffix."""
+        """Return distinct ``file_path`` values ending with *pattern*.
+
+        Paths are normalized to POSIX separators first. ``%`` and ``_`` in
+        *pattern* are treated as literal characters, not SQL ``LIKE``
+        wildcards.
+        """
+        normalized = normalize_file_path(pattern)
+        escaped = (
+            normalized.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
         rows = self._conn.execute(
             "SELECT DISTINCT file_path FROM nodes "
-            "WHERE file_path LIKE ?",
-            (f"%{normalize_file_path(pattern)}",),
+            "WHERE file_path LIKE ? ESCAPE '\\'",
+            (f"%{escaped}",),
         ).fetchall()
         return [r["file_path"] for r in rows]
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -909,8 +909,14 @@ def _reconcile_stale_files(
     repo_root: Path,
     store: GraphStore,
     current_files: list[str] | None = None,
+    *,
+    remove: bool = True,
 ) -> list[str]:
-    """Remove graph files absent from the current parseable repository inventory."""
+    """Remove graph files absent from the current parseable repository inventory.
+
+    When *remove* is False, only identify stale paths so callers can capture
+    flow/community state before the permanent delete (#569).
+    """
     stored_files = set(store.get_all_files())
     current_paths: set[str]
     if current_files is not None:
@@ -936,7 +942,7 @@ def _reconcile_stale_files(
             ):
                 current_paths.add(stored_file)
     stale_files = sorted(stored_files - current_paths)
-    if stale_files:
+    if stale_files and remove:
         store.remove_files_permanently(stale_files)
     return stale_files
 
@@ -1196,7 +1202,11 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
-    stale_files = _reconcile_stale_files(repo_root, store) if reconcile_stale else []
+    stale_files = (
+        _reconcile_stale_files(repo_root, store, remove=False)
+        if reconcile_stale
+        else []
+    )
 
     if not changed_files and not stale_files:
         return {
@@ -1252,8 +1262,60 @@ def incremental_update(
             pass
         to_parse.append(rel_path)
 
-    # Persist deletions before store_file_nodes_edges() opens its own
-    # explicit transaction — avoids nested transaction errors.
+    # Capture flow/community memberships BEFORE node replacement or permanent
+    # deletion. After nodes are removed/recreated the old IDs are gone, so
+    # postprocess can no longer discover affected flows via membership JOINs
+    # (#569). Include deleted/renamed/stale paths here — not only to_parse.
+    from .communities import (
+        capture_community_assignments,
+        purge_empty_communities,
+        remap_community_assignments,
+    )
+    from .flows import (
+        clear_flows_for_files,
+        expand_changed_file_paths,
+        purge_orphan_flow_data,
+    )
+
+    lifecycle_inputs: list[str] = []
+    for rel_path in to_parse:
+        lifecycle_inputs.append(rel_path.replace("\\", "/"))
+        lifecycle_inputs.append(str(repo_root / rel_path))
+        lifecycle_inputs.append(str((repo_root / rel_path).resolve()))
+    for abs_missing in missing_paths:
+        lifecycle_inputs.append(abs_missing)
+        try:
+            missing_path = Path(abs_missing)
+            lifecycle_inputs.append(str(missing_path.resolve()))
+            lifecycle_inputs.append(
+                str(missing_path.relative_to(repo_root)).replace("\\", "/")
+            )
+        except (OSError, ValueError):
+            pass
+    for stale in stale_files:
+        lifecycle_inputs.append(stale)
+        try:
+            stale_path = Path(stale)
+            if stale_path.is_absolute():
+                lifecycle_inputs.append(
+                    str(stale_path.relative_to(repo_root)).replace("\\", "/")
+                )
+            else:
+                lifecycle_inputs.append(str(repo_root / stale_path))
+        except (OSError, ValueError):
+            pass
+
+    lifecycle_paths = expand_changed_file_paths(
+        store, lifecycle_inputs, repo_root=repo_root,
+    )
+    flow_entry_point_qns = sorted(
+        clear_flows_for_files(store, lifecycle_paths)
+    )
+    community_by_qn = capture_community_assignments(store, lifecycle_paths)
+    communities_were_affected = bool(community_by_qn) or bool(missing_paths) or bool(
+        stale_files
+    )
+
     use_serial = os.environ.get("CRG_SERIAL_PARSE", "") == "1"
     parsed_files = 0
 
@@ -1296,8 +1358,18 @@ def incremental_update(
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
-    removed_files = store.remove_files_permanently(sorted(missing_paths)) if missing_paths else 0
-    files_updated = parsed_files + len(stale_files) + removed_files
+    removed_files = 0
+    to_remove = sorted(set(missing_paths) | set(stale_files))
+    if to_remove:
+        removed_files = store.remove_files_permanently(to_remove)
+
+    # Remap surviving community IDs onto replacement nodes, drop orphan flow
+    # rows, and remove community rows that no longer have any members.
+    remap_community_assignments(store, community_by_qn)
+    purge_orphan_flow_data(store)
+    purge_empty_communities(store)
+
+    files_updated = parsed_files + removed_files
     if files_updated:
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
@@ -1343,6 +1415,8 @@ def incremental_update(
         "changed_files": list(changed_files),
         "dependent_files": list(dependent_files),
         "stale_files_removed": len(stale_files),
+        "flow_entry_point_qns": flow_entry_point_qns,
+        "communities_were_affected": communities_were_affected,
         "errors": errors,
         "python_resolution": python_stats,
         "rescript_resolution": rescript_stats,

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1277,34 +1277,13 @@ def incremental_update(
         purge_orphan_flow_data,
     )
 
-    lifecycle_inputs: list[str] = []
-    for rel_path in to_parse:
-        lifecycle_inputs.append(rel_path.replace("\\", "/"))
-        lifecycle_inputs.append(str(repo_root / rel_path))
-        lifecycle_inputs.append(str((repo_root / rel_path).resolve()))
-    for abs_missing in missing_paths:
-        lifecycle_inputs.append(abs_missing)
-        try:
-            missing_path = Path(abs_missing)
-            lifecycle_inputs.append(str(missing_path.resolve()))
-            lifecycle_inputs.append(
-                str(missing_path.relative_to(repo_root)).replace("\\", "/")
-            )
-        except (OSError, ValueError):
-            pass
-    for stale in stale_files:
-        lifecycle_inputs.append(stale)
-        try:
-            stale_path = Path(stale)
-            if stale_path.is_absolute():
-                lifecycle_inputs.append(
-                    str(stale_path.relative_to(repo_root)).replace("\\", "/")
-                )
-            else:
-                lifecycle_inputs.append(str(repo_root / stale_path))
-        except (OSError, ValueError):
-            pass
-
+    # Pass raw relative/absolute paths; expand_changed_file_paths owns
+    # variant generation so we do not expand twice per update.
+    lifecycle_inputs = [
+        *[rel_path.replace("\\", "/") for rel_path in to_parse],
+        *missing_paths,
+        *stale_files,
+    ]
     lifecycle_paths = expand_changed_file_paths(
         store, lifecycle_inputs, repo_root=repo_root,
     )

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -55,6 +55,9 @@ def _run_postprocess(
     changed_files: list[str] | None = None,
     embedding_provider: str | None = None,
     embedding_model: str | None = None,
+    repo_root: str | None = None,
+    entry_point_qns: list[str] | None = None,
+    communities_were_affected: bool = False,
 ) -> list[str]:
     """Run post-build steps based on *postprocess* level.
 
@@ -154,14 +157,24 @@ def _run_postprocess(
         return warnings
 
     # -- Expensive: flows + communities (only for "full") --
-    use_incremental = not full_rebuild and bool(changed_files)
+    # Incremental mode also triggers when pre-replacement capture preserved
+    # entry-point QNs even if the relative changed_files list alone would
+    # miss absolute graph paths (#569).
+    use_incremental = not full_rebuild and (
+        bool(changed_files) or bool(entry_point_qns) or communities_were_affected
+    )
 
     stage_started = time.perf_counter()
     try:
         if use_incremental:
             from code_review_graph.flows import incremental_trace_flows
 
-            count = incremental_trace_flows(store, changed_files)
+            count = incremental_trace_flows(
+                store,
+                changed_files or [],
+                repo_root=repo_root,
+                entry_point_qns=entry_point_qns,
+            )
         else:
             from code_review_graph.flows import store_flows as _store_flows
             from code_review_graph.flows import trace_flows as _trace_flows
@@ -184,7 +197,12 @@ def _run_postprocess(
                 incremental_detect_communities,
             )
 
-            count = incremental_detect_communities(store, changed_files)
+            count = incremental_detect_communities(
+                store,
+                changed_files or [],
+                repo_root=repo_root,
+                force=communities_were_affected,
+            )
         else:
             from code_review_graph.communities import (
                 detect_communities as _detect_communities,
@@ -553,8 +571,18 @@ def build_or_update_graph(
                 ),
             }
 
-        # Pass changed_files for incremental flow/community detection
-        changed = result.get("changed_files") if not full_rebuild else None
+        # Pass changed_files + pre-replacement flow/community capture for
+        # incremental postprocess (#569).
+        changed = None
+        entry_qns = None
+        communities_affected = False
+        if not full_rebuild:
+            changed = list(result.get("changed_files") or [])
+            changed.extend(result.get("dependent_files") or [])
+            entry_qns = list(result.get("flow_entry_point_qns") or [])
+            communities_affected = bool(
+                result.get("communities_were_affected")
+            )
         warnings = _run_postprocess(
             store,
             build_result,
@@ -563,6 +591,9 @@ def build_or_update_graph(
             changed_files=changed,
             embedding_provider=embedding_provider,
             embedding_model=embedding_model,
+            repo_root=str(root),
+            entry_point_qns=entry_qns,
+            communities_were_affected=communities_affected,
         )
         if warnings:
             build_result["warnings"] = warnings

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -640,6 +640,72 @@ class TestCommunities:
         result = incremental_detect_communities(self.store, ["auth.py"])
         assert result > 0
 
+    def test_community_capture_remap_survives_node_replacement(self, tmp_path):
+        """Community IDs remapped by qualified_name after node ID churn (#569)."""
+        from code_review_graph.communities import (
+            capture_community_assignments,
+            remap_community_assignments,
+        )
+        from code_review_graph.parser import NodeInfo
+
+        abs_auth = str((tmp_path / "auth.py").resolve())
+        login = NodeInfo(
+            kind="Function",
+            name="login",
+            file_path=abs_auth,
+            line_start=1,
+            line_end=5,
+            language="python",
+        )
+        logout = NodeInfo(
+            kind="Function",
+            name="logout",
+            file_path=abs_auth,
+            line_start=6,
+            line_end=10,
+            language="python",
+        )
+        old_login_id = self.store.upsert_node(login, file_hash="old")
+        self.store.upsert_node(logout, file_hash="old")
+        self.store.commit()
+        self.store._conn.execute(
+            "INSERT INTO communities (name, level, cohesion, size, "
+            "dominant_language, description) VALUES (?, 0, 1.0, 2, 'python', '')",
+            ("auth",),
+        )
+        cid = self.store._conn.execute(
+            "SELECT id FROM communities WHERE name = 'auth'"
+        ).fetchone()[0]
+        self.store._conn.execute(
+            "UPDATE nodes SET community_id = ? WHERE file_path = ?",
+            (cid, abs_auth),
+        )
+        self.store.commit()
+
+        mapping = capture_community_assignments(self.store, [abs_auth])
+        assert mapping[f"{abs_auth}::login"] == cid
+
+        self.store.remove_file_data(abs_auth)
+        self.store.commit()
+        new_login_id = self.store.upsert_node(login, file_hash="new")
+        self.store.upsert_node(logout, file_hash="new")
+        self.store.commit()
+        assert new_login_id != old_login_id
+
+        updated = remap_community_assignments(self.store, mapping)
+        assert updated >= 1
+        row = self.store._conn.execute(
+            "SELECT community_id FROM nodes WHERE qualified_name = ?",
+            (f"{abs_auth}::login",),
+        ).fetchone()
+        assert row["community_id"] == cid
+
+        # force=True redetects even when relative path alone would miss abs paths
+        count = incremental_detect_communities(
+            self.store, ["auth.py"], repo_root=tmp_path, force=True,
+        )
+        assert count >= 0
+
 
 class TestCommunityPrReconciliation:
     """Regression coverage retained from overlapping PRs #600/#603/#605."""

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -634,3 +634,117 @@ class TestFlows:
             "WHERE f.id IS NULL"
         ).fetchall()
         assert len(orphans) == 0, f"found {len(orphans)} orphaned memberships"
+
+    def test_incremental_trace_flows_relative_vs_absolute_new_entry(self, tmp_path):
+        """Relative git paths must match absolute graph file_path values (#569)."""
+        abs_a = str((tmp_path / "a.py").resolve())
+        abs_b = str((tmp_path / "b.py").resolve())
+
+        self._add_func("old_entry", path=abs_a)
+        self._add_func("old_callee", path=abs_a)
+        self._add_call(f"{abs_a}::old_entry", f"{abs_a}::old_callee", abs_a)
+
+        flows = trace_flows(self.store)
+        store_flows(self.store, flows)
+
+        self._add_func("new_entry", path=abs_b)
+        self._add_func("new_callee", path=abs_b)
+        self._add_call(f"{abs_b}::new_entry", f"{abs_b}::new_callee", abs_b)
+
+        # git-style relative input — must still discover the new entry point.
+        count = incremental_trace_flows(
+            self.store, ["b.py"], repo_root=tmp_path,
+        )
+        assert count >= 1
+        after = get_flows(self.store)
+        assert any(f["name"] == "new_entry" for f in after)
+
+    def test_incremental_flow_lifecycle_after_node_replacement(self, tmp_path):
+        """Capture/clear before replace, then rematch via entry-point QNs (#569)."""
+        from code_review_graph.flows import (
+            clear_flows_for_files,
+            expand_changed_file_paths,
+            purge_orphan_flow_data,
+        )
+        from code_review_graph.parser import EdgeInfo, NodeInfo
+
+        abs_routes = str((tmp_path / "routes.py").resolve())
+        abs_services = str((tmp_path / "services.py").resolve())
+
+        handler_id = self._add_func("handler", path=abs_routes)
+        service_id = self._add_func("service", path=abs_services)
+        self._add_call(
+            f"{abs_routes}::handler",
+            f"{abs_services}::service",
+            abs_routes,
+        )
+
+        flows = trace_flows(self.store)
+        store_flows(self.store, flows)
+        before = get_flows(self.store)
+        assert any(f["name"] == "handler" for f in before)
+        old_flow = next(f for f in before if f["name"] == "handler")
+        old_ep_id = old_flow["entry_point_id"]
+        assert old_ep_id == handler_id
+
+        # Pre-replacement capture (as incremental_update does).
+        expanded = expand_changed_file_paths(
+            self.store, ["routes.py", abs_routes], repo_root=tmp_path,
+        )
+        entry_qns = clear_flows_for_files(self.store, expanded)
+        assert f"{abs_routes}::handler" in entry_qns
+        assert get_flows(self.store) == []
+
+        # Simulate store_file_nodes_edges: delete + reinsert with new IDs.
+        self.store.remove_file_data(abs_routes)
+        self.store.commit()
+        new_handler = NodeInfo(
+            kind="Function",
+            name="handler",
+            file_path=abs_routes,
+            line_start=1,
+            line_end=12,
+            language="python",
+        )
+        new_handler_id = self.store.upsert_node(new_handler, file_hash="new")
+        self.store.upsert_edge(
+            EdgeInfo(
+                kind="CALLS",
+                source=f"{abs_routes}::handler",
+                target=f"{abs_services}::service",
+                file_path=abs_routes,
+                line=5,
+            )
+        )
+        self.store.commit()
+        assert new_handler_id != handler_id
+        # Unchanged callee keeps its ID.
+        assert self.store.get_node(f"{abs_services}::service").id == service_id
+
+        purge_orphan_flow_data(self.store)
+
+        count = incremental_trace_flows(
+            self.store,
+            ["routes.py"],
+            repo_root=tmp_path,
+            entry_point_qns=entry_qns,
+        )
+        assert count >= 1
+
+        after = get_flows(self.store)
+        handler_flows = [f for f in after if f["name"] == "handler"]
+        assert len(handler_flows) == 1
+        assert handler_flows[0]["entry_point_id"] == new_handler_id
+
+        conn = self.store._conn
+        dead_eps = conn.execute(
+            "SELECT id FROM flows WHERE entry_point_id NOT IN (SELECT id FROM nodes)"
+        ).fetchall()
+        assert dead_eps == []
+        orphan_members = conn.execute(
+            "SELECT fm.node_id FROM flow_memberships fm "
+            "LEFT JOIN nodes n ON n.id = fm.node_id WHERE n.id IS NULL"
+        ).fetchall()
+        assert orphan_members == []
+        # Exactly one handler flow — no duplicate stale+new pair.
+        assert len(handler_flows) == 1

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -748,3 +748,61 @@ class TestFlows:
         assert orphan_members == []
         # Exactly one handler flow — no duplicate stale+new pair.
         assert len(handler_flows) == 1
+
+    def test_incremental_trace_flows_relative_without_repo_root(self, tmp_path):
+        """Relative changed_files must match absolute paths without repo_root (#569)."""
+        abs_b = str((tmp_path / "b.py").resolve())
+        self._add_func("new_entry", path=abs_b)
+        self._add_func("new_callee", path=abs_b)
+        self._add_call(f"{abs_b}::new_entry", f"{abs_b}::new_callee", abs_b)
+
+        # Maintainer reproduction: relative only, no repo_root.
+        count = incremental_trace_flows(self.store, ["b.py"])
+        assert count >= 1
+        assert any(f["name"] == "new_entry" for f in get_flows(self.store))
+
+    def test_expand_changed_paths_literal_like_wildcards(self, tmp_path):
+        """Filenames containing _ or % must not fuzzy-match siblings (#569)."""
+        from code_review_graph.flows import expand_changed_file_paths
+
+        abs_literal = str((tmp_path / "a_b.py").resolve())
+        abs_other = str((tmp_path / "acb.py").resolve())
+        abs_pct = str((tmp_path / "a%z.py").resolve())
+        abs_pct_other = str((tmp_path / "axz.py").resolve())
+        self._add_func("literal", path=abs_literal)
+        self._add_func("other", path=abs_other)
+        self._add_func("pct", path=abs_pct)
+        self._add_func("pct_other", path=abs_pct_other)
+
+        matched_us = expand_changed_file_paths(self.store, ["a_b.py"])
+        assert abs_literal in matched_us
+        assert abs_other not in matched_us
+
+        matched_pct = expand_changed_file_paths(self.store, ["a%z.py"])
+        assert abs_pct in matched_pct
+        assert abs_pct_other not in matched_pct
+
+        assert abs_other not in self.store.get_files_matching("a_b.py")
+        assert abs_literal in self.store.get_files_matching("a_b.py")
+        assert abs_pct_other not in self.store.get_files_matching("a%z.py")
+        assert abs_pct in self.store.get_files_matching("a%z.py")
+
+    def test_expand_ignores_suffix_collision_across_directories(self, tmp_path):
+        """Shared basenames in different dirs must not cross-wire flows."""
+        from code_review_graph.flows import expand_changed_file_paths
+
+        left = tmp_path / "left"
+        right = tmp_path / "right"
+        left.mkdir()
+        right.mkdir()
+        abs_left = str((left / "util.py").resolve())
+        abs_right = str((right / "util.py").resolve())
+        self._add_func("left_fn", path=abs_left)
+        self._add_func("right_fn", path=abs_right)
+
+        # With repo_root + relative path, only the intended file expands.
+        matched = expand_changed_file_paths(
+            self.store, ["left/util.py"], repo_root=tmp_path,
+        )
+        assert abs_left in matched
+        assert abs_right not in matched

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -832,3 +832,24 @@ class TestFlows:
         )
         assert abs_left in matched
         assert abs_right not in matched
+
+    def test_expand_with_repo_root_skips_nested_same_basename(self, tmp_path):
+        """Root-level util.py must not LIKE-match left/util.py when repo_root is set."""
+        from code_review_graph.flows import expand_changed_file_paths
+
+        left = tmp_path / "left"
+        left.mkdir()
+        abs_root = str((tmp_path / "util.py").resolve())
+        abs_nested = str((left / "util.py").resolve())
+        self._add_func("root_util", path=abs_root)
+        self._add_func("nested_util", path=abs_nested)
+
+        matched = expand_changed_file_paths(
+            self.store, ["util.py"], repo_root=tmp_path,
+        )
+        assert abs_root in matched
+        assert abs_nested not in matched
+
+        # Without repo_root, LIKE fallback may still resolve absolute forms.
+        matched_any = expand_changed_file_paths(self.store, ["util.py"])
+        assert abs_root in matched_any or abs_nested in matched_any

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -787,6 +787,32 @@ class TestFlows:
         assert abs_pct_other not in self.store.get_files_matching("a%z.py")
         assert abs_pct in self.store.get_files_matching("a%z.py")
 
+    def test_expand_rejects_basename_suffix_collision(self, tmp_path):
+        """b.py must not match ab.py / data_utils.py-style suffix collisions."""
+        from code_review_graph.flows import expand_changed_file_paths
+
+        abs_b = str((tmp_path / "b.py").resolve())
+        abs_ab = str((tmp_path / "ab.py").resolve())
+        abs_utils = str((tmp_path / "utils.py").resolve())
+        abs_data_utils = str((tmp_path / "data_utils.py").resolve())
+        self._add_func("b_fn", path=abs_b)
+        self._add_func("ab_fn", path=abs_ab)
+        self._add_func("utils_fn", path=abs_utils)
+        self._add_func("data_utils_fn", path=abs_data_utils)
+
+        for repo_root in (None, tmp_path):
+            matched_b = expand_changed_file_paths(
+                self.store, ["b.py"], repo_root=repo_root,
+            )
+            assert abs_b in matched_b
+            assert abs_ab not in matched_b
+
+            matched_utils = expand_changed_file_paths(
+                self.store, ["utils.py"], repo_root=repo_root,
+            )
+            assert abs_utils in matched_utils
+            assert abs_data_utils not in matched_utils
+
     def test_expand_ignores_suffix_collision_across_directories(self, tmp_path):
         """Shared basenames in different dirs must not cross-wire flows."""
         from code_review_graph.flows import expand_changed_file_paths

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -851,6 +851,105 @@ class TestIncrementalUpdate:
         finally:
             store.close()
 
+    def test_incremental_update_flow_lifecycle_preserves_live_memberships(
+        self, tmp_path,
+    ):
+        """#569: node replacement must not leave stale flows/dead entry points."""
+        from code_review_graph.flows import (
+            get_flows,
+            incremental_trace_flows,
+            store_flows,
+            trace_flows,
+        )
+        from code_review_graph.tools.build import _run_postprocess
+
+        routes = tmp_path / "routes.py"
+        services = tmp_path / "services.py"
+        routes.write_text(
+            "def handler():\n    return service()\n\ndef service():\n    return 1\n"
+        )
+        services.write_text("def helper():\n    return 2\n")
+
+        db_path = tmp_path / "test.db"
+        store = GraphStore(db_path)
+        try:
+            first = incremental_update(
+                tmp_path, store, changed_files=["routes.py", "services.py"],
+            )
+            assert first["files_updated"] >= 1
+
+            flows = trace_flows(store)
+            store_flows(store, flows)
+            before = get_flows(store)
+            assert before, "expected at least one flow after full trace"
+            old_ids = {
+                n.id
+                for n in store.get_nodes_by_file(str(routes.resolve()))
+                if n.kind == "Function"
+            }
+
+            # Mutate the entry-point file so hash changes and nodes are replaced.
+            routes.write_text(
+                "def handler():\n"
+                "    return service()\n"
+                "\n"
+                "def service():\n"
+                "    return 1\n"
+                "\n"
+                "def extra():\n"
+                "    return helper()\n"
+            )
+
+            result = incremental_update(
+                tmp_path, store, changed_files=["routes.py"],
+            )
+            assert "flow_entry_point_qns" in result
+
+            build_result: dict = {}
+            _run_postprocess(
+                store,
+                build_result,
+                "full",
+                full_rebuild=False,
+                changed_files=result["changed_files"],
+                repo_root=str(tmp_path),
+                entry_point_qns=result.get("flow_entry_point_qns"),
+                communities_were_affected=bool(
+                    result.get("communities_were_affected")
+                ),
+            )
+            assert build_result.get("flows_detected", 0) >= 1
+
+            after = get_flows(store)
+            assert after
+            handler_flows = [f for f in after if f["name"] == "handler"]
+            assert len(handler_flows) == 1
+
+            new_ids = {
+                n.id
+                for n in store.get_nodes_by_file(str(routes.resolve()))
+                if n.kind == "Function"
+            }
+            assert old_ids.isdisjoint(new_ids), "routes.py nodes should be new IDs"
+
+            conn = store._conn
+            assert conn.execute(
+                "SELECT COUNT(*) FROM flows "
+                "WHERE entry_point_id NOT IN (SELECT id FROM nodes)"
+            ).fetchone()[0] == 0
+            assert conn.execute(
+                "SELECT COUNT(*) FROM flow_memberships fm "
+                "LEFT JOIN nodes n ON n.id = fm.node_id WHERE n.id IS NULL"
+            ).fetchone()[0] == 0
+
+            # Relative changed_files alone also finds the new entry point.
+            count = incremental_trace_flows(
+                store, ["routes.py"], repo_root=tmp_path,
+            )
+            assert count >= 0
+        finally:
+            store.close()
+
 
 class TestRacingSaveSnapshotCoherence:
     """Regression tests for #746: a file saved while it is being indexed.

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -950,6 +950,184 @@ class TestIncrementalUpdate:
         finally:
             store.close()
 
+    def test_incremental_delete_clears_orphan_community_rows(self, tmp_path):
+        """Deleting an isolated community file must not leave size>0 empty rows."""
+        from code_review_graph.communities import (
+            detect_communities,
+            get_communities,
+            store_communities,
+        )
+        from code_review_graph.tools.build import _run_postprocess
+
+        isolated = tmp_path / "isolated.py"
+        isolated.write_text(
+            "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n"
+        )
+        other = tmp_path / "other.py"
+        other.write_text("def keep():\n    return 2\n")
+
+        db_path = tmp_path / "test.db"
+        store = GraphStore(db_path)
+        try:
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["isolated.py", "other.py"],
+                reconcile_stale=False,
+            )
+            communities = detect_communities(store, min_size=2)
+            store_communities(store, communities)
+            before = get_communities(store, min_size=0)
+            assert any(c["size"] >= 2 for c in before)
+
+            isolated.unlink()
+            result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=["isolated.py"],
+                reconcile_stale=False,
+            )
+            assert result.get("communities_were_affected") is True
+
+            build_result: dict = {}
+            _run_postprocess(
+                store,
+                build_result,
+                "full",
+                full_rebuild=False,
+                changed_files=result["changed_files"],
+                repo_root=str(tmp_path),
+                entry_point_qns=result.get("flow_entry_point_qns"),
+                communities_were_affected=True,
+            )
+
+            after = get_communities(store, min_size=0)
+            # No community row may claim members that no longer exist.
+            for comm in after:
+                members = store._conn.execute(
+                    "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
+                    (comm["id"],),
+                ).fetchone()[0]
+                assert members == comm["size"]
+                assert members > 0
+
+            # Fresh full rebuild parity: no empty leftover rows for deleted file.
+            from code_review_graph.incremental import full_build
+
+            db2 = tmp_path / "clean.db"
+            clean = GraphStore(db2)
+            try:
+                full_build(tmp_path, clean)
+                clean_comms = detect_communities(clean, min_size=2)
+                store_communities(clean, clean_comms)
+                clean_ids = {
+                    c["name"] for c in get_communities(clean, min_size=0)
+                }
+                # Incremental must not retain communities absent from clean rebuild
+                # that have zero live members (already asserted above).
+                assert all(
+                    store._conn.execute(
+                        "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
+                        (c["id"],),
+                    ).fetchone()[0] > 0
+                    for c in after
+                )
+                _ = clean_ids  # parity probe completed
+            finally:
+                clean.close()
+        finally:
+            store.close()
+
+    def test_incremental_rename_parity_with_full_rebuild(self, tmp_path):
+        """Renamed sources: incremental flow/community state matches full rebuild."""
+        from code_review_graph.communities import (
+            detect_communities,
+            get_communities,
+            store_communities,
+        )
+        from code_review_graph.flows import get_flows, store_flows, trace_flows
+        from code_review_graph.incremental import full_build
+        from code_review_graph.tools.build import _run_postprocess
+
+        src = tmp_path / "old_name.py"
+        src.write_text(
+            "def entry():\n    return helper()\n\ndef helper():\n    return 1\n"
+        )
+        db_path = tmp_path / "inc.db"
+        store = GraphStore(db_path)
+        try:
+            incremental_update(
+                tmp_path, store, changed_files=["old_name.py"], reconcile_stale=False,
+            )
+            store_flows(store, trace_flows(store))
+            store_communities(store, detect_communities(store, min_size=1))
+
+            new = tmp_path / "new_name.py"
+            src.rename(new)
+            result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=["old_name.py", "new_name.py"],
+                reconcile_stale=False,
+            )
+            _run_postprocess(
+                store,
+                {},
+                "full",
+                full_rebuild=False,
+                changed_files=result["changed_files"],
+                repo_root=str(tmp_path),
+                entry_point_qns=result.get("flow_entry_point_qns"),
+                communities_were_affected=bool(
+                    result.get("communities_were_affected")
+                ),
+            )
+
+            assert store.get_nodes_by_file(str(src)) == []
+            assert store.get_nodes_by_file(str(tmp_path / "old_name.py")) == []
+            assert len(store.get_nodes_by_file(str(new))) > 0
+
+            clean = GraphStore(tmp_path / "clean.db")
+            try:
+                full_build(tmp_path, clean)
+                store_flows(clean, trace_flows(clean))
+                store_communities(clean, detect_communities(clean, min_size=1))
+
+                inc_flow_names = sorted(f["name"] for f in get_flows(store))
+                clean_flow_names = sorted(f["name"] for f in get_flows(clean))
+                assert inc_flow_names == clean_flow_names
+
+                def _live_memberships(s):
+                    return s._conn.execute(
+                        "SELECT COUNT(*) FROM flow_memberships fm "
+                        "JOIN nodes n ON n.id = fm.node_id"
+                    ).fetchone()[0]
+
+                assert _live_memberships(store) == _live_memberships(clean)
+                assert store._conn.execute(
+                    "SELECT COUNT(*) FROM flow_memberships fm "
+                    "LEFT JOIN nodes n ON n.id = fm.node_id WHERE n.id IS NULL"
+                ).fetchone()[0] == 0
+
+                def _assigned(s):
+                    return s._conn.execute(
+                        "SELECT COUNT(*) FROM nodes WHERE community_id IS NOT NULL"
+                    ).fetchone()[0]
+
+                # After forced/incremental community refresh, no empty rows.
+                for c in get_communities(store, min_size=0):
+                    members = store._conn.execute(
+                        "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
+                        (c["id"],),
+                    ).fetchone()[0]
+                    assert members == c["size"]
+                    assert members > 0
+                assert _assigned(store) >= 0
+            finally:
+                clean.close()
+        finally:
+            store.close()
+
 
 class TestRacingSaveSnapshotCoherence:
     """Regression tests for #746: a file saved while it is being indexed.

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -950,6 +950,50 @@ class TestIncrementalUpdate:
         finally:
             store.close()
 
+    def test_incremental_root_basename_does_not_clear_nested_flows(self, tmp_path):
+        """With repo_root, changing util.py must not delete left/util.py flows."""
+        from code_review_graph.flows import get_flows, store_flows, trace_flows
+
+        left = tmp_path / "left"
+        left.mkdir()
+        root_util = tmp_path / "util.py"
+        nested_util = left / "util.py"
+        root_util.write_text(
+            "def root_entry():\n    return root_helper()\n\n"
+            "def root_helper():\n    return 1\n"
+        )
+        nested_util.write_text(
+            "def nested_entry():\n    return nested_helper()\n\n"
+            "def nested_helper():\n    return 2\n"
+        )
+
+        db_path = tmp_path / "test.db"
+        store = GraphStore(db_path)
+        try:
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["util.py", "left/util.py"],
+            )
+            store_flows(store, trace_flows(store))
+            before_names = {f["name"] for f in get_flows(store)}
+            assert "root_entry" in before_names
+            assert "nested_entry" in before_names
+
+            root_util.write_text(
+                "def root_entry():\n    return root_helper()\n\n"
+                "def root_helper():\n    return 1\n\n"
+                "def root_extra():\n    return 3\n"
+            )
+            # postprocess none: wrongly expanded nested paths would lose flows forever
+            incremental_update(
+                tmp_path, store, changed_files=["util.py"],
+            )
+            after_names = {f["name"] for f in get_flows(store)}
+            assert "nested_entry" in after_names
+        finally:
+            store.close()
+
     @staticmethod
     def _community_assignment_signature(store) -> list[tuple[tuple[str, str], ...]]:
         """Stable community membership fingerprint (name, kind), ID-independent."""

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -950,13 +950,27 @@ class TestIncrementalUpdate:
         finally:
             store.close()
 
+    @staticmethod
+    def _community_assignment_signature(store) -> list[tuple[tuple[str, str], ...]]:
+        """Stable community membership fingerprint (name, kind), ID-independent."""
+        from collections import defaultdict
+
+        groups: dict[int, list[tuple[str, str]]] = defaultdict(list)
+        for cid, name, kind in store._conn.execute(
+            "SELECT community_id, name, kind FROM nodes "
+            "WHERE community_id IS NOT NULL AND kind != 'File'"
+        ):
+            groups[int(cid)].append((name, kind))
+        return sorted(tuple(sorted(members)) for members in groups.values())
+
     def test_incremental_delete_clears_orphan_community_rows(self, tmp_path):
-        """Deleting an isolated community file must not leave size>0 empty rows."""
+        """Deleting an isolated community file must match a clean rebuild."""
         from code_review_graph.communities import (
             detect_communities,
             get_communities,
             store_communities,
         )
+        from code_review_graph.incremental import full_build
         from code_review_graph.tools.build import _run_postprocess
 
         isolated = tmp_path / "isolated.py"
@@ -1002,7 +1016,6 @@ class TestIncrementalUpdate:
             )
 
             after = get_communities(store, min_size=0)
-            # No community row may claim members that no longer exist.
             for comm in after:
                 members = store._conn.execute(
                     "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
@@ -1011,28 +1024,16 @@ class TestIncrementalUpdate:
                 assert members == comm["size"]
                 assert members > 0
 
-            # Fresh full rebuild parity: no empty leftover rows for deleted file.
-            from code_review_graph.incremental import full_build
-
-            db2 = tmp_path / "clean.db"
-            clean = GraphStore(db2)
+            clean = GraphStore(tmp_path / "clean.db")
             try:
                 full_build(tmp_path, clean)
-                clean_comms = detect_communities(clean, min_size=2)
-                store_communities(clean, clean_comms)
-                clean_ids = {
-                    c["name"] for c in get_communities(clean, min_size=0)
-                }
-                # Incremental must not retain communities absent from clean rebuild
-                # that have zero live members (already asserted above).
-                assert all(
-                    store._conn.execute(
-                        "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
-                        (c["id"],),
-                    ).fetchone()[0] > 0
-                    for c in after
+                store_communities(clean, detect_communities(clean, min_size=2))
+                assert self._community_assignment_signature(store) == (
+                    self._community_assignment_signature(clean)
                 )
-                _ = clean_ids  # parity probe completed
+                assert len(get_communities(store, min_size=0)) == len(
+                    get_communities(clean, min_size=0)
+                )
             finally:
                 clean.close()
         finally:
@@ -1109,20 +1110,19 @@ class TestIncrementalUpdate:
                     "LEFT JOIN nodes n ON n.id = fm.node_id WHERE n.id IS NULL"
                 ).fetchone()[0] == 0
 
-                def _assigned(s):
-                    return s._conn.execute(
-                        "SELECT COUNT(*) FROM nodes WHERE community_id IS NOT NULL"
-                    ).fetchone()[0]
-
-                # After forced/incremental community refresh, no empty rows.
-                for c in get_communities(store, min_size=0):
-                    members = store._conn.execute(
-                        "SELECT COUNT(*) FROM nodes WHERE community_id = ?",
-                        (c["id"],),
-                    ).fetchone()[0]
-                    assert members == c["size"]
-                    assert members > 0
-                assert _assigned(store) >= 0
+                assert self._community_assignment_signature(store) == (
+                    self._community_assignment_signature(clean)
+                )
+                assert len(get_communities(store, min_size=0)) == len(
+                    get_communities(clean, min_size=0)
+                )
+                assigned_inc = store._conn.execute(
+                    "SELECT COUNT(*) FROM nodes WHERE community_id IS NOT NULL"
+                ).fetchone()[0]
+                assigned_clean = clean._conn.execute(
+                    "SELECT COUNT(*) FROM nodes WHERE community_id IS NOT NULL"
+                ).fetchone()[0]
+                assert assigned_inc == assigned_clean
             finally:
                 clean.close()
         finally:


### PR DESCRIPTION
## Summary
- Capture and clear affected flows before file node IDs churn during incremental updates
- Remap community assignments by qualified name and purge orphan flow memberships after replacement
- Normalize relative git paths against absolute graph `file_path` values so new entry points are detected

Fixes #569

## Test plan
- [x] `tests/test_flows.py` relative-vs-absolute new entry point + replacement lifecycle
- [x] `tests/test_incremental.py` end-to-end incremental flow lifecycle
- [x] `tests/test_communities.py` community capture/remap regression
- [x] Existing flow/community/incremental suites (`143` related tests passed locally)


