### PR TITLE
fix(codex): emit commandWindows override for Windows hooks (fixes #620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed Codex hooks on Windows: `code-review-graph install --platform codex` now
+  emits a `commandWindows` override (PowerShell) so hooks no longer fail with
+  `hook exited with code 1` (fixes #620).
+
 ## [2.3.7] - 2026-07-18
 
 **Maintainer-reconciliation release.** This release packages the verified work

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -21,6 +21,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Codex hook command used on Windows (PowerShell). Drains stdin so large
+# tool payloads never break the hook, then runs the CRG command and exits 0.
+_CODEX_WINDOWS_HOOK_PREFIX = "powershell.exe -NoProfile -NonInteractive -Command "
+
 
 # --- Multi-platform MCP install ---
 
@@ -788,6 +792,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
+                            "commandWindows": (
+                                _CODEX_WINDOWS_HOOK_PREFIX
+                                + "[Console]::In.ReadToEnd() | Out-Null; "
+                                "code-review-graph update --skip-flows; "
+                                "exit 0"
+                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -805,6 +815,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
+                            ),
+                            "commandWindows": (
+                                _CODEX_WINDOWS_HOOK_PREFIX
+                                + "[Console]::In.ReadToEnd() | Out-Null; "
+                                "code-review-graph status; "
+                                "exit 0"
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -545,6 +545,27 @@ class TestGenerateCodexHooksConfig:
         assert "code-review-graph update --skip-flows" in post_cmd
         assert "code-review-graph status" in session_cmd
 
+    def test_command_windows_present_for_both_hooks(self, tmp_path):
+        config = generate_codex_hooks_config(tmp_path)
+        post = config["hooks"]["PostToolUse"][0]["hooks"][0]
+        session = config["hooks"]["SessionStart"][0]["hooks"][0]
+        assert "commandWindows" in post
+        assert "commandWindows" in session
+
+    def test_command_windows_uses_powershell(self, tmp_path):
+        config = generate_codex_hooks_config(tmp_path)
+        post = config["hooks"]["PostToolUse"][0]["hooks"][0]["commandWindows"]
+        session = config["hooks"]["SessionStart"][0]["hooks"][0]["commandWindows"]
+        prefix = "powershell.exe -NoProfile -NonInteractive -Command "
+        assert post.startswith(prefix)
+        assert "code-review-graph update --skip-flows" in post
+        assert "code-review-graph status" in session
+        # stdin must be drained and the hook must always exit 0
+        assert "[Console]::In.ReadToEnd() | Out-Null" in post
+        assert "[Console]::In.ReadToEnd() | Out-Null" in session
+        assert post.rstrip().endswith("exit 0")
+        assert session.rstrip().endswith("exit 0")
+
 
 class TestInstallCodexHooks:
     def test_creates_hooks_file(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Root cause

`generate_codex_hooks_config()` in `code_review_graph/skills.py` builds `~/.codex/hooks.json` but only emitted the Unix `command` field for both `PostToolUse` and `SessionStart` hooks. On Windows, Codex runs the hook via the OS shell, where the Unix `command` string is invalid in PowerShell, so every hook fails with `hook exited with code 1` (issue #620).

Codex natively supports a per-hook `commandWindows` override that takes precedence on Windows. The function never emitted it.

## Fix

This is a small, additive change:

- Added a module-level helper constant `_CODEX_WINDOWS_HOOK_PREFIX = "powershell.exe -NoProfile -NonInteractive -Command "`.
- Each hook dict now also emits a `commandWindows` field that drains stdin (`[Console]::In.ReadToEnd() | Out-Null`), runs the matching CRG command, and `exit 0` so the hook never fails on payload size and always returns 0.
- The existing Unix `command` strings, `type`, `timeout`, and `statusMessage` are **untouched** — macOS/Linux behavior is completely unchanged.

## Tests

- Added two regression tests (`test_command_windows_present_for_both_hooks`, `test_command_windows_uses_powershell`) that assert the generated JSON contains `commandWindows` (PowerShell prefix + correct CRG command + `exit 0`) for both hooks.
- The test suite intentionally never spawns `powershell.exe`, so it passes on any OS CI runner.

## Verification

- `uvx ruff check code_review_graph/skills.py` -> clean.
- `uv run pytest tests/test_skills.py` -> 177 passed (only the unrelated `bash`-based stdin test is skipped on this Windows host; it passes on Linux/macOS CI).

Closes #620
