### PR TITLE
fix(parser): extract Ruby method calls as CALLS edges

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5432,10 +5432,14 @@ class CodeParser:
 
             # --- Imports ---
             if node_type in import_types:
-                self._extract_imports(
+                if self._extract_imports(
                     child, language, source, file_path, edges,
-                )
-                continue
+                ):
+                    continue
+                # Node type is shared between imports and calls (e.g. Ruby
+                # `call` covers both `require` and method invocation). If it
+                # was not an import, fall through to call extraction below
+                # rather than dropping it.
 
             # --- Calls ---
             if node_type in call_types:
@@ -9377,8 +9381,15 @@ class CodeParser:
         source: bytes,
         file_path: str,
         edges: list[EdgeInfo],
-    ) -> None:
-        """Extract import edges from an import statement node."""
+    ) -> bool:
+        """Extract import edges from an import statement node.
+
+        Returns True if at least one import edge was emitted. Some grammars
+        reuse a single node type for both imports and ordinary calls (e.g.
+        Ruby's ``call`` covers both ``require``/``require_relative`` and method
+        invocation). Returning False lets the dispatcher fall through to call
+        extraction instead of silently dropping the call. See: Ruby call graph.
+        """
         imports = self._extract_import(child, language, source)
         for imp_target in imports:
             resolved = self._resolve_module_to_file(
@@ -9391,6 +9402,7 @@ class CodeParser:
                 file_path=file_path,
                 line=child.start_point[0] + 1,
             ))
+        return bool(imports)
 
     def _extract_calls(
         self,
@@ -13713,6 +13725,16 @@ class CodeParser:
                 if child.type == "identifier":
                     return child.text.decode("utf-8", errors="replace")
             return None
+
+        # Ruby: `call` nodes expose a `method` field for both receiver calls
+        # (`Bar.new.run` -> `run`) and paren calls (`helper_method(1)` ->
+        # `helper_method`). `require`/`require_relative` are handled earlier as
+        # imports, so they never reach here. Bare implicit-self calls with no
+        # parens parse as plain `identifier` (not `call`) and are not captured.
+        if language == "ruby" and node.type in ("call", "method_call"):
+            method_node = node.child_by_field_name("method")
+            if method_node is not None:
+                return method_node.text.decode("utf-8", errors="replace")
 
         # Bash: `command` node's first child is the command name.
         if language == "bash" and node.type == "command":

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -655,6 +655,41 @@ class TestRubyParsing:
         names = {f.name for f in funcs}
         assert "initialize" in names or "find_by_id" in names or "save" in names
 
+    def test_finds_calls(self):
+        """Ruby method calls must produce CALLS edges.
+
+        Ruby's grammar uses the same ``call`` node type for both
+        ``require`` and ordinary method invocation, so the dispatcher must
+        not treat every ``call`` as an import. Paren calls (``save(user)``),
+        command calls (``puts ...``) and member calls (``User.new`` /
+        ``@users.size``) are all captured. Bare implicit-self calls with no
+        parens (e.g. a lone ``helper``) parse as ``identifier`` rather than
+        ``call`` and are intentionally not covered here.
+        """
+        calls = [e for e in self.edges if e.kind == "CALLS"]
+        assert len(calls) >= 1
+
+        targets = {e.target for e in calls}
+        target_names = {t.split("::")[-1].split(".")[-1] for t in targets}
+
+        # Paren, command and member calls are all captured.
+        assert "save" in target_names
+        assert "puts" in target_names
+        assert "new" in target_names
+        assert "size" in target_names
+
+        # A same-class call resolves to the defining method node, not a bare
+        # name, so callers_of/callees_of work within a file.
+        assert any(t.endswith("sample.rb::UserRepository.save") for t in targets)
+
+        # Calls are attributed to their enclosing method.
+        create_user_targets = {
+            e.target for e in calls
+            if e.source.endswith("UserRepository.create_user")
+        }
+        assert any(t.endswith("UserRepository.save") for t in create_user_targets)
+        assert any(t.endswith("new") for t in create_user_targets)
+
 
 class TestPHPParsing:
     def setup_method(self):


### PR DESCRIPTION
# fix(parser): extract Ruby method calls as CALLS edges

## Problem

Ruby produces **zero** `CALLS` edges — `callers_of`, `callees_of`, impact radius,
and caller-based dead-code are all blind on Ruby codebases. Definitions parse fine
(classes/methods/`CONTAINS`), but the call graph is empty.

Reproduce on any Ruby repo:

```ruby
# app.rb
class Foo
  def greet
    helper(1)      # expect CALLS Foo.greet -> Foo.helper
  end
  def helper(n) = n
end
```

`query callers_of helper` → 0 results.

## Root cause

Two issues in `parser.py`:

1. **Dispatch swallows calls.** Ruby's Tree-sitter grammar reuses the `call` node
   type for both `require`/`require_relative` *and* ordinary method invocation.
   `_extract_from_tree` checks import node types before call node types and
   `continue`s unconditionally, so every Ruby `call` is consumed by the import
   branch (which only emits an edge when the text contains `require`) and never
   reaches call extraction.
2. **No Ruby case in `_get_call_name`.** Even when a `call` node is reached, there
   was no Ruby handling, so member calls (`User.new`, `@users.size`) produced no
   call name and no edge.

## Fix

- `_extract_imports` now returns `bool` (whether it emitted an import edge). The
  dispatcher only skips call extraction when an import was actually produced, so
  non-import `call` nodes fall through to call handling. This is a general
  improvement for any grammar that overloads a node type for imports and calls.
- `_get_call_name` handles Ruby `call`/`method_call` via the node's `method` field,
  covering paren calls (`save(user)`), command calls (`puts ...`), and member calls
  (`User.new`, `@users.size`).

## Result

Same-file / same-class calls resolve to the defining method node, so
`callers_of`/`callees_of` work within a file:

```
create_user  ->  sample.rb::UserRepository.save   (resolved)
create_user  ->  new, size                         (bare, cross-type)
```

## Scope / limitations

- Cross-file, receiver-typed targets (`Bar.new.run` → `run`) remain **bare**, exactly
  like the existing behavior for unresolved JS/TS calls. Precise typed resolution for
  Ruby is best handled by a follow-up **Sorbet-backed resolver** (analogous to the
  existing `jedi`/Spring resolvers).
- **Bare implicit-self calls** with no parens (a lone `helper`) parse as `identifier`
  rather than `call`, so they are not captured here (also a Sorbet-resolver concern —
  it can disambiguate a send from a local variable).

## Tests

- Adds `tests/test_multilang.py::TestRubyParsing::test_finds_calls` (fails on `main`
  with 0 CALLS; passes with this change).
- Full suite: **1962 passed, 5 skipped, 2 xpassed**; `ruff check` clean.
