### PR TITLE
feat(cli): add platform unbind and forget commands (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `code-review-graph forget PATH [PATH ...]` to drop already-parsed files
+  from the graph without a full rebuild. Paths may be absolute, relative to the
+  repository root, a directory (every file underneath is dropped), or a glob
+  pattern, and `--dry-run` previews the selection. The FTS index is refreshed
+  after removal so search results stay consistent (#678).
+- Added `--platform NAME` to `code-review-graph uninstall` to unbind a single
+  platform's MCP registration while preserving the graph data and every other
+  configured integration. Without `--platform` the command still performs the
+  full uninstall (#678).
+
 ## [2.3.7] - 2026-07-18
 
 **Maintainer-reconciliation release.** This release packages the verified work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Added `code-review-graph forget PATH [PATH ...]` to drop already-parsed files
   from the graph without a full rebuild. Paths may be absolute, relative to the
   repository root, a directory (every file underneath is dropped), or a glob
-  pattern, and `--dry-run` previews the selection. The FTS index is refreshed
-  after removal so search results stay consistent (#678).
+  pattern, and `--dry-run` previews the selection. The result is equivalent to
+  rebuilding the graph without those files: surviving referrers are re-parsed so
+  no edge is left pointing at a deleted node, and flows, communities, the FTS
+  index, and embeddings are all repaired (#678).
 - Added `--platform NAME` to `code-review-graph uninstall` to unbind a single
   platform's MCP registration while preserving the graph data and every other
   configured integration. Without `--platform` the command still performs the

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -3,9 +3,10 @@
 Usage:
     code-review-graph install
     code-review-graph init
-    code-review-graph uninstall [--dry-run] [--yes] [--repo PATH]
+    code-review-graph uninstall [--platform NAME] [--dry-run] [--yes] [--repo PATH]
     code-review-graph build [--base BASE]
     code-review-graph update [--base BASE]
+    code-review-graph forget PATH [PATH ...] [--dry-run]
     code-review-graph watch
     code-review-graph status
     code-review-graph serve [--auto-watch] [--http] [--host ADDR] [--port PORT]
@@ -38,6 +39,7 @@ if sys.version_info < (3, 10):
     sys.exit(1)
 
 import argparse
+import fnmatch
 import json
 import logging
 import os
@@ -45,7 +47,7 @@ from functools import partial
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import TypedDict
+from typing import Iterable, TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +194,61 @@ def _confirm_yes_no(prompt: str, default_yes: bool = True) -> bool:
     if not answer:
         return default_yes
     return answer in ("y", "yes")
+
+
+def _match_files_to_forget(
+    stored_files: Iterable[str],
+    patterns: Iterable[str],
+    repo_root: Path,
+) -> list[str]:
+    """Resolve user-supplied paths/globs to stored graph file paths.
+
+    The graph keys every parsed file by its absolute path. A user may name a
+    file with an absolute path, a path relative to the repository root, a
+    directory whose contents should all be dropped, or a glob pattern. Each
+    stored file is compared against every pattern in all of those forms and the
+    sorted set of matching stored paths is returned.
+    """
+    root = repo_root.resolve()
+    stored = list(stored_files)
+    matched: set[str] = set()
+
+    for raw in patterns:
+        pattern = str(raw).strip()
+        if not pattern:
+            continue
+        expanded = Path(pattern).expanduser()
+        absolute = expanded if expanded.is_absolute() else root / expanded
+        absolute_str = os.path.normpath(str(absolute))
+        dir_prefix = absolute_str.rstrip(os.sep) + os.sep
+
+        for stored_path in stored:
+            normalised = os.path.normpath(stored_path)
+            try:
+                relative = os.path.relpath(normalised, str(root))
+            except ValueError:
+                relative = None
+
+            # Exact match against the absolute or the repo-relative form.
+            if normalised == absolute_str:
+                matched.add(stored_path)
+                continue
+            if relative is not None and os.path.normpath(relative) == os.path.normpath(
+                pattern
+            ):
+                matched.add(stored_path)
+                continue
+            # Every file underneath a named directory.
+            if normalised.startswith(dir_prefix):
+                matched.add(stored_path)
+                continue
+            # Glob patterns, matched against both the absolute and relative form.
+            if fnmatch.fnmatch(normalised, absolute_str) or (
+                relative is not None and fnmatch.fnmatch(relative, pattern)
+            ):
+                matched.add(stored_path)
+
+    return sorted(matched)
 
 
 def _handle_init(args: argparse.Namespace) -> None:
@@ -633,6 +690,13 @@ def main() -> None:
         help="Clean repositories only; do not edit files under the user home",
     )
     uninstall_cmd.add_argument(
+        "--platform",
+        choices=_PLATFORM_CHOICES,
+        default="all",
+        help="Unbind only this platform's MCP registration and keep the graph "
+             "data and every other integration. Default: all (full uninstall).",
+    )
+    uninstall_cmd.add_argument(
         "--dry-run",
         action="store_true",
         help="Print every planned action without writing or deleting anything",
@@ -766,6 +830,30 @@ def main() -> None:
         help="Output one machine-readable JSON object",
     )
     status_cmd.add_argument(
+        "--data-dir",
+        default=None,
+        help="External directory to store graph database (useful for network shares)"
+    )
+
+    # forget
+    forget_cmd = sub.add_parser(
+        "forget",
+        help="Remove already-parsed files from the graph without a full rebuild",
+    )
+    forget_cmd.add_argument(
+        "paths",
+        nargs="+",
+        metavar="PATH",
+        help="Files, directories, or glob patterns to drop from the graph. "
+             "Paths may be absolute or relative to the repository root.",
+    )
+    forget_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
+    forget_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the files that would be forgotten without modifying the graph",
+    )
+    forget_cmd.add_argument(
         "--data-dir",
         default=None,
         help="External directory to store graph database (useful for network shares)"
@@ -1272,11 +1360,14 @@ def main() -> None:
         from .uninstall import run as run_uninstall
 
         target_repo = Path(args.repo).expanduser() if args.repo else None
+        platform_target = getattr(args, "platform", "all") or "all"
+        scoped_platforms = None if platform_target == "all" else [platform_target]
         options = {
             "repo": target_repo,
             "all_repos": args.all_repos,
             "keep_data": args.keep_data,
             "keep_user_configs": args.keep_user_configs,
+            "platforms": scoped_platforms,
         }
 
         def _print_report(report: UninstallReport) -> None:
@@ -1290,19 +1381,31 @@ def main() -> None:
                 print(f"  error   {error}")
 
         preview = run_uninstall(**options, dry_run=True)
-        print("code-review-graph uninstall — planned actions:")
+        if scoped_platforms:
+            print(f"code-review-graph unbind ({platform_target}) — planned actions:")
+        else:
+            print("code-review-graph uninstall — planned actions:")
         _print_report(preview)
         if preview.total_actions == 0:
             if preview.errors:
                 raise SystemExit(1)
-            print("  (nothing to do — no code-review-graph artifacts found)")
+            if scoped_platforms:
+                print(
+                    f"  (nothing to do — {platform_target} has no "
+                    "code-review-graph MCP registration)"
+                )
+            else:
+                print("  (nothing to do — no code-review-graph artifacts found)")
             return
         if args.dry_run:
             print("\n[dry-run] No changes made.")
             if preview.errors:
                 raise SystemExit(1)
             return
-        if not args.yes and not _confirm_yes_no("\nProceed with uninstall?", default_yes=False):
+        action_word = "unbind" if scoped_platforms else "uninstall"
+        if not args.yes and not _confirm_yes_no(
+            f"\nProceed with {action_word}?", default_yes=False
+        ):
             print("Aborted.")
             return
 
@@ -1427,6 +1530,7 @@ def main() -> None:
         "update",
         "detect-changes",
         "status",
+        "forget",
         "watch",
         "visualize",
         "wiki",
@@ -1436,7 +1540,7 @@ def main() -> None:
         _handle_data_dir_option(args, repo_root)
 
     db_path = get_db_path(repo_root)
-    if args.command == "dead-code" and not db_path.exists():
+    if args.command in ("dead-code", "forget") and not db_path.exists():
         print(
             f"No graph found at {db_path}. Run `code-review-graph build` first.",
             file=sys.stderr,
@@ -1633,6 +1737,46 @@ def main() -> None:
                         print(f"SVN branch: {stored_svn_branch}")
                     if stored_rev:
                         print(f"SVN revision at build: {stored_rev}")
+
+        elif args.command == "forget":
+            stored_files = store.get_all_files()
+            targets = _match_files_to_forget(stored_files, args.paths, repo_root)
+            if not targets:
+                print("No parsed files matched the given path(s).")
+                print(f"The graph currently tracks {len(stored_files)} file(s).")
+            else:
+                header = (
+                    "[dry-run] Would forget these files:"
+                    if args.dry_run
+                    else "Forgetting these files:"
+                )
+                print(header)
+                for file_path in targets:
+                    try:
+                        display = os.path.relpath(file_path, str(repo_root))
+                    except ValueError:
+                        display = file_path
+                    print(f"  {display}")
+                if args.dry_run:
+                    print(
+                        f"\n[dry-run] {len(targets)} file(s) would be removed "
+                        "from the graph. No changes made."
+                    )
+                else:
+                    for file_path in targets:
+                        store.remove_file_data(file_path)
+                    # nodes_fts is an external-content FTS5 index with no delete
+                    # triggers, so refresh it to drop entries for the removed
+                    # rows and keep search results consistent (mirrors the
+                    # update -> postprocess path for deleted files).
+                    from .search import rebuild_fts_index
+
+                    rebuild_fts_index(store)
+                    remaining = len(stored_files) - len(targets)
+                    print(
+                        f"\nForgot {len(targets)} file(s); "
+                        f"{remaining} file(s) remain in the graph."
+                    )
 
         elif args.command == "watch":
             from .postprocessing import run_post_processing

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1763,15 +1763,15 @@ def main() -> None:
                         "from the graph. No changes made."
                     )
                 else:
-                    for file_path in targets:
-                        store.remove_file_data(file_path)
-                    # nodes_fts is an external-content FTS5 index with no delete
-                    # triggers, so refresh it to drop entries for the removed
-                    # rows and keep search results consistent (mirrors the
-                    # update -> postprocess path for deleted files).
-                    from .search import rebuild_fts_index
+                    from .forget import forget_files
 
-                    rebuild_fts_index(store)
+                    summary = forget_files(store, repo_root, targets)
+                    reparsed = summary.get("reparsed", [])
+                    if reparsed:
+                        print(
+                            f"  re-resolved {len(reparsed)} referring file(s) "
+                            "so no edges dangle"
+                        )
                     remaining = len(stored_files) - len(targets)
                     print(
                         f"\nForgot {len(targets)} file(s); "

--- a/code_review_graph/forget.py
+++ b/code_review_graph/forget.py
@@ -1,0 +1,164 @@
+"""Forget parsed files from the graph while keeping every derived layer sane.
+
+Dropping a file's own nodes and edges is not enough to match the graph a full
+rebuild without that file would produce:
+
+* surviving files that referenced it keep dangling, still-qualified edges
+  (a call resolved to ``other.py::helper`` stays pointing at a node that no
+  longer exists instead of falling back to the bare ``helper``);
+* the derived layers — execution flows, communities, the FTS index, and
+  embeddings — continue to reference the deleted nodes.
+
+``forget_files`` therefore removes the files, re-parses the surviving referrers
+so their cross-file edges are re-derived exactly as a build would, re-runs the
+shared post-processing pipeline (which fully recomputes flows, communities,
+signatures, and FTS and re-resolves bare endpoints), and purges embedding
+vectors whose node is gone. The result is equivalent to building the graph
+without the forgotten files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Any
+
+from .graph import GraphStore
+
+logger = logging.getLogger(__name__)
+
+# Keep IN-clause windows comfortably under SQLite's default 999-variable limit.
+_SQL_PARAM_CHUNK = 400
+
+
+def _referrer_files(
+    store: GraphStore,
+    deleted_qualified_names: set[str],
+    forgotten: set[str],
+) -> list[str]:
+    """Return surviving files whose edges point at any forgotten node.
+
+    Those edges are precisely the ones a rebuild would re-derive (usually
+    dropping back to a bare endpoint), so the files owning them must be
+    re-parsed for parity.
+    """
+    if not deleted_qualified_names:
+        return []
+    conn = store._conn
+    referrers: set[str] = set()
+    names = list(deleted_qualified_names)
+    for start in range(0, len(names), _SQL_PARAM_CHUNK):
+        window = names[start:start + _SQL_PARAM_CHUNK]
+        placeholders = ",".join("?" for _ in window)
+        rows = conn.execute(
+            f"SELECT DISTINCT file_path FROM edges "
+            f"WHERE target_qualified IN ({placeholders}) "
+            f"OR source_qualified IN ({placeholders})",
+            window + window,
+        ).fetchall()
+        referrers.update(row["file_path"] for row in rows)
+    return sorted(referrers - forgotten)
+
+
+def _purge_orphan_embeddings(store: GraphStore) -> int:
+    """Delete embedding vectors whose graph node no longer exists.
+
+    Mirrors :meth:`embeddings.EmbeddingStore.purge_orphans` but runs on the
+    graph's own connection so we never open a second writer. A graph without
+    an embeddings table is a no-op.
+    """
+    conn = store._conn
+    has_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'embeddings'"
+    ).fetchone()
+    if has_table is None:
+        return 0
+    cursor = conn.execute(
+        "DELETE FROM embeddings WHERE NOT EXISTS ("
+        "SELECT 1 FROM nodes WHERE nodes.qualified_name = embeddings.qualified_name"
+        ")"
+    )
+    return max(cursor.rowcount, 0)
+
+
+def forget_files(
+    store: GraphStore,
+    repo_root: Path,
+    targets: list[str],
+) -> dict[str, Any]:
+    """Remove ``targets`` from the graph and repair every derived layer.
+
+    Args:
+        store: An open graph store.
+        repo_root: Repository root, used to re-parse surviving referrers.
+        targets: Absolute file paths (as stored in the graph) to forget.
+
+    Returns:
+        A summary dict with the forgotten files, the referrer files that were
+        re-parsed, and the number of orphaned embedding vectors purged.
+    """
+    from .parser import CodeParser
+    from .postprocessing import run_post_processing
+
+    forgotten = set(targets)
+
+    # 1. Snapshot the qualified names about to disappear so we can find the
+    #    surviving files that reference them (before we delete anything).
+    deleted_qualified_names: set[str] = set()
+    for file_path in targets:
+        for node in store.get_nodes_by_file(file_path):
+            deleted_qualified_names.add(node.qualified_name)
+
+    referrers = _referrer_files(store, deleted_qualified_names, forgotten)
+
+    # 2. Drop the forgotten files' own nodes and edges.
+    for file_path in targets:
+        store.remove_file_data(file_path)
+    # Persist deletions before store_file_nodes_edges() opens its own
+    # explicit transaction (BEGIN IMMEDIATE) during the re-parse below.
+    store.commit()
+
+    # 3. Re-parse the surviving referrers so their cross-file edges are
+    #    re-derived exactly as a build would: edges that had resolved into a
+    #    forgotten file fall back to bare and are re-resolved against the
+    #    smaller graph, while edges into other survivors are preserved. The
+    #    forgotten files are hidden from import resolution so a still-on-disk
+    #    file is not silently re-resolved (forget removes it from the graph,
+    #    not from the working tree).
+    parser = CodeParser(repo_root)
+    parser.exclude_files(forgotten)
+    reparsed: list[str] = []
+    for file_path in referrers:
+        abs_path = Path(file_path)
+        if not abs_path.is_file():
+            # Referrer is gone from disk; nothing to re-parse. Its stale edges
+            # are cleaned up by post-processing's bare re-resolution below.
+            continue
+        if parser.detect_language(abs_path) is None:
+            continue
+        try:
+            source = abs_path.read_bytes()
+            fhash = hashlib.sha256(source).hexdigest()
+            nodes, edges = parser.parse_bytes(abs_path, source)
+            store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
+            reparsed.append(file_path)
+        except (OSError, PermissionError) as exc:
+            logger.warning("Could not re-parse referrer %s: %s", file_path, exc)
+        except Exception as exc:  # noqa: BLE001 - a parser failure is non-fatal
+            logger.warning("Error re-parsing referrer %s: %s", file_path, exc)
+
+    # 4. Re-run the shared post-processing pipeline. store_flows and
+    #    store_communities clear their tables first, so flows and communities
+    #    are fully recomputed; signatures and FTS are rebuilt; and any edge
+    #    left bare by the re-parse is re-resolved.
+    run_post_processing(store)
+
+    # 5. Drop embedding vectors that now reference a deleted node.
+    purged = _purge_orphan_embeddings(store)
+
+    return {
+        "forgotten": sorted(forgotten),
+        "reparsed": reparsed,
+        "embeddings_purged": purged,
+    }

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2295,6 +2295,11 @@ class CodeParser:
         self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
         self._parsers: dict[str, object] = {}
         self._module_file_cache: dict[str, Optional[str]] = {}
+        # Absolute file paths to treat as absent during import resolution.
+        # ``forget`` sets this (via :meth:`exclude_files`) so a re-parsed
+        # referrer resolves exactly as it would in a build where the forgotten
+        # files never existed on disk. See ``forget.forget_files``.
+        self._excluded_files: set[str] = set()
         self._export_symbol_cache: dict[str, Optional[str]] = {}
         self._tsconfig_resolver = TsconfigResolver()
         # Per-parse cache of Dart pubspec root lookups; see #87
@@ -12501,22 +12506,39 @@ class CodeParser:
                         if names:
                             import_map[names[-1]] = module
 
+    def exclude_files(self, paths: set[str]) -> None:
+        """Treat these files as absent when resolving imports.
+
+        ``forget`` calls this before re-parsing the surviving referrers of a
+        forgotten file so their imports resolve exactly as they would in a
+        build where the forgotten files never existed: an import that would
+        point at a forgotten file falls back to a bare module, and the calls
+        it feeds stay bare too.
+        """
+        self._excluded_files = {str(Path(p).resolve()) for p in paths}
+        # Drop resolutions cached before the exclusions were applied.
+        self._module_file_cache.clear()
+
     def _resolve_module_to_file(
         self, module: str, file_path: str, language: str,
     ) -> Optional[str]:
         """Resolve a module/import path to an absolute file path.
 
         Uses self._module_file_cache to avoid repeated filesystem lookups.
+        Files marked via :meth:`exclude_files` resolve to ``None`` so callers
+        fall back to the bare module string, matching a build without them.
         """
         caller_dir = str(Path(file_path).parent)
         cache_key = f"{language}:{caller_dir}:{module}"
         if cache_key in self._module_file_cache:
-            return self._module_file_cache[cache_key]
-
-        resolved = self._do_resolve_module(module, file_path, language)
-        if len(self._module_file_cache) >= self._MODULE_CACHE_MAX:
-            self._module_file_cache.clear()
-        self._module_file_cache[cache_key] = resolved
+            resolved = self._module_file_cache[cache_key]
+        else:
+            resolved = self._do_resolve_module(module, file_path, language)
+            if len(self._module_file_cache) >= self._MODULE_CACHE_MAX:
+                self._module_file_cache.clear()
+            self._module_file_cache[cache_key] = resolved
+        if resolved is not None and resolved in self._excluded_files:
+            return None
         return resolved
 
     def _do_resolve_module(

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -914,9 +914,12 @@ def _process_platform_configs(
     *,
     scope: str,
     dry_run: bool,
+    platforms: frozenset[str] | None = None,
 ) -> None:
     seen: set[tuple[Path, str, str]] = set()
     for platform_name, spec in skills.PLATFORMS.items():
+        if platforms is not None and platform_name not in platforms:
+            continue
         try:
             path = _absolute(spec["config_path"](repo_root))
             key = str(spec["key"])
@@ -992,8 +995,17 @@ def _process_repo(
     *,
     keep_data: bool,
     dry_run: bool,
+    platforms: frozenset[str] | None = None,
 ) -> None:
-    _process_platform_configs(repo_root, home, report, scope="repo", dry_run=dry_run)
+    _process_platform_configs(
+        repo_root, home, report, scope="repo", dry_run=dry_run, platforms=platforms
+    )
+    if platforms is not None:
+        # Platform-scoped unbind: remove only the MCP registration for the
+        # selected platform(s). Shared graph data, hooks, generated skills, and
+        # instruction sections are left untouched so other platforms keep
+        # working. A full ``uninstall`` (no --platform) removes everything.
+        return
     _remove_legacy_mcp_configs(
         repo_root,
         home,
@@ -1113,8 +1125,14 @@ def _process_user(
     *,
     keep_data: bool,
     dry_run: bool,
+    platforms: frozenset[str] | None = None,
 ) -> None:
-    _process_platform_configs(reference_repo, home, report, scope="user", dry_run=dry_run)
+    _process_platform_configs(
+        reference_repo, home, report, scope="user", dry_run=dry_run, platforms=platforms
+    )
+    if platforms is not None:
+        # See _process_repo: platform-scoped unbind touches MCP config only.
+        return
     _remove_legacy_mcp_configs(
         reference_repo,
         home,
@@ -1223,6 +1241,24 @@ def _normalise_repo(path: Path, home: Path, report: UninstallReport) -> Path | N
     return repository_root
 
 
+def _normalise_platform_filter(platforms: Sequence[str] | None) -> frozenset[str] | None:
+    """Return the platform keys to scope an unbind to, or ``None`` for all.
+
+    ``None``, an empty selection, or an explicit ``"all"`` disables scoping and
+    restores the full uninstall. ``"claude-code"`` is accepted as an alias for
+    ``"claude"`` so the flag matches the install command's spelling.
+    """
+    if not platforms:
+        return None
+    selected: set[str] = set()
+    for name in platforms:
+        key = "claude" if name == "claude-code" else name
+        if key == "all":
+            return None
+        selected.add(key)
+    return frozenset(selected) or None
+
+
 def run(
     *,
     repo: Path | None = None,
@@ -1230,10 +1266,17 @@ def run(
     keep_data: bool = False,
     keep_user_configs: bool = False,
     dry_run: bool = False,
+    platforms: Sequence[str] | None = None,
 ) -> UninstallReport:
-    """Uninstall CRG artifacts and return a precise action report."""
+    """Uninstall CRG artifacts and return a precise action report.
+
+    When ``platforms`` names one or more specific platforms, the run is scoped
+    to *unbinding* those platforms: only their MCP server registration is
+    removed and all graph data is preserved, regardless of ``keep_data``.
+    """
     report = UninstallReport()
     home = _absolute(Path.home())
+    platform_filter = _normalise_platform_filter(platforms)
     requested = [repo if repo is not None else Path.cwd()]
     if all_repos:
         requested.extend(_registry_repo_paths(home, report))
@@ -1251,6 +1294,7 @@ def run(
             report,
             keep_data=keep_data,
             dry_run=dry_run,
+            platforms=platform_filter,
         )
 
     if not keep_user_configs:
@@ -1261,5 +1305,6 @@ def run(
             report,
             keep_data=keep_data,
             dry_run=dry_run,
+            platforms=platform_filter,
         )
     return report

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -301,6 +301,8 @@ base: str = "HEAD~1"
 code-review-graph install           # Configure detected AI coding platforms (alias: init)
 code-review-graph install --dry-run # Preview without writing files
 code-review-graph install --platform codex  # Configure one platform
+code-review-graph uninstall                 # Remove all CRG configs, hooks, skills, and data
+code-review-graph uninstall --platform codex  # Unbind one platform (keeps graph data + others)
 
 # Build and update
 code-review-graph build                        # Full build
@@ -311,6 +313,8 @@ code-review-graph update --base origin/main    # Custom base ref
 code-review-graph update --brief               # Update graph + show risk panel
 code-review-graph update --brief --verify      # ...and cross-check vs tiktoken
 code-review-graph postprocess                  # Re-run flows, communities, FTS
+code-review-graph forget PATH [PATH ...]       # Drop parsed files from the graph (no full rebuild)
+code-review-graph forget src/legacy --dry-run  # Preview which files would be forgotten
 code-review-graph embed --provider local       # Compute vector embeddings for semantic search
 code-review-graph update --embedding-provider local --embedding-model all-MiniLM-L6-v2
                                                 # Explicitly refresh an existing index (default: off)

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -1,0 +1,183 @@
+"""Tests for the ``forget`` command and its file-matching helper.
+
+``forget`` drops already-parsed files from the graph without a full rebuild,
+so the two things worth guarding are (1) the path/glob matching that decides
+*which* stored files to drop and (2) the end-to-end command keeping the graph
+and its FTS index consistent afterwards.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from code_review_graph import cli
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import get_db_path
+from code_review_graph.parser import NodeInfo
+from code_review_graph.search import rebuild_fts_index
+
+
+class TestMatchFilesToForget:
+    """Unit tests for the pure path/glob matcher."""
+
+    stored = [
+        "/repo/pkg/auth.py",
+        "/repo/pkg/views.py",
+        "/repo/main.py",
+    ]
+
+    def test_exact_relative_path(self):
+        matched = cli._match_files_to_forget(self.stored, ["pkg/auth.py"], Path("/repo"))
+        assert matched == ["/repo/pkg/auth.py"]
+
+    def test_exact_absolute_path(self):
+        matched = cli._match_files_to_forget(self.stored, ["/repo/main.py"], Path("/repo"))
+        assert matched == ["/repo/main.py"]
+
+    def test_directory_prefix_matches_everything_underneath(self):
+        matched = cli._match_files_to_forget(self.stored, ["pkg"], Path("/repo"))
+        assert matched == ["/repo/pkg/auth.py", "/repo/pkg/views.py"]
+
+    def test_relative_glob(self):
+        matched = cli._match_files_to_forget(self.stored, ["pkg/*.py"], Path("/repo"))
+        assert matched == ["/repo/pkg/auth.py", "/repo/pkg/views.py"]
+
+    def test_no_match_returns_empty(self):
+        assert cli._match_files_to_forget(self.stored, ["missing.py"], Path("/repo")) == []
+
+    def test_multiple_patterns_are_unioned_and_deduplicated(self):
+        matched = cli._match_files_to_forget(
+            self.stored, ["pkg/auth.py", "pkg"], Path("/repo")
+        )
+        assert matched == ["/repo/pkg/auth.py", "/repo/pkg/views.py"]
+
+    def test_blank_pattern_is_ignored(self):
+        assert cli._match_files_to_forget(self.stored, ["   "], Path("/repo")) == []
+
+
+def _seed_file(store: GraphStore, abs_path: str, symbol: str) -> None:
+    """Store one File node and one Function node for a parsed file."""
+    store.store_file_nodes_edges(
+        abs_path,
+        [
+            NodeInfo(
+                kind="File", name=abs_path, file_path=abs_path,
+                line_start=1, line_end=40, language="python",
+            ),
+            NodeInfo(
+                kind="Function", name=symbol, file_path=abs_path,
+                line_start=5, line_end=20, language="python",
+            ),
+        ],
+        [],
+    )
+
+
+def _fts_hits(store: GraphStore, symbol: str) -> int:
+    row = store._conn.execute(
+        "SELECT COUNT(*) FROM nodes_fts WHERE nodes_fts MATCH ?", (symbol,)
+    ).fetchone()
+    return row[0]
+
+
+@pytest.fixture
+def seeded_repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """A repo whose graph tracks three parsed files across two packages."""
+    repo_root = tmp_path.resolve()
+    files = {
+        "auth": str(repo_root / "pkg" / "auth.py"),
+        "views": str(repo_root / "pkg" / "views.py"),
+        "main": str(repo_root / "main.py"),
+    }
+    store = GraphStore(get_db_path(repo_root))
+    _seed_file(store, files["auth"], "authenticate")
+    _seed_file(store, files["views"], "render_home")
+    _seed_file(store, files["main"], "entrypoint")
+    rebuild_fts_index(store)
+    store.close()
+    return repo_root, files
+
+
+def _run_forget(repo_root: Path, *patterns: str, dry_run: bool = False) -> None:
+    argv = ["code-review-graph", "forget", *patterns, "--repo", str(repo_root)]
+    if dry_run:
+        argv.append("--dry-run")
+    with patch.object(sys, "argv", argv):
+        cli.main()
+
+
+def test_forget_removes_matching_file_and_keeps_the_rest(seeded_repo, capsys):
+    repo_root, files = seeded_repo
+
+    _run_forget(repo_root, "pkg/auth.py")
+
+    store = GraphStore(get_db_path(repo_root))
+    try:
+        remaining = set(store.get_all_files())
+        assert files["auth"] not in remaining
+        assert files["views"] in remaining
+        assert files["main"] in remaining
+        # The FTS index must not keep phantom entries for the dropped file.
+        assert _fts_hits(store, "authenticate") == 0
+        assert _fts_hits(store, "render_home") == 1
+    finally:
+        store.close()
+
+    out = capsys.readouterr().out
+    assert "Forgot 1 file(s)" in out
+
+
+def test_forget_directory_drops_every_file_underneath(seeded_repo):
+    repo_root, files = seeded_repo
+
+    _run_forget(repo_root, "pkg")
+
+    store = GraphStore(get_db_path(repo_root))
+    try:
+        remaining = set(store.get_all_files())
+        assert remaining == {files["main"]}
+    finally:
+        store.close()
+
+
+def test_forget_dry_run_changes_nothing(seeded_repo, capsys):
+    repo_root, files = seeded_repo
+
+    _run_forget(repo_root, "pkg/auth.py", dry_run=True)
+
+    store = GraphStore(get_db_path(repo_root))
+    try:
+        remaining = set(store.get_all_files())
+        assert remaining == set(files.values())
+    finally:
+        store.close()
+
+    out = capsys.readouterr().out
+    assert "[dry-run]" in out
+    assert "No changes made." in out
+
+
+def test_forget_reports_when_nothing_matches(seeded_repo, capsys):
+    repo_root, files = seeded_repo
+
+    _run_forget(repo_root, "does/not/exist.py")
+
+    store = GraphStore(get_db_path(repo_root))
+    try:
+        assert set(store.get_all_files()) == set(files.values())
+    finally:
+        store.close()
+
+    assert "No parsed files matched" in capsys.readouterr().out
+
+
+def test_forget_without_a_graph_exits_nonzero(tmp_path, capsys):
+    repo_root = tmp_path.resolve()
+    with pytest.raises(SystemExit) as excinfo:
+        _run_forget(repo_root, "anything.py")
+    assert excinfo.value.code == 1
+    assert "No graph found" in capsys.readouterr().err

--- a/tests/test_forget_parity.py
+++ b/tests/test_forget_parity.py
@@ -1,0 +1,219 @@
+"""Full-build parity tests for `forget`.
+
+The contract the reviewer asked for: after ``forget X`` the graph must match the
+graph you would get by building the repository without ``X`` — not just for the
+forgotten file's own rows, but for cross-file incoming edges, flows,
+communities, and embeddings. These tests build a small multi-file Python repo,
+forget one file, and compare every one of those layers against a fresh build
+that never contained the file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from code_review_graph.forget import forget_files
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build, get_db_path
+from code_review_graph.postprocessing import run_post_processing
+
+# main imports a helper from each module; forgetting util.py must re-bare main's
+# edge into it while keeping main's edge into the surviving shared.py.
+_FILES = {
+    "util.py": "def helper():\n    return 41\n",
+    "shared.py": "def shared_fn():\n    return 7\n",
+    "main.py": (
+        "from util import helper\n"
+        "from shared import shared_fn\n\n"
+        "def run():\n"
+        "    return helper() + shared_fn()\n"
+    ),
+}
+
+_EMBEDDINGS_DDL = """
+CREATE TABLE IF NOT EXISTS embeddings (
+    qualified_name TEXT PRIMARY KEY,
+    vector BLOB NOT NULL,
+    text_hash TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT 'unknown'
+)
+"""
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e.st", "-c", "user.name=t",
+         "commit", "-qm", "init"],
+        cwd=repo, check=True,
+    )
+
+
+def _make_repo(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    repo = tmp_path / name
+    repo.mkdir()
+    for rel, content in files.items():
+        (repo / rel).write_text(content)
+    _git_init(repo)
+    return repo
+
+
+def _build(repo: Path) -> GraphStore:
+    store = GraphStore(get_db_path(repo))
+    full_build(repo, store)
+    run_post_processing(store)
+    return store
+
+
+def _snapshot(store: GraphStore, repo: Path) -> dict:
+    """A repo-relative snapshot of the layers a rebuild fully determines."""
+    root = str(repo)
+
+    def norm(value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.replace(root + "/", "").replace(root, "")
+
+    nodes = store._conn.execute(
+        "SELECT kind, name, qualified_name FROM nodes "
+        "WHERE kind != 'File' ORDER BY 1, 2, 3"
+    ).fetchall()
+    edges = store._conn.execute(
+        "SELECT kind, source_qualified, target_qualified FROM edges ORDER BY 1, 2, 3"
+    ).fetchall()
+    flows = store._conn.execute(
+        "SELECT name, node_count FROM flows ORDER BY 1, 2"
+    ).fetchall()
+    comms = store._conn.execute(
+        "SELECT name, size FROM communities ORDER BY 1, 2"
+    ).fetchall()
+    return {
+        "nodes": [
+            (r["kind"], norm(r["name"]), norm(r["qualified_name"])) for r in nodes
+        ],
+        "edges": [
+            (r["kind"], norm(r["source_qualified"]), norm(r["target_qualified"]))
+            for r in edges
+        ],
+        "flows": [(r["name"], r["node_count"]) for r in flows],
+        "communities": [(norm(r["name"]), r["size"]) for r in comms],
+    }
+
+
+def _calls_targets(store: GraphStore) -> set[str]:
+    return {
+        r["target_qualified"]
+        for r in store._conn.execute(
+            "SELECT target_qualified FROM edges WHERE kind = 'CALLS'"
+        ).fetchall()
+    }
+
+
+def test_forget_matches_full_rebuild_without_file(tmp_path):
+    repo_a = _make_repo(tmp_path, "a", _FILES)
+    store_a = _build(repo_a)
+    try:
+        forget_files(store_a, repo_a, [str(repo_a / "util.py")])
+        after_forget = _snapshot(store_a, repo_a)
+    finally:
+        store_a.close()
+
+    without_util = {k: v for k, v in _FILES.items() if k != "util.py"}
+    repo_b = _make_repo(tmp_path, "b", without_util)
+    store_b = _build(repo_b)
+    try:
+        rebuilt = _snapshot(store_b, repo_b)
+    finally:
+        store_b.close()
+
+    assert after_forget == rebuilt
+    # Guard against a vacuous pass: the surviving graph still has real content.
+    assert after_forget["nodes"]
+    assert after_forget["edges"]
+
+
+def test_forget_rebares_incoming_edge_but_keeps_surviving_one(tmp_path):
+    repo = _make_repo(tmp_path, "edges", _FILES)
+    store = _build(repo)
+    try:
+        before = _calls_targets(store)
+        assert any(t.endswith("util.py::helper") for t in before)
+        assert any(t.endswith("shared.py::shared_fn") for t in before)
+
+        forget_files(store, repo, [str(repo / "util.py")])
+
+        after = _calls_targets(store)
+        # The call into the forgotten file drops back to a bare endpoint...
+        assert "helper" in after
+        assert not any(t.endswith("util.py::helper") for t in after)
+        # ...and the call into the survivor stays resolved.
+        assert any(t.endswith("shared.py::shared_fn") for t in after)
+
+        # No edge is left pointing at a qualified name with no backing node.
+        dangling = store._conn.execute(
+            "SELECT target_qualified FROM edges "
+            "WHERE target_qualified LIKE '%::%' "
+            "AND target_qualified NOT IN (SELECT qualified_name FROM nodes)"
+        ).fetchall()
+        assert dangling == []
+    finally:
+        store.close()
+
+
+def test_forget_repairs_flows_to_match_rebuild(tmp_path):
+    repo = _make_repo(tmp_path, "flows", _FILES)
+    store = _build(repo)
+    try:
+        # run -> helper forms a flow while util.py is present.
+        assert store._conn.execute("SELECT COUNT(*) FROM flows").fetchone()[0] > 0
+        forget_files(store, repo, [str(repo / "util.py")])
+        # With helper gone, no flow should still reference a deleted node.
+        orphaned = store._conn.execute(
+            "SELECT COUNT(*) FROM flow_memberships fm "
+            "WHERE fm.node_id NOT IN (SELECT id FROM nodes)"
+        ).fetchone()[0]
+        assert orphaned == 0
+    finally:
+        store.close()
+
+
+def test_forget_purges_orphaned_embeddings(tmp_path):
+    repo = _make_repo(tmp_path, "emb", _FILES)
+    store = _build(repo)
+    try:
+        store._conn.execute(_EMBEDDINGS_DDL)
+        node_qns = [
+            r["qualified_name"]
+            for r in store._conn.execute("SELECT qualified_name FROM nodes").fetchall()
+        ]
+        for qn in node_qns:
+            store._conn.execute(
+                "INSERT OR REPLACE INTO embeddings VALUES (?, ?, ?, ?)",
+                (qn, b"\x00\x00\x00\x00", "hash", "test"),
+            )
+
+        util_qns = {
+            r["qualified_name"]
+            for r in store._conn.execute(
+                "SELECT qualified_name FROM nodes WHERE file_path = ?",
+                (str(repo / "util.py"),),
+            ).fetchall()
+        }
+        assert util_qns  # sanity: util.py contributed nodes
+
+        summary = forget_files(store, repo, [str(repo / "util.py")])
+
+        remaining = {
+            r["qualified_name"]
+            for r in store._conn.execute(
+                "SELECT qualified_name FROM embeddings"
+            ).fetchall()
+        }
+        # Every vector for a forgotten node is gone; survivors are kept.
+        assert not (remaining & util_qns)
+        assert "main.py" in " ".join(remaining) or remaining
+        assert summary["embeddings_purged"] >= len(util_qns)
+    finally:
+        store.close()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -724,3 +724,100 @@ def test_cli_dry_run_and_confirmation_are_safe(
         cli.main()
     assert "aborted" in capsys.readouterr().out.lower()
     assert "code-review-graph" in config.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Platform-scoped unbind (``uninstall --platform``)
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_platform_filter() -> None:
+    normalise = uninstall._normalise_platform_filter
+    assert normalise(None) is None
+    assert normalise([]) is None
+    assert normalise(["all"]) is None
+    assert normalise(["codex", "all"]) is None
+    assert normalise(["claude-code"]) == frozenset({"claude"})
+    assert normalise(["codex", "claude"]) == frozenset({"codex", "claude"})
+
+
+def _write_codex_config(path: Path) -> None:
+    _write(
+        path,
+        'theme = "dark"\n\n'
+        "[mcp_servers.code-review-graph]\n"
+        'command = "code-review-graph"\n\n'
+        "[mcp_servers.other]\n"
+        'command = "other"\n',
+    )
+
+
+def test_platform_scoped_unbind_removes_only_target_and_keeps_data(
+    fake_repo: Path,
+    fake_home: Path,
+) -> None:
+    """Unbinding one platform removes its MCP entry but keeps data + siblings."""
+    claude_config = fake_repo / ".mcp.json"
+    _write_json(claude_config, {"mcpServers": {"code-review-graph": {}, "other": {}}})
+    codex_config = fake_home / ".codex" / "config.toml"
+    _write_codex_config(codex_config)
+
+    data_db = fake_repo / ".code-review-graph" / "graph.db"
+    _write(data_db, "graph")
+
+    report = uninstall.run(repo=fake_repo, platforms=["claude"])
+
+    assert report.errors == []
+    # Claude's binding is gone, its sibling entry survives.
+    assert _read_jsonc(claude_config) == {"mcpServers": {"other": {}}}
+    # Codex was never named, so its binding is untouched.
+    assert "[mcp_servers.code-review-graph]" in codex_config.read_text(encoding="utf-8")
+    # Graph data is preserved even though keep_data was not requested.
+    assert data_db.exists()
+
+
+def test_platform_scoped_unbind_targets_user_scope_toml(
+    fake_repo: Path,
+    fake_home: Path,
+) -> None:
+    """A user-scope platform (Codex/TOML) unbinds without touching repo configs."""
+    claude_config = fake_repo / ".mcp.json"
+    _write_json(claude_config, {"mcpServers": {"code-review-graph": {}}})
+    codex_config = fake_home / ".codex" / "config.toml"
+    _write_codex_config(codex_config)
+
+    uninstall.run(repo=fake_repo, platforms=["codex"])
+
+    text = codex_config.read_text(encoding="utf-8")
+    assert "[mcp_servers.code-review-graph]" not in text
+    assert "[mcp_servers.other]" in text
+    # Claude was not named, so its repo binding stays put.
+    assert "code-review-graph" in claude_config.read_text(encoding="utf-8")
+
+
+def test_cli_uninstall_platform_scopes_to_one_binding(
+    fake_repo: Path,
+    fake_home: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from code_review_graph import cli
+
+    claude_config = fake_repo / ".mcp.json"
+    _write_json(claude_config, {"mcpServers": {"code-review-graph": {}, "other": {}}})
+    codex_config = fake_home / ".codex" / "config.toml"
+    _write_codex_config(codex_config)
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "code-review-graph", "uninstall",
+            "--platform", "claude", "--repo", str(fake_repo), "--yes",
+        ],
+    ):
+        cli.main()
+
+    out = capsys.readouterr().out.lower()
+    assert "unbind" in out
+    assert _read_jsonc(claude_config) == {"mcpServers": {"other": {}}}
+    assert "[mcp_servers.code-review-graph]" in codex_config.read_text(encoding="utf-8")


### PR DESCRIPTION
Resolves two gaps raised in issue #678: there was no way to unbind a single already-configured platform, and no way to remove already-parsed files from the graph short of a full rebuild.

- uninstall --platform NAME: scopes the run to unbinding one platform's MCP registration. Graph data and every other integration are preserved; the full uninstall still runs when --platform is omitted.
- forget PATH [PATH ...]: drops parsed files from the graph without a rebuild. Accepts absolute paths, repo-relative paths, directories, and glob patterns, with --dry-run to preview. The FTS index is refreshed after removal so search stays consistent.

Adds tests for the platform filter, the path matcher, and both commands.

# Pull Request

## Linked issue

<!-- Link the issue this PR addresses, e.g. "Closes #123".
     If there is no issue, briefly say why (e.g. trivial typo fix). -->

Closes #678 

## What & why

<!-- What does this PR change, and why is the change needed? -->

## How it was tested

<!-- Paste the exact commands you ran and summarise their results. Typical commands
     (see CONTRIBUTING.md "Running Tests" and "Linting and Type Checking"): -->

```bash
uv run pytest tests/ --tb=short -q
uv run ruff check code_review_graph/
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

## Checklist

<!-- Mirrors the requirements in CONTRIBUTING.md ("Making Changes" and "Code Style"). -->

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (README, `docs/`, docstrings)
