### PR TITLE
Fix incremental update leaving stale nodes after a file rename

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -534,9 +534,37 @@ _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
 _SAFE_SVN_REV = re.compile(r"^r?\d+(:r?\d+|:HEAD|:BASE|:COMMITTED)?$", re.IGNORECASE)
 
 
-def _decode_nul_paths(output: bytes) -> list[str]:
-    """Decode Git's NUL-delimited path output without quote mangling."""
-    return [os.fsdecode(path) for path in output.split(b"\0") if path]
+def _parse_name_status_z(output: bytes) -> list[str]:
+    """Decode ``git diff --name-status -z`` output to a list of changed paths.
+
+    Unlike ``--name-only``, ``--name-status`` distinguishes renames/copies. Its
+    ``-z`` records are NUL-separated fields: ``<status>`` then the path(s).
+    A rename/copy (``R``/``C``) emits ``<status>\\0<old>\\0<new>``; every other
+    status emits ``<status>\\0<path>``.
+
+    Both the old *and* new path of a rename are returned, so the old path is
+    seen by :func:`incremental_update` and purged when it no longer exists on
+    disk — keeping an incremental update equivalent to a full rebuild (a plain
+    ``--name-only`` diff reports only the new path, leaving the old file's nodes
+    and edges stale).
+    """
+    fields = [os.fsdecode(f) for f in output.split(b"\0") if f]
+    paths: list[str] = []
+    i = 0
+    n = len(fields)
+    while i < n:
+        status = fields[i]
+        i += 1
+        # Rename (R) and copy (C) statuses carry a similarity score (e.g. "R100")
+        # and are followed by TWO paths (old, new); all others by a single path.
+        if status[:1] in ("R", "C") and i + 1 < n:
+            paths.append(fields[i])      # old path (renamed away / copy source)
+            paths.append(fields[i + 1])  # new path
+            i += 2
+        elif i < n:
+            paths.append(fields[i])
+            i += 1
+    return paths
 
 
 def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
@@ -572,7 +600,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         return []
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "-z", base, "--"],
+            ["git", "diff", "--name-status", "-z", base, "--"],
             capture_output=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -581,7 +609,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
             result = subprocess.run(
-                ["git", "diff", "--name-only", "-z", "--cached"],
+                ["git", "diff", "--name-status", "-z", "--cached"],
                 capture_output=True,
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
@@ -590,7 +618,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         if result.returncode != 0:
             logger.warning("git diff failed while discovering changed files")
             return []
-        return _decode_nul_paths(result.stdout)
+        return _parse_name_status_z(result.stdout)
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -525,9 +525,10 @@ class TestIsBinary:
 class TestGitOperations:
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_changed_files(self, mock_run, tmp_path):
+        # --name-status -z output: each record is <status>\0<path>[\0<path2>].
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=b"src/a.py\0src/b.py\0",
+            stdout=b"M\0src/a.py\0A\0src/b.py\0",
         )
         result = get_changed_files(tmp_path)
         assert result == ["src/a.py", "src/b.py"]
@@ -535,15 +536,28 @@ class TestGitOperations:
         call_args = mock_run.call_args
         assert "git" in call_args[0][0]
         assert "-z" in call_args[0][0]
+        # Renames must be detectable, so --name-status (not --name-only) is used.
+        assert "--name-status" in call_args[0][0]
         assert call_args[1].get("timeout") == 30
         assert "text" not in call_args[1]
+
+    @patch("code_review_graph.incremental.subprocess.run")
+    def test_get_changed_files_reports_both_rename_paths(self, mock_run, tmp_path):
+        # A rename (R<score>) carries BOTH the old and new path; both must be
+        # returned so the old path's stale nodes/edges get purged downstream.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=b"R100\0old/a.py\0new/b.py\0M\0keep.py\0",
+        )
+        result = get_changed_files(tmp_path)
+        assert result == ["old/a.py", "new/b.py", "keep.py"]
 
     @patch("code_review_graph.incremental.subprocess.run")
     def test_get_changed_files_fallback(self, mock_run, tmp_path):
         # First call fails, second succeeds
         mock_run.side_effect = [
             MagicMock(returncode=1, stdout=b""),
-            MagicMock(returncode=0, stdout=b"staged.py\0"),
+            MagicMock(returncode=0, stdout=b"A\0staged.py\0"),
         ]
         result = get_changed_files(tmp_path)
         assert result == ["staged.py"]

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -233,6 +233,52 @@ def test_incremental_update_real_git(git_repo: Path) -> None:
         Path(db_path).unlink(missing_ok=True)
 
 
+def test_incremental_update_purges_renamed_source(tmp_path: Path) -> None:
+    """A committed rename must leave the graph equal to a full rebuild.
+
+    Regression: ``git diff --name-only`` reports only the *new* path of a
+    rename, so the old file's nodes/edges survived an incremental update while
+    a full rebuild dropped them. ``--name-status`` reports both paths, letting
+    the incremental purge remove the old path.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+
+    (repo / "a.py").write_text("def foo():\n    return 1\n")
+    _git(repo, "add", "a.py")
+    _git(repo, "commit", "-m", "add a.py")
+
+    # Full build with a.py on disk.
+    inc_store = GraphStore(str(tmp_path / "inc.db"))
+    full_build(repo, inc_store)
+    assert inc_store.get_nodes_by_file(str(repo / "a.py")), "a.py should be indexed"
+
+    # Rename a.py -> b.py and commit.
+    assert _git(repo, "mv", "a.py", "b.py").returncode == 0
+    _git(repo, "commit", "-m", "rename a.py to b.py")
+
+    # Incremental update across the rename (base defaults to HEAD~1).
+    incremental_update(repo, inc_store)
+
+    # The renamed-away source must be fully purged; the new path must exist.
+    assert inc_store.get_nodes_by_file(str(repo / "a.py")) == []
+    assert inc_store.get_nodes_by_file(str(repo / "b.py"))
+
+    # Incremental result must equal a fresh full rebuild of the post-rename tree.
+    full_store = GraphStore(str(tmp_path / "full.db"))
+    full_build(repo, full_store)
+
+    assert set(inc_store.get_all_files()) == set(full_store.get_all_files())
+    assert inc_store.get_stats().total_nodes == full_store.get_stats().total_nodes
+    assert inc_store.get_stats().total_edges == full_store.get_stats().total_edges
+
+    inc_store.close()
+    full_store.close()
+
+
 # ------------------------------------------------------------------
 # 4. base ref injection is rejected
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue

Closes #684

## What & why

`get_changed_files()` discovered changes with `git diff --name-only`, which reports a rename `a.py → b.py` as **only the new path** `b.py`. `incremental_update()` therefore never saw `a.py`, and its purge loop only removes paths that are in the changed/dependent set **and** missing on disk — the old path is in neither. Unlike `full_build()` (which purges `existing_files - current_abs`), the incremental path had no "purge files no longer on disk" step, so the renamed-away file's File/Function/Class nodes and every edge keyed to it survived. The incremental graph diverged from a full rebuild.

This switches change discovery to `git diff --name-status -z` and adds `_parse_name_status_z()`, which emits **both** the old and new path for rename/copy (`R`/`C`) records. The old path then flows through the existing purge loop and is removed, so an incremental update again equals a full rebuild. The `--cached` fallback branch gets the same treatment. The now-unused `_decode_nul_paths()` helper is removed.

## How it was tested

```bash
uv run pytest tests/test_incremental.py tests/test_integration_git.py -q   # 85 passed
uv run pytest tests/ --tb=short -q   # 1962 passed (1 pre-existing Windows/py3.14 failure, unrelated)
uv run ruff check code_review_graph/
uv run mypy code_review_graph/incremental.py --ignore-missing-imports --no-strict-optional   # Success
```

New tests (both fail on `main`, pass here):
- `test_incremental.py::TestGitOperations::test_get_changed_files_reports_both_rename_paths` — unit test of the name-status parser.
- `test_integration_git.py::test_incremental_update_purges_renamed_source` — real-git test asserting the renamed-away source is purged and node/edge/file counts match a fresh `full_build`.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q` (one pre-existing, unrelated Windows/py3.14 failure)
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/incremental.py --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (docstrings on the new/changed functions)
