### PR TITLE
Fix Temporal resolver never reaching the concrete implementation

### DIFF
--- a/code_review_graph/temporal_resolver.py
+++ b/code_review_graph/temporal_resolver.py
@@ -168,7 +168,12 @@ def resolve_temporal_calls(store: GraphStore) -> dict:
 
         interface_qual = temporal_interfaces.get(interface_bare, interface_bare)
 
-        impls = implementors.get(interface_qual, [])
+        # ``implementors`` is keyed by the bare interface name (INHERITS'
+        # target_qualified is bare for Java), so look it up with the bare name.
+        # Using ``interface_qual`` (the fully-qualified name) never matches, so
+        # the ``len(impls) == 1`` branch was dead and every stub call resolved
+        # to the interface method instead of the concrete implementation.
+        impls = implementors.get(interface_bare, [])
         if len(impls) == 1:
             concrete_class = impls[0].split("::")[-1]
             fallback = f"{impls[0]}.{method_name}"

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -2783,6 +2783,27 @@ class TestTemporalResolver:
                 f"Resolved target should be qualified, got: {target!r}"
             )
 
+    def test_resolved_target_is_concrete_impl_not_interface(self, tmp_path):
+        # paymentActivity.charge(...) has a single implementor, so it must
+        # resolve to PaymentActivityImpl.charge, not the interface method
+        # PaymentActivity.charge. Regression: implementors was keyed by the
+        # bare interface name but looked up by the qualified name, so the
+        # unique-implementor branch was dead and every stub call resolved to
+        # the interface.
+        store, _ = self._build(tmp_path)
+        rows = store._conn.execute(
+            "SELECT target_qualified FROM edges WHERE kind='CALLS' "
+            "AND extra LIKE '%temporal_resolved%'"
+        ).fetchall()
+        targets = [t for (t,) in rows]
+        assert targets, "Expected at least one temporal-resolved CALLS edge"
+        assert any(t.endswith("PaymentActivityImpl.charge") for t in targets), (
+            f"Expected resolution to the concrete impl, got: {targets!r}"
+        )
+        assert not any(t.endswith("PaymentActivity.charge") for t in targets), (
+            f"Should not resolve to the interface method, got: {targets!r}"
+        )
+
 
 class TestKafkaParsing:
     """Tests for Kafka CONSUMES / PRODUCES edge detection."""


### PR DESCRIPTION
## Linked issue

Closes #685

## What & why

`resolve_temporal_calls()` builds `implementors` keyed by the **bare** interface name (Java `INHERITS.target_qualified` is bare) but looked it up with `interface_qual`, the fully-qualified name. Because `interface_qual` is always the qualified form, `implementors.get(interface_qual, [])` always returned `[]`, the `len(impls) == 1` branch was dead, and every Temporal stub call resolved to the **interface** method instead of the unique concrete implementation. `callers_of()` and impact analysis through the real implementation returned nothing.

This looks up `implementors` with the bare interface name — matching how it is keyed, and how the sibling Spring resolver already works.

## How it was tested

```bash
uv run pytest tests/test_multilang.py -q -k Temporal   # 14 passed
uv run pytest tests/ --tb=short -q   # 1961 passed (1 pre-existing Windows/py3.14 failure, unrelated)
uv run ruff check code_review_graph/
uv run mypy code_review_graph/temporal_resolver.py --ignore-missing-imports --no-strict-optional   # Success
```

New test (fails on `main`, passes here):
- `test_multilang.py::TestTemporalResolver::test_resolved_target_is_concrete_impl_not_interface` — asserts a single-implementor stub call resolves to `PaymentActivityImpl.charge`, not the interface `PaymentActivity.charge`.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q` (one pre-existing, unrelated Windows/py3.14 failure)
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/temporal_resolver.py --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (explanatory comment at the fix site)
