### PR TITLE
fix(embeddings): default to OpenAI provider when env vars are configured (#551)

### DIFF
--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -681,6 +681,13 @@ def get_provider(
             "Valid: local, openai, google, minimax"
         )
 
+    # When no explicit provider is given but OpenAI-compatible env vars are
+    # configured, default to the openai provider so MCP tool calls that omit
+    # the optional `provider` parameter still use the configured backend
+    # (#551).
+    if not name and os.environ.get("CRG_OPENAI_API_KEY") and os.environ.get("CRG_OPENAI_BASE_URL"):
+        name = "openai"
+
     if name == "openai":
         api_key = os.environ.get("CRG_OPENAI_API_KEY")
         base_url = os.environ.get("CRG_OPENAI_BASE_URL")

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -654,9 +654,11 @@ def get_provider(
 
     Args:
         provider: Provider name. One of "local", "google", "minimax", "openai",
-                  or None for local. Names are case-insensitive and surrounding
-                  whitespace is ignored; unknown names raise ValueError instead
-                  of silently falling back to the local provider.
+                  or None. When omitted, configured OpenAI-compatible
+                  credentials select OpenAI; otherwise the local provider is
+                  used. Names are case-insensitive and surrounding whitespace
+                  is ignored; unknown names raise ValueError instead of
+                  silently falling back to the local provider.
                   Google requires GOOGLE_API_KEY env var and explicit opt-in.
                   MiniMax requires MINIMAX_API_KEY env var and explicit opt-in.
                   OpenAI requires CRG_OPENAI_API_KEY + CRG_OPENAI_BASE_URL +
@@ -685,7 +687,11 @@ def get_provider(
     # configured, default to the openai provider so MCP tool calls that omit
     # the optional `provider` parameter still use the configured backend
     # (#551).
-    if not name and os.environ.get("CRG_OPENAI_API_KEY") and os.environ.get("CRG_OPENAI_BASE_URL"):
+    if (
+        provider is None
+        and os.environ.get("CRG_OPENAI_API_KEY")
+        and os.environ.get("CRG_OPENAI_BASE_URL")
+    ):
         name = "openai"
 
     if name == "openai":

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -237,6 +237,28 @@ class TestGetProviderValidation:
         assert get_provider("") is mock_cls.return_value
         assert get_provider("   ") is mock_cls.return_value
 
+    @patch("code_review_graph.embeddings.OpenAIEmbeddingProvider")
+    def test_none_defaults_to_openai_when_env_configured(self, mock_cls):
+        """When provider is omitted but OpenAI env vars are set, default to
+        the OpenAI-compatible provider instead of local (#551)."""
+        mock_cls.return_value = MagicMock()
+        env = {
+            "CRG_OPENAI_API_KEY": "fake-key",
+            "CRG_OPENAI_BASE_URL": "http://localhost:11434/v1",
+            "CRG_OPENAI_MODEL": "nomic-embed-text",
+            "CRG_ACCEPT_CLOUD_EMBEDDINGS": "1",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            provider = get_provider(None)
+        assert provider is mock_cls.return_value
+        mock_cls.assert_called_once_with(
+            api_key="fake-key",
+            base_url="http://localhost:11434/v1",
+            model="nomic-embed-text",
+            dimension=None,
+            batch_size=None,
+        )
+
 
 class TestGetProviderModel:
     """Tests for model parameter in get_provider()."""

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -259,6 +259,24 @@ class TestGetProviderValidation:
             batch_size=None,
         )
 
+    @patch("code_review_graph.embeddings.OpenAIEmbeddingProvider")
+    @patch("code_review_graph.embeddings.LocalEmbeddingProvider")
+    @patch("code_review_graph.embeddings._check_available", return_value=True)
+    def test_explicit_blank_stays_local_when_openai_env_configured(
+        self, _mock_available, local_cls, openai_cls,
+    ):
+        """Only an omitted provider should use the configured OpenAI default."""
+        local_cls.return_value = MagicMock()
+        env = {
+            "CRG_OPENAI_API_KEY": "fake-key",
+            "CRG_OPENAI_BASE_URL": "http://localhost:11434/v1",
+            "CRG_OPENAI_MODEL": "nomic-embed-text",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert get_provider("") is local_cls.return_value
+            assert get_provider("   ") is local_cls.return_value
+        openai_cls.assert_not_called()
+
 
 class TestGetProviderModel:
     """Tests for model parameter in get_provider()."""


### PR DESCRIPTION
## Summary
Fixes #551. When `provider` is omitted from `get_provider()` (the default for MCP tool calls like `semantic_search_nodes`), the function used to fall straight back to the local sentence-transformers provider even when `CRG_OPENAI_API_KEY` and `CRG_OPENAI_BASE_URL` were configured. This made OpenAI-compatible embeddings (e.g., Ollama, vLLM, LocalAI, LiteLLM) unreachable from AI assistants unless they explicitly passed `provider="openai"`.

## Problem
`semantic_search_nodes` and other callers that omit `provider` relied on `EmbeddingStore` forwarding `provider=None` to `get_provider()`. That path immediately dropped to the local default without checking whether OpenAI env vars were present, so configured cloud/local OpenAI endpoints were ignored.

## Solution
- After normalizing the provider name in `get_provider()`, if no explicit provider was given and both `CRG_OPENAI_API_KEY` and `CRG_OPENAI_BASE_URL` are set, route to the `openai` branch instead of local.
- The existing `openai` branch already validates `CRG_OPENAI_MODEL` and raises a clear `ValueError` if it is missing, so callers get actionable feedback rather than a silent fallback.

## Out of scope
- Did not change behavior when `provider="local"` is explicitly passed; local still wins in that case.
- Did not add defaulting for Google or MiniMax env vars; those require explicit opt-in (`GOOGLE_API_KEY`, `MINIMAX_API_KEY`) and the issue only covered OpenAI-compatible endpoints.
- Did not touch `prewarm_local_embeddings()` startup behavior; that is a separate concern.

## Test plan
- [x] Added `test_none_defaults_to_openai_when_env_configured` to verify `get_provider(None)` returns an `OpenAIEmbeddingProvider` when the OpenAI env vars are set.
- [x] Existing `test_none_and_empty_default_to_local` still passes when no OpenAI env vars are configured.
- [x] `uv run pytest tests/test_embeddings.py -q` — 99 passed.
- [x] `uv run --extra dev ruff check code_review_graph/embeddings.py tests/test_embeddings.py` — all checks passed.
- [ ] Full CI suite on the PR.

## Related
- #551 — `semantic_search_nodes` ignores `CRG_OPENAI_*` env vars when `provider` is not passed

Made with [Cursor](https://cursor.com)