### PR TITLE
Improve Gemini API retry logging

### DIFF
--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -211,18 +211,35 @@ class GoogleEmbeddingProvider(EmbeddingProvider):
     @staticmethod
     def _call_with_retry(fn, max_retries: int = 3):
         """Call fn with exponential backoff on transient API errors."""
+        retryable_statuses = ("429", "500", "503")
         for attempt in range(max_retries):
             try:
                 return fn()
             except Exception as e:
                 # Retry on rate-limit (429) or server errors (5xx)
                 err_str = str(e)
-                is_retryable = "429" in err_str or "500" in err_str or "503" in err_str
-                if not is_retryable or attempt == max_retries - 1:
+                is_retryable = any(status in err_str for status in retryable_statuses)
+                if not is_retryable:
+                    logger.debug("Non-retryable Gemini API error: %s",
+                    type(e).__name__,)
                     raise
+                if attempt == max_retries - 1:
+                    logger.error(
+                        "Gemini API request failed after %d requests.",
+                        max_retries,
+                    )
+                    raise
+
                 wait = 2 ** attempt
-                logger.warning("Gemini API error (attempt %d/%d), retrying in %ds: %s",
-                               attempt + 1, max_retries, wait, e)
+
+                logger.warning("Gemini API retry %d%d in %ds (%s): %s",
+                               attempt + 1,
+                               max_retries,
+                               wait,
+                               type(e).__name__,
+                               e,
+                )
+                
                 time.sleep(wait)
 
     def embed_query(self, text: str) -> list[float]:

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -220,8 +220,10 @@ class GoogleEmbeddingProvider(EmbeddingProvider):
                 err_str = str(e)
                 is_retryable = any(status in err_str for status in retryable_statuses)
                 if not is_retryable:
-                    logger.debug("Non-retryable Gemini API error: %s",
-                    type(e).__name__,)
+                    logger.debug(
+                        "Non-retryable Gemini API error: %s",
+                        type(e).__name__,
+                    )
                     raise
                 if attempt == max_retries - 1:
                     logger.error(
@@ -232,14 +234,15 @@ class GoogleEmbeddingProvider(EmbeddingProvider):
 
                 wait = 2 ** attempt
 
-                logger.warning("Gemini API retry %d%d in %ds (%s): %s",
-                               attempt + 1,
-                               max_retries,
-                               wait,
-                               type(e).__name__,
-                               e,
+                logger.warning(
+                    "Gemini API retry %d/%d in %ds (%s): %s",
+                    attempt + 1,
+                    max_retries,
+                    wait,
+                    type(e).__name__,
+                    e,
                 )
-                
+
                 time.sleep(wait)
 
     def embed_query(self, text: str) -> list[float]:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -10,6 +10,7 @@ import pytest
 from code_review_graph.embeddings import (
     LOCAL_DEFAULT_MODEL,
     EmbeddingStore,
+    GoogleEmbeddingProvider,
     LocalEmbeddingProvider,
     MiniMaxEmbeddingProvider,
     OpenAIEmbeddingProvider,
@@ -187,6 +188,48 @@ class TestLocalEmbeddingProviderModelName:
             provider = LocalEmbeddingProvider()
             assert provider._model_name == "BAAI/bge-small-en-v1.5"
             assert provider.name == "local:BAAI/bge-small-en-v1.5"
+
+
+class TestGoogleEmbeddingProviderRetryLogging:
+    def test_retryable_error_logs_attempt_fraction_then_succeeds(self, caplog):
+        fn = MagicMock(side_effect=[RuntimeError("429 rate limited"), [1.0]])
+
+        with patch("code_review_graph.embeddings.time.sleep") as sleep:
+            result = GoogleEmbeddingProvider._call_with_retry(fn)
+
+        assert result == [1.0]
+        assert fn.call_count == 2
+        sleep.assert_called_once_with(1)
+        assert "Gemini API retry 1/3 in 1s (RuntimeError)" in caplog.text
+
+    def test_non_retryable_error_logs_once_without_sleeping(self, caplog):
+        caplog.set_level("DEBUG")
+        fn = MagicMock(side_effect=ValueError("400 invalid request"))
+
+        with (
+            patch("code_review_graph.embeddings.time.sleep") as sleep,
+            pytest.raises(ValueError, match="400 invalid request"),
+        ):
+            GoogleEmbeddingProvider._call_with_retry(fn)
+
+        fn.assert_called_once_with()
+        sleep.assert_not_called()
+        assert "Non-retryable Gemini API error: ValueError" in caplog.text
+
+    def test_exhausted_retries_log_each_attempt_and_final_error(self, caplog):
+        fn = MagicMock(side_effect=RuntimeError("503 unavailable"))
+
+        with (
+            patch("code_review_graph.embeddings.time.sleep") as sleep,
+            pytest.raises(RuntimeError, match="503 unavailable"),
+        ):
+            GoogleEmbeddingProvider._call_with_retry(fn)
+
+        assert fn.call_count == 3
+        assert [call.args for call in sleep.call_args_list] == [(1,), (2,)]
+        assert "Gemini API retry 1/3 in 1s (RuntimeError)" in caplog.text
+        assert "Gemini API retry 2/3 in 2s (RuntimeError)" in caplog.text
+        assert "Gemini API request failed after 3 requests" in caplog.text
 
 
 class TestGetProviderValidation:


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #699 

## What & why

This PR improves the retry helper used by the Google embedding provider.

### Changes
- Refactored retryable status detection using `any()` over a centralized tuple of retryable status codes.
- Improved retry logging by including the exception type.
- Added debug logging for non-retryable exceptions.
- Preserved the existing retry behavior and exponential backoff logic.

These changes improve the readability and maintainability of `_call_with_retry()` without changing its intended behavior.

## How it was tested

The local development environment has not yet been fully configured, so I was not able to run the project's test suite, linting, or type checking. The change is localized to `_call_with_retry()` and preserves the existing retry semantics.

## Checklist

- [ ] Tests added for new functionality
- [ ] All tests pass: `uv run pytest tests/ --tb=short -q`
- [ ] Linting passes: `uv run ruff check code_review_graph/`
- [ ] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [ ] Docs updated where behaviour changed (README, `docs/`, docstrings)
