### PR TITLE
fix: honor --repo pointing at a module's own .code-review-graph dir

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1162,7 +1162,22 @@ def main() -> None:
         from .incremental import find_project_root, get_db_path
 
         requested_root = Path(args.repo).expanduser() if args.repo else None
-        repo_root = find_project_root(requested_root)
+        if requested_root is not None and (requested_root / ".code-review-graph").is_dir():
+            # An explicit --repo that already has its own .code-review-graph
+            # directory must be honored as-is. This matters for monorepos
+            # with a single .git at the top and independently
+            # build/register-ed modules as subdirectories (each carrying
+            # its own .code-review-graph marker but no .git of their own):
+            # find_project_root() below only walks *up* looking for
+            # .git/.svn, so it would silently climb past the module's own
+            # marker to the monorepo root and miss the graph that was
+            # built right here. build/register/status avoid this via
+            # tools._common._validate_repo_root; do the equivalent here,
+            # scoped to the case where evidence of a real build already
+            # exists at the requested path.
+            repo_root = requested_root.resolve()
+        else:
+            repo_root = find_project_root(requested_root)
         db_path = get_db_path(repo_root)
         if not db_path.exists():
             print(

--- a/tests/test_cli_tool_commands.py
+++ b/tests/test_cli_tool_commands.py
@@ -144,3 +144,38 @@ def test_tool_command_missing_graph_exits_nonzero(tmp_path, monkeypatch, capsys)
 
     assert exc_info.value.code == 1
     assert "No graph found" in capsys.readouterr().err
+
+
+def test_tool_command_honors_repo_flag_over_ancestor_git_in_monorepo(
+    tmp_path, monkeypatch, capsys,
+):
+    """Regression test: a single ``.git`` at a monorepo root must not shadow
+    a module subdirectory's own ``.code-review-graph`` graph when ``--repo``
+    points directly at that module (e.g. ``llvm-project`` with ``llvm/`` and
+    ``clang/`` independently built/registered as CRG projects)."""
+    monorepo = tmp_path / "monorepo"
+    module = monorepo / "llvm"
+    module.mkdir(parents=True)
+    (monorepo / ".git").mkdir()
+
+    # A graph exists for the module itself...
+    module_data = module / ".code-review-graph"
+    module_data.mkdir()
+    (module_data / "graph.db").touch()
+
+    # ...but NOT at the monorepo root, so the buggy resolution (walking up
+    # to the nearest .git) would report "no graph found" there instead.
+    monorepo_data = monorepo / ".code-review-graph"
+    monorepo_data.mkdir()
+
+    argv = ["code-review-graph", "search", "raw_ostream", "--repo", str(module)]
+    result = {"status": "ok", "tool": "semantic_search_nodes"}
+
+    with patch.object(sys, "argv", argv):
+        with patch(
+            "code_review_graph.tools.semantic_search_nodes", return_value=result,
+        ) as tool:
+            cli.main()
+
+    assert json.loads(capsys.readouterr().out) == result
+    tool.assert_called_once_with(repo_root=str(module), query="raw_ostream", kind=None, limit=20)


### PR DESCRIPTION
Fixes #697.

## Problem

`search`/`query`/`impact` (and the rest of `_GRAPH_TOOL_COMMANDS`) resolve an
explicit `--repo` via `find_project_root()`, which only walks *up* looking for
`.git`/`.svn`. In a monorepo with a single `.git` at the root and independently
`build`/`register`-ed module subdirectories (each carrying its own
`.code-review-graph` marker but no `.git` of their own — e.g. `llvm-project`'s
`llvm/` and `clang/`), this silently climbs past the module's own graph to the
monorepo root and reports "No graph found" even though the graph exists
exactly where `--repo` pointed.

## Fix

When `--repo` points directly at a directory that already has its own
`.code-review-graph` subdirectory, honor that path as-is instead of using it
only as a starting point for the upward git-root walk. This mirrors how
`build`/`register`/`status` already treat `.code-review-graph` as sufficient
evidence of a project root via `tools._common._validate_repo_root`.

When `--repo` has no `.code-review-graph` of its own, behavior is unchanged
(falls through to the existing `find_project_root` walk), so the existing
"nested subdirectory of a single repo" case is unaffected.

## Testing

- Added `test_tool_command_honors_repo_flag_over_ancestor_git_in_monorepo`,
  which reproduces the monorepo shape (one `.git` at the top, a module
  subdirectory with its own `.code-review-graph/graph.db`) and asserts
  `search --repo <module>` resolves to `<module>`, not the ancestor with
  `.git`. Verified it fails on `main` and passes with this fix.
- Ran the full test suite locally on Windows before and after the change;
  no new failures (only pre-existing, unrelated Windows-only failures around
  `chmod`/`symlink` privileges and git submodule fixtures remain, present on
  `main` too).
- Verified against the real-world case that surfaced this: a 21-module,
  ~180K-file `llvm-project` checkout built/registered module-by-module with
  CRG, where `search`/`query callers_of`/`impact --files` now return correct
  results with `--repo` pointing at a module (e.g. the largest module,
  `llvm/`, ~80K files).
