### PR TITLE
fix(install): copilot-cli MCP config key (servers → mcpServers) and Copilot instructions path (#616)

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -149,7 +149,10 @@ PLATFORMS: dict[str, dict[str, Any]] = {
     "copilot-cli": {
         "name": "GitHub Copilot CLI",
         "config_path": lambda root: Path.home() / ".copilot" / "mcp-config.json",
-        "key": "servers",
+        # Copilot CLI only reads "mcpServers"; releases before #616 wrote
+        # "servers", which it silently ignores.
+        "key": "mcpServers",
+        "legacy_keys": ("servers",),
         "detect": lambda: (Path.home() / ".copilot").exists(),
         "format": "object",
         "needs_type": True,
@@ -542,8 +545,17 @@ def install_platform_configs(
             arr.append(arr_entry)
             existing[server_key] = arr
         else:
+            # Drop entries older releases wrote under a key the platform never
+            # reads (e.g. Copilot CLI's "servers" vs "mcpServers", #616).
+            migrated = False
+            for legacy_key in plat.get("legacy_keys", ()):
+                legacy = existing.get(legacy_key)
+                if isinstance(legacy, dict) and legacy.pop("code-review-graph", None):
+                    if not legacy:
+                        del existing[legacy_key]
+                    migrated = True
             servers = existing.get(server_key, {})
-            if "code-review-graph" in servers:
+            if "code-review-graph" in servers and not migrated:
                 print(f"  {plat['name']}: already configured in {config_path}")
                 _record_configured(key, plat)
                 continue
@@ -1113,8 +1125,13 @@ cover what you need.
 """
 
 # Maps instruction file path → (marker, section) for files that need content
-# different from the default _CLAUDE_MD_SECTION.
+# different from the default _CLAUDE_MD_SECTION. Includes legacy paths so
+# uninstall can strip sections written by older releases.
 _PLATFORM_INSTRUCTION_CUSTOM_SECTIONS: dict[str, tuple[str, str]] = {
+    ".github/instructions/code-review-graph.instructions.md": (
+        _CLAUDE_MD_SECTION_MARKER,
+        _COPILOT_SECTION,
+    ),
     ".github/code-review-graph.instruction.md": (_CLAUDE_MD_SECTION_MARKER, _COPILOT_SECTION),
 }
 
@@ -1162,9 +1179,40 @@ _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     ".windsurfrules": ("windsurf",),
     "QODER.md": ("qoder",),
     ".kiro/steering/code-review-graph.md": ("kiro",),
-    ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
+    # Copilot (VS Code and CLI) only auto-loads instruction files matching
+    # .github/instructions/**/*.instructions.md (#616).
+    ".github/instructions/code-review-graph.instructions.md": ("copilot", "copilot-cli"),
     "CODEBUDDY.md": ("codebuddy",),
 }
+
+# Superseded locations written by older releases, cleaned up on install so
+# upgrades don't leave stale never-loaded copies behind (#616).
+_LEGACY_PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
+    ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
+}
+
+
+def _remove_legacy_instruction_file(path: Path) -> None:
+    """Strip our injected section from a superseded instruction file.
+
+    Deletes the file when nothing else remains. Files without our marker, or
+    with a section that no longer matches any known release, are left alone.
+    """
+    if not path.exists():
+        return
+    content = path.read_text(encoding="utf-8", errors="replace")
+    if _CLAUDE_MD_SECTION_MARKER not in content:
+        return
+    for section in (_COPILOT_SECTION, _CLAUDE_MD_SECTION):
+        content = content.replace(section, "")
+    if _CLAUDE_MD_SECTION_MARKER in content:
+        return
+    if content.strip():
+        path.write_text(content.rstrip() + "\n", encoding="utf-8")
+        logger.info("Removed legacy instruction section from %s", path)
+    else:
+        path.unlink()
+        logger.info("Removed legacy instruction file %s", path)
 
 
 # --- Gemini CLI hooks + skills (workspace-level: .gemini/) ---
@@ -1373,6 +1421,10 @@ def inject_platform_instructions(repo_root: Path, target: str = "all") -> list[s
             marker, section = _CLAUDE_MD_SECTION_MARKER, _CLAUDE_MD_SECTION
         if _inject_instructions(path, marker, section):
             updated.append(filename)
+    for filename, owners in _LEGACY_PLATFORM_INSTRUCTION_FILES.items():
+        if target != "all" and target not in owners:
+            continue
+        _remove_legacy_instruction_file(repo_root / filename)
     return updated
 
 

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -149,13 +149,16 @@ PLATFORMS: dict[str, dict[str, Any]] = {
     "copilot-cli": {
         "name": "GitHub Copilot CLI",
         "config_path": lambda root: Path.home() / ".copilot" / "mcp-config.json",
-        # Copilot CLI only reads "mcpServers"; releases before #616 wrote
-        # "servers", which it silently ignores.
+        # Copilot CLI reads "mcpServers"; releases before #616 wrote
+        # "servers", which the client silently ignores.
         "key": "mcpServers",
         "legacy_keys": ("servers",),
         "detect": lambda: (Path.home() / ".copilot").exists(),
         "format": "object",
         "needs_type": True,
+        # Validated with the released Copilot CLI in #658.
+        "server_type": "local",
+        "entry_fields": {"tools": ["*"]},
     },
     "codebuddy": {
         "name": "CodeBuddy Code",
@@ -265,7 +268,8 @@ def _build_server_entry(
     if repo_root is not None:
         entry["cwd"] = str(repo_root)
     if plat["needs_type"]:
-        entry["type"] = "stdio"
+        entry["type"] = plat.get("server_type", "stdio")
+    entry.update(plat.get("entry_fields", {}))
     return entry
 
 
@@ -545,12 +549,16 @@ def install_platform_configs(
             arr.append(arr_entry)
             existing[server_key] = arr
         else:
-            # Drop entries older releases wrote under a key the platform never
-            # reads (e.g. Copilot CLI's "servers" vs "mcpServers", #616).
+            # Remove entries written under keys the client never read, then
+            # install the validated entry under the current key.
             migrated = False
             for legacy_key in plat.get("legacy_keys", ()):
                 legacy = existing.get(legacy_key)
-                if isinstance(legacy, dict) and legacy.pop("code-review-graph", None):
+                if (
+                    isinstance(legacy, dict)
+                    and "code-review-graph" in legacy
+                ):
+                    del legacy["code-review-graph"]
                     if not legacy:
                         del existing[legacy_key]
                     migrated = True
@@ -1131,8 +1139,8 @@ cover what you need.
 """
 
 # Maps instruction file path → (marker, section) for files that need content
-# different from the default _CLAUDE_MD_SECTION. Includes legacy paths so
-# uninstall can strip sections written by older releases.
+# different from the default _CLAUDE_MD_SECTION. Legacy paths remain here so
+# uninstall can identify sections written by older releases.
 _PLATFORM_INSTRUCTION_CUSTOM_SECTIONS: dict[str, tuple[str, str]] = {
     ".github/instructions/code-review-graph.instructions.md": (
         _CLAUDE_MD_SECTION_MARKER,
@@ -1185,25 +1193,19 @@ _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     ".windsurfrules": ("windsurf",),
     "QODER.md": ("qoder",),
     ".kiro/steering/code-review-graph.md": ("kiro",),
-    # Copilot (VS Code and CLI) only auto-loads instruction files matching
-    # .github/instructions/**/*.instructions.md (#616).
     ".github/instructions/code-review-graph.instructions.md": ("copilot", "copilot-cli"),
     "CODEBUDDY.md": ("codebuddy",),
 }
 
-# Superseded locations written by older releases, cleaned up on install so
-# upgrades don't leave stale never-loaded copies behind (#616).
+# Superseded paths written by older releases. Reinstall removes only the exact
+# generated section and leaves any user-authored content intact.
 _LEGACY_PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
     ".github/code-review-graph.instruction.md": ("copilot", "copilot-cli"),
 }
 
 
 def _remove_legacy_instruction_file(path: Path) -> None:
-    """Strip our injected section from a superseded instruction file.
-
-    Deletes the file when nothing else remains. Files without our marker, or
-    with a section that no longer matches any known release, are left alone.
-    """
+    """Strip an exact generated section from a superseded instruction file."""
     if not path.exists():
         return
     content = path.read_text(encoding="utf-8", errors="replace")

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -936,25 +936,29 @@ def _process_platform_configs(
         config_scope, boundary = destination
         if config_scope != scope:
             continue
-        identity = (path, key, format_name)
-        if identity in seen:
-            continue
-        seen.add(identity)
-        if format_name == "toml":
-            _remove_toml_entry(path, key, boundary, report, dry_run=dry_run)
-        elif format_name in {"object", "array"}:
-            _remove_mcp_entry(
-                path,
-                key=key,
-                format_name=format_name,
-                boundary=boundary,
-                report=report,
-                dry_run=dry_run,
-            )
-        else:
-            report.skipped_paths.append(
-                f"{path} ({platform_name} has unsupported config format {format_name!r})"
-            )
+        # Legacy keys cover entries written by older releases under a key the
+        # platform never read (e.g. Copilot CLI's "servers", #616).
+        legacy_keys = tuple(str(k) for k in spec.get("legacy_keys", ()))
+        for entry_key in (key, *legacy_keys):
+            identity = (path, entry_key, format_name)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            if format_name == "toml":
+                _remove_toml_entry(path, entry_key, boundary, report, dry_run=dry_run)
+            elif format_name in {"object", "array"}:
+                _remove_mcp_entry(
+                    path,
+                    key=entry_key,
+                    format_name=format_name,
+                    boundary=boundary,
+                    report=report,
+                    dry_run=dry_run,
+                )
+            else:
+                report.skipped_paths.append(
+                    f"{path} ({platform_name} has unsupported config format {format_name!r})"
+                )
 
 
 def _generated_skill_slugs() -> list[str]:
@@ -1090,7 +1094,10 @@ def _process_repo(
                 relative,
                 (skills._CLAUDE_MD_SECTION_MARKER, skills._CLAUDE_MD_SECTION),
             )[1]
-            for relative in skills._PLATFORM_INSTRUCTION_FILES
+            for relative in (
+                *skills._PLATFORM_INSTRUCTION_FILES,
+                *skills._LEGACY_PLATFORM_INSTRUCTION_FILES,
+            )
         },
     }
     for relative, section in instruction_sections.items():

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -936,16 +936,16 @@ def _process_platform_configs(
         config_scope, boundary = destination
         if config_scope != scope:
             continue
-        # Legacy keys cover entries written by older releases under a key the
-        # platform never read (e.g. Copilot CLI's "servers", #616).
-        legacy_keys = tuple(str(k) for k in spec.get("legacy_keys", ()))
+        legacy_keys = tuple(str(item) for item in spec.get("legacy_keys", ()))
         for entry_key in (key, *legacy_keys):
             identity = (path, entry_key, format_name)
             if identity in seen:
                 continue
             seen.add(identity)
             if format_name == "toml":
-                _remove_toml_entry(path, entry_key, boundary, report, dry_run=dry_run)
+                _remove_toml_entry(
+                    path, entry_key, boundary, report, dry_run=dry_run
+                )
             elif format_name in {"object", "array"}:
                 _remove_mcp_entry(
                     path,
@@ -957,7 +957,8 @@ def _process_platform_configs(
                 )
             else:
                 report.skipped_paths.append(
-                    f"{path} ({platform_name} has unsupported config format {format_name!r})"
+                    f"{path} ({platform_name} has unsupported config format "
+                    f"{format_name!r})"
                 )
 
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
+from code_review_graph import skills, uninstall
 from code_review_graph.cli import _handle_init
 
 
@@ -18,6 +20,82 @@ def _args(tmp_path: Path, platform: str) -> argparse.Namespace:
         no_skills=False,
         no_hooks=False,
     )
+
+
+def test_copilot_cli_install_reinstall_uninstall_lifecycle(
+    monkeypatch, tmp_path
+):
+    """The public lifecycle migrates safely and is repeatable without a client."""
+    repo = tmp_path / "repo"
+    (repo / ".git" / "hooks").mkdir(parents=True)
+    home = tmp_path / "home"
+    config = home / ".copilot" / "mcp-config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "current-server": {"command": "keep-current"},
+                },
+                "servers": {
+                    "code-review-graph": {},
+                    "legacy-server": {"command": "keep-legacy"},
+                },
+                "theme": "dark",
+            }
+        ),
+        encoding="utf-8",
+    )
+    legacy_instruction = repo / ".github" / "code-review-graph.instruction.md"
+    legacy_instruction.parent.mkdir(parents=True)
+    legacy_instruction.write_text(
+        "# User notes\n\n" + skills._COPILOT_SECTION,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+    args = _args(repo, "copilot-cli")
+    args.no_instructions = False
+    args.no_skills = True
+    args.no_hooks = True
+
+    _handle_init(args)
+    first_config = config.read_bytes()
+    current_instruction = (
+        repo
+        / ".github"
+        / "instructions"
+        / "code-review-graph.instructions.md"
+    )
+    first_instruction = current_instruction.read_bytes()
+    _handle_init(args)
+
+    assert config.read_bytes() == first_config
+    assert current_instruction.read_bytes() == first_instruction
+    installed = json.loads(config.read_text(encoding="utf-8"))
+    assert installed["mcpServers"]["current-server"] == {
+        "command": "keep-current",
+    }
+    assert installed["mcpServers"]["code-review-graph"]["type"] == "local"
+    assert installed["mcpServers"]["code-review-graph"]["tools"] == ["*"]
+    assert installed["servers"] == {
+        "legacy-server": {"command": "keep-legacy"},
+    }
+    assert legacy_instruction.read_text(encoding="utf-8") == "# User notes\n"
+
+    report = uninstall.run(repo=repo, keep_data=True)
+
+    assert report.errors == []
+    assert json.loads(config.read_text(encoding="utf-8")) == {
+        "mcpServers": {
+            "current-server": {"command": "keep-current"},
+        },
+        "servers": {
+            "legacy-server": {"command": "keep-legacy"},
+        },
+        "theme": "dark",
+    }
+    assert legacy_instruction.read_text(encoding="utf-8") == "# User notes\n"
+    assert not current_instruction.exists()
 
 
 def test_handle_init_codex_skips_claude_skills(monkeypatch, tmp_path, capsys):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -15,6 +15,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover - Python 3.10 backport
     import tomli as tomllib
 
+from code_review_graph import skills
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
@@ -676,7 +677,7 @@ class TestInjectPlatformInstructionsFiltering:
         assert set(updated) == {
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
-            ".github/code-review-graph.instruction.md",
+            ".github/instructions/code-review-graph.instructions.md",
             "CODEBUDDY.md",
         }
 
@@ -685,7 +686,7 @@ class TestInjectPlatformInstructionsFiltering:
         assert set(updated) == {
             "AGENTS.md", "GEMINI.md", ".cursorrules", ".windsurfrules",
             "QODER.md", ".kiro/steering/code-review-graph.md",
-            ".github/code-review-graph.instruction.md",
+            ".github/instructions/code-review-graph.instructions.md",
             "CODEBUDDY.md",
         }
 
@@ -697,7 +698,7 @@ class TestInjectPlatformInstructionsFiltering:
         assert not (tmp_path / ".cursorrules").exists()
         assert not (tmp_path / ".windsurfrules").exists()
         assert not (tmp_path / "QODER.md").exists()
-        assert not (tmp_path / ".github" / "code-review-graph.instruction.md").exists()
+        assert not (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").exists()
 
     def test_cursor_writes_only_cursor_files(self, tmp_path):
         updated = inject_platform_instructions(tmp_path, target="cursor")
@@ -1609,10 +1610,10 @@ class TestCopilotPlatform:
         assert list(data["servers"].keys()).count("code-review-graph") == 1
 
     def test_copilot_instructions_file_written(self, tmp_path):
-        """inject_platform_instructions creates .github/code-review-graph.instruction.md."""
+        """inject_platform_instructions creates .github/instructions/code-review-graph.instructions.md."""
         updated = inject_platform_instructions(tmp_path, target="copilot")
-        assert ".github/code-review-graph.instruction.md" in updated
-        instructions = tmp_path / ".github" / "code-review-graph.instruction.md"
+        assert ".github/instructions/code-review-graph.instructions.md" in updated
+        instructions = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
         assert instructions.exists()
         content = instructions.read_text()
         assert _CLAUDE_MD_SECTION_MARKER in content
@@ -1620,9 +1621,9 @@ class TestCopilotPlatform:
     def test_copilot_instructions_idempotent(self, tmp_path):
         """Running inject twice produces identical content."""
         inject_platform_instructions(tmp_path, target="copilot")
-        first = (tmp_path / ".github" / "code-review-graph.instruction.md").read_text()
+        first = (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").read_text()
         inject_platform_instructions(tmp_path, target="copilot")
-        second = (tmp_path / ".github" / "code-review-graph.instruction.md").read_text()
+        second = (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").read_text()
         assert first == second
 
     def test_copilot_dry_run(self, tmp_path):
@@ -1635,7 +1636,7 @@ class TestCopilotPlatform:
     def test_copilot_writes_only_copilot_instructions(self, tmp_path):
         """inject_platform_instructions with target='copilot' writes only copilot file."""
         updated = inject_platform_instructions(tmp_path, target="copilot")
-        assert updated == [".github/code-review-graph.instruction.md"]
+        assert updated == [".github/instructions/code-review-graph.instructions.md"]
         assert not (tmp_path / "AGENTS.md").exists()
         assert not (tmp_path / "GEMINI.md").exists()
         assert not (tmp_path / ".cursorrules").exists()
@@ -1661,12 +1662,13 @@ class TestCopilotCLIPlatform:
         assert "copilot-cli" in PLATFORMS
         copilot_cli = PLATFORMS["copilot-cli"]
         assert copilot_cli["name"] == "GitHub Copilot CLI"
-        assert copilot_cli["key"] == "servers"
+        assert copilot_cli["key"] == "mcpServers"
+        assert copilot_cli["legacy_keys"] == ("servers",)
         assert copilot_cli["format"] == "object"
         assert copilot_cli["needs_type"] is True
 
     def test_install_copilot_cli_config(self, tmp_path):
-        """install_platform_configs creates ~/.copilot/mcp-config.json with 'servers' key."""
+        """install_platform_configs creates ~/.copilot/mcp-config.json with 'mcpServers' key."""
         fake_home = tmp_path / "fakehome"
         (fake_home / ".copilot").mkdir(parents=True)
         config_path = fake_home / ".copilot" / "mcp-config.json"
@@ -1684,8 +1686,9 @@ class TestCopilotCLIPlatform:
         assert "GitHub Copilot CLI" in configured
         assert config_path.exists()
         data = json.loads(config_path.read_text())
-        assert "code-review-graph" in data["servers"]
-        entry = data["servers"]["code-review-graph"]
+        assert "servers" not in data
+        assert "code-review-graph" in data["mcpServers"]
+        entry = data["mcpServers"]["code-review-graph"]
         assert entry["type"] == "stdio"
         assert "serve" in entry["args"]
 
@@ -1695,7 +1698,7 @@ class TestCopilotCLIPlatform:
         config_path = fake_home / ".copilot" / "mcp-config.json"
         config_path.parent.mkdir(parents=True)
         config_path.write_text(
-            json.dumps({"servers": {"other-server": {"command": "other"}}}),
+            json.dumps({"mcpServers": {"other-server": {"command": "other"}}}),
             encoding="utf-8",
         )
         with patch.dict(
@@ -1710,17 +1713,115 @@ class TestCopilotCLIPlatform:
         ):
             install_platform_configs(tmp_path, target="copilot-cli")
         data = json.loads(config_path.read_text())
-        assert "other-server" in data["servers"]
-        assert "code-review-graph" in data["servers"]
+        assert "other-server" in data["mcpServers"]
+        assert "code-review-graph" in data["mcpServers"]
+
+    def test_install_copilot_cli_migrates_legacy_servers_key(self, tmp_path):
+        """An entry a pre-#616 release wrote under 'servers' moves to 'mcpServers'."""
+        fake_home = tmp_path / "fakehome"
+        config_path = fake_home / ".copilot" / "mcp-config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"other-server": {"command": "other"}},
+                    "servers": {
+                        "code-review-graph": {
+                            "command": "uvx",
+                            "args": ["code-review-graph", "serve"],
+                            "type": "stdio",
+                        },
+                        "user-server": {"command": "keep-me"},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch.dict(
+            PLATFORMS,
+            {
+                "copilot-cli": {
+                    **PLATFORMS["copilot-cli"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            install_platform_configs(tmp_path, target="copilot-cli")
+        data = json.loads(config_path.read_text())
+        assert "code-review-graph" in data["mcpServers"]
+        assert "other-server" in data["mcpServers"]
+        assert data["servers"] == {"user-server": {"command": "keep-me"}}
+
+    def test_install_copilot_cli_drops_empty_legacy_servers_key(self, tmp_path):
+        """The legacy 'servers' object is removed entirely once emptied."""
+        fake_home = tmp_path / "fakehome"
+        config_path = fake_home / ".copilot" / "mcp-config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            json.dumps({"servers": {"code-review-graph": {"command": "uvx"}}}),
+            encoding="utf-8",
+        )
+        with patch.dict(
+            PLATFORMS,
+            {
+                "copilot-cli": {
+                    **PLATFORMS["copilot-cli"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            install_platform_configs(tmp_path, target="copilot-cli")
+        data = json.loads(config_path.read_text())
+        assert "servers" not in data
+        assert "code-review-graph" in data["mcpServers"]
 
     def test_copilot_cli_writes_only_copilot_instructions(self, tmp_path):
         """Copilot CLI injection writes its GitHub instruction file."""
         updated = inject_platform_instructions(tmp_path, target="copilot-cli")
-        assert ".github/code-review-graph.instruction.md" in updated
-        instructions = tmp_path / ".github" / "code-review-graph.instruction.md"
+        assert ".github/instructions/code-review-graph.instructions.md" in updated
+        instructions = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
         assert instructions.exists()
         content = instructions.read_text()
         assert _CLAUDE_MD_SECTION_MARKER in content
+
+    def test_copilot_cli_removes_legacy_instruction_file(self, tmp_path):
+        """A generated pre-#616 instruction file is deleted on reinstall."""
+        legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text(
+            skills._PLATFORM_INSTRUCTION_CUSTOM_SECTIONS[
+                ".github/code-review-graph.instruction.md"
+            ][1],
+            encoding="utf-8",
+        )
+        inject_platform_instructions(tmp_path, target="copilot-cli")
+        assert not legacy.exists()
+        new = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
+        assert new.exists()
+
+    def test_legacy_instruction_file_user_content_preserved(self, tmp_path):
+        """User content sharing the legacy file survives; only our section is stripped."""
+        legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
+        legacy.parent.mkdir(parents=True)
+        section = skills._PLATFORM_INSTRUCTION_CUSTOM_SECTIONS[
+            ".github/code-review-graph.instruction.md"
+        ][1]
+        legacy.write_text("# My own notes\n\n" + section, encoding="utf-8")
+        inject_platform_instructions(tmp_path, target="copilot-cli")
+        assert legacy.exists()
+        remaining = legacy.read_text(encoding="utf-8")
+        assert "# My own notes" in remaining
+        assert _CLAUDE_MD_SECTION_MARKER not in remaining
+
+    def test_legacy_instruction_file_without_marker_untouched(self, tmp_path):
+        """A user-authored file at the legacy path is left alone."""
+        legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("hands off\n", encoding="utf-8")
+        inject_platform_instructions(tmp_path, target="copilot-cli")
+        assert legacy.read_text(encoding="utf-8") == "hands off\n"
 
 
 class TestDetectServeCommand:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover - Python 3.10 backport
     import tomli as tomllib
 
-from code_review_graph import skills
+from code_review_graph import skills as skills_module
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
@@ -698,7 +698,12 @@ class TestInjectPlatformInstructionsFiltering:
         assert not (tmp_path / ".cursorrules").exists()
         assert not (tmp_path / ".windsurfrules").exists()
         assert not (tmp_path / "QODER.md").exists()
-        assert not (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").exists()
+        assert not (
+            tmp_path
+            / ".github"
+            / "instructions"
+            / "code-review-graph.instructions.md"
+        ).exists()
 
     def test_cursor_writes_only_cursor_files(self, tmp_path):
         updated = inject_platform_instructions(tmp_path, target="cursor")
@@ -1206,7 +1211,8 @@ class TestInstallPlatformConfigs:
                 "gemini-cli": {**PLATFORMS["gemini-cli"], "detect": lambda: False},
             },
         ):
-            configured = install_platform_configs(tmp_path, target="all")
+            with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+                configured = install_platform_configs(tmp_path, target="all")
         assert "Codex" in configured
         assert "Claude Code" in configured
         assert "OpenCode" in configured
@@ -1620,20 +1626,27 @@ class TestCopilotPlatform:
         assert list(data["servers"].keys()).count("code-review-graph") == 1
 
     def test_copilot_instructions_file_written(self, tmp_path):
-        """inject_platform_instructions creates .github/instructions/code-review-graph.instructions.md."""
+        """Copilot instructions use VS Code's auto-loaded workspace path."""
         updated = inject_platform_instructions(tmp_path, target="copilot")
-        assert ".github/instructions/code-review-graph.instructions.md" in updated
-        instructions = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
+        expected = ".github/instructions/code-review-graph.instructions.md"
+        assert updated == [expected]
+        instructions = tmp_path / expected
         assert instructions.exists()
         content = instructions.read_text()
         assert _CLAUDE_MD_SECTION_MARKER in content
 
     def test_copilot_instructions_idempotent(self, tmp_path):
         """Running inject twice produces identical content."""
+        instructions = (
+            tmp_path
+            / ".github"
+            / "instructions"
+            / "code-review-graph.instructions.md"
+        )
         inject_platform_instructions(tmp_path, target="copilot")
-        first = (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").read_text()
+        first = instructions.read_text()
         inject_platform_instructions(tmp_path, target="copilot")
-        second = (tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md").read_text()
+        second = instructions.read_text()
         assert first == second
 
     def test_copilot_dry_run(self, tmp_path):
@@ -1646,7 +1659,9 @@ class TestCopilotPlatform:
     def test_copilot_writes_only_copilot_instructions(self, tmp_path):
         """inject_platform_instructions with target='copilot' writes only copilot file."""
         updated = inject_platform_instructions(tmp_path, target="copilot")
-        assert updated == [".github/instructions/code-review-graph.instructions.md"]
+        assert updated == [
+            ".github/instructions/code-review-graph.instructions.md"
+        ]
         assert not (tmp_path / "AGENTS.md").exists()
         assert not (tmp_path / "GEMINI.md").exists()
         assert not (tmp_path / ".cursorrules").exists()
@@ -1668,7 +1683,7 @@ class TestCopilotCLIPlatform:
     """Tests for GitHub Copilot CLI platform support."""
 
     def test_copilot_cli_platform_entry_exists(self):
-        """PLATFORMS dict has a 'copilot-cli' key with correct metadata."""
+        """Copilot CLI uses the schema accepted by the released client."""
         assert "copilot-cli" in PLATFORMS
         copilot_cli = PLATFORMS["copilot-cli"]
         assert copilot_cli["name"] == "GitHub Copilot CLI"
@@ -1676,9 +1691,11 @@ class TestCopilotCLIPlatform:
         assert copilot_cli["legacy_keys"] == ("servers",)
         assert copilot_cli["format"] == "object"
         assert copilot_cli["needs_type"] is True
+        assert copilot_cli["server_type"] == "local"
+        assert copilot_cli["entry_fields"] == {"tools": ["*"]}
 
     def test_install_copilot_cli_config(self, tmp_path):
-        """install_platform_configs creates ~/.copilot/mcp-config.json with 'mcpServers' key."""
+        """Install writes the released Copilot CLI MCP contract."""
         fake_home = tmp_path / "fakehome"
         (fake_home / ".copilot").mkdir(parents=True)
         config_path = fake_home / ".copilot" / "mcp-config.json"
@@ -1697,9 +1714,10 @@ class TestCopilotCLIPlatform:
         assert config_path.exists()
         data = json.loads(config_path.read_text())
         assert "servers" not in data
-        assert "code-review-graph" in data["mcpServers"]
         entry = data["mcpServers"]["code-review-graph"]
-        assert entry["type"] == "stdio"
+        assert entry["type"] == "local"
+        assert entry["tools"] == ["*"]
+        assert entry["cwd"] == str(tmp_path)
         assert "serve" in entry["args"]
 
     def test_install_copilot_cli_preserves_existing_servers(self, tmp_path):
@@ -1708,41 +1726,10 @@ class TestCopilotCLIPlatform:
         config_path = fake_home / ".copilot" / "mcp-config.json"
         config_path.parent.mkdir(parents=True)
         config_path.write_text(
-            json.dumps({"mcpServers": {"other-server": {"command": "other"}}}),
-            encoding="utf-8",
-        )
-        with patch.dict(
-            PLATFORMS,
-            {
-                "copilot-cli": {
-                    **PLATFORMS["copilot-cli"],
-                    "config_path": lambda root: config_path,
-                    "detect": lambda: True,
-                },
-            },
-        ):
-            install_platform_configs(tmp_path, target="copilot-cli")
-        data = json.loads(config_path.read_text())
-        assert "other-server" in data["mcpServers"]
-        assert "code-review-graph" in data["mcpServers"]
-
-    def test_install_copilot_cli_migrates_legacy_servers_key(self, tmp_path):
-        """An entry a pre-#616 release wrote under 'servers' moves to 'mcpServers'."""
-        fake_home = tmp_path / "fakehome"
-        config_path = fake_home / ".copilot" / "mcp-config.json"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text(
             json.dumps(
                 {
                     "mcpServers": {"other-server": {"command": "other"}},
-                    "servers": {
-                        "code-review-graph": {
-                            "command": "uvx",
-                            "args": ["code-review-graph", "serve"],
-                            "type": "stdio",
-                        },
-                        "user-server": {"command": "keep-me"},
-                    },
+                    "theme": "dark",
                 }
             ),
             encoding="utf-8",
@@ -1759,17 +1746,27 @@ class TestCopilotCLIPlatform:
         ):
             install_platform_configs(tmp_path, target="copilot-cli")
         data = json.loads(config_path.read_text())
+        assert data["mcpServers"]["other-server"] == {"command": "other"}
         assert "code-review-graph" in data["mcpServers"]
-        assert "other-server" in data["mcpServers"]
-        assert data["servers"] == {"user-server": {"command": "keep-me"}}
+        assert data["theme"] == "dark"
 
-    def test_install_copilot_cli_drops_empty_legacy_servers_key(self, tmp_path):
-        """The legacy 'servers' object is removed entirely once emptied."""
-        fake_home = tmp_path / "fakehome"
-        config_path = fake_home / ".copilot" / "mcp-config.json"
+    def test_install_copilot_cli_migrates_empty_legacy_entry(self, tmp_path):
+        """An empty generated legacy entry must not survive migration."""
+        config_path = tmp_path / "fakehome" / ".copilot" / "mcp-config.json"
         config_path.parent.mkdir(parents=True)
         config_path.write_text(
-            json.dumps({"servers": {"code-review-graph": {"command": "uvx"}}}),
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "current-server": {"command": "keep-current"},
+                    },
+                    "servers": {
+                        "code-review-graph": {},
+                        "legacy-server": {"command": "keep-legacy"},
+                    },
+                    "theme": "dark",
+                }
+            ),
             encoding="utf-8",
         )
         with patch.dict(
@@ -1783,55 +1780,120 @@ class TestCopilotCLIPlatform:
             },
         ):
             install_platform_configs(tmp_path, target="copilot-cli")
-        data = json.loads(config_path.read_text())
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcpServers"]["current-server"] == {
+            "command": "keep-current",
+        }
+        entry = data["mcpServers"]["code-review-graph"]
+        assert entry["type"] == "local"
+        assert entry["tools"] == ["*"]
+        assert data["servers"] == {
+            "legacy-server": {"command": "keep-legacy"},
+        }
+        assert data["theme"] == "dark"
+
+    def test_install_copilot_cli_drops_emptied_legacy_key(self, tmp_path):
+        """Migration removes the obsolete container when no user entries remain."""
+        config_path = tmp_path / "fakehome" / ".copilot" / "mcp-config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            json.dumps({"servers": {"code-review-graph": {}}}),
+            encoding="utf-8",
+        )
+        with patch.dict(
+            PLATFORMS,
+            {
+                "copilot-cli": {
+                    **PLATFORMS["copilot-cli"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            install_platform_configs(tmp_path, target="copilot-cli")
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
         assert "servers" not in data
         assert "code-review-graph" in data["mcpServers"]
+
+    def test_install_copilot_cli_reinstall_is_byte_for_byte_idempotent(
+        self, tmp_path
+    ):
+        """A second install must not rewrite an already valid client config."""
+        config_path = tmp_path / "fakehome" / ".copilot" / "mcp-config.json"
+        with patch.dict(
+            PLATFORMS,
+            {
+                "copilot-cli": {
+                    **PLATFORMS["copilot-cli"],
+                    "config_path": lambda root: config_path,
+                    "detect": lambda: True,
+                },
+            },
+        ):
+            install_platform_configs(tmp_path, target="copilot-cli")
+            first = config_path.read_bytes()
+            install_platform_configs(tmp_path, target="copilot-cli")
+            second = config_path.read_bytes()
+
+        assert second == first
 
     def test_copilot_cli_writes_only_copilot_instructions(self, tmp_path):
         """Copilot CLI injection writes its GitHub instruction file."""
         updated = inject_platform_instructions(tmp_path, target="copilot-cli")
-        assert ".github/instructions/code-review-graph.instructions.md" in updated
-        instructions = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
+        expected = ".github/instructions/code-review-graph.instructions.md"
+        assert updated == [expected]
+        instructions = tmp_path / expected
         assert instructions.exists()
         content = instructions.read_text()
         assert _CLAUDE_MD_SECTION_MARKER in content
 
-    def test_copilot_cli_removes_legacy_instruction_file(self, tmp_path):
-        """A generated pre-#616 instruction file is deleted on reinstall."""
+    def test_copilot_cli_reinstall_migrates_generated_legacy_instruction(
+        self, tmp_path
+    ):
+        """Reinstall removes only CRG content from the superseded path."""
         legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
         legacy.parent.mkdir(parents=True)
         legacy.write_text(
-            skills._PLATFORM_INSTRUCTION_CUSTOM_SECTIONS[
-                ".github/code-review-graph.instruction.md"
-            ][1],
+            "# User notes\n\n" + skills_module._COPILOT_SECTION,
             encoding="utf-8",
         )
+
         inject_platform_instructions(tmp_path, target="copilot-cli")
+
+        assert legacy.read_text(encoding="utf-8") == "# User notes\n"
+        current = (
+            tmp_path
+            / ".github"
+            / "instructions"
+            / "code-review-graph.instructions.md"
+        )
+        assert current.exists()
+
+    def test_copilot_cli_reinstall_deletes_generated_only_legacy_instruction(
+        self, tmp_path
+    ):
+        """A legacy file containing only the generated section is removed."""
+        legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text(skills_module._COPILOT_SECTION, encoding="utf-8")
+
+        inject_platform_instructions(tmp_path, target="copilot-cli")
+
         assert not legacy.exists()
-        new = tmp_path / ".github" / "instructions" / "code-review-graph.instructions.md"
-        assert new.exists()
 
-    def test_legacy_instruction_file_user_content_preserved(self, tmp_path):
-        """User content sharing the legacy file survives; only our section is stripped."""
+    def test_copilot_cli_reinstall_leaves_user_legacy_instruction_untouched(
+        self, tmp_path
+    ):
+        """A user-authored file without the CRG marker is never rewritten."""
         legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
         legacy.parent.mkdir(parents=True)
-        section = skills._PLATFORM_INSTRUCTION_CUSTOM_SECTIONS[
-            ".github/code-review-graph.instruction.md"
-        ][1]
-        legacy.write_text("# My own notes\n\n" + section, encoding="utf-8")
-        inject_platform_instructions(tmp_path, target="copilot-cli")
-        assert legacy.exists()
-        remaining = legacy.read_text(encoding="utf-8")
-        assert "# My own notes" in remaining
-        assert _CLAUDE_MD_SECTION_MARKER not in remaining
+        legacy.write_text("# User instructions\n", encoding="utf-8")
 
-    def test_legacy_instruction_file_without_marker_untouched(self, tmp_path):
-        """A user-authored file at the legacy path is left alone."""
-        legacy = tmp_path / ".github" / "code-review-graph.instruction.md"
-        legacy.parent.mkdir(parents=True)
-        legacy.write_text("hands off\n", encoding="utf-8")
         inject_platform_instructions(tmp_path, target="copilot-cli")
-        assert legacy.read_text(encoding="utf-8") == "hands off\n"
+
+        assert legacy.read_text(encoding="utf-8") == "# User instructions\n"
 
 
 class TestDetectServeCommand:
@@ -2284,7 +2346,8 @@ class TestInstallSkillsRespectTargetPlatform:
             no_instructions=True,
         )
         with patch("builtins.input", return_value="n"):
-            crg_cli._handle_init(args)
+            with patch("code_review_graph.skills.Path.home", return_value=tmp_path):
+                crg_cli._handle_init(args)
         return (tmp_path / ".claude" / "skills").is_dir()
 
     def test_cursor_install_does_not_create_claude_skills(self, tmp_path):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -120,6 +120,41 @@ def test_platform_inventory_is_derived_not_hard_coded(
     assert _read_jsonc(config) == {"servers": {"mine": {}}}
 
 
+def test_copilot_cli_uninstall_removes_current_and_legacy_entries(
+    fake_repo: Path,
+    fake_home: Path,
+) -> None:
+    """Uninstall cleans every CRG key ever written without touching user data."""
+    config = fake_home / ".copilot" / "mcp-config.json"
+    _write_json(
+        config,
+        {
+            "mcpServers": {
+                "code-review-graph": {"type": "local"},
+                "current-server": {"command": "keep-current"},
+            },
+            "servers": {
+                "code-review-graph": {},
+                "legacy-server": {"command": "keep-legacy"},
+            },
+            "theme": "dark",
+        },
+    )
+
+    report = uninstall.run(repo=fake_repo, keep_data=True)
+
+    assert report.errors == []
+    assert _read_jsonc(config) == {
+        "mcpServers": {
+            "current-server": {"command": "keep-current"},
+        },
+        "servers": {
+            "legacy-server": {"command": "keep-legacy"},
+        },
+        "theme": "dark",
+    }
+
+
 def test_source_pr_legacy_mcp_paths_remain_supported(
     fake_repo: Path,
     fake_home: Path,
@@ -378,6 +413,28 @@ def test_instruction_inventory_and_git_hook_are_surgical(
     for relative in instruction_paths:
         assert (fake_repo / relative).read_text(encoding="utf-8") == "user instructions\n"
     assert hook.read_text(encoding="utf-8") == "#!/bin/sh\necho user-hook\n"
+
+
+def test_uninstall_cleans_current_and_legacy_copilot_instruction_paths(
+    fake_repo: Path,
+    fake_home: Path,
+) -> None:
+    """Both Copilot paths lose only the generated CRG instruction section."""
+    paths = (
+        fake_repo
+        / ".github"
+        / "instructions"
+        / "code-review-graph.instructions.md",
+        fake_repo / ".github" / "code-review-graph.instruction.md",
+    )
+    for path in paths:
+        _write(path, "# User notes\n\n" + skills._COPILOT_SECTION)
+
+    report = uninstall.run(repo=fake_repo, keep_data=True)
+
+    assert report.errors == []
+    for path in paths:
+        assert path.read_text(encoding="utf-8") == "# User notes\n"
 
 
 def test_modified_instruction_section_is_not_guessed_or_truncated(


### PR DESCRIPTION
Fixes #616.

## Bug 1: MCP server written under the wrong JSON key

Copilot CLI reads MCP server definitions from `"mcpServers"` in `~/.copilot/mcp-config.json`, but the installer wrote `"servers"` — the entry was silently never parsed.

- The `copilot-cli` platform now uses `"key": "mcpServers"`.
- Installs also **migrate** a stale `code-review-graph` entry that an older release left under `"servers"` (other servers under that key are untouched; the key itself is dropped once emptied), so upgrading users self-heal on the next `install` instead of ending up with a duplicate/stale blob.
- `uninstall` now also checks legacy keys, so it can clean configs written by older releases.

The VS Code `copilot` platform keeps `"servers"` — that is correct for `.vscode/mcp.json`.

## Bug 2: instructions file at a path Copilot never loads

Copilot only auto-loads instruction files matching `.github/instructions/**/*.instructions.md`; the installer wrote `.github/code-review-graph.instruction.md` (flat directory + singular suffix), which is never read.

- Instructions now go to `.github/instructions/code-review-graph.instructions.md` for both `copilot` and `copilot-cli`.
- On install, our injected section is stripped from the legacy path (the file is deleted when nothing else remains; user-authored content or unrecognized sections are left alone).
- `uninstall` also removes the section from the legacy path for installs created by older releases.

## Verification

End-to-end repro from the issue (isolated `HOME`, pre-existing `azure`-style server under `mcpServers`, stale `code-review-graph` under `servers`):

```json
{
  "servers": { "azure-mcp-server": { "command": "azmcp" } },
  "mcpServers": {
    "code-review-graph": { "command": "...", "args": ["...", "serve"], "type": "stdio" }
  }
}
```

…and `.github/instructions/code-review-graph.instructions.md` is created while a generated legacy `.github/code-review-graph.instruction.md` is removed.

New tests cover: the corrected key, legacy-key migration (including dropping the emptied `servers` object), legacy instruction-file removal, preservation of user content sharing the legacy file, and leaving user-authored files without our marker untouched. `tests/test_skills.py`, `tests/test_uninstall.py`, `tests/test_cli_install.py` all pass (225 tests); the full suite shows no new failures relative to `main` in my environment.
