### PR TITLE
fix(graph): preserve same-file nodes on qualified_name collision (#585)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import threading
 import time
@@ -45,6 +46,9 @@ logger = logging.getLogger(__name__)
 # ``EXTENSION_TO_LANGUAGE``; TSX keeps its own grammar name.
 _JAVASCRIPT_LANGUAGE_FAMILY = ("javascript", "typescript", "tsx")
 _JAVASCRIPT_LANGUAGE_FAMILY_SET = frozenset(_JAVASCRIPT_LANGUAGE_FAMILY)
+_COLLISION_SUFFIX_RE = re.compile(
+    r"^[0-9a-f]{12}(?::(?:[2-9]|[1-9][0-9]+))?$",
+)
 
 
 def _compatible_edge_languages(language: str) -> tuple[str, ...]:
@@ -290,7 +294,7 @@ class GraphStore:
         candidates = [
             row for row in rows
             if row["qualified_name"] == base
-            or row["qualified_name"].startswith(f"{base}:S")
+            or self._is_collision_identity(base, row["qualified_name"])
         ]
         for row in candidates:
             if row["line_start"] == node.line_start:
@@ -346,6 +350,18 @@ class GraphStore:
             bool(row["is_test"]),
         )
 
+    @staticmethod
+    def _is_collision_identity(base: str, qualified_name: str) -> bool:
+        """Return whether *qualified_name* has this store's exact suffix shape.
+
+        Checking the full generated suffix avoids treating colon-bearing symbol
+        names, such as Objective-C selectors, as collision identities.
+        """
+        prefix = f"{base}:S"
+        if not qualified_name.startswith(prefix):
+            return False
+        return _COLLISION_SUFFIX_RE.fullmatch(qualified_name[len(prefix):]) is not None
+
     def _plan_file_identities(
         self, file_path: str, nodes: list[NodeInfo],
     ) -> list[str]:
@@ -370,7 +386,7 @@ class GraphStore:
                 row
                 for row in old_rows
                 if row["qualified_name"] == base
-                or row["qualified_name"].startswith(f"{base}:S")
+                or self._is_collision_identity(base, row["qualified_name"])
             ]
 
         planned: list[str | None] = [None] * len(nodes)
@@ -378,6 +394,14 @@ class GraphStore:
         assigned: set[str] = set()
         for base, indices in new_by_base.items():
             candidates = old_by_base[base]
+            used_old_ids: set[int] = set()
+            if len(indices) == 1 and len(candidates) == 1:
+                index = indices[0]
+                row = candidates[0]
+                planned[index] = row["qualified_name"]
+                assigned.add(row["qualified_name"])
+                used_old_ids.add(row["id"])
+
             pairs: list[tuple[int, int, int, sqlite3.Row]] = []
             for index in indices:
                 signature = self._semantic_signature(nodes[index])
@@ -387,7 +411,6 @@ class GraphStore:
                     distance = abs(nodes[index].line_start - row["line_start"])
                     pairs.append((distance, index, row["id"], row))
 
-            used_old_ids: set[int] = set()
             for _, index, row_id, row in sorted(pairs):
                 if planned[index] is not None or row_id in used_old_ids:
                     continue
@@ -468,14 +491,24 @@ class GraphStore:
         """Resolve a bare edge endpoint to one lone historical suffix."""
         if self.get_node(qualified_name) is not None:
             return qualified_name
-        prefix = f"{qualified_name}:S"
+        lower = f"{qualified_name}:S"
+        upper = f"{qualified_name}:T"
         rows = self._conn.execute(
             "SELECT qualified_name FROM nodes "
-            "WHERE substr(qualified_name, 1, ?) = ? LIMIT 2",
-            (len(prefix), prefix),
-        ).fetchall()
-        if len(rows) == 1:
-            return rows[0]["qualified_name"]
+            "WHERE qualified_name >= ? AND qualified_name < ? "
+            "ORDER BY qualified_name",
+            (lower, upper),
+        )
+        matches = []
+        for row in rows:
+            candidate = row["qualified_name"]
+            if not self._is_collision_identity(qualified_name, candidate):
+                continue
+            matches.append(candidate)
+            if len(matches) == 2:
+                break
+        if len(matches) == 1:
+            return matches[0]
         return qualified_name
 
     def remove_file_data(self, file_path: str) -> None:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -230,8 +230,13 @@ class GraphStore:
 
     def upsert_node(self, node: NodeInfo, file_hash: str = "") -> int:
         """Insert or update a node. Returns the node ID."""
+        node_id, _ = self._upsert_node(node, file_hash)
+        return node_id
+
+    def _upsert_node(self, node: NodeInfo, file_hash: str = "") -> tuple[int, str]:
+        """Insert or update a node and return its ID and stored identity."""
         now = time.time()
-        qualified = self._make_qualified(node)
+        qualified = self._qualified_for_upsert(node)
         extra = json.dumps(node.extra) if node.extra else "{}"
 
         self._conn.execute(
@@ -260,7 +265,35 @@ class GraphStore:
         row = self._conn.execute(
             "SELECT id FROM nodes WHERE qualified_name = ?", (qualified,)
         ).fetchone()
-        return row["id"]
+        return row["id"], qualified
+
+    def _qualified_for_upsert(self, node: NodeInfo) -> str:
+        """Return a stable identity, suffixing genuine same-file collisions."""
+        base = self._make_qualified(node)
+        rows = self._conn.execute(
+            "SELECT qualified_name, line_start FROM nodes "
+            "WHERE file_path = ? AND name = ? AND parent_name IS ? ORDER BY id",
+            (node.file_path, node.name, node.parent_name),
+        ).fetchall()
+
+        candidates = [
+            row for row in rows
+            if row["qualified_name"] == base
+            or row["qualified_name"].startswith(f"{base}:L")
+        ]
+        for row in candidates:
+            if row["line_start"] == node.line_start:
+                return row["qualified_name"]
+
+        if self.get_node(base) is None:
+            return base
+
+        qualified = f"{base}:L{node.line_start}"
+        ordinal = 2
+        while self.get_node(qualified) is not None:
+            qualified = f"{base}:L{node.line_start}:{ordinal}"
+            ordinal += 1
+        return qualified
 
     def upsert_edge(self, edge: EdgeInfo) -> int:
         """Insert or update an edge."""
@@ -363,10 +396,7 @@ class GraphStore:
         self._begin_immediate()
         try:
             self.remove_file_data(file_path)
-            for node in nodes:
-                self.upsert_node(node, file_hash=fhash)
-            for edge in edges:
-                self.upsert_edge(edge)
+            self._store_nodes_edges(nodes, edges, fhash)
             self._conn.commit()
         except BaseException:
             self._conn.rollback()
@@ -381,15 +411,79 @@ class GraphStore:
         try:
             for file_path, nodes, edges, fhash in batch:
                 self.remove_file_data(file_path)
-                for node in nodes:
-                    self.upsert_node(node, file_hash=fhash)
-                for edge in edges:
-                    self.upsert_edge(edge)
+                self._store_nodes_edges(nodes, edges, fhash)
             self._conn.commit()
         except BaseException:
             self._conn.rollback()
             raise
         self._invalidate_cache()
+
+    def _store_nodes_edges(
+        self, nodes: list[NodeInfo], edges: list[EdgeInfo], file_hash: str,
+    ) -> None:
+        """Store one file's nodes and align edges with collision identities."""
+        identities: dict[str, list[tuple[NodeInfo, str]]] = {}
+        for node in nodes:
+            node_id = self.upsert_node(node, file_hash=file_hash)
+            row = self._conn.execute(
+                "SELECT qualified_name FROM nodes WHERE id = ?", (node_id,),
+            ).fetchone()
+            qualified = row["qualified_name"]
+            identities.setdefault(self._make_qualified(node), []).append(
+                (node, qualified),
+            )
+
+        collisions = {
+            base: entries for base, entries in identities.items()
+            if len(entries) > 1
+        }
+        for edge in edges:
+            self.upsert_edge(self._align_edge_with_collisions(edge, collisions))
+
+    def _align_edge_with_collisions(
+        self,
+        edge: EdgeInfo,
+        collisions: dict[str, list[tuple[NodeInfo, str]]],
+    ) -> EdgeInfo:
+        """Point an edge at the colliding definition evidenced by its line."""
+        source = edge.source
+        source_candidates = collisions.get(source, [])
+        containing_sources = [
+            (node, qualified)
+            for node, qualified in source_candidates
+            if node.line_start <= edge.line <= node.line_end
+        ]
+        if containing_sources:
+            _, source = min(
+                containing_sources,
+                key=lambda item: item[0].line_end - item[0].line_start,
+            )
+
+        target = edge.target
+        target_candidates = collisions.get(target, [])
+        if edge.kind == "CONTAINS" and target_candidates:
+            starting_targets = [
+                qualified
+                for node, qualified in target_candidates
+                if node.line_start == edge.line
+            ]
+            if len(starting_targets) == 1:
+                target = starting_targets[0]
+        elif edge.source == edge.target and source != edge.source:
+            # A recursive call inside a collided definition resolves to that
+            # definition rather than the canonical first occurrence.
+            target = source
+
+        if source == edge.source and target == edge.target:
+            return edge
+        return EdgeInfo(
+            kind=edge.kind,
+            source=source,
+            target=target,
+            file_path=edge.file_path,
+            line=edge.line,
+            extra=edge.extra,
+        )
 
     def set_metadata(self, key: str, value: str) -> None:
         self._conn.execute(

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -7,6 +7,7 @@ Supports impact-radius queries and subgraph extraction.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -279,7 +280,7 @@ class GraphStore:
         candidates = [
             row for row in rows
             if row["qualified_name"] == base
-            or row["qualified_name"].startswith(f"{base}:L")
+            or row["qualified_name"].startswith(f"{base}:S")
         ]
         for row in candidates:
             if row["line_start"] == node.line_start:
@@ -288,12 +289,30 @@ class GraphStore:
         if self.get_node(base) is None:
             return base
 
-        qualified = f"{base}:L{node.line_start}"
+        semantic = self._semantic_disambiguator(node)
+        qualified_base = f"{base}:S{semantic}"
+        qualified = qualified_base
         ordinal = 2
         while self.get_node(qualified) is not None:
-            qualified = f"{base}:L{node.line_start}:{ordinal}"
+            qualified = f"{qualified_base}:{ordinal}"
             ordinal += 1
         return qualified
+
+    @staticmethod
+    def _semantic_disambiguator(node: NodeInfo) -> str:
+        """Hash definition semantics that survive harmless source line shifts."""
+        signature = (
+            node.kind,
+            node.name,
+            node.parent_name,
+            node.language,
+            node.params,
+            node.return_type,
+            node.modifiers,
+            node.is_test,
+        )
+        payload = json.dumps(signature, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
     def upsert_edge(self, edge: EdgeInfo) -> int:
         """Insert or update an edge."""

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -229,15 +229,25 @@ class GraphStore:
 
     # --- Write operations ---
 
-    def upsert_node(self, node: NodeInfo, file_hash: str = "") -> int:
+    def upsert_node(
+        self,
+        node: NodeInfo,
+        file_hash: str = "",
+        qualified_name: str | None = None,
+    ) -> int:
         """Insert or update a node. Returns the node ID."""
-        node_id, _ = self._upsert_node(node, file_hash)
+        node_id, _ = self._upsert_node(node, file_hash, qualified_name)
         return node_id
 
-    def _upsert_node(self, node: NodeInfo, file_hash: str = "") -> tuple[int, str]:
+    def _upsert_node(
+        self,
+        node: NodeInfo,
+        file_hash: str = "",
+        qualified_name: str | None = None,
+    ) -> tuple[int, str]:
         """Insert or update a node and return its ID and stored identity."""
         now = time.time()
-        qualified = self._qualified_for_upsert(node)
+        qualified = qualified_name or self._qualified_for_upsert(node)
         extra = json.dumps(node.extra) if node.extra else "{}"
 
         self._conn.execute(
@@ -301,7 +311,17 @@ class GraphStore:
     @staticmethod
     def _semantic_disambiguator(node: NodeInfo) -> str:
         """Hash definition semantics that survive harmless source line shifts."""
-        signature = (
+        payload = json.dumps(
+            GraphStore._semantic_signature(node),
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _semantic_signature(node: NodeInfo) -> tuple[Any, ...]:
+        """Return definition fields that identify a node across line shifts."""
+        return (
             node.kind,
             node.name,
             node.parent_name,
@@ -311,12 +331,108 @@ class GraphStore:
             node.modifiers,
             node.is_test,
         )
-        payload = json.dumps(signature, separators=(",", ":"), ensure_ascii=True)
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _row_semantic_signature(row: sqlite3.Row) -> tuple[Any, ...]:
+        """Return the semantic signature stored for an existing node row."""
+        return (
+            row["kind"],
+            row["name"],
+            row["parent_name"],
+            row["language"] or "",
+            row["params"],
+            row["return_type"],
+            row["modifiers"],
+            bool(row["is_test"]),
+        )
+
+    def _plan_file_identities(
+        self, file_path: str, nodes: list[NodeInfo],
+    ) -> list[str]:
+        """Reconcile a replacement file's nodes with their previous identities.
+
+        Semantic matches keep their qualified name across collision-set reorder.
+        When definitions are semantically identical, the closest source location
+        preserves identity across harmless shifts, growth, and shrink transitions.
+        """
+        old_rows = self._conn.execute(
+            "SELECT id, kind, name, qualified_name, file_path, line_start, "
+            "line_end, language, parent_name, params, return_type, modifiers, "
+            "is_test FROM nodes WHERE file_path = ? ORDER BY id",
+            (file_path,),
+        ).fetchall()
+        old_by_base: dict[str, list[sqlite3.Row]] = {}
+        new_by_base: dict[str, list[int]] = {}
+        for index, node in enumerate(nodes):
+            new_by_base.setdefault(self._make_qualified(node), []).append(index)
+        for base in new_by_base:
+            old_by_base[base] = [
+                row
+                for row in old_rows
+                if row["qualified_name"] == base
+                or row["qualified_name"].startswith(f"{base}:S")
+            ]
+
+        planned: list[str | None] = [None] * len(nodes)
+        reserved = {row["qualified_name"] for row in old_rows}
+        assigned: set[str] = set()
+        for base, indices in new_by_base.items():
+            candidates = old_by_base[base]
+            pairs: list[tuple[int, int, int, sqlite3.Row]] = []
+            for index in indices:
+                signature = self._semantic_signature(nodes[index])
+                for row in candidates:
+                    if self._row_semantic_signature(row) != signature:
+                        continue
+                    distance = abs(nodes[index].line_start - row["line_start"])
+                    pairs.append((distance, index, row["id"], row))
+
+            used_old_ids: set[int] = set()
+            for _, index, row_id, row in sorted(pairs):
+                if planned[index] is not None or row_id in used_old_ids:
+                    continue
+                planned[index] = row["qualified_name"]
+                assigned.add(row["qualified_name"])
+                used_old_ids.add(row_id)
+
+            for index in indices:
+                if planned[index] is not None:
+                    continue
+                exact_location = [
+                    row
+                    for row in candidates
+                    if row["id"] not in used_old_ids
+                    and row["line_start"] == nodes[index].line_start
+                ]
+                if len(exact_location) == 1:
+                    row = exact_location[0]
+                    planned[index] = row["qualified_name"]
+                    assigned.add(row["qualified_name"])
+                    used_old_ids.add(row["id"])
+
+            for index in indices:
+                if planned[index] is not None:
+                    continue
+                if base not in reserved and base not in assigned:
+                    qualified = base
+                else:
+                    semantic = self._semantic_disambiguator(nodes[index])
+                    qualified_base = f"{base}:S{semantic}"
+                    qualified = qualified_base
+                    ordinal = 2
+                    while qualified in reserved or qualified in assigned:
+                        qualified = f"{qualified_base}:{ordinal}"
+                        ordinal += 1
+                planned[index] = qualified
+                assigned.add(qualified)
+
+        return [qualified for qualified in planned if qualified is not None]
 
     def upsert_edge(self, edge: EdgeInfo) -> int:
         """Insert or update an edge."""
         now = time.time()
+        source = self._resolve_stored_identity(edge.source)
+        target = self._resolve_stored_identity(edge.target)
         extra_dict = edge.extra if edge.extra else {}
         confidence = float(extra_dict.get("confidence", 1.0))
         confidence_tier = str(extra_dict.get("confidence_tier", "EXTRACTED"))
@@ -327,7 +443,7 @@ class GraphStore:
             """SELECT id FROM edges
                WHERE kind=? AND source_qualified=? AND target_qualified=?
                      AND file_path=? AND line=?""",
-            (edge.kind, edge.source, edge.target, edge.file_path, edge.line),
+            (edge.kind, source, target, edge.file_path, edge.line),
         ).fetchone()
 
         if existing:
@@ -343,10 +459,24 @@ class GraphStore:
                (kind, source_qualified, target_qualified, file_path, line, extra,
                 confidence, confidence_tier, updated_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (edge.kind, edge.source, edge.target, edge.file_path, edge.line, extra,
+            (edge.kind, source, target, edge.file_path, edge.line, extra,
              confidence, confidence_tier, now),
         )
         return self._conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    def _resolve_stored_identity(self, qualified_name: str) -> str:
+        """Resolve a bare edge endpoint to one lone historical suffix."""
+        if self.get_node(qualified_name) is not None:
+            return qualified_name
+        prefix = f"{qualified_name}:S"
+        rows = self._conn.execute(
+            "SELECT qualified_name FROM nodes "
+            "WHERE substr(qualified_name, 1, ?) = ? LIMIT 2",
+            (len(prefix), prefix),
+        ).fetchall()
+        if len(rows) == 1:
+            return rows[0]["qualified_name"]
+        return qualified_name
 
     def remove_file_data(self, file_path: str) -> None:
         """Remove all nodes and edges associated with a file."""
@@ -414,8 +544,9 @@ class GraphStore:
         """Atomically replace all data for a file."""
         self._begin_immediate()
         try:
+            identities = self._plan_file_identities(file_path, nodes)
             self.remove_file_data(file_path)
-            self._store_nodes_edges(nodes, edges, fhash)
+            self._store_nodes_edges(nodes, edges, fhash, identities)
             self._conn.commit()
         except BaseException:
             self._conn.rollback()
@@ -429,8 +560,9 @@ class GraphStore:
         self._begin_immediate()
         try:
             for file_path, nodes, edges, fhash in batch:
+                identities = self._plan_file_identities(file_path, nodes)
                 self.remove_file_data(file_path)
-                self._store_nodes_edges(nodes, edges, fhash)
+                self._store_nodes_edges(nodes, edges, fhash, identities)
             self._conn.commit()
         except BaseException:
             self._conn.rollback()
@@ -438,16 +570,27 @@ class GraphStore:
         self._invalidate_cache()
 
     def _store_nodes_edges(
-        self, nodes: list[NodeInfo], edges: list[EdgeInfo], file_hash: str,
+        self,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        file_hash: str,
+        qualified_names: list[str] | None = None,
     ) -> None:
         """Store one file's nodes and align edges with collision identities."""
         identities: dict[str, list[tuple[NodeInfo, str]]] = {}
-        for node in nodes:
-            node_id = self.upsert_node(node, file_hash=file_hash)
-            row = self._conn.execute(
-                "SELECT qualified_name FROM nodes WHERE id = ?", (node_id,),
-            ).fetchone()
-            qualified = row["qualified_name"]
+        for index, node in enumerate(nodes):
+            qualified_name = qualified_names[index] if qualified_names is not None else None
+            node_id = self.upsert_node(
+                node,
+                file_hash=file_hash,
+                qualified_name=qualified_name,
+            )
+            if qualified_name is None:
+                row = self._conn.execute(
+                    "SELECT qualified_name FROM nodes WHERE id = ?", (node_id,),
+                ).fetchone()
+                qualified_name = row["qualified_name"]
+            qualified = qualified_name
             identities.setdefault(self._make_qualified(node), []).append(
                 (node, qualified),
             )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -377,7 +377,55 @@ class TestGraphStore:
             (20, 24),
         ]
 
-    def test_reindex_same_colliding_definition_updates_in_place(self):
+    def test_reindex_line_shift_preserves_collision_identities_and_callers(self):
+        target_file = "/test/target.py"
+        caller_file = "/test/caller.py"
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=20, line_end=24, language="python"),
+        ]
+        self.store.store_file_nodes_edges(target_file, nodes, [])
+        original_qns = {
+            node.qualified_name
+            for node in self.store.get_nodes_by_file(target_file)
+        }
+        caller_nodes = [
+            NodeInfo(kind="Function", name="call_first", file_path=caller_file,
+                     line_start=1, line_end=3, language="python"),
+            NodeInfo(kind="Function", name="call_second", file_path=caller_file,
+                     line_start=5, line_end=7, language="python"),
+        ]
+        caller_edges = [
+            EdgeInfo(
+                kind="CALLS", source=f"{caller_file}::{caller.name}", target=target,
+                file_path=caller_file, line=caller.line_start + 1,
+            )
+            for caller, target in zip(caller_nodes, sorted(original_qns))
+        ]
+        self.store.store_file_nodes_edges(caller_file, caller_nodes, caller_edges)
+
+        shifted_nodes = [
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=11, line_end=13, language="python"),
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=21, line_end=25, language="python"),
+        ]
+        self.store.store_file_nodes_edges(target_file, shifted_nodes, [])
+
+        shifted_qns = {
+            node.qualified_name
+            for node in self.store.get_nodes_by_file(target_file)
+        }
+        assert shifted_qns == original_qns
+        for qualified_name in original_qns:
+            callers = self.store.get_edges_by_target(qualified_name)
+            assert self.store.get_node(qualified_name) is not None
+            assert len(callers) == 1
+            assert self.store.get_node(callers[0].source_qualified) is not None
+
+    def test_upsert_same_colliding_definition_updates_in_place(self):
         nodes = [
             NodeInfo(kind="Function", name="render", file_path="/test/file.py",
                      line_start=10, line_end=12, language="python"),
@@ -392,8 +440,7 @@ class TestGraphStore:
 
         node_id = self.store.upsert_node(nodes[1])
 
-        stored = self.store.get_nodes_by_file("/test/file.py")
-        assert len(stored) == 2
+        assert len(self.store.get_nodes_by_file("/test/file.py")) == 2
         assert node_id == original.id
 
     def test_recursive_edge_resolves_for_disambiguated_node(self):
@@ -419,11 +466,39 @@ class TestGraphStore:
         )
         callers = self.store.get_edges_by_target(disambiguated.qualified_name)
         callees = self.store.get_edges_by_source(disambiguated.qualified_name)
-        assert disambiguated.qualified_name == f"{base_qualified}:L20"
+        assert disambiguated.qualified_name.startswith(f"{base_qualified}:S")
         assert len(callers) == 1
         assert len(callees) == 1
         assert self.store.get_node(callers[0].source_qualified) == disambiguated
         assert self.store.get_node(callees[0].target_qualified) == disambiguated
+
+    def test_ambiguous_call_target_keeps_canonical_identity(self):
+        target_file = "/test/target.py"
+        base_qualified = f"{target_file}::render"
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=20, line_end=24, language="python"),
+        ]
+        self.store.store_file_nodes_edges(target_file, nodes, [])
+        disambiguated = next(
+            node for node in self.store.get_nodes_by_file(target_file)
+            if node.qualified_name != base_qualified
+        )
+        caller = NodeInfo(
+            kind="Function", name="call_render", file_path="/test/caller.py",
+            line_start=1, line_end=3, language="python",
+        )
+        edge = EdgeInfo(
+            kind="CALLS", source="/test/caller.py::call_render",
+            target=base_qualified, file_path="/test/caller.py", line=2,
+        )
+
+        self.store.store_file_nodes_edges("/test/caller.py", [caller], [edge])
+
+        assert len(self.store.get_edges_by_target(base_qualified)) == 1
+        assert self.store.get_edges_by_target(disambiguated.qualified_name) == []
 
     def test_store_after_remove_no_transaction_error(self):
         """Regression test for #135: store_file_nodes_edges after

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -425,6 +425,159 @@ class TestGraphStore:
             assert len(callers) == 1
             assert self.store.get_node(callers[0].source_qualified) is not None
 
+    def test_reindex_collision_shrink_preserves_survivor_identity_and_caller(self):
+        target_file = "/test/target.py"
+        caller_file = "/test/caller.py"
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=20, line_end=24, language="python"),
+        ]
+        self.store.store_file_nodes_edges(target_file, nodes, [])
+        survivor = next(
+            node for node in self.store.get_nodes_by_file(target_file)
+            if node.line_start == 20
+        )
+        caller = NodeInfo(
+            kind="Function", name="call_render", file_path=caller_file,
+            line_start=1, line_end=3, language="python",
+        )
+        self.store.store_file_nodes_edges(
+            caller_file,
+            [caller],
+            [EdgeInfo(
+                kind="CALLS", source=f"{caller_file}::call_render",
+                target=survivor.qualified_name, file_path=caller_file, line=2,
+            )],
+        )
+
+        self.store.store_file_nodes_edges(
+            target_file,
+            [NodeInfo(kind="Function", name="render", file_path=target_file,
+                      line_start=21, line_end=25, language="python")],
+            [],
+        )
+
+        stored = self.store.get_nodes_by_file(target_file)
+        assert len(stored) == 1
+        assert stored[0].qualified_name == survivor.qualified_name
+        callers = self.store.get_edges_by_target(survivor.qualified_name)
+        assert len(callers) == 1
+        assert self.store.get_node(callers[0].target_qualified) == stored[0]
+
+        later_caller_file = "/test/later_caller.py"
+        later_caller = NodeInfo(
+            kind="Function", name="call_render", file_path=later_caller_file,
+            line_start=1, line_end=3, language="python",
+        )
+        self.store.store_file_nodes_edges(
+            later_caller_file,
+            [later_caller],
+            [EdgeInfo(
+                kind="CALLS", source=f"{later_caller_file}::call_render",
+                target=f"{target_file}::render", file_path=later_caller_file, line=2,
+            )],
+        )
+        callers = self.store.get_edges_by_target(survivor.qualified_name)
+        assert len(callers) == 2
+
+    def test_reindex_collision_growth_preserves_existing_identity_and_caller(self):
+        target_file = "/test/target.py"
+        caller_file = "/test/caller.py"
+        original = NodeInfo(
+            kind="Function", name="render", file_path=target_file,
+            line_start=20, line_end=24, language="python",
+        )
+        self.store.store_file_nodes_edges(target_file, [original], [])
+        original_qn = self.store.get_nodes_by_file(target_file)[0].qualified_name
+        caller = NodeInfo(
+            kind="Function", name="call_render", file_path=caller_file,
+            line_start=1, line_end=3, language="python",
+        )
+        self.store.store_file_nodes_edges(
+            caller_file,
+            [caller],
+            [EdgeInfo(
+                kind="CALLS", source=f"{caller_file}::call_render",
+                target=original_qn, file_path=caller_file, line=2,
+            )],
+        )
+
+        self.store.store_file_nodes_edges(
+            target_file,
+            [
+                NodeInfo(kind="Function", name="render", file_path=target_file,
+                         line_start=10, line_end=12, language="python"),
+                NodeInfo(kind="Function", name="render", file_path=target_file,
+                         line_start=21, line_end=25, language="python"),
+            ],
+            [],
+        )
+
+        survivor = self.store.get_node(original_qn)
+        assert survivor is not None
+        assert (survivor.line_start, survivor.line_end) == (21, 25)
+        callers = self.store.get_edges_by_target(original_qn)
+        assert len(callers) == 1
+        assert self.store.get_node(callers[0].target_qualified) == survivor
+
+    def test_reindex_collision_reorder_preserves_identities_and_callers(self):
+        target_file = "/test/target.py"
+        caller_file = "/test/caller.py"
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=10, line_end=12, language="python", params="(first)"),
+            NodeInfo(kind="Function", name="render", file_path=target_file,
+                     line_start=20, line_end=24, language="python", params="(second)"),
+        ]
+        self.store.store_file_nodes_edges(target_file, nodes, [])
+        original_qns = {
+            node.params: node.qualified_name
+            for node in self.store.get_nodes_by_file(target_file)
+        }
+        caller_nodes = [
+            NodeInfo(kind="Function", name="call_first", file_path=caller_file,
+                     line_start=1, line_end=3, language="python"),
+            NodeInfo(kind="Function", name="call_second", file_path=caller_file,
+                     line_start=5, line_end=7, language="python"),
+        ]
+        self.store.store_file_nodes_edges(
+            caller_file,
+            caller_nodes,
+            [
+                EdgeInfo(
+                    kind="CALLS", source=f"{caller_file}::call_first",
+                    target=original_qns["(first)"], file_path=caller_file, line=2,
+                ),
+                EdgeInfo(
+                    kind="CALLS", source=f"{caller_file}::call_second",
+                    target=original_qns["(second)"], file_path=caller_file, line=6,
+                ),
+            ],
+        )
+
+        self.store.store_file_nodes_edges(
+            target_file,
+            [
+                NodeInfo(kind="Function", name="render", file_path=target_file,
+                         line_start=10, line_end=14, language="python", params="(second)"),
+                NodeInfo(kind="Function", name="render", file_path=target_file,
+                         line_start=20, line_end=22, language="python", params="(first)"),
+            ],
+            [],
+        )
+
+        reordered = {
+            node.params: node.qualified_name
+            for node in self.store.get_nodes_by_file(target_file)
+        }
+        assert reordered == original_qns
+        for qualified_name in original_qns.values():
+            callers = self.store.get_edges_by_target(qualified_name)
+            assert len(callers) == 1
+            assert self.store.get_node(callers[0].target_qualified) is not None
+
     def test_upsert_same_colliding_definition_updates_in_place(self):
         nodes = [
             NodeInfo(kind="Function", name="render", file_path="/test/file.py",

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -578,6 +578,44 @@ class TestGraphStore:
             assert len(callers) == 1
             assert self.store.get_node(callers[0].target_qualified) is not None
 
+    def test_reindex_unique_signature_and_line_change_keeps_bare_identity(self):
+        target_file = "/test/target.py"
+        caller_file = "/test/caller.py"
+        base_qualified = f"{target_file}::render"
+        original = NodeInfo(
+            kind="Function", name="render", file_path=target_file,
+            line_start=10, line_end=12, language="python", params="(a)",
+        )
+        self.store.store_file_nodes_edges(target_file, [original], [])
+        caller = NodeInfo(
+            kind="Function", name="call_render", file_path=caller_file,
+            line_start=1, line_end=3, language="python",
+        )
+        self.store.store_file_nodes_edges(
+            caller_file,
+            [caller],
+            [EdgeInfo(
+                kind="CALLS", source=f"{caller_file}::call_render",
+                target=base_qualified, file_path=caller_file, line=2,
+            )],
+        )
+
+        for line_start, params in [(12, "(a, b)"), (14, "(a, b, c)")]:
+            self.store.store_file_nodes_edges(
+                target_file,
+                [NodeInfo(
+                    kind="Function", name="render", file_path=target_file,
+                    line_start=line_start, line_end=line_start + 2,
+                    language="python", params=params,
+                )],
+                [],
+            )
+            stored = self.store.get_node(base_qualified)
+            assert stored is not None
+            assert stored.params == params
+            assert len(self.store.get_nodes_by_file(target_file)) == 1
+            assert len(self.store.get_edges_by_target(base_qualified)) == 1
+
     def test_upsert_same_colliding_definition_updates_in_place(self):
         nodes = [
             NodeInfo(kind="Function", name="render", file_path="/test/file.py",
@@ -652,6 +690,49 @@ class TestGraphStore:
 
         assert len(self.store.get_edges_by_target(base_qualified)) == 1
         assert self.store.get_edges_by_target(disambiguated.qualified_name) == []
+
+    def test_unresolved_identity_lookup_uses_qualified_name_index_range(self):
+        statements = []
+        self.store._conn.set_trace_callback(statements.append)
+        try:
+            self.store._resolve_stored_identity("/test/file.py::missing")
+        finally:
+            self.store._conn.set_trace_callback(None)
+
+        prefix_queries = [
+            statement
+            for statement in statements
+            if statement.startswith("SELECT qualified_name FROM nodes")
+        ]
+        assert len(prefix_queries) == 1
+        assert "qualified_name >=" in prefix_queries[0]
+        assert "qualified_name <" in prefix_queries[0]
+        assert "substr(" not in prefix_queries[0]
+
+    def test_colon_symbol_is_not_mistaken_for_collision_suffix(self):
+        target_file = "/test/target.m"
+        caller_file = "/test/caller.m"
+        bare_target = f"{target_file}::render"
+        selector = NodeInfo(
+            kind="Function", name="render:Save:", file_path=target_file,
+            line_start=10, line_end=12, language="objc",
+        )
+        self.store.store_file_nodes_edges(target_file, [selector], [])
+        caller = NodeInfo(
+            kind="Function", name="callRender", file_path=caller_file,
+            line_start=1, line_end=3, language="objc",
+        )
+        self.store.store_file_nodes_edges(
+            caller_file,
+            [caller],
+            [EdgeInfo(
+                kind="CALLS", source=f"{caller_file}::callRender",
+                target=bare_target, file_path=caller_file, line=2,
+            )],
+        )
+
+        assert len(self.store.get_edges_by_target(bare_target)) == 1
+        assert self.store.get_edges_by_target(f"{target_file}::render:Save:") == []
 
     def test_store_after_remove_no_transaction_error(self):
         """Regression test for #135: store_file_nodes_edges after

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -361,6 +361,70 @@ class TestGraphStore:
         result = self.store.get_nodes_by_file("/test/file.py")
         assert len(result) == 2
 
+    def test_store_file_preserves_qualified_name_collisions(self):
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=20, line_end=24, language="python"),
+        ]
+
+        self.store.store_file_nodes_edges("/test/file.py", nodes, [])
+
+        stored = self.store.get_nodes_by_file("/test/file.py")
+        assert sorted((node.line_start, node.line_end) for node in stored) == [
+            (10, 12),
+            (20, 24),
+        ]
+
+    def test_reindex_same_colliding_definition_updates_in_place(self):
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=20, line_end=24, language="python"),
+        ]
+        self.store.store_file_nodes_edges("/test/file.py", nodes, [])
+        original = next(
+            node for node in self.store.get_nodes_by_file("/test/file.py")
+            if node.line_start == 20
+        )
+
+        node_id = self.store.upsert_node(nodes[1])
+
+        stored = self.store.get_nodes_by_file("/test/file.py")
+        assert len(stored) == 2
+        assert node_id == original.id
+
+    def test_recursive_edge_resolves_for_disambiguated_node(self):
+        base_qualified = "/test/file.py::render"
+        nodes = [
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=10, line_end=12, language="python"),
+            NodeInfo(kind="Function", name="render", file_path="/test/file.py",
+                     line_start=20, line_end=24, language="python"),
+        ]
+        edges = [
+            EdgeInfo(
+                kind="CALLS", source=base_qualified, target=base_qualified,
+                file_path="/test/file.py", line=22,
+            )
+        ]
+
+        self.store.store_file_nodes_edges("/test/file.py", nodes, edges)
+
+        disambiguated = next(
+            node for node in self.store.get_nodes_by_file("/test/file.py")
+            if node.line_start == 20
+        )
+        callers = self.store.get_edges_by_target(disambiguated.qualified_name)
+        callees = self.store.get_edges_by_source(disambiguated.qualified_name)
+        assert disambiguated.qualified_name == f"{base_qualified}:L20"
+        assert len(callers) == 1
+        assert len(callees) == 1
+        assert self.store.get_node(callers[0].source_qualified) == disambiguated
+        assert self.store.get_node(callees[0].target_qualified) == disambiguated
+
     def test_store_after_remove_no_transaction_error(self):
         """Regression test for #135: store_file_nodes_edges after
         remove_file_data must not raise 'cannot start a transaction


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #585

## What & why

Two distinct definitions in the same file could produce the same base qualified name. Because `nodes.qualified_name` is unique and `upsert_node()` updated on that conflict, the later definition silently replaced the earlier node. Its line range disappeared, and distinct graph edges could collapse onto the surviving node.

Minimal reproduction:

```python
nodes = [
    NodeInfo(kind="Function", name="render", file_path="/repo/app.py", line_start=10, line_end=12),
    NodeInfo(kind="Function", name="render", file_path="/repo/app.py", line_start=20, line_end=24),
]
store.store_file_nodes_edges("/repo/app.py", nodes, [])
```

Before:

```text
[("/repo/app.py::render", 20, 24)]
```

After:

```text
[("/repo/app.py::render", 10, 12),
 ("/repo/app.py::render:S<semantic-fingerprint>", 20, 24)]
```

## Identity strategy

The first definition keeps the existing bare qualified name. Only genuine collisions are disambiguated, so all unambiguous identities remain unchanged.

A collided definition receives a deterministic suffix derived from semantic node fields rather than its source line. If multiple colliding definitions have identical semantic fields, a deterministic occurrence suffix is added. This preserves both definitions while keeping their identities stable when harmless lines are inserted above them during an incremental rebuild.

That stability matters because qualified names are also edge keys. A line-based suffix changed after a line shift, leaving cross-file incoming edges pointed at a deleted identity. The semantic suffix keeps those identities—and therefore their incoming edges—valid across the real `store_file_nodes_edges()` remove-and-replace lifecycle.

## Edge-resolution trade-off

Batch storage aligns an edge endpoint with a collided identity only when the edge provides enough evidence:

- outgoing edges use the source definition whose line range contains the edge;
- `CONTAINS` edges use the target definition's start line; and
- recursive calls use the same disambiguated identity as their source definition.

An incoming call with no evidence about which duplicate it targets deliberately remains on the canonical bare identity. It is not assigned arbitrarily to a disambiguated definition.

## How it was tested

The regression coverage now verifies:

- two same-file definitions with the same base qualified name both survive with distinct line ranges;
- direct re-indexing of the same definition updates in place without creating a duplicate;
- a harmless line insertion above duplicate definitions does not change their identities;
- distinct cross-file callers to every duplicate still resolve after re-indexing;
- recursive caller/callee queries resolve a disambiguated node; and
- ambiguous incoming targets remain explicitly attached to the canonical identity.

Validation on current `main` (`805c4c6`):

```bash
uv run pytest
uv run ruff check code_review_graph/
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

Results: 2,070 passed, 5 skipped, 2 xpassed; Ruff clean; mypy clean across 66 source files.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Implementation docstrings describe the behavior
