### PR TITLE
fix(parser): detect PHPUnit @test docblocks and #[Test] attributes

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1732,6 +1732,55 @@ def _csharp_attribute_names(node) -> list[str]:
     return names
 
 
+def _php_attribute_names(node) -> list[str]:
+    """Return PHP attribute names from ``attribute_list`` children of *node*.
+
+    PHP 8 attributes (``#[Test]``, ``#[DataProvider('x')]``) are
+    ``attribute_list`` nodes wrapping one or more ``attribute_group`` nodes,
+    each wrapping one or more ``attribute`` nodes whose ``name`` child is the
+    attribute name -- one level deeper than C#'s ``attribute_list >
+    attribute``. See: #693
+    """
+    names: list[str] = []
+    for sub in node.children:
+        if sub.type != "attribute_list":
+            continue
+        for group in sub.children:
+            if group.type != "attribute_group":
+                continue
+            for attr in group.children:
+                if attr.type != "attribute":
+                    continue
+                for ident in attr.children:
+                    if ident.type == "name":
+                        names.append(
+                            ident.text.decode("utf-8", errors="replace").strip(),
+                        )
+                        break
+    return names
+
+
+_PHP_TEST_DOC_TAG_RE = re.compile(r"@test\b")
+
+
+def _php_docblock_marks_test(node) -> bool:
+    """Return True if a PHPUnit ``/** @test */`` docblock precedes *node*.
+
+    PHPUnit's legacy convention marks a test method with an ``@test`` tag in
+    the doc comment immediately above it, instead of a ``test_`` name prefix
+    or a ``#[Test]`` attribute. Tree-sitter represents that comment as a
+    preceding sibling of the ``method_declaration``, not a child, so it needs
+    its own check rather than reuse of the attribute-based extraction above.
+    See: #693
+    """
+    sib = node.prev_sibling
+    return bool(
+        sib is not None
+        and sib.type == "comment"
+        and _PHP_TEST_DOC_TAG_RE.search(sib.text.decode("utf-8", errors="replace"))
+    )
+
+
 def _csharp_namespaces(root_node) -> list[str]:
     """Return all namespaces declared in a C# compilation unit.
 
@@ -9185,6 +9234,15 @@ class CodeParser:
         # See: #295
         if language == "csharp":
             deco_list.extend(_csharp_attribute_names(child))
+        # PHP: `#[Test]` attributes wrap `attribute_list > attribute_group >
+        # attribute > name`. PHPUnit's legacy `/** @test */` docblock tag is
+        # a preceding-sibling `comment` node instead, so it needs a separate
+        # check; when present it's folded into `deco_list` as `"Test"` since
+        # that's already in `_TEST_ANNOTATIONS`. See: #693
+        if language == "php":
+            deco_list.extend(_php_attribute_names(child))
+            if _php_docblock_marks_test(child):
+                deco_list.append("Test")
         if deco_list:
             decorators = tuple(deco_list)
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1838,6 +1838,40 @@ def _csharp_attribute_names(node) -> list[str]:
     return names
 
 
+def _php_attribute_aliases(node) -> dict[str, str]:
+    """Return PHP import aliases mapped to their final symbol name."""
+    root = node
+    while root.parent is not None:
+        root = root.parent
+
+    aliases: dict[str, str] = {}
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        if current.type == "namespace_use_clause":
+            alias = current.child_by_field_name("alias")
+            if alias is not None:
+                target = next(
+                    (
+                        child
+                        for child in current.children
+                        if child.type in ("name", "qualified_name")
+                        and child != alias
+                    ),
+                    None,
+                )
+                if target is not None:
+                    alias_text = alias.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip()
+                    target_text = target.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip()
+                    aliases[alias_text] = target_text.lstrip("\\").rsplit("\\", 1)[-1]
+        stack.extend(reversed(current.children))
+    return aliases
+
+
 def _php_attribute_names(node) -> list[str]:
     """Return PHP attribute names from ``attribute_list`` children of *node*.
 
@@ -1858,15 +1892,19 @@ def _php_attribute_names(node) -> list[str]:
                 if attr.type != "attribute":
                     continue
                 for ident in attr.children:
-                    if ident.type == "name":
-                        names.append(
-                            ident.text.decode("utf-8", errors="replace").strip(),
-                        )
+                    if ident.type in ("name", "qualified_name"):
+                        raw_name = ident.text.decode(
+                            "utf-8", errors="replace",
+                        ).strip()
+                        names.append(raw_name.lstrip("\\").rsplit("\\", 1)[-1])
                         break
-    return names
+    if not names:
+        return []
+    aliases = _php_attribute_aliases(node)
+    return [aliases.get(name, name) for name in names]
 
 
-_PHP_TEST_DOC_TAG_RE = re.compile(r"@test\b")
+_PHP_TEST_DOC_TAG_RE = re.compile(r"(?<![\w-])@test(?![\w-])")
 
 
 def _php_docblock_marks_test(node) -> bool:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1838,8 +1838,11 @@ def _csharp_attribute_names(node) -> list[str]:
     return names
 
 
+_PHPUNIT_TEST_ATTRIBUTE = "phpunit\\framework\\attributes\\test"
+
+
 def _php_attribute_aliases(node) -> dict[str, str]:
-    """Return PHP import aliases mapped to their final symbol name."""
+    """Return aliases that resolve specifically to PHPUnit's Test attribute."""
     root = node
     while root.parent is not None:
         root = root.parent
@@ -1867,7 +1870,24 @@ def _php_attribute_aliases(node) -> dict[str, str]:
                     target_text = target.text.decode(
                         "utf-8", errors="replace",
                     ).strip()
-                    aliases[alias_text] = target_text.lstrip("\\").rsplit("\\", 1)[-1]
+                    if current.parent.type == "namespace_use_group":
+                        declaration = current.parent.parent
+                        prefix = next(
+                            (
+                                child
+                                for child in declaration.children
+                                if child.type == "namespace_name"
+                            ),
+                            None,
+                        )
+                        if prefix is not None:
+                            prefix_text = prefix.text.decode(
+                                "utf-8", errors="replace",
+                            ).strip()
+                            target_text = f"{prefix_text}\\{target_text}"
+                    normalized_target = target_text.lstrip("\\").casefold()
+                    if normalized_target == _PHPUNIT_TEST_ATTRIBUTE:
+                        aliases[alias_text.casefold()] = "Test"
         stack.extend(reversed(current.children))
     return aliases
 
@@ -1896,12 +1916,16 @@ def _php_attribute_names(node) -> list[str]:
                         raw_name = ident.text.decode(
                             "utf-8", errors="replace",
                         ).strip()
-                        names.append(raw_name.lstrip("\\").rsplit("\\", 1)[-1])
+                        normalized = raw_name.lstrip("\\")
+                        if normalized.casefold() == _PHPUNIT_TEST_ATTRIBUTE:
+                            names.append("Test")
+                        else:
+                            names.append(normalized)
                         break
     if not names:
         return []
     aliases = _php_attribute_aliases(node)
-    return [aliases.get(name, name) for name in names]
+    return [aliases.get(name.casefold(), name) for name in names]
 
 
 _PHP_TEST_DOC_TAG_RE = re.compile(r"(?<![\w-])@test(?![\w-])")

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -739,6 +739,70 @@ class Service extends \\Framework\\Base implements Contract, \\Other\\Marker {
         assert "Service::factory" in calls
 
 
+class TestPHPTestAnnotations:
+    """Regression tests for #693: PHP test methods were only recognised by
+    the ``test_`` name prefix. Neither PHPUnit's legacy ``/** @test */``
+    docblock tag nor the PHP 8 ``#[Test]`` attribute was detected, so those
+    methods were misclassified as production ``Function`` nodes. Mirrors the
+    C# attribute fix from #295: PHP attributes need their own capture path
+    (``attribute_list > attribute_group > attribute``, one level deeper than
+    C#'s), and the docblock tag needs a separate preceding-sibling check.
+    """
+
+    def _parse(self, tmp_path):
+        p = tmp_path / "ExampleTest.php"
+        p.write_text(
+            "<?php\n"
+            "namespace Tests;\n\n"
+            "use PHPUnit\\Framework\\TestCase;\n"
+            "use PHPUnit\\Framework\\Attributes\\Test;\n\n"
+            "class ExampleTest extends TestCase\n"
+            "{\n"
+            "    public function test_prefixed_method_should_be_detected(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    /** @test */\n"
+            "    public function docblock_annotated_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[Test]\n"
+            "    public function php8_attribute_annotated_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    public function helperNotATest(): void\n"
+            "    {\n"
+            "    }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        return CodeParser().parse_file(p)
+
+    def test_name_prefix_still_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "test_prefixed_method_should_be_detected")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_docblock_annotation_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "docblock_annotated_method")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_php8_attribute_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "php8_attribute_annotated_method")
+        assert m.kind == "Test"
+        assert m.is_test is True
+        assert m.extra.get("decorators") == ["Test"]
+
+    def test_plain_method_not_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "helperNotATest")
+        assert m.kind == "Function"
+        assert m.is_test is False
+
+
 class TestPHPImportResolution:
     """PHP ``use`` imports resolve to absolute file paths (PSR-4 layout)."""
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -793,6 +793,7 @@ class TestPHPTestAnnotations:
             "use PHPUnit\\Framework\\Attributes\\Test;\n\n"
             "use PHPUnit\\Framework\\Attributes\\Test as UnitTest;\n"
             "use PHPUnit\\Framework\\Attributes\\DataProvider;\n\n"
+            "use App\\Attributes\\Test as OtherTest;\n\n"
             "class ExampleTest extends TestCase\n"
             "{\n"
             "    public function test_prefixed_method_should_be_detected(): void\n"
@@ -816,6 +817,14 @@ class TestPHPTestAnnotations:
             "    }\n\n"
             "    #[DataProvider('rows'), Test]\n"
             "    public function grouped_attribute_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[\\App\\Attributes\\Test]\n"
+            "    public function unrelated_qualified_attribute(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[OtherTest]\n"
+            "    public function unrelated_aliased_attribute(): void\n"
             "    {\n"
             "    }\n\n"
             "    /** @test-case is documentation, not a PHPUnit tag. */\n"
@@ -866,6 +875,22 @@ class TestPHPTestAnnotations:
         m = next(n for n in nodes if n.name == "grouped_attribute_method")
         assert m.kind == "Test"
         assert m.is_test is True
+
+    def test_unrelated_qualified_attribute_is_not_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(
+            n for n in nodes if n.name == "unrelated_qualified_attribute"
+        )
+        assert m.kind == "Function"
+        assert m.is_test is False
+
+    def test_unrelated_aliased_attribute_is_not_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(
+            n for n in nodes if n.name == "unrelated_aliased_attribute"
+        )
+        assert m.kind == "Function"
+        assert m.is_test is False
 
     def test_similar_docblock_tag_is_not_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -791,6 +791,8 @@ class TestPHPTestAnnotations:
             "namespace Tests;\n\n"
             "use PHPUnit\\Framework\\TestCase;\n"
             "use PHPUnit\\Framework\\Attributes\\Test;\n\n"
+            "use PHPUnit\\Framework\\Attributes\\Test as UnitTest;\n"
+            "use PHPUnit\\Framework\\Attributes\\DataProvider;\n\n"
             "class ExampleTest extends TestCase\n"
             "{\n"
             "    public function test_prefixed_method_should_be_detected(): void\n"
@@ -802,6 +804,22 @@ class TestPHPTestAnnotations:
             "    }\n\n"
             "    #[Test]\n"
             "    public function php8_attribute_annotated_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[\\PHPUnit\\Framework\\Attributes\\Test]\n"
+            "    public function qualified_attribute_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[UnitTest]\n"
+            "    public function aliased_attribute_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    #[DataProvider('rows'), Test]\n"
+            "    public function grouped_attribute_method(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    /** @test-case is documentation, not a PHPUnit tag. */\n"
+            "    public function documented_helper(): void\n"
             "    {\n"
             "    }\n\n"
             "    public function helperNotATest(): void\n"
@@ -830,6 +848,30 @@ class TestPHPTestAnnotations:
         assert m.kind == "Test"
         assert m.is_test is True
         assert m.extra.get("decorators") == ["Test"]
+
+    def test_qualified_php8_attribute_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "qualified_attribute_method")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_aliased_php8_attribute_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "aliased_attribute_method")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_grouped_php8_attribute_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "grouped_attribute_method")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_similar_docblock_tag_is_not_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "documented_helper")
+        assert m.kind == "Function"
+        assert m.is_test is False
 
     def test_plain_method_not_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)


### PR DESCRIPTION
## Summary

PHP test methods are currently recognized only by the `test_` name prefix. Neither PHPUnit's legacy `/** @test */` docblock tag nor the PHP 8 `#[Test]` attribute is detected, so methods using either style are classified as production `Function` nodes with `is_test: false` instead of `Test` nodes.

This is the same class of gap as the C# `attribute_list` fix (#295): PHP just never got a language branch in the decorator/annotation extraction in `_extract_functions`, so `decorators` was always empty for PHP and `_is_test_function` fell through to name matching only. `_TEST_ANNOTATIONS` already contains `"Test"`, so `#[Test]` works as soon as PHP attributes are captured.

## Fix

Two separate paths, since they're different node shapes in tree-sitter-php:

- **`#[Test]` attributes** — a new `_php_attribute_names` helper reads `attribute_list > attribute_group > attribute > name` from the method's children (one level deeper than C#'s `attribute_list > attribute`, since PHP wraps each `#[...]` group in an intermediate `attribute_group` node).
- **`/** @test */` docblocks** — not an attribute at all; it's a `comment` node that's a *preceding sibling* of the `method_declaration`, not a child. A new `_php_docblock_marks_test` helper checks the previous sibling for the `@test` tag and, when found, folds `"Test"` into the existing decorator list so it flows through the existing `_TEST_ANNOTATIONS` check unchanged.

Both wire into the existing PHP branch alongside C#'s in `_extract_functions`.

## Test evidence

Added `TestPHPTestAnnotations` in `tests/test_multilang.py`, covering all four cases from the issue in one fixture:

- `test_`-prefixed method — still detected (control)
- `/** @test */` docblock — now detected
- `#[Test]` attribute — now detected
- plain method with no marker — still not detected (control)

```
$ uv run pytest tests/test_multilang.py -k PHPTestAnnotations -v
tests/test_multilang.py::TestPHPTestAnnotations::test_name_prefix_still_detected PASSED
tests/test_multilang.py::TestPHPTestAnnotations::test_docblock_annotation_detected PASSED
tests/test_multilang.py::TestPHPTestAnnotations::test_php8_attribute_detected PASSED
tests/test_multilang.py::TestPHPTestAnnotations::test_plain_method_not_detected PASSED
4 passed
```

Confirmed the two new-detection tests fail without the fix (stashed `parser.py` only, tests unchanged):

```
tests/test_multilang.py::TestPHPTestAnnotations::test_docblock_annotation_detected FAILED
tests/test_multilang.py::TestPHPTestAnnotations::test_php8_attribute_detected FAILED
2 failed, 2 passed
```

Full suite: `ruff check` clean, `mypy --ignore-missing-imports --no-strict-optional` clean, `pytest --cov=code_review_graph --cov-fail-under=65`: **1965 passed, 5 skipped, 2 xpassed**, coverage 79.81%.

Closes #693.