### PR TITLE
fix(wiki): preserve accents and support unicode in _slugify

### DIFF
--- a/code_review_graph/wiki.py
+++ b/code_review_graph/wiki.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import re
 import sqlite3
+import unicodedata
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 def _slugify(name: str) -> str:
     """Convert a community name to a safe filename slug."""
-    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    normalized = unicodedata.normalize("NFKD", name)
+    ascii_str = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_str.lower()).strip("-")
     return slug[:80] or "unnamed"
 
 

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -253,3 +253,31 @@ class TestWiki:
         assert content_first != content_second
         assert content_first != content_third
         assert content_second != content_third
+
+
+    def test_slugify_unicode(self):
+        """Test _slugify with ASCII, accented characters, CJK scripts, and empty/special inputs."""
+        assert _slugify("Data Processing") == "data-processing"
+        assert _slugify("café") == "cafe"
+        assert _slugify("tiếng-việt") == "tieng-viet"
+
+        # Multilingual Latin accented scripts (French, German, Spanish, Swedish/Danish, Polish)
+        assert _slugify("déjà vu") == "deja-vu"
+        assert _slugify("München") == "munchen"
+        assert _slugify("El Niño") == "el-nino"
+        assert _slugify("Malmö") == "malmo"
+        assert _slugify("København") == "kbenhavn"
+
+        # Fullwidth characters
+        assert _slugify("Ｐｙｔｈｏｎ") == "python"
+
+        # Empty and special characters
+        assert _slugify("") == "unnamed"
+        assert _slugify("---") == "unnamed"
+
+        # Non-ASCII CJK scripts fall back to unnamed
+        assert _slugify("パーサー") == "unnamed"
+        assert _slugify("解析器") == "unnamed"
+
+
+


### PR DESCRIPTION
# Pull Request

## Linked issue

N/A — Minor bugfix for Latin accent normalization in community wiki slugs.

## What & why

- Updated `_slugify()` in `code_review_graph/wiki.py` using `unicodedata.normalize("NFKD", ...)` before stripping non-ASCII characters.
- Accented letters in community names (e.g. `café` -> `cafe`, `tiếng-việt` -> `tieng-viet`, `déjà vu` -> `deja-vu`, `München` -> `munchen`) are now properly converted to base ASCII instead of being truncated.
- Non-Latin CJK scripts fall back to `unnamed` as before.

## How it was tested

Added unit tests in `tests/test_wiki.py` (`test_slugify_unicode`).

Run verification suite:
- `uv run pytest tests/test_wiki.py -v` (10 passed)
- `uv run pytest tests/ --tb=short -q` (1962 passed)
- `uv run ruff check code_review_graph/` (passed)
- `uvx mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` (passed)

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (README, `docs/`, docstrings)
