### PR TITLE
fix(incremental): purge old paths on rename — parse git diff --name-status

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -534,9 +534,29 @@ _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
 _SAFE_SVN_REV = re.compile(r"^r?\d+(:r?\d+|:HEAD|:BASE|:COMMITTED)?$", re.IGNORECASE)
 
 
-def _decode_nul_paths(output: bytes) -> list[str]:
-    """Decode Git's NUL-delimited path output without quote mangling."""
-    return [os.fsdecode(path) for path in output.split(b"\0") if path]
+def _decode_name_status_paths(output: bytes) -> list[str]:
+    """Decode ``git diff --name-status -z`` output into a list of paths.
+
+    Renames and copies (``R<score>``/``C<score>`` records) carry two paths —
+    the old and the new one.  Both are emitted so the old path flows through
+    the purge loop in :func:`incremental_update`; otherwise a rename leaves
+    the old path's nodes and edges in the graph and the incremental result
+    diverges from a full rebuild.
+    """
+    fields = [os.fsdecode(f) for f in output.split(b"\0") if f]
+    paths: list[str] = []
+    seen: set[str] = set()
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        takes_two = status[:1] in ("R", "C")
+        entry = fields[i + 1 : i + (3 if takes_two else 2)]
+        i += 3 if takes_two else 2
+        for path in entry:
+            if path not in seen:
+                seen.add(path)
+                paths.append(path)
+    return paths
 
 
 def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
@@ -571,8 +591,10 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         logger.warning("Invalid git ref rejected: %s", base)
         return []
     try:
+        # --name-status (not --name-only): renames/copies must report BOTH
+        # paths, or the old path never reaches the purge loop (issue #684).
         result = subprocess.run(
-            ["git", "diff", "--name-only", "-z", base, "--"],
+            ["git", "diff", "--name-status", "-z", base, "--"],
             capture_output=True,
             cwd=str(repo_root),
             timeout=_GIT_TIMEOUT,
@@ -581,7 +603,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         if result.returncode != 0:
             # Fallback: try diff against empty tree (initial commit)
             result = subprocess.run(
-                ["git", "diff", "--name-only", "-z", "--cached"],
+                ["git", "diff", "--name-status", "-z", "--cached"],
                 capture_output=True,
                 cwd=str(repo_root),
                 timeout=_GIT_TIMEOUT,
@@ -590,7 +612,7 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         if result.returncode != 0:
             logger.warning("git diff failed while discovering changed files")
             return []
-        return _decode_nul_paths(result.stdout)
+        return _decode_name_status_paths(result.stdout)
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch  # noqa: F401 – patch used in tests
 import code_review_graph.incremental as incremental_module
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
+    _decode_name_status_paths,
     _is_binary,
     _load_ignore_patterns,
     _parse_single_file,
@@ -527,7 +528,7 @@ class TestGitOperations:
     def test_get_changed_files(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=b"src/a.py\0src/b.py\0",
+            stdout=b"M\0src/a.py\0A\0src/b.py\0",
         )
         result = get_changed_files(tmp_path)
         assert result == ["src/a.py", "src/b.py"]
@@ -543,7 +544,7 @@ class TestGitOperations:
         # First call fails, second succeeds
         mock_run.side_effect = [
             MagicMock(returncode=1, stdout=b""),
-            MagicMock(returncode=0, stdout=b"staged.py\0"),
+            MagicMock(returncode=0, stdout=b"A\0staged.py\0"),
         ]
         result = get_changed_files(tmp_path)
         assert result == ["staged.py"]
@@ -554,7 +555,7 @@ class TestGitOperations:
     def test_get_changed_files_rejects_failed_fallback(self, mock_run, tmp_path):
         mock_run.side_effect = [
             MagicMock(returncode=128, stdout=b""),
-            MagicMock(returncode=128, stdout=b"misleading.py\0"),
+            MagicMock(returncode=128, stdout=b"A\0misleading.py\0"),
         ]
 
         assert get_changed_files(tmp_path) == []
@@ -981,5 +982,59 @@ class TestStartWatchThread:
             with patch.dict("sys.modules", {"watchdog": None}):
                 thread = start_watch_thread(tmp_path, store, daemon=True)
             assert thread is None
+        finally:
+            store.close()
+
+
+class TestRenamePurgeParity:
+    """Issue #684: a rename must purge the old path so an incremental update
+    converges to the same graph as a full rebuild."""
+
+    def _git(self, cwd, *args):
+        subprocess.run(
+            ["git", "-c", "user.email=t@test", "-c", "user.name=t", *args],
+            cwd=str(cwd), check=True, capture_output=True,
+        )
+
+    def test_decode_name_status_emits_both_rename_paths(self):
+        out = b"M\0app.py\0R100\0old.py\0new.py\0A\0added.py\0"
+        assert _decode_name_status_paths(out) == ["app.py", "old.py", "new.py", "added.py"]
+
+    def test_decode_name_status_copy_records_and_dedupe(self):
+        out = b"C75\0src/a.py\0src/b.py\0M\0src/a.py\0"
+        assert _decode_name_status_paths(out) == ["src/a.py", "src/b.py"]
+
+    def test_decode_name_status_empty(self):
+        assert _decode_name_status_paths(b"") == []
+
+    @patch("code_review_graph.incremental.subprocess.run")
+    def test_get_changed_files_reports_both_sides_of_rename(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=b"R100\0old.py\0new.py\0",
+        )
+        assert get_changed_files(tmp_path) == ["old.py", "new.py"]
+
+    def test_rename_purges_old_path_end_to_end(self, tmp_path):
+        self._git(tmp_path, "init", "-q")
+        (tmp_path / "a.py").write_text("def foo():\n    return 1\n")
+        self._git(tmp_path, "add", ".")
+        self._git(tmp_path, "commit", "-qm", "init")
+
+        store = GraphStore(tmp_path / "g.db")
+        try:
+            incremental_update(tmp_path, store, changed_files=["a.py"])
+            assert store.get_nodes_by_file(str(tmp_path / "a.py"))
+
+            self._git(tmp_path, "mv", "a.py", "b.py")
+            self._git(tmp_path, "commit", "-qm", "rename")
+
+            changed = get_changed_files(tmp_path, base="HEAD~1")
+            assert set(changed) == {"a.py", "b.py"}
+
+            incremental_update(tmp_path, store, changed_files=changed)
+            # Old path fully purged, new path present — full-rebuild parity.
+            assert store.get_nodes_by_file(str(tmp_path / "a.py")) == []
+            assert store.get_nodes_by_file(str(tmp_path / "b.py"))
         finally:
             store.close()

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -352,3 +352,50 @@ def test_wiki_page_path_traversal_blocked(tmp_path: Path) -> None:
     # Attempt a path traversal — should return None
     result = get_wiki_page(str(wiki_dir), "../../etc/passwd")
     assert result is None
+
+
+def test_incremental_rename_matches_a_fresh_full_rebuild(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A committed rename must not leave graph state behind at the old path."""
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    repo = tmp_path / "rename-repo"
+    repo.mkdir()
+    assert _git(repo, "init").returncode == 0
+    assert _git(repo, "config", "user.email", "test@test.com").returncode == 0
+    assert _git(repo, "config", "user.name", "Test").returncode == 0
+
+    (repo / "a.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    assert _git(repo, "add", "--", "a.py").returncode == 0
+    assert _git(repo, "commit", "-m", "add a.py").returncode == 0
+
+    incremental_store = GraphStore(tmp_path / "incremental.db")
+    full_store = None
+    try:
+        full_build(repo, incremental_store)
+        assert incremental_store.get_nodes_by_file(str(repo / "a.py"))
+
+        assert _git(repo, "mv", "--", "a.py", "b.py").returncode == 0
+        assert _git(repo, "commit", "-m", "rename a.py to b.py").returncode == 0
+
+        incremental_update(repo, incremental_store)
+
+        full_store = GraphStore(tmp_path / "full.db")
+        full_build(repo, full_store)
+
+        assert set(incremental_store.get_all_files()) == set(
+            full_store.get_all_files()
+        )
+        assert (
+            incremental_store.get_stats().total_nodes
+            == full_store.get_stats().total_nodes
+        )
+        assert (
+            incremental_store.get_stats().total_edges
+            == full_store.get_stats().total_edges
+        )
+    finally:
+        incremental_store.close()
+        if full_store is not None:
+            full_store.close()


### PR DESCRIPTION
Fixes #684.

## Problem
`git diff --name-only` reports a rename `a.py → b.py` as **only the new path**, so `incremental_update()` never sees `a.py`. The purge loop only removes paths present in the changed/dependent set, so the old path's File/Function/Class nodes and every edge keyed to it survive — an incremental update permanently diverges from a full rebuild (stale nodes, dangling importer edges, inflated counts).

## Fix
- Change discovery now uses `git diff --name-status -z` (both in the primary call and the `--cached` fallback).
- New `_decode_name_status_paths()` parses the NUL-delimited records and emits **both** sides of `R*`/`C*` entries (order-preserving, deduped). The old path then flows through the existing purge loop's `is_file()` check and is removed — no changes needed to the purge logic itself.
- `_decode_nul_paths` had no remaining callers and is removed.

## Tests
- Unit: record parser — `M/A/D`, `R100` (two paths), `C75`, dedupe, empty input.
- `get_changed_files` with a mocked rename returns both paths.
- **End-to-end repro from the issue:** real git repo, `git mv a.py b.py` + commit, `get_changed_files(base="HEAD~1")` → `{a.py, b.py}`, then `incremental_update` — asserts the old path is fully purged and the new one is present (full-rebuild parity).
- Updated the three existing `get_changed_files` mocks to the `--name-status` output format.

Full suite: **1966 passed, 5 skipped**. `ruff check` clean.

AI-assisted; every change reviewed and understood.