### PR TITLE
fix(cli): --repo recognises registered subprojects in a monorepo

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -441,6 +441,30 @@ _GRAPH_TOOL_COMMANDS = {
 }
 
 
+def _find_explicit_repo_root(start: Path) -> "Path | None":
+    """Resolve an explicit --repo for graph-tool commands.
+
+    Walks upward from ``start``, stopping at the nearest directory that
+    contains a ``.code-review-graph``, ``.git``, or ``.svn`` marker. Unlike
+    ``find_repo_root``, a registered subproject (``.code-review-graph``)
+    counts as a boundary, so a monorepo subdirectory built with
+    ``build --repo mono/module`` resolves to the module — not to the
+    monorepo's top-level ``.git`` (#697).
+    """
+    current = start.resolve()
+    if not current.is_dir():
+        return None
+    while True:
+        if any(
+            (current / marker).exists()
+            for marker in (".code-review-graph", ".git", ".svn")
+        ):
+            return current
+        if current == current.parent:
+            return None
+        current = current.parent
+
+
 def _run_graph_tool_command(args, repo_root: Path) -> None:
     """Run one graph-tool CLI wrapper and emit exactly one JSON value."""
     from . import tools
@@ -1161,8 +1185,22 @@ def main() -> None:
     if args.command in _GRAPH_TOOL_COMMANDS:
         from .incremental import find_project_root, get_db_path
 
-        requested_root = Path(args.repo).expanduser() if args.repo else None
-        repo_root = find_project_root(requested_root)
+        if args.repo:
+            # For an explicit --repo the walk must treat .code-review-graph
+            # as a project boundary too: the plain .git/.svn walk resolves a
+            # registered monorepo subdirectory to the monorepo root and the
+            # graph built at the --repo path is never found (#697). Nearest
+            # marker wins, so pointing inside a repo still works.
+            repo_root = _find_explicit_repo_root(Path(args.repo).expanduser())
+            if repo_root is None:
+                print(
+                    f"--repo does not look like a project root (no .git, .svn, "
+                    f"or .code-review-graph found at or above): {args.repo}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+        else:
+            repo_root = find_project_root()
         db_path = get_db_path(repo_root)
         if not db_path.exists():
             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,3 +406,53 @@ class TestDetectChangesEndToEnd:
         savings = result["context_savings"]
         assert result["changed_functions"]
         assert savings["saved_percent"] < 100
+
+
+class TestGraphToolExplicitRepoResolution:
+    """Issue #697: an explicit --repo must win over the upward git-root walk."""
+
+    def _make_monorepo(self, tmp_path):
+        mono = tmp_path / "mono"
+        (mono / ".git").mkdir(parents=True)
+        module = mono / "llvm"
+        crg = module / ".code-review-graph"
+        crg.mkdir(parents=True)
+        (crg / "graph.db").write_bytes(b"")
+        return mono, module
+
+    def test_explicit_repo_in_monorepo_uses_subproject_root(self, tmp_path):
+        _, module = self._make_monorepo(tmp_path)
+        argv = ["code-review-graph", "search", "raw_ostream", "--repo", str(module)]
+        with patch.object(sys, "argv", argv):
+            with patch.object(cli, "_run_graph_tool_command") as mock_run:
+                cli.main()
+
+        mock_run.assert_called_once()
+        repo_root = mock_run.call_args.args[1]
+        assert repo_root == module.resolve()
+
+    def test_explicit_repo_without_markers_errors_cleanly(self, tmp_path, capsys):
+        bare = tmp_path / "not-a-project"
+        bare.mkdir()
+        argv = ["code-review-graph", "search", "x", "--repo", str(bare)]
+        with patch.object(sys, "argv", argv):
+            with patch.object(cli, "_run_graph_tool_command") as mock_run:
+                try:
+                    cli.main()
+                    raised = False
+                except SystemExit as exc:
+                    raised = exc.code == 1
+        assert raised
+        mock_run.assert_not_called()
+        assert "does not look like a project root" in capsys.readouterr().err
+
+    def test_repo_inside_module_resolves_to_nearest_marker(self, tmp_path):
+        _, module = self._make_monorepo(tmp_path)
+        nested = module / "src" / "deep"
+        nested.mkdir(parents=True)
+        argv = ["code-review-graph", "search", "x", "--repo", str(nested)]
+        with patch.object(sys, "argv", argv):
+            with patch.object(cli, "_run_graph_tool_command") as mock_run:
+                cli.main()
+
+        assert mock_run.call_args.args[1] == module.resolve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -408,6 +408,63 @@ class TestDetectChangesEndToEnd:
         assert savings["saved_percent"] < 100
 
 
+def test_explicit_monorepo_subproject_runs_a_real_graph_search(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """The CLI must open the graph at the explicit subproject, not its parent repo."""
+    mono = tmp_path / "mono"
+    (mono / ".git").mkdir(parents=True)
+    module = mono / "llvm"
+    nested = module / "src" / "deep"
+    nested.mkdir(parents=True)
+    (module / "stream.py").write_text(
+        "def raw_stream_lookup():\n    return 1\n",
+        encoding="utf-8",
+    )
+
+    # Keep registry writes away from the developer's real home.
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("CRG_HOME", str(state_dir))
+    from code_review_graph import registry as registry_module
+
+    monkeypatch.setattr(
+        registry_module,
+        "_REGISTRY_PATH",
+        state_dir / "registry.json",
+        raising=False,
+    )
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+
+    from code_review_graph.graph import GraphStore
+    from code_review_graph.incremental import full_build
+    from code_review_graph.search import rebuild_fts_index
+
+    db_path = module / ".code-review-graph" / "graph.db"
+    db_path.parent.mkdir(parents=True)
+    store = GraphStore(db_path)
+    try:
+        full_build(module, store)
+        rebuild_fts_index(store)
+    finally:
+        store.close()
+
+    argv = [
+        "code-review-graph",
+        "search",
+        "raw_stream_lookup",
+        "--repo",
+        str(nested),
+    ]
+    with patch.object(sys, "argv", argv):
+        cli.main()
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "ok"
+    assert any(row["name"] == "raw_stream_lookup" for row in result["results"])
+
+
 class TestGraphToolExplicitRepoResolution:
     """Issue #697: an explicit --repo must win over the upward git-root walk."""
 


### PR DESCRIPTION
Fixes #697.

## Problem
`search`/`query`/`impact` resolve `--repo` through `find_project_root()`, whose upward walk looks only for `.git`/`.svn`. In a monorepo (one top-level `.git`, modules registered as independent CRG projects — the llvm-project layout from the issue) an explicit `--repo mono/module` is overridden by the monorepo root, and the command fails with *"No graph found at <monorepo_root>…"* even though the graph exists exactly where `--repo` pointed. `build`/`register`/`status` already accept such paths.

## Fix
Explicit `--repo` now resolves via a dedicated upward walk that treats **`.code-review-graph` as a project boundary alongside `.git`/`.svn`** — nearest marker wins:
- a registered monorepo module resolves to itself;
- a path *inside* a module/repo still resolves to its nearest root (preserves the existing "point anywhere inside the repo" behaviour the test-suite encodes);
- no marker anywhere above → exit 1 with a clear message instead of a misleading "No graph found at <wrong root>".

cwd auto-detect (no `--repo`) is untouched.

## Tests
- monorepo module with own `.code-review-graph` resolves to the module;
- nested path inside the module resolves to the module (nearest marker beats the top-level `.git`);
- markerless path errors cleanly (exit 1, message, tool not invoked).

Full suite: **1964 passed, 5 skipped**, `ruff check` clean. The first iteration of this fix (strict exact-path validation) broke 10 existing `--repo <nested>` tests — the walk-with-extra-marker approach keeps them all green, which is why it's the chosen design.

AI-assisted; every change reviewed and understood.