### PR TITLE
fix(graph): scope bare CALLS/INHERITS name fallback to caller's language

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -398,7 +398,9 @@ class GraphStore:
             ).fetchall())
         return [self._row_to_edge(row) for row in rows]
 
-    def search_edges_by_target_name(self, name: str, kind: str = "CALLS") -> list[GraphEdge]:
+    def search_edges_by_target_name(
+        self, name: str, kind: str = "CALLS", language: str | None = None,
+    ) -> list[GraphEdge]:
         """Search for edges where target_qualified matches an unqualified name.
 
         CALLS edges often store unqualified target names (e.g. ``generateTestCode``)
@@ -406,17 +408,31 @@ class GraphStore:
         method finds those edges by exact match on the plain function name so that
         reverse call tracing (callers_of) works even when qualified-name lookup
         returns nothing.
+
+        When ``language`` is given, only edges whose source node was parsed from
+        that language are returned. Bare (unqualified) names are ambiguous across
+        the whole graph, so without this filter a common method name like
+        ``clone`` can match a same-named method in an unrelated language (#708).
         """
-        return list(self.iter_edges_by_target_name(name, kind=kind))
+        return list(self.iter_edges_by_target_name(name, kind=kind, language=language))
 
     def iter_edges_by_target_name(
-        self, name: str, kind: str = "CALLS",
+        self, name: str, kind: str = "CALLS", language: str | None = None,
     ) -> Iterator[GraphEdge]:
         """Yield exact bare-target edges without materializing all matches."""
-        rows = self._conn.execute(
-            "SELECT * FROM edges WHERE target_qualified = ? AND kind = ?",
-            (name, kind),
-        )
+        if language:
+            rows = self._conn.execute(
+                "SELECT edges.* FROM edges "
+                "JOIN nodes ON nodes.qualified_name = edges.source_qualified "
+                "WHERE edges.target_qualified = ? AND edges.kind = ? "
+                "AND nodes.language = ?",
+                (name, kind, language),
+            )
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM edges WHERE target_qualified = ? AND kind = ?",
+                (name, kind),
+            )
         for row in rows:
             yield self._row_to_edge(row)
 

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -354,7 +354,9 @@ def query_graph(
             # (e.g. "generateTestCode") while qn is fully qualified
             # (e.g. "file.ts::generateTestCode"). Search by plain name too.
             if node:
-                for e in store.iter_edges_by_target_name(node.name):
+                for e in store.iter_edges_by_target_name(
+                    node.name, language=node.language or None,
+                ):
                     if e.source_qualified not in seen_sources:
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
@@ -468,7 +470,9 @@ def query_graph(
             # (e.g. "sample.dart::Animal"). Search by plain name too. See: #87
             if total_results == 0 and node:
                 for kind in ("INHERITS", "IMPLEMENTS"):
-                    for e in store.iter_edges_by_target_name(node.name, kind=kind):
+                    for e in store.iter_edges_by_target_name(
+                        node.name, kind=kind, language=node.language or None,
+                    ):
                         child = store.get_node(e.source_qualified)
                         if child:
                             add_result(node_to_dict(child), e)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -289,6 +289,40 @@ class TestQueryGraphCallTargetFallbacks:
             "external_helper",
         }
 
+    def test_callers_of_bare_fallback_does_not_cross_languages(self):
+        """Regression for #708: a bare-name CALLS edge from an unrelated
+        language (e.g. an Apex ``.clone()`` call) must not be reported as a
+        caller of a same-named function in a different language (JS)."""
+        js_file = str(self.root / "clone.js")
+        apex_file = str(self.root / "Clone.cls")
+        with GraphStore(self.db_path) as store:
+            store.upsert_node(NodeInfo(
+                kind="Function", name="clone", file_path=js_file,
+                line_start=1, line_end=3, language="javascript",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function", name="apexCaller", file_path=apex_file,
+                line_start=1, line_end=5, language="apex",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{apex_file}::apexCaller",
+                target="clone",
+                file_path=apex_file,
+                line=3,
+            ))
+            store.commit()
+
+        result = query_graph(
+            pattern="callers_of",
+            target=f"{js_file}::clone",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        names = {r["name"] for r in result["results"]}
+        assert "apexCaller" not in names
+
 
 def _seed_repo_relative_graph(root: Path) -> None:
     """Seed graph data with cwd-relative paths, as eval repos currently do."""


### PR DESCRIPTION
## Summary
- Bare (unqualified) CALLS/INHERITS target names are matched by exact string across the *entire* graph when qualified-name resolution fails — with no language filter, a common short name (e.g. `clone`) can wrongly resolve to a same-named node in a completely unrelated language.
- Adds an optional `language` filter to `search_edges_by_target_name` / `iter_edges_by_target_name` (`graph.py`), and threads the resolved target node's language through the `callers_of` and `inheritors_of` bare-name fallbacks in `query.py`.
- Fixes #708 ("Cross boundary CALLS incorrect" — an Apex `.clone()` call was reported as calling any same-named JS `clone()` method anywhere in the graph).

## Scope note
Left the 3 other `search_edges_by_target_name` call sites in `refactor.py` (rename preview / dead-code detection) untouched to keep this change small and reviewable. Happy to extend the same fix there in a follow-up if wanted.

## Test plan
- [x] Added a regression test (`test_callers_of_bare_fallback_does_not_cross_languages`) reproducing the exact Apex→JS `clone` collision from the issue.
- [x] `pytest tests/test_tools.py tests/test_graph.py tests/test_refactor.py tests/test_hints.py` — 235 passed
- [x] `pytest tests/` — 1959 passed, 1 pre-existing unrelated failure (Windows-only asyncio test failing under Python 3.14 on macOS, unrelated to this change)
- [x] `ruff check` and `mypy` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)