### PR TITLE
fix(parser): index TS interfaces/type aliases and emit type-position edges

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -804,8 +804,19 @@ _TASK_META_KEYS: frozenset[str] = frozenset({
 _CLASS_TYPES: dict[str, list[str]] = {
     "python": ["class_definition"],
     "javascript": ["class_declaration", "class"],
-    "typescript": ["class_declaration", "class"],
-    "tsx": ["class_declaration", "class"],
+    # TS types are declarations, not just runtime classes: an interface or type
+    # alias is the thing callers depend on, so it needs a node of its own the way
+    # Java/C#/PHP interfaces do. Without them a types-only module (types.ts,
+    # *.d.ts) contributes zero symbol nodes and its blast radius collapses to
+    # whole-file IMPORTS_FROM fan-out. See: #737
+    "typescript": [
+        "class_declaration", "class",
+        "interface_declaration", "type_alias_declaration", "enum_declaration",
+    ],
+    "tsx": [
+        "class_declaration", "class",
+        "interface_declaration", "type_alias_declaration", "enum_declaration",
+    ],
     "go": ["type_declaration"],
     # impl_item is a scope for methods, not a second type definition. It is
     # dispatched separately so repeated impl blocks cannot overwrite structs.
@@ -873,6 +884,20 @@ _CLASS_TYPES: dict[str, list[str]] = {
     # _extract_hcl_constructs.
     "hcl": [],
 }
+
+# TS/TSX heritage clauses. Classes wrap theirs in class_heritage; interfaces use
+# extends_type_clause. A type_identifier inside one is already covered by an
+# INHERITS edge, so it must not also emit REFERENCES.
+_TS_HERITAGE_CLAUSES = frozenset({
+    "extends_clause", "implements_clause", "extends_type_clause",
+})
+
+# TS/TSX declarations whose ``name`` field is a type_identifier. That occurrence
+# is the definition site, not a use of the type.
+_TS_TYPE_DECLARATIONS = frozenset({
+    "class_declaration", "abstract_class_declaration", "interface_declaration",
+    "type_alias_declaration", "enum_declaration",
+})
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
     "python": ["function_definition"],
@@ -5744,6 +5769,14 @@ class CodeParser:
                 and node_type in ("jsx_opening_element", "jsx_self_closing_element")
             ):
                 self._extract_jsx_component_call(
+                    child, language, file_path, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names,
+                )
+
+            # --- TS type-position references ---
+            if language in ("typescript", "tsx") and node_type == "type_identifier":
+                self._extract_ts_type_reference(
                     child, language, file_path, edges,
                     enclosing_class, enclosing_func,
                     import_map, defined_names,
@@ -10931,6 +10964,62 @@ class CodeParser:
         "self", "this", "cls", "super",
     })
 
+    def _extract_ts_type_reference(
+        self,
+        child,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+    ) -> None:
+        """Emit a ``REFERENCES`` edge for a type used in a TS type position.
+
+        ``function summarize(items: Finding[])`` is a real dependency on
+        ``Finding``, but a type annotation is not call syntax, so neither
+        _extract_calls nor _extract_value_references sees it and callers_of on
+        an interface stays empty.
+
+        ``REFERENCES`` (0.6 in IMPACT_EDGE_WEIGHTS) rather than ``CALLS`` (1.0):
+        a type use is a weaker signal than an invocation, and folding the two
+        together would let type churn outrank call churn in impact ranking.
+        """
+        parent = child.parent
+        if parent is not None:
+            # The declaration's own name is a definition, not a use. Compare by
+            # byte span: child_by_field_name returns a fresh wrapper object, so
+            # identity/equality checks against *child* are unreliable.
+            if parent.type in _TS_TYPE_DECLARATIONS:
+                name_node = parent.child_by_field_name("name")
+                if (
+                    name_node is not None
+                    and name_node.start_byte == child.start_byte
+                    and name_node.end_byte == child.end_byte
+                ):
+                    return
+            # extends/implements are already covered by INHERITS edges.
+            if parent.type in _TS_HERITAGE_CLAUSES:
+                return
+
+        # Attribute to the enclosing function, else the enclosing type, else the
+        # file — so `interface Wrapper { nested: Verdict }` names Wrapper as the
+        # dependent rather than collapsing to the whole module.
+        if enclosing_func:
+            caller = self._qualify(enclosing_func, file_path, enclosing_class)
+        elif enclosing_class:
+            caller = self._qualify(enclosing_class, file_path, None)
+        else:
+            caller = file_path
+
+        self._emit_reference_if_known(
+            child.text.decode("utf-8", errors="replace"),
+            language, file_path, caller, edges,
+            import_map or {}, defined_names or set(),
+            line=child.start_point[0] + 1,
+        )
+
     def _extract_value_references(
         self,
         child,
@@ -13912,12 +14001,28 @@ class CodeParser:
                         if sub.type == "type_identifier":
                             bases.append(sub.text.decode("utf-8", errors="replace"))
         elif language in ("typescript", "javascript", "tsx"):
-            # extends clause
+            # Classes nest their heritage one level down, under class_heritage
+            # (`class C extends B implements I`); interfaces carry
+            # extends_type_clause as a direct child. Scanning only direct
+            # children therefore missed every class base.
+            clauses: list = []
             for child in node.children:
-                if child.type in ("extends_clause", "implements_clause"):
-                    for sub in child.children:
-                        if sub.type in ("identifier", "type_identifier", "nested_identifier"):
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                if child.type == "class_heritage":
+                    clauses.extend(child.children)
+                else:
+                    clauses.append(child)
+            for clause in clauses:
+                if clause.type not in _TS_HERITAGE_CLAUSES:
+                    continue
+                for sub in clause.children:
+                    if sub.type in ("identifier", "type_identifier", "nested_identifier"):
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+                    elif sub.type == "generic_type":
+                        # `extends Base<T>` — the base is the generic's head.
+                        for ident in sub.children:
+                            if ident.type in ("type_identifier", "nested_type_identifier"):
+                                bases.append(ident.text.decode("utf-8", errors="replace"))
+                                break
         elif language == "solidity":
             # contract Foo is Bar, Baz { ... }
             for child in node.children:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1957,3 +1957,213 @@ class TestCppScopedFunctionName:
         fns = [n for n in nodes if n.kind == "Function"]
         assert len(fns) == 1
         assert fns[0].name == "get_obj_fingerprint"
+
+
+class TestTypeScriptTypeDeclarations:
+    """TS interfaces / type aliases / enums are graph nodes, and type positions
+    are dependencies.
+
+    Before this, ``_CLASS_TYPES`` covered only ``class_declaration`` for TS, so a
+    types-only module produced zero symbol nodes and its blast radius collapsed
+    to whole-file ``IMPORTS_FROM`` fan-out. Java/C#/PHP already indexed
+    ``interface_declaration``. See: #737
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def _project(self, root: Path) -> tuple[Path, Path]:
+        types = root / "types.ts"
+        types.write_text(
+            "export interface Finding {\n"
+            "  id: string;\n"
+            "}\n\n"
+            "export type Verdict = 'ok' | 'bad';\n\n"
+            "export enum Severity {\n"
+            "  Low,\n"
+            "  High,\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        use = root / "use.ts"
+        use.write_text(
+            "import { Finding, Verdict, Severity } from './types';\n\n"
+            "export function summarize(items: Finding[]): Verdict {\n"
+            "  const cache: Map<string, Severity> = new Map();\n"
+            "  return cache.size ? 'bad' : 'ok';\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        return types, use
+
+    def test_interface_type_alias_and_enum_become_nodes(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            types, _ = self._project(Path(tmp_dir))
+
+            nodes, _ = self.parser.parse_file(types)
+
+            names = {n.name for n in nodes if n.kind == "Class"}
+            assert {"Finding", "Verdict", "Severity"} <= names
+
+    def test_declaration_name_is_not_a_reference_to_itself(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            types, _ = self._project(Path(tmp_dir))
+
+            _, edges = self.parser.parse_file(types)
+
+            refs = [e for e in edges if e.kind == "REFERENCES"]
+            assert not [e for e in refs if e.source == e.target]
+
+    def test_type_annotation_emits_reference_to_the_declaring_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            refs = {
+                (e.source, e.target)
+                for e in edges
+                if e.kind == "REFERENCES"
+            }
+            assert (f"{use}::summarize", f"{types.resolve()}::Finding") in refs
+            assert (f"{use}::summarize", f"{types.resolve()}::Verdict") in refs
+
+    def test_type_argument_inside_a_generic_is_a_reference(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            # Severity appears only as Map<string, Severity>.
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{use}::summarize"
+                and e.target == f"{types.resolve()}::Severity"
+                for e in edges
+            )
+
+    def test_unknown_and_builtin_types_do_not_emit_references(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            bare = {e.target.split("::")[-1] for e in edges if e.kind == "REFERENCES"}
+            # Neither a predefined type nor an unimported global becomes an edge.
+            assert "string" not in bare
+            assert "Map" not in bare
+
+    def test_interface_member_attributes_to_the_interface_not_the_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, _ = self._project(root)
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Verdict } from './types';\n\n"
+                "export interface Wrapper {\n"
+                "  nested: Verdict;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{wrapper}::Wrapper"
+                and e.target == f"{types.resolve()}::Verdict"
+                for e in edges
+            )
+
+    def test_class_heritage_emits_inherits_edges(self):
+        """`class C extends B implements I` nests its clauses under
+        class_heritage, so scanning only direct children found no bases at all.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text(
+                "export class Base {}\n"
+                "export interface Findable { id: string }\n",
+                encoding="utf-8",
+            )
+            impl = root / "impl.ts"
+            impl.write_text(
+                "import { Base, Findable } from './base';\n\n"
+                "export class Impl extends Base implements Findable {\n"
+                "  id = 'x';\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(impl)
+
+            inherits = {
+                (e.source, e.target) for e in edges if e.kind == "INHERITS"
+            }
+            assert (f"{impl}::Impl", "Base") in inherits
+            assert (f"{impl}::Impl", "Findable") in inherits
+
+    def test_interface_extends_emits_inherits_edge(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text("export interface Findable { id: string }\n", encoding="utf-8")
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Findable } from './base';\n\n"
+                "export interface Wrapper extends Findable {\n"
+                "  extra: string;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            inherits = {(e.source, e.target) for e in edges if e.kind == "INHERITS"}
+            assert (f"{wrapper}::Wrapper", "Findable") in inherits
+
+    def test_heritage_does_not_double_emit_a_reference(self):
+        """A base is already an INHERITS edge; it must not also be REFERENCES."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text("export interface Findable { id: string }\n", encoding="utf-8")
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Findable } from './base';\n\n"
+                "export interface Wrapper extends Findable {\n"
+                "  extra: string;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            bare = {e.target.split("::")[-1] for e in edges if e.kind == "REFERENCES"}
+            assert "Findable" not in bare
+
+    def test_tsx_type_positions_are_also_covered(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, _ = self._project(root)
+            panel = root / "Panel.tsx"
+            panel.write_text(
+                "import { Finding } from './types';\n\n"
+                "export function Panel({ finding }: { finding: Finding }) {\n"
+                "  return null;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(panel)
+
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{panel}::Panel"
+                and e.target == f"{types.resolve()}::Finding"
+                for e in edges
+            )


### PR DESCRIPTION
Fixes #737.

## Problem

`_CLASS_TYPES` listed only `class_declaration` / `class` for `typescript` and `tsx`, so **interfaces, type aliases, and enums were never indexed**. Java, C#, PHP, and Solidity already index `interface_declaration`, so this was an asymmetry rather than a deliberate TS scope decision.

The sharp edge is a types-only module — `types.ts`, `*.d.ts`, very common in TS/React codebases. It contributed **zero symbol nodes**, so its blast radius collapsed to whole-file `IMPORTS_FROM` fan-out: every importer impacted, no matter which of the file's declarations actually changed, and nothing addressable to query.

## Changes

**1. Index TS type declarations.** `interface_declaration`, `type_alias_declaration`, and `enum_declaration` added to `_CLASS_TYPES` for `typescript`/`tsx`. They become `Class` nodes, matching how Go `type_declaration` and Rust `struct_item`/`trait_item` are already handled — no new node kind.

**2. Emit `REFERENCES` from type positions.** `function summarize(items: Finding[])` is a real dependency on `Finding`, but a type annotation is not call syntax, so neither `_extract_calls` nor `_extract_value_references` ever saw it. New `_extract_ts_type_reference` covers annotations and type arguments, reusing the existing `_emit_reference_if_known` gate (must be a local definition or an import, so `string`/`Map`/`Promise` produce no noise).

`REFERENCES` (0.6 in `IMPACT_EDGE_WEIGHTS`) rather than `CALLS` (1.0) on purpose — a type use is a weaker signal than an invocation, and folding them together would let type churn outrank call churn in impact ranking. Two positions are deliberately skipped: the declaration's own name, and heritage clauses that already produce `INHERITS`.

Edges attribute to the enclosing function, else the enclosing type, else the file — so `interface Wrapper { nested: Verdict }` names `Wrapper` as the dependent instead of collapsing to the module.

**3. Fix `_get_bases` for TS/TSX** — *this one is a pre-existing bug, independent of the above, found while testing.* Class heritage nests under `class_heritage`, but the TS branch scanned only direct children, so `class Impl extends Base implements Findable` emitted **no `INHERITS` edges at all**. Interfaces use `extends_type_clause`, which wasn't listed either. Generic bases (`extends Base<T>`) now resolve to the generic's head.

Happy to split this third change into its own PR if you'd rather review it separately — I bundled it because newly-indexed interfaces would otherwise have no heritage edges, which undercuts change 1.

## Measured on this repo's own `code-review-graph-vscode` extension (17 `.ts` files)

| | before | after |
|---|---:|---:|
| `Class` nodes | 15 | **40** |
| `REFERENCES` edges | 4 | **164** |
| `INHERITS` edges | 0 | **5** |
| `CALLS` edges | 1095 | 1095 (unchanged) |
| full build | 0.93s | 1.04s |

`CALLS` being byte-identical is the point: no existing call extraction is disturbed.

Minimal repro from the issue, before → after:

```
# before
Full build: 2 files, 3 nodes, 2 edges
query callers_of "src/types.ts::Finding"  ->  {"status": "not_found"}
impact --files src/types.ts               ->  changed: ['File:src/types.ts']

# after
Full build: 2 files, 5 nodes, 6 edges
impact --files src/types.ts               ->  changed: ['File:src/types.ts',
                                                        'Class:Finding', 'Class:Verdict']
                                              impacted: ['Function:summarize', 'File:src/use.ts']
inheritors_of "src/base.ts::Base"         ->  ['Impl']   (was empty — no INHERITS edges existed)
```

## Known limit, stated plainly

`callers_of` filters `kind == "CALLS"`, so it still returns 0 results for a type — it now returns `ok` with an empty list rather than `not_found`. The gains here are impact radius granularity, `inheritors_of` working for TS at all, and dead-code accuracy. If you want type users directly queryable, a `references_to` pattern in `query.py` would be the additive way to do it (I'd rather not widen `callers_of`'s documented "functions that call a given function" semantics for every language) — happy to add it here or in a follow-up.

## Tests

10 new tests in `TestTypeScriptTypeDeclarations` (`tests/test_parser.py`), covering nodes for all three declaration forms, annotation and generic-argument references, TSX coverage, interface-member attribution, both heritage forms, and three negative guards: no self-reference from the declaration name, no builtin/unimported noise, no `REFERENCES`/`INHERITS` double-emit on heritage.

7 of the 10 fail on the unpatched parser (the 3 guards pass trivially when no edges exist).

## Checks

- `pytest tests/` — 2075 passed, 5 skipped, 2 xpassed (2065 before this PR)
- `ruff check code_review_graph/` — clean
- `mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` — Success: no issues found in 66 source files
- `dead-code` does not flag the newly indexed type nodes
