### PR TITLE
feat(parser): extract dbt model refs as IMPORTS_FROM edges

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -56,6 +56,16 @@ _SQL_TABLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# dbt model dependencies: {{ ref('model') }}, {{ ref('package', 'model') }}
+# and {{ source('source_name', 'table') }}. String-literal arguments only —
+# dynamic ref() calls cannot be resolved statically.
+_DBT_REF_RE = re.compile(
+    r"\{\{-?\s*(ref|source)\s*\(\s*"
+    r"['\"]([^'\"]+)['\"]"
+    r"(?:\s*,\s*['\"]([^'\"]+)['\"])?"
+    r"\s*\)",
+)
+
 _PYTHON_STAR_CACHE_MAX = 15_000
 _PYTHON_STAR_EXPORT_CACHE: dict[tuple[str, int, int], dict[str, str]] = {}
 _PYTHON_STAR_EXPORT_CACHE_LOCK = threading.RLock()
@@ -3946,6 +3956,11 @@ class CodeParser:
 
         Data dependencies (FROM/JOIN table references) are recorded as
         IMPORTS_FROM edges so the impact-radius query can follow them.
+
+        dbt models (detected by {{ ref() }} / {{ source() }} calls in the
+        file) use a dedicated extraction instead: one Class node per model,
+        named after the file stem, with IMPORTS_FROM edges from the Jinja
+        dependency calls.
         """
         text = source.decode("utf-8", errors="replace")
         file_path_str = str(path)
@@ -3963,6 +3978,18 @@ class CodeParser:
             language="sql",
             is_test=test_file,
         ))
+
+        # --- dbt model pass ---
+        # A dbt model has no DDL (dbt wraps the SELECT at build time), its
+        # dependencies live in Jinja calls the FROM/JOIN regex cannot see,
+        # and the plain-SQL passes below would only pick up CTE names as
+        # phantom IMPORTS_FROM targets. Handle it separately and skip them.
+        dbt_refs = list(_DBT_REF_RE.finditer(text))
+        if dbt_refs:
+            self._extract_dbt_model(
+                path, text, dbt_refs, file_path_str, test_file, nodes, edges,
+            )
+            return nodes, edges
 
         # --- tree-sitter pass ---
         parser = self._get_parser("sql")
@@ -4012,6 +4039,68 @@ class CodeParser:
                 ))
 
         return nodes, edges
+
+    def _extract_dbt_model(
+        self,
+        path: Path,
+        text: str,
+        dbt_refs: list[re.Match],
+        file_path_str: str,
+        test_file: bool,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Extract a dbt model file: one Class node plus its Jinja deps.
+
+        dbt materializes each model file as a table or view named after the
+        file stem, and model names are unique project-wide, so the stem is
+        the node name — which lets a `{{ ref('other_model') }}` edge resolve
+        against the referenced model's node by bare name.
+
+        - `{{ ref('m') }}` / `{{ ref('pkg', 'm') }}` → IMPORTS_FROM target `m`
+        - `{{ source('src', 'tbl') }}` → IMPORTS_FROM target `src.tbl`
+          (kept qualified: sources are external tables, not project models,
+          so the target must not collide with a model node of the same name)
+        """
+        model_name = path.stem
+        qualified = f"{file_path_str}::{model_name}"
+        nodes.append(NodeInfo(
+            kind="Class",
+            name=model_name,
+            file_path=file_path_str,
+            line_start=1,
+            line_end=text.count("\n") + 1,
+            language="sql",
+            is_test=test_file,
+            extra={"sql_kind": "dbt_model"},
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=file_path_str,
+            target=qualified,
+            file_path=file_path_str,
+            line=1,
+        ))
+
+        seen_targets: set[str] = set()
+        for m in dbt_refs:
+            func, first_arg, second_arg = m.group(1), m.group(2), m.group(3)
+            if func == "source":
+                if second_arg is None:
+                    continue  # source() requires two args; malformed call
+                target = f"{first_arg}.{second_arg}"
+            else:
+                # ref('model') or ref('package', 'model') — model is last.
+                target = second_arg if second_arg is not None else first_arg
+            if target and target != model_name and target not in seen_targets:
+                seen_targets.add(target)
+                edges.append(EdgeInfo(
+                    kind="IMPORTS_FROM",
+                    source=file_path_str,
+                    target=target,
+                    file_path=file_path_str,
+                    line=text[: m.start()].count("\n") + 1,
+                ))
 
     def _walk_sql_tree(
         self,

--- a/tests/test_dbt_parser.py
+++ b/tests/test_dbt_parser.py
@@ -1,0 +1,127 @@
+"""dbt model SQL parser tests: {{ ref() }} / {{ source() }} extraction."""
+
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.parser import CodeParser
+
+DBT_MODEL = b"""\
+with
+
+source as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select * from {{ ref('analytics_utils', 'dim_customers') }}
+),
+
+payments as (
+    select * from {{ source('core_db', 'payments') }}
+),
+
+final as (
+    select
+        source.order_id,
+        customers.customer_id,
+        payments.amount
+    from source
+    left join customers on source.customer_id = customers.customer_id
+    left join payments on source.order_id = payments.order_id
+)
+
+select * from final
+"""
+
+
+class TestDbtModelParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_bytes(
+            Path("models/staging/fct_orders.sql"), DBT_MODEL,
+        )
+
+    def test_model_node_named_after_file_stem(self):
+        models = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("sql_kind") == "dbt_model"
+        ]
+        assert len(models) == 1
+        assert models[0].name == "fct_orders"
+        assert models[0].language == "sql"
+
+    def test_contains_edge(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target for e in contains}
+        assert "models/staging/fct_orders.sql::fct_orders" in targets
+
+    def test_ref_and_source_dependency_edges(self):
+        imports = {e.target for e in self.edges if e.kind == "IMPORTS_FROM"}
+        assert imports == {
+            "stg_orders",            # ref('stg_orders')
+            "dim_customers",         # ref('package', 'model') → model
+            "core_db.payments",      # source() stays qualified
+        }
+
+    def test_cte_names_are_not_dependency_edges(self):
+        # The FROM/JOIN regex pass must not run on dbt models: it would
+        # record the CTE names as phantom IMPORTS_FROM targets.
+        imports = {e.target for e in self.edges if e.kind == "IMPORTS_FROM"}
+        assert not imports & {"source", "customers", "payments", "final"}
+
+    def test_duplicate_refs_are_deduplicated(self):
+        nodes, edges = self.parser.parse_bytes(
+            Path("models/dupes.sql"),
+            b"select * from {{ ref('stg_orders') }}\n"
+            b"union all\n"
+            b"select * from {{ ref('stg_orders') }}\n",
+        )
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert [e.target for e in imports] == ["stg_orders"]
+
+    def test_plain_sql_without_jinja_keeps_ddl_extraction(self):
+        nodes, edges = self.parser.parse_bytes(
+            Path("schema.sql"),
+            b"CREATE TABLE users (id INT);\n"
+            b"CREATE VIEW active_users AS SELECT id FROM users;\n",
+        )
+        kinds = {n.extra.get("sql_kind") for n in nodes if n.kind == "Class"}
+        assert kinds == {"table", "view"}
+        assert not any(
+            n.extra.get("sql_kind") == "dbt_model" for n in nodes
+        )
+
+
+def test_full_build_links_dbt_models_by_ref(tmp_path: Path) -> None:
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "stg_orders.sql").write_text(
+        "select * from {{ source('core_db', 'orders') }}\n",
+        encoding="utf-8",
+    )
+    (models / "fct_orders.sql").write_text(
+        "with orders as (\n"
+        "    select * from {{ ref('stg_orders') }}\n"
+        ")\n"
+        "select * from orders\n",
+        encoding="utf-8",
+    )
+
+    store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+    try:
+        full_build(tmp_path, store)
+
+        model_names = {n.name for n in store.get_nodes_by_kind(["Class"])}
+        assert {"stg_orders", "fct_orders"} <= model_names
+
+        fct_file = str(models / "fct_orders.sql")
+        targets = {
+            e.target_qualified
+            for e in store.get_edges_by_source(fct_file)
+            if e.kind == "IMPORTS_FROM"
+        }
+        assert "stg_orders" in targets
+        assert "orders" not in targets  # CTE name must not leak in
+    finally:
+        store.close()


### PR DESCRIPTION
### Summary
- SQL files containing `{{ ref() }}` / `{{ source() }}` are dbt models: they carry no DDL (dbt wraps the SELECT at build time), so the tree-sitter DDL walk found no nodes, and the FROM/JOIN regex recorded CTE names as phantom `IMPORTS_FROM` targets while missing every real dependency.
- Detect dbt models by content, the same approach as the Ansible sniff, and extract them directly: one `Class` node per model named after the file stem with `extra["sql_kind"]="dbt_model"`, `{{ ref('m') }}` and `{{ ref('pkg', 'm') }}` become `IMPORTS_FROM` edges targeting `m`, and `{{ source('src', 'tbl') }}` becomes an edge targeting `src.tbl`, kept qualified so external source tables never collide with model names.
- Skip the DDL and FROM/JOIN passes for these files. Plain SQL files are unaffected.
- On a real 1,318-model dbt project this goes from 0 nodes and 4,927 phantom edges to 1,218 model nodes and 1,943 real dependency edges.

### Notes
- Known limitation: a dbt model with no `ref()` or `source()` calls (for example, one selecting only from hardcoded tables) is not detected and falls through to the plain-SQL passes. That accounts for the 100-model gap in the numbers above and is inherent to content sniffing.
- Model names resolve by bare name because dbt enforces project-wide model-name uniqueness.

### Verification
- Command: `pytest tests/` → 2071 passed, 5 skipped; includes 7 new tests in `tests/test_dbt_parser.py` covering ref/source extraction, package-qualified refs, dedup, CTE phantom-edge suppression, plain-SQL non-regression, and an end-to-end `full_build` cross-file resolution test
- Command: `ruff check` → clean
- Command: `mypy code_review_graph/parser.py` → clean