### PR TITLE
fix(embeddings): gate `dimensions` on OpenAI text-embedding-3-* models

### DIFF
--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -446,8 +446,11 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
 
         body: dict[str, Any] = {"model": self._model, "input": texts}
         # OpenAI v3 models (text-embedding-3-*) support dimension reduction;
-        # only forward the param when the user explicitly pinned one.
-        if self._dimension is not None:
+        # only forward the param when the user explicitly pinned one AND the
+        # endpoint is expected to honor it. Compatibility providers like
+        # SiliconFlow (BAAI/bge-m3) reject unknown `dimensions` with HTTP 400,
+        # so we gate this on the v3 model name prefix to keep them healthy.
+        if self._dimension is not None and self._model.startswith("text-embedding-3-"):
             body["dimensions"] = self._dimension
 
         payload = _json.dumps(body).encode("utf-8")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -679,6 +679,65 @@ class TestOpenAIEmbeddingProvider:
         payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
         assert payload["dimensions"] == 256
 
+    def test_auto_learned_dimension_omitted_for_non_v3_models(self):
+        # Many OpenAI-compatible providers (SiliconFlow, Cohere, voyage-3,
+        # custom vLLM gateways) reject the `dimensions` body field with
+        # HTTP 400. The provider auto-learns dimension from the first
+        # response and would otherwise forward it on every subsequent call.
+        p = OpenAIEmbeddingProvider(
+            api_key="k", base_url="http://localhost:3000/v1",
+            model="BAAI/bge-m3",
+        )
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_openai_response([[0.1] * 1024]),
+        ) as mock_urlopen:
+            vec = p.embed_query("x")
+        assert len(vec) == 1024
+        assert p.dimension == 1024  # still learned for cache key
+
+        # Second call would have auto-forwarded dimensions before the fix.
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_openai_response([[0.1] * 1024]),
+        ) as mock_urlopen:
+            p.embed_query("y")
+        payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert "dimensions" not in payload, (
+            f"non-v3 model {p._model!r} should not send `dimensions`; "
+            f"got payload keys: {list(payload)}"
+        )
+
+    def test_explicit_dimension_ignored_for_non_v3_models(self):
+        # Even when the user pins a dimension explicitly, we don't forward
+        # it to non-v3 endpoints — they reject it. Pinning a dimension
+        # here only sets the cache partition key.
+        p = OpenAIEmbeddingProvider(
+            api_key="k", base_url="http://localhost:3000/v1",
+            model="BAAI/bge-m3", dimension=1024,
+        )
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_openai_response([[0.1] * 1024]),
+        ) as mock_urlopen:
+            p.embed_query("x")
+        payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert "dimensions" not in payload
+
+    def test_explicit_dimension_forwarded_for_v3_models(self):
+        # Regression guard: v3 models must still honor the pinned dimension.
+        p = OpenAIEmbeddingProvider(
+            api_key="k", base_url="http://localhost:3000/v1",
+            model="text-embedding-3-large", dimension=512,
+        )
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_openai_response([[0.1] * 512]),
+        ) as mock_urlopen:
+            p.embed_query("x")
+        payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert payload["dimensions"] == 512
+
     def test_base_url_trailing_slash_stripped(self):
         p = OpenAIEmbeddingProvider(
             api_key="k", base_url="http://localhost:3000/v1/", model="m",


### PR DESCRIPTION
## Bug

The `OpenAIEmbeddingProvider` auto-learns the embedding dimension from the first response and then unconditionally appends `dimensions=N` to every subsequent request. OpenAI `text-embedding-3-*` honors it; many OpenAI-compatible providers (**SiliconFlow** `BAAI/bge-m3`, Cohere, voyage-3, custom vLLM gateways) reject it with HTTP 400:

```json
{"code":20015,"message":"The parameter is invalid. Please check again.","data":null}
```

This contradicts the README, which already documents `CRG_OPENAI_DIMENSION` as:

> `export CRG_OPENAI_DIMENSION=1536  # pin dim (v3 models support reduction)`

The code violates the documented contract.

## Fix

Gate the `dimensions` body field on `self._model.startswith("text-embedding-3-")`.

- v3 users keep dimension reduction — existing behavior preserved.
- Models with fixed dimensions (bge-m3, etc.) stop triggering 400s on the second-and-later calls.
- Even when a user pins a dimension on a non-v3 model, we silently drop it; the pinned value still partitions the local embedding cache.

## Tests

`tests/test_embeddings.py::TestOpenAIEmbeddingProvider` (34/34 passing, including 3 new):

- `test_auto_learned_dimension_omitted_for_non_v3_models` — `BAAI/bge-m3`: first call learns dimension, second call must NOT include `dimensions` in payload.
- `test_explicit_dimension_ignored_for_non_v3_models` — pinning `dimension=1024` on a non-v3 model does NOT emit `dimensions` (pin still used for cache partition key).
- `test_explicit_dimension_forwarded_for_v3_models` — regression guard: v3 models with pinned dimension still emit `dimensions`.

All pre-existing v3 tests (`test_embed_calls_api_with_correct_payload`, `test_explicit_dimension_forwarded_in_payload`) continue to pass unchanged.

## Diff

```
code_review_graph/embeddings.py |  7 +++--
tests/test_embeddings.py        | 59 +++++++++++++++++++++++++++++++++++
2 files changed, 64 insertions(+), 2 deletions(-)
```

## Reproducer

```bash
export CRG_OPENAI_BASE_URL="https://api.siliconflow.cn/v1"
export CRG_OPENAI_API_KEY="sk-..."
export CRG_OPENAI_MODEL="BAAI/bge-m3"
# Without fix: first embed succeeds, every subsequent embed returns HTTP 400.
```