### PR TITLE
fix(watch): handle rename events so renamed files don't go stale

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1258,22 +1258,64 @@ def watch(
             if self._should_handle(event.src_path):
                 self._schedule(event.src_path)
 
-        def on_deleted(self, event):
-            if event.is_directory:
-                return
+        def _remove(self, abs_path: str):
+            """Purge one path's nodes and edges from the graph."""
             # Only handle files we would normally track
             try:
-                rel = str(Path(event.src_path).relative_to(repo_root))
+                rel = str(Path(abs_path).relative_to(repo_root))
             except ValueError:
                 return
             if _should_ignore(rel, ignore_patterns):
                 return
             try:
-                store.remove_file_data(event.src_path)
+                store.remove_file_data(abs_path)
                 store.commit()
                 logger.info("Removed: %s", rel)
             except Exception as e:
                 logger.error("Error removing %s: %s", rel, e)
+
+        def on_deleted(self, event):
+            if event.is_directory:
+                return
+            self._remove(event.src_path)
+
+        def on_moved(self, event):
+            """Handle a rename.
+
+            Watchdog reports a rename as a single move event rather than a
+            delete followed by a create, so without this handler the old path's
+            nodes and edges survive and the new path is never indexed — the
+            watched graph drifts from a full rebuild.
+            """
+            if event.is_directory:
+                self._move_directory(event.src_path, event.dest_path)
+                return
+            self._remove(event.src_path)
+            if self._should_handle(event.dest_path):
+                self._schedule(event.dest_path)
+
+        def _move_directory(self, src_dir: str, dest_dir: str):
+            """Re-key every indexed file beneath a renamed directory.
+
+            A directory rename arrives as one event with no per-file events for
+            the contents, so each tracked file underneath has to be purged at
+            its old path and re-indexed at the new one.
+            """
+            prefix = os.path.join(src_dir, "")
+            try:
+                indexed = store.get_all_files()
+            except Exception as e:
+                logger.error("Error listing files under %s: %s", src_dir, e)
+                return
+            for old_path in indexed:
+                if not old_path.startswith(prefix):
+                    continue
+                self._remove(old_path)
+                new_path = os.path.join(
+                    dest_dir, os.path.relpath(old_path, src_dir)
+                )
+                if self._should_handle(new_path):
+                    self._schedule(new_path)
 
         def _schedule(self, abs_path: str):
             """Add file to pending set and reset the debounce timer."""

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,6 +1,7 @@
 """Tests for the incremental graph update module."""
 
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch  # noqa: F401 – used in tests
 
 import code_review_graph.incremental as incremental_module
@@ -22,6 +23,7 @@ from code_review_graph.incremental import (
     get_staged_and_unstaged,
     incremental_update,
     start_watch_thread,
+    watch,
 )
 
 
@@ -1044,3 +1046,103 @@ class TestStartWatchThread:
             assert thread is None
         finally:
             store.close()
+
+
+class TestWatchRenameHandling:
+    """Renames arrive as a single watchdog move event, not delete + create."""
+
+    @staticmethod
+    def _handler(repo_root, store):
+        """Run watch() far enough to capture the handler it registers."""
+        captured = {}
+
+        class FakeObserver:
+            def schedule(self, handler, path, recursive=False):
+                captured["handler"] = handler
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def join(self):
+                pass
+
+        import watchdog.observers
+
+        with patch.object(watchdog.observers, "Observer", FakeObserver), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            watch(repo_root, store)
+        return captured["handler"]
+
+    def test_file_rename_purges_old_path_and_indexes_new(self, tmp_path):
+        (tmp_path / "new.py").write_text("def a():\n    pass\n")
+        store = MagicMock()
+        handler = self._handler(tmp_path, store)
+
+        scheduled = []
+        handler._schedule = scheduled.append
+        handler.on_moved(
+            SimpleNamespace(
+                is_directory=False,
+                src_path=str(tmp_path / "old.py"),
+                dest_path=str(tmp_path / "new.py"),
+            )
+        )
+
+        store.remove_file_data.assert_called_once_with(str(tmp_path / "old.py"))
+        assert scheduled == [str(tmp_path / "new.py")]
+
+    def test_directory_rename_rekeys_indexed_files(self, tmp_path):
+        new_dir = tmp_path / "newpkg"
+        new_dir.mkdir()
+        (new_dir / "mod.py").write_text("def a():\n    pass\n")
+        old_dir = tmp_path / "oldpkg"
+
+        store = MagicMock()
+        store.get_all_files.return_value = [
+            str(old_dir / "mod.py"),
+            str(tmp_path / "unrelated.py"),
+        ]
+        handler = self._handler(tmp_path, store)
+
+        scheduled = []
+        handler._schedule = scheduled.append
+        handler.on_moved(
+            SimpleNamespace(
+                is_directory=True,
+                src_path=str(old_dir),
+                dest_path=str(new_dir),
+            )
+        )
+
+        # Only files beneath the renamed directory are touched.
+        store.remove_file_data.assert_called_once_with(str(old_dir / "mod.py"))
+        assert scheduled == [str(new_dir / "mod.py")]
+
+    def test_on_deleted_still_purges(self, tmp_path):
+        """Regression guard for the _remove() extraction."""
+        store = MagicMock()
+        handler = self._handler(tmp_path, store)
+
+        handler.on_deleted(
+            SimpleNamespace(is_directory=False, src_path=str(tmp_path / "gone.py"))
+        )
+
+        store.remove_file_data.assert_called_once_with(str(tmp_path / "gone.py"))
+
+    def test_paths_outside_the_repo_are_ignored(self, tmp_path):
+        store = MagicMock()
+        handler = self._handler(tmp_path, store)
+
+        handler.on_moved(
+            SimpleNamespace(
+                is_directory=False,
+                src_path="/somewhere/else/old.py",
+                dest_path="/somewhere/else/new.py",
+            )
+        )
+
+        store.remove_file_data.assert_not_called()


### PR DESCRIPTION
## Linked issue

Closes #742

## What & why

`GraphUpdateHandler` in `start_watch_thread()` / `watch()` implements
`on_modified`, `on_created` and `on_deleted`, but not `on_moved`. Watchdog
reports a rename as a single `FileMovedEvent` rather than a delete followed by
a create, so a renamed file was dropped on both ends — the old path's nodes and
edges survived, and the new path was never indexed. A watched graph drifted
from a full rebuild over time, silently.

This is the watchdog-side counterpart to #684, which covers the same class of
problem in the git-diff path (`get_changed_files()`). The two are independent:
neither #686 nor #729 touches the handler class, so `--watch` users stay
affected after either merges.

## Changes

- Add `on_moved`: purge the old path, then schedule the new one through the
  existing debounce, so a rename behaves exactly like a delete plus a create.
- Extract the purge logic shared with `on_deleted` into a `_remove()` helper
  rather than duplicating it.
- Handle directory renames in `_move_directory()`. Watchdog emits a single
  event with no per-file events for the contents, so every indexed file beneath
  the old directory is re-keyed using `store.get_all_files()`. Without this a
  package or module rename would leave its whole subtree stale.

Behaviour is unchanged for every existing event type; `on_deleted` keeps its
current semantics via `_remove()`.

## Tests

Four cases in `TestWatchRenameHandling`, which capture the handler by running
`watch()` against a fake `Observer`:

- a file rename purges the old path and schedules the new one
- a directory rename re-keys only files beneath it, leaving unrelated files alone
- `on_deleted` still purges (regression guard for the `_remove()` extraction)
- paths outside the repo root are ignored

I confirmed the two rename tests fail against `main` and pass with this change.

Full suite: 2069 passed, 5 skipped, 2 xpassed. `ruff check` clean.

## Context

Found while investigating a 1,373-file Rails repo whose graph had been
watcher-maintained since April. A single full `build` took it from
17,047 nodes / 78,230 edges to 10,960 / 52,339 — roughly 36% of nodes were
stale, and the embedding table had ~5,000 orphaned vectors, so semantic search
was ranking against code that no longer existed.

Happy to adjust the approach — in particular, if you'd rather see directory
renames trigger a rescan instead of the `get_all_files()` prefix walk, or split
into a separate PR, I'm glad to rework it.
