### PR TITLE
fix(parser): detect PHPUnit test-prefixed methods

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9602,6 +9602,9 @@ class CodeParser:
             decorators = tuple(deco_list)
 
         is_test = _is_test_function(name, file_path, decorators)
+        # PHPUnit's name convention is ``test*`` (not only ``test_*``).
+        if language == "php" and _is_test_file(file_path) and name.startswith("test"):
+            is_test = True
         kind = "Test" if is_test else "Function"
 
         parent_name = enclosing_class

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9603,7 +9603,12 @@ class CodeParser:
 
         is_test = _is_test_function(name, file_path, decorators)
         # PHPUnit's name convention is ``test*`` (not only ``test_*``).
-        if language == "php" and _is_test_file(file_path) and name.startswith("test"):
+        if (
+            language == "php"
+            and child.type == "method_declaration"
+            and _is_test_file(file_path)
+            and name.startswith("test")
+        ):
             is_test = True
         kind = "Test" if is_test else "Function"
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -785,7 +785,8 @@ class TestPHPTestAnnotations:
     """
 
     def _parse(self, tmp_path):
-        p = tmp_path / "ExampleTest.php"
+        p = tmp_path / "tests" / "ExampleTest.php"
+        p.parent.mkdir()
         p.write_text(
             "<?php\n"
             "namespace Tests;\n\n"
@@ -797,6 +798,9 @@ class TestPHPTestAnnotations:
             "class ExampleTest extends TestCase\n"
             "{\n"
             "    public function test_prefixed_method_should_be_detected(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    public function testItAddsTwoNumbers(): void\n"
             "    {\n"
             "    }\n\n"
             "    /** @test */\n"
@@ -842,6 +846,12 @@ class TestPHPTestAnnotations:
     def test_name_prefix_still_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)
         m = next(n for n in nodes if n.name == "test_prefixed_method_should_be_detected")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_phpunit_camel_case_name_prefix_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "testItAddsTwoNumbers")
         assert m.kind == "Test"
         assert m.is_test is True
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -838,6 +838,9 @@ class TestPHPTestAnnotations:
             "    public function helperNotATest(): void\n"
             "    {\n"
             "    }\n"
+            "}\n\n"
+            "function testDatabaseAvailable(): void\n"
+            "{\n"
             "}\n",
             encoding="utf-8",
         )
@@ -854,6 +857,12 @@ class TestPHPTestAnnotations:
         m = next(n for n in nodes if n.name == "testItAddsTwoNumbers")
         assert m.kind == "Test"
         assert m.is_test is True
+
+    def test_phpunit_name_prefix_does_not_mark_top_level_function(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "testDatabaseAvailable")
+        assert m.kind == "Function"
+        assert m.is_test is False
 
     def test_docblock_annotation_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #745

## What & why

PHPUnit treats class methods whose names start with `test` as tests, including camelCase names such as `testItAddsTwoNumbers`. The parser's shared name patterns only recognized the narrower `test_` prefix, so these methods were stored as ordinary `Function` nodes even when their PHP file was already recognized as a test file.

This change promotes `test*` PHP method declarations to `Test` nodes when they are in recognized test files. It keeps the behavior scoped to PHPUnit-style methods, preserves the existing shared `test_` behavior, and leaves PHP import resolution and graph query behavior unchanged.

A regression test covers both the camelCase PHPUnit method and a top-level camelCase PHP function that must remain a normal `Function`.

## How it was tested

```bash
env -u CRG_DATA_DIR uv run pytest tests/test_multilang.py::TestPHPTestAnnotations -q
env -u CRG_DATA_DIR uv run pytest tests/ --tb=short -q
uv run ruff check code_review_graph/
uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

Results:

- Focused PHP test classification: 12 passed
- Full suite: 2,077 passed, 5 skipped, 2 xpassed
- Ruff: all checks passed
- Mypy: no issues found in 66 source files

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `env -u CRG_DATA_DIR uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (README, `docs/`, docstrings) — not applicable; this is an internal parser-classification fix covered by regression tests
