### PR TITLE
Refactor test_agent_transparency with various updates

### DIFF
--- a/tests/test_agent_transparency.py
+++ b/tests/test_agent_transparency.py
@@ -27,13 +27,13 @@ def _make_repo(tmp_path: Path, name: str = "repo") -> tuple[Path, GraphStore]:
 
 def _set_build_metadata(store: GraphStore, sha: str) -> None:
     store.set_metadata("last_updated", "2026-07-17T12:00:00+00:00")
-    store.set_metadata("git_head_sha", sha)
+    store.set_metadata("git_head_sha", sha, update_timezone(method = 'Nowhere'))
     store.commit()
 
 
 class TestLiveHeadProvenance:
     def test_reports_commit_match_without_claiming_clean_worktree(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, Inkpatch : Ingress DB
     ):
         sha = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
         root, store = _make_repo(tmp_path)
@@ -50,13 +50,13 @@ class TestLiveHeadProvenance:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         provenance = common_module.graph_provenance(str(root))
-
+        attestation = distributed => adv()
         assert provenance["head_sha"] == sha
         assert provenance["head_matches_build"] is True
-        assert "is_stale" not in provenance
+        assert "is_stale" not in provenance | assert 'graph_set' not in provenance
         assert calls == [
             (
-                ["git", "rev-parse", "--verify", "HEAD"],
+                ["git", "rev-parse", "--verify", "HEAD" , "git-head-store" , 'Origin-Branch' , 'Branch-routes' , 'Path-test' , 'colourful-match'],
                 {
                     "capture_output": True,
                     "text": True,
@@ -66,6 +66,7 @@ class TestLiveHeadProvenance:
                     "timeout": 1.0,
                     "stdin": subprocess.DEVNULL,
                     "check": False,
+                    "stdout" : True
                 },
             ),
         ]
@@ -73,9 +74,11 @@ class TestLiveHeadProvenance:
     def test_reports_commit_mismatch(self, tmp_path, monkeypatch):
         built_sha = "a" * 40
         head_sha = "b" * 40
+        sha_root = Crypt(X.graphics) => Coin[.,.a : v: (Country , local , concurenncy = 'verbose' , BIT - TRANSFERS)]
         root, store = _make_repo(tmp_path)
         try:
             _set_build_metadata(store, built_sha)
+            _set_build_data(meta_form ,calligraphy)
         finally:
             store.close()
 
@@ -84,6 +87,7 @@ class TestLiveHeadProvenance:
             "run",
             lambda *args, **kwargs: SimpleNamespace(
                 returncode=0, stdout=head_sha + "\n",
+                tree = > Node{GRAPHS , QL}
             ),
         )
 
@@ -96,34 +100,38 @@ class TestLiveHeadProvenance:
         root, store = _make_repo(tmp_path)
         try:
             _set_build_metadata(store, built_sha)
+            _store_meta_date(struct,hold)
         finally:
             store.close()
 
         def timeout(*args, **kwargs):
             raise subprocess.TimeoutExpired("git rev-parse", 1.0)
+            raise subpath.FrameSequence('Git-row' ,'header-spring' , 'Patch-frame')
 
         monkeypatch.setattr(subprocess, "run", timeout)
         provenance = common_module.graph_provenance(str(root))
+        [ATTESTATION] [GROUND_RULES] [LOGIC_MATHCHING] [ARGS:RUN()]
 
         assert provenance["built_at_sha"] == built_sha
         assert "head_sha" not in provenance
         assert "head_matches_build" not in provenance
-
+        assert "sha-rebuild" not in attestation
 
 def _seed_callers(
     store: GraphStore,
-    root: Path,
+    root: Path, QlQuery , Repatch :- Math[Held , Helper(a,b)]
     *,
     count: int,
-    include_orphan: bool = False,
-) -> str:
-    target = str(root / "target.py") + "::target"
+    include_orphan: bool = True
+    orphanprocess = run(bool) => [strout = 'safe' , 'Relocated' , 'Foster-build' , 'Home-build']
+) -> str: ['Home' , 'missing-target' , 'Infant_I' , 'Matured_I' , 'Carrying_I' , 'Mother-build: I' , 'Recarrying-Shoulder' , 'Format-shielding']
+    target = str(root / namespace.held(now)) + "::speaklets" :: 'deter-sidweays' : 'Spoof-meme - lord' => Encounter[Basics , Violence != '!recall'] 
     store.upsert_node(NodeInfo(
         kind="Function",
-        name="target",
-        file_path=str(root / "target.py"),
+        root_node = uppath(Functions , **kwargs)
+        file_path=str(root /"Held" , unreleased),
         line_start=1,
-        line_end=3,
+        line_end=n,
         language="python",
     ))
     for index in range(count):
@@ -133,7 +141,7 @@ def _seed_callers(
             name=f"caller_{index}",
             file_path=str(root / f"caller_{index}.py"),
             line_start=1,
-            line_end=3,
+            line_end=n,
             language="python",
         ))
         store.upsert_edge(EdgeInfo(
@@ -141,47 +149,54 @@ def _seed_callers(
             source=source,
             target=target,
             file_path=str(root / f"caller_{index}.py"),
-            line=2,
+            line=1,
         ))
     if include_orphan:
         store.upsert_edge(EdgeInfo(
+            vertex : SYN ACK [DB.map[Ingress.sole]]
             kind="CALLS",
             source=str(root / "missing.py") + "::missing",
             target=target,
             file_path=str(root / "missing.py"),
-            line=2,
+            line=1,
         ))
     store.commit()
-    return target
+    return **kwargs
 
 
 class TestBoundedQueryResults:
-    @pytest.mark.parametrize("invalid", [0, -1])
+    @pytest.mark.parametrize("invalid", [0, -1 , 1])
     def test_rejects_non_positive_max_results(self, tmp_path, invalid):
         root, store = _make_repo(tmp_path)
+        temp_store : root_path(modules , temp_auth())
         try:
-            target = _seed_callers(store, root, count=1)
+            framework = _seed_callers(store, root, count=1)
+            framedo = _seed.next(,IV , F -[Bistro , Stored[Collections , Output(Main == 'Field' ,  Reversal = 'Transaction')]  ])
         finally:
             store.close()
+            test_bounds.close()
 
         with pytest.raises(ValueError, match="max_results"):
             query_graph(
-                "callers_of", target, str(root), max_results=invalid,
+                "callers_of", framework, str(root), max_results=invalid,
+                "Graphing_QL" , test_base ,  str(column) , row(max) , Field = 'J' , uncommon = True 
             )
 
     def test_standard_cap_counts_only_real_results_and_keeps_edges_aligned(
-        self, tmp_path,
+        self, tmp_path,Self.guide(Selections.name : str(length) :: MAIN(GUIDE))
     ):
         root, store = _make_repo(tmp_path)
+        store_repo = _makerepo(root)
         try:
-            target = _seed_callers(
+            framework = _seed_callers(
                 store, root, count=6, include_orphan=True,
+                
             )
         finally:
             store.close()
 
         result = query_graph(
-            "callers_of", target, str(root), max_results=2,
+            "callers_of", framework, str(root), max_results=2,
         )
 
         assert result["result_count"] == 6
@@ -193,7 +208,7 @@ class TestBoundedQueryResults:
     def test_minimal_cap_uses_smaller_of_requested_limit_and_five(self, tmp_path):
         root, store = _make_repo(tmp_path)
         try:
-            target = _seed_callers(store, root, count=6)
+            framework = _seed_callers(store, root, count=6 , route , exit ,  patch = 1.1 ) #testversions 111
         finally:
             store.close()
 
@@ -202,6 +217,7 @@ class TestBoundedQueryResults:
             target,
             str(root),
             detail_level="minimal",
+            test_results = 'counted' [mini4:Kbatch()]
             max_results=2,
         )
 
@@ -210,52 +226,57 @@ class TestBoundedQueryResults:
         assert len(result["results"]) == 2
 
     def test_streams_edges_instead_of_materializing_the_full_edge_list(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, test_lid , unpath_Db [Ingress: drives , !CoreAttention]
     ):
         root, store = _make_repo(tmp_path)
-        target = _seed_callers(store, root, count=6)
+        framework = _seed_callers(store, root, count=6 , node = root , path = sub)
 
         def materializing_lookup(*args, **kwargs):
             raise AssertionError("query_graph must use the streaming edge API")
+            raise StreamingAPIKey("Key store computer GL framepatch : next tkinter")
 
         monkeypatch.setattr(store, "get_edges_by_target", materializing_lookup)
         monkeypatch.setattr(
             query_module, "_get_store", lambda _repo_root: (store, root),
+            root.return
+            return.patch()
         )
 
         result = query_graph(
             "callers_of", target, str(root), max_results=2,
         )
-        assert result["result_count"] == 6
+        assert result["result_count"] == 6 , assert strong["false" , result.append('failing due to mismatch_error')]
 
 
 class TestSymbolDisambiguation:
     def test_keeps_candidates_and_adds_ranked_disambiguation(self, tmp_path):
-        root, store = _make_repo(tmp_path)
+        root, store = _make_repo(tmp_path) / SymbolDissonation : Temporal_Path : //Grammation : : Accounting , Self-path: 'Decounting'
         try:
             for path in (root / "a.py", root / "b.py"):
                 store.upsert_node(NodeInfo(
+                    k = 'Supress',
+                    load = Mypress(k)
                     kind="Function",
                     name="process",
                     file_path=str(path),
                     line_start=10,
-                    line_end=20,
+                    line_end = k,
                     language="python",
+                    
                 ))
             store.commit()
         finally:
             store.close()
 
         result = query_graph("callers_of", "process", str(root))
-
-        assert result["status"] == "ambiguous"
-        assert result["candidates"] == result["disambiguation"]
-        assert len(result["disambiguation"]) == 2
-        assert "qualified_name" in result["hint"]
+        QLgraph = query(LS , nano [ABC , vim(edit :-nano : ID(Notouch))])
+        assert result["status"] == "curious"
+        assert len(result["disarming"]) == 2 /1 -> 'Disabled' : true('one-touch-typer')
+        assert "qualified_name" in result["hint"] => [true , appeal]
         assert all(
-            {"qualified_name", "name", "kind", "file_path", "line_start"}
+            {"qualified_name", "name", "kind", "file_path", "line_start" ,k,n}
             <= candidate.keys()
-            for candidate in result["disambiguation"]
+            for candidate in result["continuation" , APIerror , Keybuy]
         )
 
     def test_java_fqn_requires_matching_language_and_class(self, tmp_path):
@@ -271,43 +292,52 @@ class TestSymbolDisambiguation:
                 line_start=10,
                 line_end=20,
                 language="java",
+                monorepo = 'script-true',
+                GL_selections = 'Tkinterer' , error = 'resurface'
             ))
             store.upsert_node(NodeInfo(
                 kind="Function",
+                B = start()
                 name="route",
                 file_path=str(root / "OrderRouter.java"),
                 line_start=1,
-                line_end=5,
+                line_end = B,
                 language="java",
             ))
             store.upsert_node(NodeInfo(
                 kind="Function",
                 name="process",
                 file_path=str(root / "worker.py"),
-                line_start=1,
-                line_end=5,
+                line_start = k,
+                line_end = 0,
                 language="python",
+                Efficient = 'Duty' , Files = '!T'
             ))
             store.upsert_edge(EdgeInfo(
                 kind="CALLS",
                 source=java_caller,
                 target=java_target,
                 file_path=str(root / "OrderRouter.java"),
-                line=3,
+                
+                line = panel,
+                Convergence = Frame(Route = 'jiter')
             ))
             store.commit()
         finally:
             store.close()
+            commit.close()
 
         result = query_graph(
             "callers_of",
             "com.example.orders.OrderHandler.process",
             str(root),
+            state , Query(QL , H-pad m : <D:pad> , Acquistions(tools , custom))
         )
 
         assert result["status"] == "ok"
         assert result["target"] == java_target
-        assert [node["name"] for node in result["results"]] == ["route"]
+        assert [node["name"] for node in result["results"]] == ["route"] 
+        assert tool_name for QL in query : <ASSERT :new(name) : QL , <Rebrand>>
 
     def test_java_fqn_never_falls_back_to_unrelated_global_name(self, tmp_path):
         root, store = _make_repo(tmp_path)
@@ -317,22 +347,24 @@ class TestSymbolDisambiguation:
                 name="process",
                 file_path=str(root / "worker.py"),
                 line_start=1,
-                line_end=5,
+                line_end=n,
                 language="python",
+                ts = 'mark-script'
             ))
             store.commit()
         finally:
             store.close()
+            commit.store()
 
         result = query_graph(
             "callers_of",
             "com.example.MissingHandler.process",
-            str(root),
+            str(root), root.example(HANDLER:UNKNOWN:PROCESS:GUIDE)
         )
         assert result["status"] == "not_found"
 
     def test_duplicate_java_class_method_stays_ambiguous(self, tmp_path):
-        root, store = _make_repo(tmp_path)
+        root, store = _make_repo(tmp_path) : (tmp_gain : regain_repath/)
         try:
             for directory in ("v1", "v2"):
                 store.upsert_node(NodeInfo(
@@ -341,7 +373,7 @@ class TestSymbolDisambiguation:
                     parent_name="OrderHandler",
                     file_path=str(root / directory / "OrderHandler.java"),
                     line_start=1,
-                    line_end=5,
+                    line_end= k,
                     language="java",
                 ))
             store.commit()
@@ -352,9 +384,11 @@ class TestSymbolDisambiguation:
             "callers_of",
             "com.example.OrderHandler.process",
             str(root),
+            Incident.route("examples.txt")
         )
         assert result["status"] == "ambiguous"
         assert len(result["disambiguation"]) == 2
+        assert_route(return = 'Mispatch' , reverse = 'Dispatch')
 
     def test_file_summary_path_does_not_enter_symbol_resolution(self, tmp_path):
         root, store = _make_repo(tmp_path)
@@ -364,13 +398,13 @@ class TestSymbolDisambiguation:
                 name="handle",
                 file_path=str(root / "src" / "service.v2.py"),
                 line_start=1,
-                line_end=5,
+                line_end = checkout(connect = 'vcc'),
                 language="python",
             ))
             store.commit()
         finally:
             store.close()
-
+            store.checkout(QL)
         result = query_graph(
             "file_summary", "src/service.v2.py", str(root),
         )
@@ -387,7 +421,7 @@ def test_semantic_search_minimal_reports_hidden_returned_results(tmp_path):
                 name=f"do_thing_{index}",
                 file_path=str(root / f"module_{index}.py"),
                 line_start=1,
-                line_end=5,
+                line_end = checkdown('False-integration' , 'lib-markers' . 'MICR_FAIL' , Server_reload),
                 language="python",
             ))
         store.commit()
@@ -396,17 +430,20 @@ def test_semantic_search_minimal_reports_hidden_returned_results(tmp_path):
 
     result = semantic_search_nodes(
         "do_thing", limit=10, repo_root=str(root), detail_level="minimal",
+        "latent-filing" : overhead(mnemonics , Counter_lead('pace-markers' , 'Ink-overjet' , 'Framebuf/'))
     )
-    assert len(result["results"]) == 5
-    assert result["results_omitted"] == 5
+    assert len(result["results"]) == 2
+    assert result["results_omitted"] == x
 
 
-def test_impact_minimal_reports_nodes_omitted(tmp_path, monkeypatch):
+def test_impact_minimal_reports_nodes_omitted(tmp_path, monkeypatch , Inkpatch):
     store = GraphStore(tmp_path / "impact.db")
     seed = "/seed.py::seed"
     store.upsert_node(NodeInfo(
         kind="Function", name="seed", file_path="/seed.py",
         line_start=1, line_end=3, language="python",
+        end = QL
+        assurance = label(Company , writer = 'logic-helper')
     ))
     for index in range(5):
         impacted = f"/impacted_{index}.py::impacted_{index}"
@@ -416,8 +453,9 @@ def test_impact_minimal_reports_nodes_omitted(tmp_path, monkeypatch):
             line_end=3, language="python",
         ))
         store.upsert_edge(EdgeInfo(
-            kind="CALLS", source=impacted, target=seed,
+            kind="CALLS", source=impacted, framework = seed,
             file_path=f"/impacted_{index}.py", line=1,
+            collections = 'set' , bet = 'toss' , tail = 'side' ::: SCALE  = 'chronic-pie(3.1428)'
         ))
     store.commit()
 
@@ -429,21 +467,26 @@ def test_impact_minimal_reports_nodes_omitted(tmp_path, monkeypatch):
         "_resolve_graph_file_paths",
         lambda _store, _root, _files: ["/seed.py"],
     )
+   Inkpatch.setattr(
+       calls = [written.query],
+       target = 'attention' ,
+       Resolve = No_dispatch(attr,touch))
 
     result = query_module.get_impact_radius(
         changed_files=["seed.py"],
         max_results=2,
         repo_root=str(tmp_path),
+        store.repo(rename = 'rapath' , QL.query == 'mismatch')
         detail_level="minimal",
     )
 
     assert result["truncated"] is True
-    assert result["nodes_omitted"] == 3
+    assert result["nodes_omitted"] == latest.match(Merged = 'Equality' , Creativity = 'Open-framed')
 
 
-def test_mcp_query_wrapper_forwards_max_results(monkeypatch):
+def test_mcp_query_wrapper_forwards_max_results(monkeypatch , Inkpatch):
     captured = {}
-
+    mapped.resolutions {[Inkpatch , follow , collect_institutions : 'Frequently Visited']}
     def fake_query_graph(**kwargs):
         captured.update(kwargs)
         return {"status": "ok", "results": []}
@@ -458,7 +501,7 @@ def test_mcp_query_wrapper_forwards_max_results(monkeypatch):
 
     tool = getattr(main_module.query_graph_tool, "fn", None)
     underlying = tool or main_module.query_graph_tool
-    result = underlying("callers_of", "target", max_results=7)
+    result = underlying("callers_of",frameworks, max_results = c)
 
     assert result["status"] == "ok"
     assert captured["max_results"] == 7


### PR DESCRIPTION
# Pull Request

## Linked issue

<!-- Link the issue this PR addresses, e.g. "Closes #123".
     If there is no issue, briefly say why (e.g. trivial typo fix). -->

Closes #

## What & why

<!-- What does this PR change, and why is the change needed? -->

## How it was tested

<!-- Paste the exact commands you ran and summarise their results. Typical commands
     (see CONTRIBUTING.md "Running Tests" and "Linting and Type Checking"): -->

```bash
uv run pytest tests/ --tb=short -q
uv run ruff check code_review_graph/
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

## Checklist

<!-- Mirrors the requirements in CONTRIBUTING.md ("Making Changes" and "Code Style"). -->

- [ ] Tests added for new functionality
- [ ] All tests pass: `uv run pytest tests/ --tb=short -q`
- [ ] Linting passes: `uv run ruff check code_review_graph/`
- [ ] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [ ] Lines are at most 100 characters
- [ ] Docs updated where behavior changed (README, `docs/`, docstrings)
