### PR TITLE
fix(parser): safely resolve PHP and Rust scoped calls

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -131,6 +131,17 @@ def _run_hcl_resolver(store: GraphStore) -> Optional[dict]:
         logger.warning("Terraform/HCL resolver failed: %s", exc)
         return None
 
+
+def _run_scoped_resolver(store: GraphStore) -> Optional[dict]:
+    """Resolve static/scoped ``Class::method`` calls without failing a build."""
+    try:
+        from .scoped_resolver import resolve_scoped_calls
+        return resolve_scoped_calls(store)
+    except Exception as exc:  # noqa: BLE001 - best-effort post-pass
+        logger.warning("Scoped call resolver failed: %s", exc)
+        return None
+
+
 # Default ignore patterns (in addition to .gitignore).
 #
 # ``**/<dir>/**`` patterns are safe-anywhere directory exclusions.  A leading
@@ -1009,6 +1020,7 @@ def full_build(
     spring_event_stats = _run_spring_event_resolver(store)
     temporal_stats = _run_temporal_resolver(store)
     hcl_stats = _run_hcl_resolver(store)
+    scoped_stats = _run_scoped_resolver(store)
 
     return {
         "files_parsed": len(files),
@@ -1020,6 +1032,7 @@ def full_build(
         "event_resolution": spring_event_stats,
         "temporal_resolution": temporal_stats,
         "hcl_resolution": hcl_stats,
+        "scoped_resolution": scoped_stats,
     }
 
 
@@ -1178,6 +1191,8 @@ def incremental_update(
     temporal_stats = _run_temporal_resolver(store) if spring_changed else None
     hcl_changed = any(rp.endswith((".tf", ".hcl")) for rp in all_files)
     hcl_stats = _run_hcl_resolver(store) if hcl_changed else None
+    scoped_changed = any(rp.endswith((".php", ".rs")) for rp in all_files)
+    scoped_stats = _run_scoped_resolver(store) if scoped_changed else None
 
     return {
         "files_updated": len(all_files),
@@ -1191,6 +1206,7 @@ def incremental_update(
         "event_resolution": spring_event_stats,
         "temporal_resolution": temporal_stats,
         "hcl_resolution": hcl_stats,
+        "scoped_resolution": scoped_stats,
     }
 
 

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -91,20 +91,52 @@ def _path_tokens(file_path: str) -> list[str]:
     ``/repo/src/Queue/Mailer.php`` → ``["repo", "src", "Queue", "Mailer"]``;
     ``/repo/src/mailer.rs`` → ``["repo", "src", "mailer"]``.
     """
-    parts = [p for p in file_path.split("/") if p]
+    parts = [p for p in file_path.replace("\\", "/").split("/") if p]
     if parts:
         parts[-1] = parts[-1].rsplit(".", 1)[0]
     return parts
 
 
-def _common_suffix_len(a: list[str], b: list[str], language: str) -> int:
-    """Length of the longest common trailing run of *a* and *b* (case per lang)."""
-    count = 0
-    for left, right in zip(reversed(a), reversed(b)):
-        if _fold(left, language) != _fold(right, language):
-            break
-        count += 1
-    return count
+def _path_key(file_path: str) -> str:
+    """Normalize path separators for exact resolved-import comparisons."""
+    return file_path.replace("\\", "/")
+
+
+def _path_ends_with(
+    path_tokens: list[str], suffix: list[str], language: str
+) -> bool:
+    """Whether a complete import/module suffix matches a defining file path."""
+    if not suffix or len(suffix) > len(path_tokens):
+        return False
+    path_tail = path_tokens[-len(suffix) :]
+    return all(
+        _fold(left, language) == _fold(right, language)
+        for left, right in zip(path_tail, suffix)
+    )
+
+
+def _safe_import_suffixes(segments: list[str], language: str) -> list[list[str]]:
+    """Return complete import suffixes that can safely identify a source path.
+
+    PHP projects commonly map one leading namespace root (for example ``App``)
+    onto a source directory. Rust imports carry a trailing type and may start
+    with a module-root keyword. We strip only those known structural segments;
+    arbitrary leading namespace/module segments are never discarded.
+    """
+    if language == "php":
+        suffixes = [segments]
+        if len(segments) > 2:
+            suffixes.append(segments[1:])
+        return [suffix for suffix in suffixes if len(suffix) >= 2]
+
+    if language == "rust" and len(segments) >= 2:
+        module_path = segments[:-1]
+        suffixes = [module_path]
+        if module_path and module_path[0] in {"crate", "self", "super"}:
+            suffixes.append(module_path[1:])
+        return [suffix for suffix in suffixes if suffix]
+
+    return []
 
 
 def _is_unresolved_scoped_target(target: str) -> bool:
@@ -251,42 +283,42 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         # (1) Prefer a candidate whose defining file is explicitly imported.
         # #574's PHP import resolver rewrites resolvable ``use`` targets to the
         # absolute path of the class file, so a direct path match is exact.
-        imported_paths = {t for t in imported if "/" in t}
-        matched = [c for c in candidates if file_of.get(c) in imported_paths]
+        imported_paths = {
+            _path_key(target)
+            for target in imported
+            if "/" in target or "\\" in target
+        }
+        matched = [
+            candidate
+            for candidate in candidates
+            if _path_key(file_of.get(candidate, "")) in imported_paths
+        ]
         if len(matched) == 1:
             return matched[0]
         # (2) Fall back to a fully-qualified ``use`` target that could not be
-        # resolved to a path (no composer PSR-4 map). Score each candidate by
-        # how much of the imported namespace/module path matches a *suffix* of
-        # the candidate's file path, so ``use App\Order\Queue\Mailer`` picks
-        # ``src/Order/Queue/Mailer.php`` over an unrelated ``src/Queue/Mailer.php``
-        # that merely shares a single segment. The class name lives in the path
-        # for PHP (``Mailer.php``) but not for Rust (``mailer.rs`` holds the
-        # ``Mailer`` type), so each import is scored both with and without its
-        # trailing class segment.
-        best: Optional[str] = None
-        best_score = 0
-        tied = False
+        # resolved to a path (no composer/module map). A candidate must match a
+        # complete normalized import suffix, not merely have the longest partial
+        # overlap. Otherwise an unrelated import such as
+        # ``App\Warehouse\Queue\Mailer`` could be fabricated as
+        # ``src/Order/Queue/Mailer.php`` just because both end in Queue/Mailer.
+        matched_by_suffix: set[str] = set()
         for candidate in candidates:
             tokens = _path_tokens(file_of.get(candidate, ""))
-            score = 0
             for target in imported:
                 segments = _import_segments(target)
                 if not segments:
                     continue
                 if _fold(segments[-1], language) != _fold(class_name, language):
                     continue
-                score = max(
-                    score,
-                    _common_suffix_len(segments, tokens, language),
-                    _common_suffix_len(segments[:-1], tokens, language),
-                )
-            if score > best_score:
-                best_score, best, tied = score, candidate, False
-            elif score == best_score and score > 0:
-                tied = True
-        if best_score >= 1 and not tied:
-            return best
+                suffixes = _safe_import_suffixes(segments, language)
+                if any(
+                    _path_ends_with(tokens, suffix, language)
+                    for suffix in suffixes
+                ):
+                    matched_by_suffix.add(candidate)
+                    break
+        if len(matched_by_suffix) == 1:
+            return next(iter(matched_by_suffix))
         return None
 
     calls_rows = conn.execute(
@@ -358,4 +390,3 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         resolved, len(file_language),
     )
     return {"files_indexed": len(file_language), "calls_resolved": resolved}
-

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -1,0 +1,361 @@
+"""Post-build resolver for static/scoped ``Class::method`` calls.
+
+Tree-sitter extraction records a scoped/static call such as ``Mailer::send($x)``
+(PHP) or ``Mailer::send(x)`` / ``Self::new()`` (Rust) as a ``CALLS`` edge whose
+target is the intermediate ``Class::method`` string.  That string matches
+neither the canonical node key (``<file>::Class.method``) nor a bare method
+name, so ``callers_of``, ``get_impact_radius`` and ``tests_for`` never see the
+edge and report zero callers for a method that is obviously being called
+(GitHub #567).
+
+This module runs after the graph is built and rewrites the resolvable
+``Class::method`` targets to the canonical qualified name of the defined
+method node, in the same style as the Spring/Temporal/ReScript resolvers.
+
+It is deliberately conservative so it never fabricates an edge:
+
+* Only genuine ``Class::method`` targets are considered; already-resolved
+  targets (``<file>::Class.method``) are left alone.
+* ``self`` / ``static`` (PHP) and ``self`` / ``Self`` (Rust) resolve to the
+  enclosing class/type of the caller.
+* A target resolves when exactly one ``(class, method)`` node exists in the
+  graph, or when the caller file's ``IMPORTS_FROM`` edges disambiguate between
+  several same-named definitions.
+* Ambiguous or unknown targets (external types such as ``Vec::new`` or
+  ``Redis::get`` with no in-graph definition) are left untouched, keeping the
+  behaviour of unresolved external calls exactly as it is today.
+
+Rewritten edges are tagged ``confidence_tier = INFERRED`` to distinguish a
+heuristically resolved scoped call from a directly-extracted one.
+
+Language notes:
+
+* PHP scopes are namespace-qualified (``App\\Mail\\Mailer``) and PHP keywords
+  are case-insensitive, so ``self`` / ``static`` (any case) mean the enclosing
+  class.
+* Rust scoped calls come through as ``::``-joined path segments.  Only genuine
+  two-segment ``Type::method`` targets are resolved; multi-segment module paths
+  (``crate::mailer::Mailer::new``) are left alone because resolving them by
+  their last two segments would point at an unrelated type.  ``Self`` (the
+  associated-function receiver) resolves to the enclosing type, while lowercase
+  ``self`` is a *module* path — never a type — so it is not resolved here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .graph import GraphStore
+
+logger = logging.getLogger(__name__)
+
+# Languages whose scoped/static calls dangle as ``Class::method`` targets.
+_SCOPED_LANGUAGES = ("php", "rust")
+
+# Node kinds that can be a scoped-call target (methods live under a class).
+_METHOD_KINDS = ("Function", "Test", "Method")
+
+# PHP scope receivers (case-insensitive) that mean the enclosing class.
+_PHP_SELF_SCOPES = {"self", "static"}
+
+# Separators that split an import target into path segments across languages
+# (PHP ``App\Mail\Mailer``, Rust ``crate::mail::Mailer``, resolved paths).
+_IMPORT_SEGMENT_SEPARATORS = ("::", "\\", "/")
+
+
+def _import_segments(target: str) -> list[str]:
+    """Split an import target into its path segments on any separator."""
+    normalized = target
+    for sep in _IMPORT_SEGMENT_SEPARATORS[1:]:
+        normalized = normalized.replace(sep, "::")
+    return [seg for seg in normalized.split("::") if seg]
+
+
+def _fold(name: str, language: str) -> str:
+    """Case-fold identifiers for PHP (case-insensitive) but not Rust.
+
+    PHP class and function names are matched case-insensitively by the language,
+    so ``Mailer::DISPATCH`` and ``mailer::dispatch`` name the same symbol.  Rust
+    identifiers are case-sensitive, so ``Mailer::send`` and ``Mailer::Send`` are
+    different symbols and must never be conflated.
+    """
+    return name.casefold() if language == "php" else name
+
+
+def _path_tokens(file_path: str) -> list[str]:
+    """Path split into segments, with the file extension stripped off the last.
+
+    ``/repo/src/Queue/Mailer.php`` → ``["repo", "src", "Queue", "Mailer"]``;
+    ``/repo/src/mailer.rs`` → ``["repo", "src", "mailer"]``.
+    """
+    parts = [p for p in file_path.split("/") if p]
+    if parts:
+        parts[-1] = parts[-1].rsplit(".", 1)[0]
+    return parts
+
+
+def _common_suffix_len(a: list[str], b: list[str], language: str) -> int:
+    """Length of the longest common trailing run of *a* and *b* (case per lang)."""
+    count = 0
+    for left, right in zip(reversed(a), reversed(b)):
+        if _fold(left, language) != _fold(right, language):
+            break
+        count += 1
+    return count
+
+
+def _is_unresolved_scoped_target(target: str) -> bool:
+    """True when *target* is a raw ``Class::method`` string, not a node key.
+
+    Canonical node names have the shape ``<abs-file>::Class.method`` — the head
+    before the first ``::`` is a filesystem path and the tail after the last
+    ``::`` contains a ``.``.  A raw scoped call (``Mailer::dispatch``,
+    ``App\\Mail\\Mailer::dispatch``) has neither, so it is what we resolve.
+    """
+    if "::" not in target:
+        return False
+    head = target.split("::", 1)[0]
+    if "/" in head:  # already a <file>::... qualified name
+        return False
+    tail = target.rsplit("::", 1)[1]
+    if "." in tail:  # already a Class.method qualified name
+        return False
+    return True
+
+
+def _enclosing_class(source_qualified: str) -> Optional[str]:
+    """Return the class/type short name that encloses a caller node, if any.
+
+    ``<file>::Mailer.dispatch`` → ``Mailer``; a free function
+    ``<file>::register`` (no ``.``) → ``None``.
+    """
+    if "::" not in source_qualified:
+        return None
+    tail = source_qualified.split("::", 1)[1]
+    if "." not in tail:
+        return None
+    return tail.rsplit(".", 1)[0]
+
+
+def _scope_and_method(
+    target: str, language: str
+) -> Optional[tuple[Optional[str], str, bool]]:
+    """Parse a raw scoped target into ``(class, method, needs_enclosing)``.
+
+    ``class`` is ``None`` when ``needs_enclosing`` is set (``self`` / ``Self`` /
+    ``static``), signalling the caller's enclosing class should be used.
+    Returns ``None`` for targets that must be left untouched (``parent::``, a
+    Rust module path, a lowercase ``self::`` module call, …).
+    """
+    if language == "php":
+        scope, _, method = target.partition("::")
+        if not scope or not method or "::" in method:
+            return None
+        lowered = scope.strip("\\").casefold()
+        if lowered in _PHP_SELF_SCOPES:
+            return None, method, True
+        if lowered == "parent":
+            return None
+        # Strip a namespace prefix: ``App\Mail\Mailer`` → ``Mailer``.
+        class_name = scope.strip("\\").rsplit("\\", 1)[-1]
+        if not class_name:
+            return None
+        return class_name, method, False
+
+    if language == "rust":
+        # Only genuine two-segment ``Type::method`` calls are resolvable;
+        # longer module paths are deliberately left alone.
+        segments = target.split("::")
+        if len(segments) != 2:
+            return None
+        scope, method = segments
+        if not scope or not method:
+            return None
+        if scope == "Self":
+            return None, method, True
+        if scope == "self":
+            # ``self::foo`` is a module-relative function, never a type method.
+            return None
+        return scope, method, False
+
+    return None
+
+
+def resolve_scoped_calls(store: GraphStore) -> dict:
+    """Rewrite resolvable ``Class::method`` CALLS targets to node qualified names.
+
+    Safe to call repeatedly — rewritten edges start with a path head (and carry
+    ``extra.scoped_resolved``), so they are no longer treated as candidates.
+
+    Returns a dict with resolution counts for telemetry.
+    """
+    conn = store._conn
+
+    lang_placeholders = ",".join("?" for _ in _SCOPED_LANGUAGES)
+    # file_language: file_path → language, restricted to the scoped languages.
+    file_language: dict[str, str] = {
+        row["file_path"]: row["language"]
+        for row in conn.execute(
+            "SELECT DISTINCT file_path, language FROM nodes "
+            f"WHERE language IN ({lang_placeholders})",  # nosec B608
+            _SCOPED_LANGUAGES,
+        ).fetchall()
+    }
+    if not file_language:
+        return {"files_indexed": 0, "calls_resolved": 0}
+
+    # ------------------------------------------------------------------
+    # method_map: (language, class_key, method_key) → [qualified, ...]
+    # Keyed by language so a PHP class never resolves a same-named Rust type;
+    # keys are case-folded for PHP only (Rust identifiers are case-sensitive).
+    # ------------------------------------------------------------------
+    method_map: dict[tuple[str, str, str], list[str]] = {}
+    file_of: dict[str, str] = {}
+    kind_placeholders = ",".join("?" for _ in _METHOD_KINDS)
+    for row in conn.execute(
+        "SELECT name, parent_name, qualified_name, file_path, language FROM nodes "
+        f"WHERE kind IN ({kind_placeholders}) "  # nosec B608
+        f"AND language IN ({lang_placeholders}) "  # nosec B608
+        "AND parent_name IS NOT NULL",
+        (*_METHOD_KINDS, *_SCOPED_LANGUAGES),
+    ).fetchall():
+        lang = row["language"]
+        key = (lang, _fold(row["parent_name"], lang), _fold(row["name"], lang))
+        method_map.setdefault(key, []).append(row["qualified_name"])
+        file_of[row["qualified_name"]] = row["file_path"]
+
+    if not method_map:
+        return {"files_indexed": len(file_language), "calls_resolved": 0}
+
+    # ------------------------------------------------------------------
+    # imports_by_file: caller file → set of imported target strings, used to
+    # disambiguate between several same-named definitions.
+    # ------------------------------------------------------------------
+    imports_by_file: dict[str, set[str]] = {}
+    for row in conn.execute(
+        "SELECT file_path, target_qualified FROM edges WHERE kind = 'IMPORTS_FROM'"
+    ).fetchall():
+        imports_by_file.setdefault(row["file_path"], set()).add(
+            row["target_qualified"]
+        )
+
+    def disambiguate(
+        candidates: list[str], caller_file: str, class_name: str, language: str
+    ) -> Optional[str]:
+        imported = imports_by_file.get(caller_file, set())
+        if not imported:
+            return None
+        # (1) Prefer a candidate whose defining file is explicitly imported.
+        # #574's PHP import resolver rewrites resolvable ``use`` targets to the
+        # absolute path of the class file, so a direct path match is exact.
+        imported_paths = {t for t in imported if "/" in t}
+        matched = [c for c in candidates if file_of.get(c) in imported_paths]
+        if len(matched) == 1:
+            return matched[0]
+        # (2) Fall back to a fully-qualified ``use`` target that could not be
+        # resolved to a path (no composer PSR-4 map). Score each candidate by
+        # how much of the imported namespace/module path matches a *suffix* of
+        # the candidate's file path, so ``use App\Order\Queue\Mailer`` picks
+        # ``src/Order/Queue/Mailer.php`` over an unrelated ``src/Queue/Mailer.php``
+        # that merely shares a single segment. The class name lives in the path
+        # for PHP (``Mailer.php``) but not for Rust (``mailer.rs`` holds the
+        # ``Mailer`` type), so each import is scored both with and without its
+        # trailing class segment.
+        best: Optional[str] = None
+        best_score = 0
+        tied = False
+        for candidate in candidates:
+            tokens = _path_tokens(file_of.get(candidate, ""))
+            score = 0
+            for target in imported:
+                segments = _import_segments(target)
+                if not segments:
+                    continue
+                if _fold(segments[-1], language) != _fold(class_name, language):
+                    continue
+                score = max(
+                    score,
+                    _common_suffix_len(segments, tokens, language),
+                    _common_suffix_len(segments[:-1], tokens, language),
+                )
+            if score > best_score:
+                best_score, best, tied = score, candidate, False
+            elif score == best_score and score > 0:
+                tied = True
+        if best_score >= 1 and not tied:
+            return best
+        return None
+
+    calls_rows = conn.execute(
+        "SELECT id, source_qualified, target_qualified, extra, file_path "
+        "FROM edges WHERE kind = 'CALLS'"
+    ).fetchall()
+
+    resolved = 0
+    for row in calls_rows:
+        language = file_language.get(row["file_path"])
+        if language is None:
+            continue
+        target = row["target_qualified"]
+        if not _is_unresolved_scoped_target(target):
+            continue
+
+        parsed = _scope_and_method(target, language)
+        if parsed is None:
+            continue
+        class_name, method, needs_enclosing = parsed
+
+        if needs_enclosing:
+            enclosing = _enclosing_class(row["source_qualified"])
+            if not enclosing:
+                continue
+            class_name = enclosing
+        assert class_name is not None  # non-enclosing parse always sets a class
+
+        candidates = method_map.get(
+            (language, _fold(class_name, language), _fold(method, language))
+        )
+        if not candidates:
+            continue
+
+        if len(candidates) == 1:
+            new_target = candidates[0]
+            via = "single_match"
+        else:
+            new_target = disambiguate(
+                candidates, row["file_path"], class_name, language
+            )
+            if new_target is None:
+                continue
+            via = "import"
+
+        try:
+            extra = json.loads(row["extra"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            extra = {}
+        extra["scoped_resolved"] = True
+        extra["scoped_via"] = via
+
+        conn.execute(
+            "UPDATE edges SET target_qualified = ?, extra = ?, "
+            "confidence_tier = 'INFERRED' WHERE id = ?",
+            (new_target, json.dumps(extra), row["id"]),
+        )
+        resolved += 1
+        logger.debug(
+            "Scoped resolver: %s → %s (via %s)",
+            target, new_target, via,
+        )
+
+    if resolved:
+        conn.commit()
+
+    logger.info(
+        "Scoped resolver: resolved %d CALLS edges across %d files",
+        resolved, len(file_language),
+    )
+    return {"files_indexed": len(file_language), "calls_resolved": resolved}
+

--- a/tests/test_php_scoped_calls.py
+++ b/tests/test_php_scoped_calls.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import full_build, incremental_update
+from code_review_graph.scoped_resolver import _path_tokens, resolve_scoped_calls
 from code_review_graph.tools.query import get_impact_radius, query_graph
 
 
@@ -35,6 +36,17 @@ def _calls(store: GraphStore) -> list[dict]:
             "SELECT source_qualified, target_qualified, confidence_tier "
             "FROM edges WHERE kind = 'CALLS'"
         ).fetchall()
+    ]
+
+
+def test_path_tokens_normalizes_windows_separators() -> None:
+    assert _path_tokens(r"C:\repo\src\Order\Queue\Mailer.php") == [
+        "C:",
+        "repo",
+        "src",
+        "Order",
+        "Queue",
+        "Mailer",
     ]
 
 
@@ -187,6 +199,57 @@ def test_ambiguous_same_named_methods_disambiguated_by_import(tmp_path: Path) ->
     assert "Mail/Mailer" not in resolved[0]["target_qualified"]
 
 
+def test_windows_resolved_import_path_disambiguates_same_named_methods(
+    tmp_path: Path,
+) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/Mail/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Mail;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 1; }\n"
+                "}\n"
+            ),
+            "src/Queue/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Queue;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 2; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Unknown\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    queue_file = store._conn.execute(
+        "SELECT file_path FROM nodes "
+        "WHERE name = 'dispatch' AND file_path LIKE '%/Queue/Mailer.php'"
+    ).fetchone()["file_path"]
+    store._conn.execute(
+        "UPDATE edges SET target_qualified = ? WHERE kind = 'IMPORTS_FROM'",
+        (queue_file.replace("/", "\\"),),
+    )
+    store._conn.commit()
+
+    stats = resolve_scoped_calls(store)
+    assert stats["calls_resolved"] == 1
+    resolved = [
+        call
+        for call in _calls(store)
+        if call["confidence_tier"] == "INFERRED"
+    ]
+    assert len(resolved) == 1
+    assert "Queue/Mailer.php::Mailer.dispatch" in resolved[0]["target_qualified"]
+
+
 def test_php_method_matching_is_case_insensitive(tmp_path: Path) -> None:
     # PHP class/function names are case-insensitive, so a differently-cased call
     # still resolves to the same definition.
@@ -245,6 +308,45 @@ def test_unrelated_import_namespace_does_not_resolve(tmp_path: Path) -> None:
     )
     assert not any(c["confidence_tier"] == "INFERRED" for c in _calls(store))
     dangling = [c for c in _calls(store) if c["target_qualified"] == "Mailer::dispatch"]
+    assert len(dangling) == 1
+
+
+def test_partial_suffix_from_unrelated_namespace_does_not_resolve(
+    tmp_path: Path,
+) -> None:
+    """A coincidental Queue/Mailer suffix is not proof of the imported namespace."""
+    store = _build(
+        tmp_path,
+        {
+            "src/Order/Queue/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Order\\Queue;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 1; }\n"
+                "}\n"
+            ),
+            "src/Billing/Legacy/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Billing\\Legacy;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 2; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Warehouse\\Queue\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    assert not any(c["confidence_tier"] == "INFERRED" for c in _calls(store))
+    dangling = [
+        c for c in _calls(store) if c["target_qualified"] == "Mailer::dispatch"
+    ]
     assert len(dangling) == 1
 
 
@@ -371,4 +473,3 @@ def test_resolver_is_idempotent(tmp_path: Path) -> None:
     stats = resolve_scoped_calls(store)
     assert stats["calls_resolved"] == 0
     assert _calls(store) == before
-

--- a/tests/test_php_scoped_calls.py
+++ b/tests/test_php_scoped_calls.py
@@ -1,0 +1,374 @@
+"""Scoped/static ``Class::method`` calls are tracked as callers in PHP (#567).
+
+A PHP call written ``Mailer::dispatch($x)`` used to store a ``CALLS`` edge whose
+target was the intermediate string ``Mailer::dispatch``.  That key matched
+neither the canonical node name (``<file>::Mailer.dispatch``) nor a bare method
+name, so ``callers_of`` / ``get_impact_radius`` reported zero callers.  The
+post-build scoped resolver rewrites the resolvable ones to the defining node.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build, incremental_update
+from code_review_graph.tools.query import get_impact_radius, query_graph
+
+
+def _build(tmp_path: Path, files: dict[str, str]) -> GraphStore:
+    for rel, source in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir(exist_ok=True)
+    store = GraphStore(graph_dir / "graph.db")
+    full_build(tmp_path, store)
+    return store
+
+
+def _calls(store: GraphStore) -> list[dict]:
+    return [
+        dict(row)
+        for row in store._conn.execute(
+            "SELECT source_qualified, target_qualified, confidence_tier "
+            "FROM edges WHERE kind = 'CALLS'"
+        ).fetchall()
+    ]
+
+
+def test_cross_file_scoped_call_makes_caller_visible(tmp_path: Path) -> None:
+    _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/SignupController.php": (
+                "<?php\n"
+                "class SignupController {\n"
+                "    public function register($email) {\n"
+                "        return Mailer::dispatch($email);\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    result = query_graph("callers_of", "dispatch", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["register"]
+    assert result["results"][0]["parent_name"] == "SignupController"
+
+
+def test_scoped_call_edge_is_tagged_inferred(tmp_path: Path) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/Ctrl.php": (
+                "<?php\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    calls = [c for c in _calls(store) if c["target_qualified"].endswith("Mailer.dispatch")]
+    assert len(calls) == 1
+    assert calls[0]["confidence_tier"] == "INFERRED"
+    assert "::" in calls[0]["target_qualified"]
+    assert calls[0]["target_qualified"].endswith("::Mailer.dispatch")
+
+
+def test_impact_radius_of_definition_file_includes_caller(tmp_path: Path) -> None:
+    _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/SignupController.php": (
+                "<?php\n"
+                "class SignupController {\n"
+                "    public function register($email) {\n"
+                "        return Mailer::dispatch($email);\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    impact = get_impact_radius(
+        changed_files=["src/Mailer.php"], repo_root=str(tmp_path)
+    )
+    assert impact["status"] == "ok"
+    impacted = {n["name"] for n in impact["impacted_nodes"]}
+    assert "register" in impacted
+
+
+def test_namespaced_scoped_call_with_use_import_resolves(tmp_path: Path) -> None:
+    _build(
+        tmp_path,
+        {
+            "src/Mail/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Mail;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Mail\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    result = query_graph("callers_of", "dispatch", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["reg"]
+
+
+def test_ambiguous_same_named_methods_disambiguated_by_import(tmp_path: Path) -> None:
+    # Two different classes both define ``dispatch``; only the imported one
+    # should become the caller target.
+    store = _build(
+        tmp_path,
+        {
+            "src/Mail/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Mail;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 1; }\n"
+                "}\n"
+            ),
+            "src/Queue/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Queue;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 2; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Queue\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    resolved = [
+        c for c in _calls(store)
+        if c["confidence_tier"] == "INFERRED" and "dispatch" in c["target_qualified"]
+    ]
+    assert len(resolved) == 1
+    # Disambiguated to the imported Queue\Mailer, not Mail\Mailer.
+    assert "Queue" in resolved[0]["target_qualified"]
+    assert "Mail/Mailer" not in resolved[0]["target_qualified"]
+
+
+def test_php_method_matching_is_case_insensitive(tmp_path: Path) -> None:
+    # PHP class/function names are case-insensitive, so a differently-cased call
+    # still resolves to the same definition.
+    _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/Ctrl.php": (
+                "<?php\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return MAILER::Dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    result = query_graph("callers_of", "dispatch", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["reg"]
+
+
+def test_unrelated_import_namespace_does_not_resolve(tmp_path: Path) -> None:
+    # Two same-named classes in different namespaces; the caller imports a third
+    # namespace matching neither, so the ambiguous call stays unresolved rather
+    # than picking an unrelated same-named definition on a single shared segment.
+    store = _build(
+        tmp_path,
+        {
+            "src/Billing/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Billing;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 1; }\n"
+                "}\n"
+            ),
+            "src/Shipping/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Shipping;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 2; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Warehouse\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    assert not any(c["confidence_tier"] == "INFERRED" for c in _calls(store))
+    dangling = [c for c in _calls(store) if c["target_qualified"] == "Mailer::dispatch"]
+    assert len(dangling) == 1
+
+
+def test_import_suffix_match_selects_correct_namespace(tmp_path: Path) -> None:
+    # A deep import path must select by the full path suffix, not a single
+    # shared middle segment: ``App\Order\Queue\Mailer`` picks Order/Queue/Mailer
+    # over an unrelated Queue/Mailer that only shares the ``Queue`` segment.
+    store = _build(
+        tmp_path,
+        {
+            "src/Queue/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Queue;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 1; }\n"
+                "}\n"
+            ),
+            "src/Order/Queue/Mailer.php": (
+                "<?php\n"
+                "namespace App\\Order\\Queue;\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return 2; }\n"
+                "}\n"
+            ),
+            "src/Http/Ctrl.php": (
+                "<?php\n"
+                "namespace App\\Http;\n"
+                "use App\\Order\\Queue\\Mailer;\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    resolved = [
+        c for c in _calls(store)
+        if c["confidence_tier"] == "INFERRED" and "dispatch" in c["target_qualified"]
+    ]
+    assert len(resolved) == 1
+    assert "Order/Queue/Mailer" in resolved[0]["target_qualified"]
+
+
+def test_unresolved_external_scoped_call_is_left_untouched(tmp_path: Path) -> None:
+    # ``Redis`` is not defined anywhere in the graph — the edge must stay a
+    # raw, directly-extracted target and must not fabricate a resolved caller.
+    store = _build(
+        tmp_path,
+        {
+            "src/Cache.php": (
+                "<?php\n"
+                "class Cache {\n"
+                "    public function warm($k) { return Redis::get($k); }\n"
+                "}\n"
+            ),
+        },
+    )
+    external = [c for c in _calls(store) if c["target_qualified"] == "Redis::get"]
+    assert len(external) == 1
+    assert external[0]["confidence_tier"] == "EXTRACTED"
+
+    result = query_graph("callers_of", "get", repo_root=str(tmp_path))
+    # No node named ``get`` exists, so there is nothing to (falsely) resolve.
+    assert result["status"] in ("not_found", "ok")
+    if result["status"] == "ok":
+        assert result["results"] == []
+
+
+def test_incremental_update_reresolves_scoped_call(tmp_path: Path) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/Ctrl.php": (
+                "<?php\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return 0; }\n"
+                "}\n"
+            ),
+        },
+    )
+    # Initially Ctrl does not call Mailer.
+    assert query_graph("callers_of", "dispatch", repo_root=str(tmp_path))["results"] == []
+
+    (tmp_path / "src/Ctrl.php").write_text(
+        "<?php\n"
+        "class Ctrl {\n"
+        "    public function reg($e) { return Mailer::dispatch($e); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    incremental_update(tmp_path, store, changed_files=["src/Ctrl.php"])
+
+    result = query_graph("callers_of", "dispatch", repo_root=str(tmp_path))
+    assert [r["name"] for r in result["results"]] == ["reg"]
+
+
+def test_resolver_is_idempotent(tmp_path: Path) -> None:
+    from code_review_graph.scoped_resolver import resolve_scoped_calls
+
+    store = _build(
+        tmp_path,
+        {
+            "src/Mailer.php": (
+                "<?php\n"
+                "class Mailer {\n"
+                "    public static function dispatch($to) { return true; }\n"
+                "}\n"
+            ),
+            "src/Ctrl.php": (
+                "<?php\n"
+                "class Ctrl {\n"
+                "    public function reg($e) { return Mailer::dispatch($e); }\n"
+                "}\n"
+            ),
+        },
+    )
+    before = _calls(store)
+    # A second pass must not resolve anything further or change targets.
+    stats = resolve_scoped_calls(store)
+    assert stats["calls_resolved"] == 0
+    assert _calls(store) == before
+

--- a/tests/test_rust_scoped_calls.py
+++ b/tests/test_rust_scoped_calls.py
@@ -1,0 +1,343 @@
+"""Scoped/static ``Type::method`` calls are tracked as callers in Rust (#567).
+
+In Rust, ``Type::method()`` / ``Self::method()`` / ``Type::new()`` is the
+dominant call form for associated functions and constructors.  These used to be
+stored as a ``CALLS`` edge whose target was the intermediate ``Type::method``
+string, which matched no node key, so ``callers_of`` / ``get_impact_radius``
+reported zero callers.  The post-build scoped resolver rewrites the resolvable
+two-segment targets to the defining node.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.tools.query import get_impact_radius, query_graph
+
+
+def _build(tmp_path: Path, files: dict[str, str]) -> GraphStore:
+    for rel, source in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir(exist_ok=True)
+    store = GraphStore(graph_dir / "graph.db")
+    full_build(tmp_path, store)
+    return store
+
+
+def _calls(store: GraphStore) -> list[dict]:
+    return [
+        dict(row)
+        for row in store._conn.execute(
+            "SELECT source_qualified, target_qualified, confidence_tier "
+            "FROM edges WHERE kind = 'CALLS'"
+        ).fetchall()
+    ]
+
+
+def test_cross_file_scoped_call_makes_caller_visible(tmp_path: Path) -> None:
+    _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn dispatch(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/signup.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn register(email: &str) -> bool {\n"
+                "    Mailer::dispatch(email)\n"
+                "}\n"
+            ),
+        },
+    )
+
+    result = query_graph("callers_of", "dispatch", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["register"]
+
+
+def test_scoped_call_edge_is_tagged_inferred(tmp_path: Path) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn dispatch(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/signup.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn register(email: &str) -> bool {\n"
+                "    Mailer::dispatch(email)\n"
+                "}\n"
+            ),
+        },
+    )
+    resolved = [
+        c for c in _calls(store)
+        if c["target_qualified"].endswith("Mailer.dispatch")
+    ]
+    assert len(resolved) == 1
+    assert resolved[0]["confidence_tier"] == "INFERRED"
+
+
+def test_constructor_new_call_resolves(tmp_path: Path) -> None:
+    # ``Type::new()`` is the idiomatic Rust constructor form.
+    _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn build() -> Mailer { Mailer }\n"
+                "}\n"
+            ),
+            "src/app.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn boot() -> Mailer {\n"
+                "    Mailer::build()\n"
+                "}\n"
+            ),
+        },
+    )
+    result = query_graph("callers_of", "build", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["boot"]
+
+
+def test_self_scoped_call_resolves_to_enclosing_type(tmp_path: Path) -> None:
+    # ``Self::helper()`` inside an impl must resolve to the enclosing type's
+    # method so the caller shows up (this same-file case is resolved from
+    # lexical evidence during parsing; the resolver leaves already-resolved
+    # targets alone). What matters is that the call is tracked as a caller.
+    store = _build(
+        tmp_path,
+        {
+            "src/worker.rs": (
+                "pub struct Worker;\n"
+                "impl Worker {\n"
+                "    pub fn helper(n: u32) -> u32 { n + 1 }\n"
+                "    pub fn run(&self) -> u32 { Self::helper(41) }\n"
+                "}\n"
+            ),
+        },
+    )
+    resolved = [
+        c for c in _calls(store)
+        if c["target_qualified"].endswith("Worker.helper")
+    ]
+    assert len(resolved) == 1
+    assert resolved[0]["source_qualified"].endswith("Worker.run")
+    # The dangling ``Self::helper`` / ``Worker::helper`` form must not survive.
+    targets = {c["target_qualified"] for c in _calls(store)}
+    assert "Self::helper" not in targets
+    assert "Worker::helper" not in targets
+
+    result = query_graph("callers_of", "helper", repo_root=str(tmp_path))
+    assert [r["name"] for r in result["results"]] == ["run"]
+
+
+def test_impact_radius_of_definition_file_includes_caller(tmp_path: Path) -> None:
+    _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn dispatch(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/signup.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn register(email: &str) -> bool {\n"
+                "    Mailer::dispatch(email)\n"
+                "}\n"
+            ),
+        },
+    )
+    impact = get_impact_radius(
+        changed_files=["src/mailer.rs"], repo_root=str(tmp_path)
+    )
+    assert impact["status"] == "ok"
+    impacted = {n["name"] for n in impact["impacted_nodes"]}
+    assert "register" in impacted
+
+
+def test_unresolved_external_scoped_call_is_left_untouched(tmp_path: Path) -> None:
+    # ``Vec::new`` / ``String::from`` are stdlib types with no in-graph node —
+    # the edge must stay a raw, directly-extracted target.
+    store = _build(
+        tmp_path,
+        {
+            "src/app.rs": (
+                "pub fn make() -> Vec<u8> {\n"
+                "    Vec::new()\n"
+                "}\n"
+            ),
+        },
+    )
+    external = [c for c in _calls(store) if c["target_qualified"] == "Vec::new"]
+    assert len(external) == 1
+    assert external[0]["confidence_tier"] == "EXTRACTED"
+
+
+def test_case_sensitive_identifiers_are_not_conflated(tmp_path: Path) -> None:
+    # Rust is case-sensitive: a call to ``Mailer::send`` must NOT resolve to a
+    # differently-cased definition ``Mailer::Send``. The edge must stay a raw,
+    # directly-extracted target rather than a bogus resolved caller.
+    store = _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn Send(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/signup.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn register(email: &str) -> bool {\n"
+                "    Mailer::send(email)\n"
+                "}\n"
+            ),
+        },
+    )
+    dangling = [c for c in _calls(store) if c["target_qualified"] == "Mailer::send"]
+    assert len(dangling) == 1
+    assert dangling[0]["confidence_tier"] == "EXTRACTED"
+    # And nothing falsely resolved onto the capital-S ``Send`` definition.
+    assert not any(
+        c["target_qualified"].endswith("Mailer.Send")
+        and c["confidence_tier"] == "INFERRED"
+        for c in _calls(store)
+    )
+
+
+def test_case_sensitive_matching_definition_resolves(tmp_path: Path) -> None:
+    # The exact-case sibling of the previous test: ``Mailer::Send`` resolves.
+    _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn Send(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/signup.rs": (
+                "use crate::mailer::Mailer;\n"
+                "pub fn register(email: &str) -> bool {\n"
+                "    Mailer::Send(email)\n"
+                "}\n"
+            ),
+        },
+    )
+    result = query_graph("callers_of", "Send", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert [r["name"] for r in result["results"]] == ["register"]
+
+
+def test_import_suffix_match_selects_correct_module(tmp_path: Path) -> None:
+    # Two same-named types with the same method in different modules; the
+    # imported one must win by a multi-segment path-suffix match, not by a
+    # single shared segment.
+    store = _build(
+        tmp_path,
+        {
+            "src/billing/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/shipping/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/app.rs": (
+                "use crate::shipping::mailer::Mailer;\n"
+                "pub fn run() -> bool {\n"
+                "    Mailer::go(\"x\")\n"
+                "}\n"
+            ),
+        },
+    )
+    resolved = [
+        c for c in _calls(store)
+        if c["confidence_tier"] == "INFERRED" and c["target_qualified"].endswith(
+            "Mailer.go"
+        )
+    ]
+    assert len(resolved) == 1
+    assert "shipping/mailer.rs" in resolved[0]["target_qualified"]
+    assert "billing/mailer.rs" not in resolved[0]["target_qualified"]
+
+
+def test_unrelated_import_path_does_not_resolve(tmp_path: Path) -> None:
+    # The imported module matches neither same-named definition's path, so the
+    # ambiguous call must be left unresolved rather than pick an unrelated one.
+    store = _build(
+        tmp_path,
+        {
+            "src/billing/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/shipping/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/app.rs": (
+                "use crate::warehouse::mailer::Mailer;\n"
+                "pub fn run() -> bool {\n"
+                "    Mailer::go(\"x\")\n"
+                "}\n"
+            ),
+        },
+    )
+    assert not any(c["confidence_tier"] == "INFERRED" for c in _calls(store))
+    dangling = [c for c in _calls(store) if c["target_qualified"] == "Mailer::go"]
+    assert len(dangling) == 1
+
+
+def test_multi_segment_module_path_is_left_untouched(tmp_path: Path) -> None:
+    # A fully-qualified ``crate::mailer::Mailer::dispatch`` is a multi-segment
+    # path; resolving it by its last two segments would be unsound, so it stays
+    # an unresolved, directly-extracted edge.
+    store = _build(
+        tmp_path,
+        {
+            "src/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn dispatch(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/app.rs": (
+                "pub fn run() -> bool {\n"
+                "    crate::mailer::Mailer::dispatch(\"x\")\n"
+                "}\n"
+            ),
+        },
+    )
+    multi = [
+        c for c in _calls(store)
+        if c["target_qualified"] == "crate::mailer::Mailer::dispatch"
+    ]
+    assert len(multi) == 1
+    assert multi[0]["confidence_tier"] == "EXTRACTED"
+

--- a/tests/test_rust_scoped_calls.py
+++ b/tests/test_rust_scoped_calls.py
@@ -314,6 +314,39 @@ def test_unrelated_import_path_does_not_resolve(tmp_path: Path) -> None:
     assert len(dangling) == 1
 
 
+def test_partial_suffix_from_unrelated_module_does_not_resolve(
+    tmp_path: Path,
+) -> None:
+    """A coincidental queue/mailer suffix is not the imported Rust module."""
+    store = _build(
+        tmp_path,
+        {
+            "src/order/queue/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/billing/legacy/mailer.rs": (
+                "pub struct Mailer;\n"
+                "impl Mailer {\n"
+                "    pub fn go(to: &str) -> bool { true }\n"
+                "}\n"
+            ),
+            "src/app.rs": (
+                "use crate::warehouse::queue::mailer::Mailer;\n"
+                "pub fn run() -> bool {\n"
+                "    Mailer::go(\"x\")\n"
+                "}\n"
+            ),
+        },
+    )
+
+    assert not any(c["confidence_tier"] == "INFERRED" for c in _calls(store))
+    dangling = [c for c in _calls(store) if c["target_qualified"] == "Mailer::go"]
+    assert len(dangling) == 1
+
+
 def test_multi_segment_module_path_is_left_untouched(tmp_path: Path) -> None:
     # A fully-qualified ``crate::mailer::Mailer::dispatch`` is a multi-segment
     # path; resolving it by its last two segments would be unsound, so it stays
@@ -340,4 +373,3 @@ def test_multi_segment_module_path_is_left_untouched(tmp_path: Path) -> None:
     ]
     assert len(multi) == 1
     assert multi[0]["confidence_tier"] == "EXTRACTED"
-


### PR DESCRIPTION
Integrates and preserves the contribution from #716 against current `main` (contributor credited as co-author), then fixes the remaining false-link case found during maintainer validation.

The resolver now requires a complete normalized import suffix, keeps PHP matching case-insensitive, keeps Rust matching case-sensitive, normalizes Windows import paths, and refuses ambiguous partial `Queue/Mailer` suffixes.

Validation on the exact head:
- 822 affected tests passed; 1 skipped; 1 multiprocessing parity test intentionally run separately
- 26 focused scoped-call tests passed
- Ruff and diff checks passed
- full serial graph build: 245 files, 4,700 nodes, 36,890 edges, zero errors

Incorporates #716 and addresses #567.