### PR TITLE
fix(graph): constrain bare edges to compatible languages

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -34,6 +34,21 @@ from .parser import EdgeInfo, NodeInfo
 
 logger = logging.getLogger(__name__)
 
+# These are the canonical language values stored for the JavaScript ecosystem.
+# JSX files are stored as ``javascript`` and Astro files as ``typescript`` by
+# ``EXTENSION_TO_LANGUAGE``; TSX keeps its own grammar name.
+_JAVASCRIPT_LANGUAGE_FAMILY = ("javascript", "typescript", "tsx")
+_JAVASCRIPT_LANGUAGE_FAMILY_SET = frozenset(_JAVASCRIPT_LANGUAGE_FAMILY)
+
+
+def _compatible_edge_languages(language: str) -> tuple[str, ...]:
+    """Return languages that can safely share unresolved bare edge targets."""
+    normalized = language.casefold()
+    if normalized in _JAVASCRIPT_LANGUAGE_FAMILY_SET:
+        return _JAVASCRIPT_LANGUAGE_FAMILY
+    return (language,)
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -416,10 +431,13 @@ class GraphStore:
         reverse call tracing (callers_of) works even when qualified-name lookup
         returns nothing.
 
-        When ``language`` is given, only edges whose source node was parsed from
-        that language are returned. Bare (unqualified) names are ambiguous across
-        the whole graph, so without this filter a common method name like
-        ``clone`` can match a same-named method in an unrelated language (#708).
+        When ``language`` is given, only edges whose source node has a compatible
+        language are returned. JavaScript, TypeScript, and TSX form one family
+        because calls and inheritance routinely cross those source types (JSX is
+        stored as JavaScript; Astro as TypeScript). Other languages require an
+        exact match. Bare names are ambiguous across the whole graph, so without
+        this filter a common method name like ``clone`` can match a same-named
+        method in an unrelated language (#708).
         """
         return list(self.iter_edges_by_target_name(name, kind=kind, language=language))
 
@@ -428,12 +446,14 @@ class GraphStore:
     ) -> Iterator[GraphEdge]:
         """Yield exact bare-target edges without materializing all matches."""
         if language:
+            languages = _compatible_edge_languages(language)
+            placeholders = ", ".join("?" for _ in languages)
             rows = self._conn.execute(
                 "SELECT edges.* FROM edges "
                 "JOIN nodes ON nodes.qualified_name = edges.source_qualified "
                 "WHERE edges.target_qualified = ? AND edges.kind = ? "
-                "AND nodes.language = ?",
-                (name, kind, language),
+                f"AND nodes.language IN ({placeholders})",
+                (name, kind, *languages),
             )
         else:
             rows = self._conn.execute(

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -405,7 +405,9 @@ class GraphStore:
             ).fetchall())
         return [self._row_to_edge(row) for row in rows]
 
-    def search_edges_by_target_name(self, name: str, kind: str = "CALLS") -> list[GraphEdge]:
+    def search_edges_by_target_name(
+        self, name: str, kind: str = "CALLS", language: str | None = None,
+    ) -> list[GraphEdge]:
         """Search for edges where target_qualified matches an unqualified name.
 
         CALLS edges often store unqualified target names (e.g. ``generateTestCode``)
@@ -413,17 +415,31 @@ class GraphStore:
         method finds those edges by exact match on the plain function name so that
         reverse call tracing (callers_of) works even when qualified-name lookup
         returns nothing.
+
+        When ``language`` is given, only edges whose source node was parsed from
+        that language are returned. Bare (unqualified) names are ambiguous across
+        the whole graph, so without this filter a common method name like
+        ``clone`` can match a same-named method in an unrelated language (#708).
         """
-        return list(self.iter_edges_by_target_name(name, kind=kind))
+        return list(self.iter_edges_by_target_name(name, kind=kind, language=language))
 
     def iter_edges_by_target_name(
-        self, name: str, kind: str = "CALLS",
+        self, name: str, kind: str = "CALLS", language: str | None = None,
     ) -> Iterator[GraphEdge]:
         """Yield exact bare-target edges without materializing all matches."""
-        rows = self._conn.execute(
-            "SELECT * FROM edges WHERE target_qualified = ? AND kind = ?",
-            (name, kind),
-        )
+        if language:
+            rows = self._conn.execute(
+                "SELECT edges.* FROM edges "
+                "JOIN nodes ON nodes.qualified_name = edges.source_qualified "
+                "WHERE edges.target_qualified = ? AND edges.kind = ? "
+                "AND nodes.language = ?",
+                (name, kind, language),
+            )
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM edges WHERE target_qualified = ? AND kind = ?",
+                (name, kind),
+            )
         for row in rows:
             yield self._row_to_edge(row)
 

--- a/code_review_graph/refactor.py
+++ b/code_review_graph/refactor.py
@@ -121,7 +121,11 @@ def rename_preview(
             })
 
     # Also search by bare name for unqualified edges.
-    bare_edges = store.search_edges_by_target_name(old_name, kind="CALLS")
+    bare_edges = store.search_edges_by_target_name(
+        old_name,
+        kind="CALLS",
+        language=node.language or None,
+    )
     seen = {(e["file"], e["line"]) for e in edits}
     for edge in bare_edges:
         key = (edge.file_path, edge.line)
@@ -481,7 +485,11 @@ def find_dead_code(
         # CALLS targets may be bare ("funcName"), class-qualified
         # ("Class::method"), or workspace-qualified ("pkg/dir::funcName").
         if not any(e.kind == "CALLS" for e in incoming):
-            bare = store.search_edges_by_target_name(node.name, kind="CALLS")
+            bare = store.search_edges_by_target_name(
+                node.name,
+                kind="CALLS",
+                language=node.language or None,
+            )
             # Also search for partially-qualified targets ending with ::name
             suffix_rows = conn.execute(
                 "SELECT * FROM edges WHERE kind = 'CALLS'"
@@ -523,7 +531,11 @@ def find_dead_code(
             ]
         # Check INHERITS -- classes with subclasses are not dead.
         if node.kind == "Class" and not any(e.kind == "INHERITS" for e in incoming):
-            bare_inh = store.search_edges_by_target_name(node.name, kind="INHERITS")
+            bare_inh = store.search_edges_by_target_name(
+                node.name,
+                kind="INHERITS",
+                language=node.language or None,
+            )
             incoming = incoming + bare_inh
         has_callers = any(e.kind == "CALLS" for e in incoming)
         has_test_refs = bool(outgoing_tb)

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -370,7 +370,10 @@ def query_graph(
                     if node.language == "cpp"
                     else 0
                 )
-                for e in store.iter_edges_by_target_name(node.name):
+                for e in store.iter_edges_by_target_name(
+                    node.name,
+                    language=node.language or None,
+                ):
                     # A C++ overload set deliberately keeps the target bare.
                     # Its candidates support disambiguation, but do not prove
                     # that any one exact overload was called.
@@ -540,7 +543,9 @@ def query_graph(
             # (e.g. "sample.dart::Animal"). Search by plain name too. See: #87
             if total_results == 0 and node:
                 for kind in ("INHERITS", "IMPLEMENTS"):
-                    for e in store.iter_edges_by_target_name(node.name, kind=kind):
+                    for e in store.iter_edges_by_target_name(
+                        node.name, kind=kind, language=node.language or None,
+                    ):
                         child = store.get_node(e.source_qualified)
                         if child:
                             add_result(node_to_dict(child), e)

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -92,6 +92,37 @@ class TestRenamePreview:
         assert "/repo/utils.py" in files  # definition
         assert "/repo/main.py" in files   # call site + import site
 
+    def test_rename_bare_callers_use_js_family_without_crossing_to_apex(self):
+        """A JS rename includes a TSX bare caller but not an Apex name collision."""
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="formatValue", file_path="/repo/format.js",
+            line_start=1, line_end=5, language="javascript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="tsxCaller", file_path="/repo/caller.tsx",
+            line_start=1, line_end=5, language="tsx",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="apexCaller", file_path="/repo/Caller.cls",
+            line_start=1, line_end=5, language="apex",
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/repo/caller.tsx::tsxCaller",
+            target="formatValue", file_path="/repo/caller.tsx", line=3,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/repo/Caller.cls::apexCaller",
+            target="formatValue", file_path="/repo/Caller.cls", line=3,
+        ))
+        self.store.commit()
+
+        result = rename_preview(self.store, "formatValue", "renderValue")
+
+        assert result is not None
+        edit_files = {edit["file"] for edit in result["edits"]}
+        assert "/repo/caller.tsx" in edit_files
+        assert "/repo/Caller.cls" not in edit_files
+
     def test_rename_not_found(self):
         """rename_preview returns None if symbol not found."""
         result = rename_preview(self.store, "nonexistent_function", "new_name")
@@ -358,6 +389,10 @@ class TestFindDeadCode:
             kind="Class", name="BaseConnector", file_path="/repo/connectors.py",
             line_start=5, line_end=50, language="python",
         ))
+        self.store.upsert_node(NodeInfo(
+            kind="Class", name="GarminConnector", file_path="/repo/connectors.py",
+            line_start=60, line_end=90, language="python",
+        ))
         # A subclass inherits from BaseConnector (bare-name target)
         self.store.upsert_edge(EdgeInfo(
             kind="INHERITS", source="/repo/connectors.py::GarminConnector",
@@ -367,6 +402,72 @@ class TestFindDeadCode:
         dead = find_dead_code(self.store)
         dead_names = {d["name"] for d in dead}
         assert "BaseConnector" not in dead_names
+
+    def test_find_dead_code_bare_calls_use_js_family_without_apex(self):
+        """TS callers keep JS code live; same-named Apex calls do not."""
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="usedFromTs", file_path="/repo/shared.js",
+            line_start=1, line_end=5, language="javascript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="apexOnlyCollision", file_path="/repo/shared.js",
+            line_start=10, line_end=15, language="javascript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="tsCaller", file_path="/repo/caller.ts",
+            line_start=1, line_end=5, language="typescript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="apexCaller", file_path="/repo/Caller.cls",
+            line_start=1, line_end=5, language="apex",
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/repo/caller.ts::tsCaller",
+            target="usedFromTs", file_path="/repo/caller.ts", line=3,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/repo/Caller.cls::apexCaller",
+            target="apexOnlyCollision", file_path="/repo/Caller.cls", line=3,
+        ))
+        self.store.commit()
+
+        dead_names = {item["name"] for item in find_dead_code(self.store)}
+
+        assert "usedFromTs" not in dead_names
+        assert "apexOnlyCollision" in dead_names
+
+    def test_find_dead_code_bare_inheritance_uses_js_family_without_apex(self):
+        """TS subclasses keep JS bases live; Apex subclasses do not."""
+        self.store.upsert_node(NodeInfo(
+            kind="Class", name="UsedJsBase", file_path="/repo/base.js",
+            line_start=1, line_end=8, language="javascript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Class", name="ApexOnlyBase", file_path="/repo/base.js",
+            line_start=10, line_end=18, language="javascript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Class", name="TsChild", file_path="/repo/child.ts",
+            line_start=1, line_end=8, language="typescript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Class", name="ApexChild", file_path="/repo/Child.cls",
+            line_start=1, line_end=8, language="apex",
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="INHERITS", source="/repo/child.ts::TsChild",
+            target="UsedJsBase", file_path="/repo/child.ts", line=1,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="INHERITS", source="/repo/Child.cls::ApexChild",
+            target="ApexOnlyBase", file_path="/repo/Child.cls", line=1,
+        ))
+        self.store.commit()
+
+        dead_names = {item["name"] for item in find_dead_code(self.store)}
+
+        assert "UsedJsBase" not in dead_names
+        assert "ApexOnlyBase" in dead_names
 
     def test_find_dead_code_bare_name_not_tricked_by_unrelated_caller(self):
         """Bare-name CALLS from unrelated files don't save a dead function
@@ -379,6 +480,10 @@ class TestFindDeadCode:
         self.store.upsert_node(NodeInfo(
             kind="Function", name="processor", file_path="/repo/worker/tasks.py",
             line_start=10, line_end=20, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="start", file_path="/repo/main.py",
+            line_start=1, line_end=20, language="python",
         ))
         # A bare CALLS edge from a third file that imports only routes.py
         self.store.upsert_edge(EdgeInfo(
@@ -905,6 +1010,11 @@ class TestTransitiveImportResolution:
             kind="Function", name="safeJsonParse",
             file_path="/repo/lib/utils.ts",
             line_start=10, line_end=20, language="typescript",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="processData",
+            file_path="/repo/consumer.ts",
+            line_start=1, line_end=8, language="typescript",
         ))
         # Import chain: consumer -> index -> utils
         self.store.upsert_edge(EdgeInfo(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -289,6 +289,40 @@ class TestQueryGraphCallTargetFallbacks:
             "external_helper",
         }
 
+    def test_callers_of_bare_fallback_does_not_cross_languages(self):
+        """Regression for #708: a bare-name CALLS edge from an unrelated
+        language (e.g. an Apex ``.clone()`` call) must not be reported as a
+        caller of a same-named function in a different language (JS)."""
+        js_file = str(self.root / "clone.js")
+        apex_file = str(self.root / "Clone.cls")
+        with GraphStore(self.db_path) as store:
+            store.upsert_node(NodeInfo(
+                kind="Function", name="clone", file_path=js_file,
+                line_start=1, line_end=3, language="javascript",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function", name="apexCaller", file_path=apex_file,
+                line_start=1, line_end=5, language="apex",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{apex_file}::apexCaller",
+                target="clone",
+                file_path=apex_file,
+                line=3,
+            ))
+            store.commit()
+
+        result = query_graph(
+            pattern="callers_of",
+            target=f"{js_file}::clone",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        names = {r["name"] for r in result["results"]}
+        assert "apexCaller" not in names
+
 
 def _seed_repo_relative_graph(root: Path) -> None:
     """Seed graph data with cwd-relative paths, as eval repos currently do."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -183,6 +183,57 @@ class TestTools:
         assert len(edges) == 1
         assert edges[0].source_qualified == "/repo/main.py::process"
 
+    def test_search_edges_by_target_name_uses_javascript_language_family(self):
+        """JS-family filtering keeps JS/JSX/TS/TSX/Astro callers, not Apex."""
+        callers = (
+            ("/repo/caller.js", "javascript"),
+            ("/repo/caller.jsx", "javascript"),
+            ("/repo/caller.ts", "typescript"),
+            ("/repo/caller.tsx", "tsx"),
+            ("/repo/caller.astro", "typescript"),
+            ("/repo/Caller.cls", "apex"),
+        )
+        for file_path, language in callers:
+            source = f"{file_path}::invoke"
+            self.store.upsert_node(NodeInfo(
+                kind="Function",
+                name="invoke",
+                file_path=file_path,
+                line_start=1,
+                line_end=3,
+                language=language,
+            ))
+            self.store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=source,
+                target="sharedHelper",
+                file_path=file_path,
+                line=2,
+            ))
+        self.store.commit()
+
+        expected_sources = {
+            "/repo/caller.js::invoke",
+            "/repo/caller.jsx::invoke",
+            "/repo/caller.ts::invoke",
+            "/repo/caller.tsx::invoke",
+            "/repo/caller.astro::invoke",
+        }
+        for target_language in ("javascript", "typescript", "tsx"):
+            edges = self.store.search_edges_by_target_name(
+                "sharedHelper",
+                language=target_language,
+            )
+            assert {edge.source_qualified for edge in edges} == expected_sources
+
+        apex_edges = self.store.search_edges_by_target_name(
+            "sharedHelper",
+            language="apex",
+        )
+        assert {edge.source_qualified for edge in apex_edges} == {
+            "/repo/Caller.cls::invoke",
+        }
+
 
 class TestQueryGraphCallTargetFallbacks:
     """Regression tests for mixed qualified and bare CALLS targets."""
@@ -289,11 +340,10 @@ class TestQueryGraphCallTargetFallbacks:
             "external_helper",
         }
 
-    def test_callers_of_bare_fallback_does_not_cross_languages(self):
-        """Regression for #708: a bare-name CALLS edge from an unrelated
-        language (e.g. an Apex ``.clone()`` call) must not be reported as a
-        caller of a same-named function in a different language (JS)."""
+    def test_callers_of_bare_fallback_uses_js_family_without_crossing_to_apex(self):
+        """Regression for #708: JS-family callers match, unrelated Apex does not."""
         js_file = str(self.root / "clone.js")
+        tsx_file = str(self.root / "caller.tsx")
         apex_file = str(self.root / "Clone.cls")
         with GraphStore(self.db_path) as store:
             store.upsert_node(NodeInfo(
@@ -301,8 +351,19 @@ class TestQueryGraphCallTargetFallbacks:
                 line_start=1, line_end=3, language="javascript",
             ))
             store.upsert_node(NodeInfo(
+                kind="Function", name="tsxCaller", file_path=tsx_file,
+                line_start=1, line_end=5, language="tsx",
+            ))
+            store.upsert_node(NodeInfo(
                 kind="Function", name="apexCaller", file_path=apex_file,
                 line_start=1, line_end=5, language="apex",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{tsx_file}::tsxCaller",
+                target="clone",
+                file_path=tsx_file,
+                line=3,
             ))
             store.upsert_edge(EdgeInfo(
                 kind="CALLS",
@@ -321,7 +382,66 @@ class TestQueryGraphCallTargetFallbacks:
 
         assert result["status"] == "ok"
         names = {r["name"] for r in result["results"]}
+        assert "tsxCaller" in names
         assert "apexCaller" not in names
+
+    def test_inheritors_of_bare_fallback_uses_js_family_without_apex(self):
+        """Bare INHERITS/IMPLEMENTS edges stay inside the JS language family."""
+        base_file = str(self.root / "base.js")
+        ts_file = str(self.root / "child.ts")
+        jsx_file = str(self.root / "implementer.jsx")
+        apex_file = str(self.root / "Child.cls")
+        with GraphStore(self.db_path) as store:
+            store.upsert_node(NodeInfo(
+                kind="Class", name="BaseWidget", file_path=base_file,
+                line_start=1, line_end=8, language="javascript",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Class", name="TsChild", file_path=ts_file,
+                line_start=1, line_end=8, language="typescript",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Class", name="JsxImplementer", file_path=jsx_file,
+                line_start=1, line_end=8, language="javascript",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Class", name="ApexChild", file_path=apex_file,
+                line_start=1, line_end=8, language="apex",
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="INHERITS",
+                source=f"{ts_file}::TsChild",
+                target="BaseWidget",
+                file_path=ts_file,
+                line=1,
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="IMPLEMENTS",
+                source=f"{jsx_file}::JsxImplementer",
+                target="BaseWidget",
+                file_path=jsx_file,
+                line=1,
+            ))
+            store.upsert_edge(EdgeInfo(
+                kind="INHERITS",
+                source=f"{apex_file}::ApexChild",
+                target="BaseWidget",
+                file_path=apex_file,
+                line=1,
+            ))
+            store.commit()
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{base_file}::BaseWidget",
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        assert {item["name"] for item in result["results"]} == {
+            "TsChild",
+            "JsxImplementer",
+        }
 
 
 def _seed_repo_relative_graph(root: Path) -> None:


### PR DESCRIPTION
Integrates the contributor-authored #733 commit against current `main`, then closes the remaining language-compatibility gaps found during maintainer validation.

The original exact-language filter broke valid JS/JSX/TS/TSX/Astro relationships and was not threaded through every query, rename, and dead-code path. This integration keeps Apex isolated, permits only the established JS-family compatibility groups, and covers CALLS and INHERITS end to end.

Exact-head validation:
- 221 graph/query/refactor tests passed; 1 skipped
- six new regressions were RED before the maintainer fix and GREEN after it
- Ruff and diff checks passed
- serial graph build: 242 files, 4,662 nodes, 36,702 edges, zero errors

Incorporates #733.

Closes #708.