### PR TITLE
fix(context): report unready graphs

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -302,7 +302,7 @@ def _write_data_dir_gitignore(data_dir: Path) -> None:
             pass
 
 
-def get_data_dir(repo_root: Path) -> Path:
+def get_data_dir(repo_root: Path, *, create: bool = True) -> Path:
     """Return the directory where this project's graph data lives.
 
     Resolution priority:
@@ -315,19 +315,25 @@ def get_data_dir(repo_root: Path) -> Path:
     instead — letting you keep graphs outside the working tree (useful
     for ephemeral workspaces, Docker volumes, or shared caches). See: #155
 
-    The directory is created if it does not already exist; an inner
-    ``.gitignore`` (with ``*``) is written so any accidentally-nested
-    files never get committed. Both are idempotent.
+    By default the directory is created if it does not already exist; an
+    inner ``.gitignore`` (with ``*``) is written so any accidentally-nested
+    files never get committed. Both are idempotent. Pass ``create=False``
+    when resolving the path for a read-only existence check.
     """
     # Check registry first
     try:
-        from .registry import Registry
-        registry_data_dir = Registry().get_data_dir_for_repo(str(repo_root))
-        if registry_data_dir:
-            data_dir = Path(registry_data_dir).resolve()
-            data_dir.mkdir(parents=True, exist_ok=True)
-            _write_data_dir_gitignore(data_dir)
-            return data_dir
+        from .registry import _REGISTRY_PATH, Registry
+
+        # Registry construction creates its parent directory. A read-only
+        # lookup must skip it entirely when no registry file exists.
+        if create or _REGISTRY_PATH.is_file():
+            registry_data_dir = Registry().get_data_dir_for_repo(str(repo_root))
+            if registry_data_dir:
+                data_dir = Path(registry_data_dir).resolve()
+                if create:
+                    data_dir.mkdir(parents=True, exist_ok=True)
+                    _write_data_dir_gitignore(data_dir)
+                return data_dir
     except Exception as exc:
         # If registry lookup fails, log and fall through to other methods
         logger.debug("Registry lookup failed for %s: %s", repo_root, exc)
@@ -339,21 +345,27 @@ def get_data_dir(repo_root: Path) -> Path:
     else:
         data_dir = repo_root / ".code-review-graph"
 
-    data_dir.mkdir(parents=True, exist_ok=True)
-    _write_data_dir_gitignore(data_dir)
+    if create:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _write_data_dir_gitignore(data_dir)
 
     return data_dir
 
 
-def get_db_path(repo_root: Path) -> Path:
+def get_db_path(repo_root: Path, *, read_only: bool = False) -> Path:
     """Determine the database path for a repository.
 
     Respects ``CRG_DATA_DIR`` (see :func:`get_data_dir`). Migrates a
     legacy top-level ``.code-review-graph.db`` file into the new
-    directory when it exists (WAL/SHM side-files are discarded).
+    directory when it exists (WAL/SHM side-files are discarded). Pass
+    ``read_only=True`` to resolve the current path without creating a data
+    directory, migrating a legacy database, or deleting side-files.
     """
-    crg_dir = get_data_dir(repo_root)
+    crg_dir = get_data_dir(repo_root, create=not read_only)
     new_db = crg_dir / "graph.db"
+
+    if read_only:
+        return new_db
 
     # Migrate legacy database if present (only meaningful when the
     # legacy file sits at the repo root — if CRG_DATA_DIR is set we

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -322,11 +322,11 @@ def get_data_dir(repo_root: Path, *, create: bool = True) -> Path:
     """
     # Check registry first
     try:
-        from .registry import _REGISTRY_PATH, Registry
+        from .registry import Registry, default_registry_path
 
         # Registry construction creates its parent directory. A read-only
         # lookup must skip it entirely when no registry file exists.
-        if create or _REGISTRY_PATH.is_file():
+        if create or default_registry_path().is_file():
             registry_data_dir = Registry().get_data_dir_for_repo(str(repo_root))
             if registry_data_dir:
                 data_dir = Path(registry_data_dir).resolve()

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -194,7 +194,9 @@ def get_minimal_context_tool(
 
     Returns graph stats, risk score, top communities/flows, and suggested
     next tools in a single compact response. Use this as the entry point
-    before any other graph tool to minimize token usage.
+    before any other graph tool to minimize token usage. Returns
+    ``status: not_ready`` with a build suggestion when the graph is missing,
+    empty, or known to have been built at a different Git commit.
 
     Args:
         task: What you are doing (e.g. "review PR #42", "debug login timeout").

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -64,7 +64,7 @@ def graph_provenance(repo_root: str | None = None) -> dict[str, Any] | None:
     """
     try:
         root = _resolve_root(repo_root)
-        db_path = get_db_path(root)
+        db_path = get_db_path(root, read_only=True)
         if not db_path.exists():
             return None
 
@@ -87,36 +87,36 @@ def graph_provenance(repo_root: str | None = None) -> dict[str, Any] | None:
         finally:
             connection.close()
 
+        provenance: dict[str, Any] = {}
         updated_at = rows.get("last_updated")
-        if not isinstance(updated_at, str) or not updated_at:
-            return None
+        if isinstance(updated_at, str) and updated_at:
+            provenance["updated_at"] = updated_at
+            try:
+                built_at = datetime.fromisoformat(updated_at)
+                # Match aware timestamps with an aware ``now`` in the same
+                # timezone; None preserves the stored naive/local format.
+                now = datetime.now(tz=built_at.tzinfo)
+                provenance["age_seconds"] = max(
+                    0, int((now - built_at).total_seconds()),
+                )
+            except (OverflowError, TypeError, ValueError):
+                # A malformed timestamp only removes the derived age. The raw
+                # timestamp and independently valid branch/SHA remain useful.
+                pass
 
-        provenance: dict[str, Any] = {"updated_at": updated_at}
-        try:
-            built_at = datetime.fromisoformat(updated_at)
-            # Match aware timestamps with an aware ``now`` in the same
-            # timezone; None preserves the stored naive/local format.
-            now = datetime.now(tz=built_at.tzinfo)
-            provenance["age_seconds"] = max(
-                0, int((now - built_at).total_seconds()),
-            )
-        except (OverflowError, TypeError, ValueError):
-            # A malformed timestamp only removes the derived age. The raw
-            # timestamp and independently valid branch/SHA remain useful.
-            pass
-
-        branch = rows.get("git_branch")
-        if isinstance(branch, str) and branch:
-            provenance["built_on_branch"] = branch
         head_sha = rows.get("git_head_sha")
         if isinstance(head_sha, str) and head_sha:
             provenance["built_at_sha"] = head_sha
-        live_head_sha = _read_live_git_head(root)
-        if live_head_sha:
-            provenance["head_sha"] = live_head_sha
-            if isinstance(head_sha, str) and head_sha:
-                provenance["head_matches_build"] = live_head_sha == head_sha
-        return provenance
+        if provenance:
+            branch = rows.get("git_branch")
+            if isinstance(branch, str) and branch:
+                provenance["built_on_branch"] = branch
+            live_head_sha = _read_live_git_head(root)
+            if live_head_sha:
+                provenance["head_sha"] = live_head_sha
+                if isinstance(head_sha, str) and head_sha:
+                    provenance["head_matches_build"] = live_head_sha == head_sha
+        return provenance or None
     except Exception:
         return None
 

--- a/code_review_graph/tools/context.py
+++ b/code_review_graph/tools/context.py
@@ -8,9 +8,20 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from ._common import _get_store, compact_response
+from ..incremental import get_db_path
+from ._common import _get_store, _resolve_root, compact_response, graph_provenance
 
 logger = logging.getLogger(__name__)
+
+
+def _not_ready(reason: str, summary: str) -> dict[str, Any]:
+    """Return a compact response that directs callers to initialize the graph."""
+    return {
+        "status": "not_ready",
+        "reason": reason,
+        "summary": summary,
+        "next_tool_suggestions": ["build_or_update_graph"],
+    }
 
 
 def _has_git_changes(root: Path, base: str) -> bool:
@@ -51,11 +62,36 @@ def get_minimal_context(
         changed_files: Explicit changed files. Auto-detected from git if None.
         repo_root: Repository root path. Auto-detected if None.
         base: Git ref for diff comparison.
+
+    Returns:
+        Compact graph context, or ``status: not_ready`` when the graph is
+        missing, empty, or known to have been built at a different Git commit.
     """
-    store, root = _get_store(repo_root)
+    root = _resolve_root(repo_root)
+    db_path = get_db_path(root, read_only=True)
+    if not db_path.is_file():
+        return _not_ready(
+            "missing_graph",
+            "No graph database found. Build the graph before requesting context.",
+        )
+
+    store, root = _get_store(str(root))
     try:
         # 1. Quick stats
         stats = store.get_stats()
+        if stats.total_nodes == 0:
+            return _not_ready(
+                "empty_graph",
+                "The graph database contains no nodes. Build the graph before requesting context.",
+            )
+
+        provenance = graph_provenance(str(root))
+        if provenance and provenance.get("head_matches_build") is False:
+            return _not_ready(
+                "stale_graph",
+                "The graph was built at a different Git commit. "
+                "Update it before requesting context.",
+            )
 
         # 2. Risk from changed files
         risk = "unknown"

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -175,6 +175,23 @@ class TestGetDbPath:
         for suffix in ("-wal", "-shm", "-journal"):
             assert not (tmp_path / f".code-review-graph.db{suffix}").exists()
 
+    def test_read_only_resolution_does_not_create_migrate_or_clean(self, tmp_path):
+        legacy = tmp_path / ".code-review-graph.db"
+        legacy.write_text("legacy data")
+        side_files = [
+            tmp_path / f".code-review-graph.db{suffix}"
+            for suffix in ("-wal", "-shm", "-journal")
+        ]
+        for side_file in side_files:
+            side_file.write_text("side")
+
+        db_path = get_db_path(tmp_path, read_only=True)
+
+        assert db_path == tmp_path / ".code-review-graph" / "graph.db"
+        assert not db_path.parent.exists()
+        assert legacy.read_text() == "legacy data"
+        assert all(side_file.read_text() == "side" for side_file in side_files)
+
 
 class TestEnsureRepoGitignoreExcludesCrg:
     def test_creates_gitignore_when_missing(self, tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1804,6 +1804,109 @@ class TestGetMinimalContext:
         assert "summary" in result
         assert "next_tool_suggestions" in result
 
+    def test_missing_graph_returns_not_ready_without_creating_database(self, tmp_path):
+        from code_review_graph.tools.context import get_minimal_context
+
+        repo = tmp_path / "cold-worktree"
+        repo.mkdir()
+        # Linked worktrees use a .git pointer file instead of a directory.
+        (repo / ".git").write_text("gitdir: ../main/.git/worktrees/cold\n")
+        db_path = repo / ".code-review-graph" / "graph.db"
+
+        result = get_minimal_context(repo_root=str(repo))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "missing_graph"
+        assert result["next_tool_suggestions"] == ["build_or_update_graph"]
+        assert not db_path.exists()
+        assert not db_path.parent.exists()
+
+    def test_mcp_wrapper_reports_missing_graph_without_creating_state(self, tmp_path):
+        from code_review_graph.main import get_minimal_context_tool
+
+        repo = tmp_path / "cold-worktree"
+        repo.mkdir()
+        (repo / ".git").write_text("gitdir: ../main/.git/worktrees/cold\n")
+
+        result = get_minimal_context_tool(repo_root=str(repo))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "missing_graph"
+        assert not (repo / ".code-review-graph").exists()
+
+    def test_missing_graph_does_not_create_external_data_dir(self, tmp_path, monkeypatch):
+        from code_review_graph.tools.context import get_minimal_context
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        external_data = tmp_path / "external-data"
+        monkeypatch.setenv("CRG_DATA_DIR", str(external_data))
+
+        result = get_minimal_context(repo_root=str(repo))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "missing_graph"
+        assert not external_data.exists()
+
+    def test_missing_registered_graph_does_not_create_registered_data_dir(
+        self, tmp_path, monkeypatch,
+    ):
+        import json
+
+        import code_review_graph.registry as registry_module
+        from code_review_graph.tools.context import get_minimal_context
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        external_data = tmp_path / "registered-data"
+        registry_path = tmp_path / "registry" / "registry.json"
+        registry_path.parent.mkdir()
+        registry_path.write_text(json.dumps({
+            "repos": [{"path": str(repo.resolve()), "data_dir": str(external_data)}],
+        }))
+        monkeypatch.setattr(registry_module, "_REGISTRY_PATH", registry_path)
+
+        result = get_minimal_context(repo_root=str(repo))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "missing_graph"
+        assert not external_data.exists()
+
+    def test_empty_graph_returns_not_ready(self, tmp_path):
+        from code_review_graph.tools.context import get_minimal_context
+
+        repo = tmp_path / "empty-graph"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        graph_dir = repo / ".code-review-graph"
+        graph_dir.mkdir()
+        store = GraphStore(graph_dir / "graph.db")
+        store.close()
+
+        result = get_minimal_context(repo_root=str(repo))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "empty_graph"
+        assert result["next_tool_suggestions"] == ["build_or_update_graph"]
+
+    def test_graph_built_at_another_commit_returns_not_ready(self, monkeypatch):
+        from code_review_graph.tools.context import get_minimal_context
+
+        db_path = self.root / ".code-review-graph" / "graph.db"
+        store = GraphStore(db_path)
+        store.set_metadata("git_head_sha", "built-sha")
+        store.commit()
+        store.close()
+        monkeypatch.setattr(common_module, "_read_live_git_head", lambda _root: "live-sha")
+
+        result = get_minimal_context(repo_root=str(self.root))
+
+        assert result["status"] == "not_ready"
+        assert result["reason"] == "stale_graph"
+        assert result["next_tool_suggestions"] == ["build_or_update_graph"]
+
     def test_output_is_compact(self):
         import json
 
@@ -1991,6 +2094,7 @@ class TestGraphProvenance:
         repo.mkdir()
         (repo / ".git").mkdir()
         assert common_module.graph_provenance(str(repo)) is None
+        assert not (repo / ".code-review-graph").exists()
 
     def test_corrupt_graph_database_has_no_envelope(self, tmp_path):
         repo = tmp_path / "repo"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1854,7 +1854,6 @@ class TestGetMinimalContext:
     ):
         import json
 
-        import code_review_graph.registry as registry_module
         from code_review_graph.tools.context import get_minimal_context
 
         repo = tmp_path / "repo"
@@ -1866,7 +1865,7 @@ class TestGetMinimalContext:
         registry_path.write_text(json.dumps({
             "repos": [{"path": str(repo.resolve()), "data_dir": str(external_data)}],
         }))
-        monkeypatch.setattr(registry_module, "_REGISTRY_PATH", registry_path)
+        monkeypatch.setenv("CRG_HOME", str(registry_path.parent))
 
         result = get_minimal_context(repo_root=str(repo))
 


### PR DESCRIPTION
## Linked issue

Closes #734

## What & why

`get_minimal_context_tool` opened `GraphStore` before checking graph readiness. In a
cold worktree, that created an empty database and returned `status: ok`, which could
make an agent trust analysis that contained no graph data.

This change resolves graph paths without filesystem side effects before opening the
store and returns an actionable `not_ready` response for missing, empty, or
commit-stale graphs. The normal build path keeps its existing directory creation and
legacy migration behavior.

Regression coverage includes linked worktrees, default and external data directories,
registry overrides, legacy databases and sidecars, empty graphs, and stale build SHAs.

## How it was tested

```bash
uv run pytest tests/ --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65
uv run ruff check code_review_graph/
uv run --with mypy --with types-networkx mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
uv run --with bandit bandit -r code_review_graph/ -c pyproject.toml -q
```

- 2090 passed, 5 skipped, 2 xpassed
- 80.67% coverage

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (README, `docs/`, docstrings)
