### PR TITLE
fix(eval): build and reuse the requested vector index safely

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -864,6 +864,28 @@ def main() -> None:
     eval_cmd.add_argument("--all", action="store_true", dest="run_all", help="Run all benchmarks")
     eval_cmd.add_argument("--report", action="store_true", help="Generate report from results")
     eval_cmd.add_argument("--output-dir", default=None, help="Output directory for results")
+    eval_cmd.add_argument(
+        "--embed",
+        action="store_true",
+        help=(
+            "Build the vector index after each graph build. Required by the "
+            "agent_baseline, search_quality and multi_hop_retrieval "
+            "benchmarks: without it their natural-language questions hit "
+            "FTS5 only and return zero results (default: disabled)"
+        ),
+    )
+    eval_cmd.add_argument(
+        "--embed-provider",
+        choices=["local", "openai", "google", "minimax"],
+        default=None,
+        help="Provider for --embed (default: local, needs "
+             "code-review-graph[embeddings])",
+    )
+    eval_cmd.add_argument(
+        "--embed-model",
+        default=None,
+        help="Model for --embed (default: the provider's own default)",
+    )
 
     # detect-changes
     detect_cmd = sub.add_parser(
@@ -1300,6 +1322,9 @@ def main() -> None:
                 repos=repos,
                 benchmarks=benchmarks,
                 output_dir=getattr(args, "output_dir", None),
+                embed=getattr(args, "embed", False),
+                embedding_provider=getattr(args, "embed_provider", None),
+                embedding_model=getattr(args, "embed_model", None),
             )
             print(f"\nCompleted {len(results)} benchmark(s).")
             print("Run 'code-review-graph eval --report' to generate tables.")

--- a/code_review_graph/constants.py
+++ b/code_review_graph/constants.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import os
+from pathlib import Path
 
 
 def _bounded_float_env(
@@ -71,3 +72,28 @@ IMPACT_DEPTH_DECAY = _bounded_float_env(
 IMPACT_SCORE_FLOOR = _bounded_float_env(
     "CRG_IMPACT_SCORE_FLOOR", 0.05, lower=0.0, upper=1.0,
 )
+
+
+#: Overrides the per-user state directory that holds ``registry.json``,
+#: ``watch.toml``, ``daemon.pid``, ``daemon-state.json`` and ``logs/``.
+#: Follows the same convention as CRG_DATA_DIR.
+CRG_HOME_ENV = "CRG_HOME"
+
+_DEFAULT_CRG_HOME = Path.home() / ".code-review-graph"
+
+
+def crg_home() -> Path:
+    """Return the per-user state directory for code-review-graph.
+
+    ``$CRG_HOME`` wins when set and non-empty; otherwise
+    ``~/.code-review-graph``.
+
+    Resolved per call rather than captured in a module-level constant. An
+    import-time constant cannot be redirected afterwards, which is what let
+    the test suite write into the real home directory of whoever ran it: by
+    the time a fixture set the variable, the value had already been frozen.
+    """
+    override = os.environ.get(CRG_HOME_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_CRG_HOME

--- a/code_review_graph/daemon.py
+++ b/code_review_graph/daemon.py
@@ -32,15 +32,71 @@ else:
     except ImportError:
         tomllib = None  # type: ignore[assignment]
 
+from .constants import crg_home
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Config file location
 # ---------------------------------------------------------------------------
 
-CONFIG_PATH: Path = Path.home() / ".code-review-graph" / "watch.toml"
-PID_PATH: Path = Path.home() / ".code-review-graph" / "daemon.pid"
-STATE_PATH: Path = Path.home() / ".code-review-graph" / "daemon-state.json"
+def default_config_path() -> Path:
+    """Path to ``watch.toml`` under the per-user state directory."""
+    return crg_home() / "watch.toml"
+
+
+def default_pid_path() -> Path:
+    """Path to the daemon PID file."""
+    return crg_home() / "daemon.pid"
+
+
+def default_state_path() -> Path:
+    """Path to the persisted daemon state."""
+    return crg_home() / "daemon-state.json"
+
+
+def default_log_dir() -> Path:
+    """Directory for per-repo daemon logs."""
+    return crg_home() / "logs"
+
+
+# These four were module-level constants built from Path.home(). They resolve
+# per call now so $CRG_HOME can redirect them: an import-time constant is
+# frozen before any caller — a test fixture, a sandboxed run — gets the chance
+# to set the variable, which is how the test suite ended up writing into the
+# real home directory of whoever ran it.
+#
+# The PEP 562 shim below keeps the old attribute names working for anything
+# that already imported them: both ``daemon.CONFIG_PATH`` and
+# ``from …daemon import CONFIG_PATH`` route through ``__getattr__``, and
+# ``__dir__`` keeps them visible to introspection. Not covered: ``import *``
+# (this module defines no ``__all__``, and adding one would change what the
+# star exports for every other name) and static analysers, which cannot see
+# dynamic attributes. Both are acceptable — these were never public API, and
+# the alternative is deleting the names outright.
+_LAZY_PATHS = {
+    "CONFIG_PATH": default_config_path,
+    "PID_PATH": default_pid_path,
+    "STATE_PATH": default_state_path,
+}
+
+
+def __getattr__(name: str) -> Path:
+    if name in _LAZY_PATHS:
+        return _LAZY_PATHS[name]()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include the lazy names so ``dir()`` and tab-completion still find them.
+
+    ``__getattr__`` alone covers attribute access and ``from … import X``,
+    but names absent from module globals are otherwise invisible to
+    ``dir()``, ``from … import *`` and static analysers.
+    """
+    return sorted(set(globals()) | set(_LAZY_PATHS))
+
+
 _HEALTH_CHECK_INTERVAL = 30
 
 # ---------------------------------------------------------------------------
@@ -66,7 +122,7 @@ class DaemonConfig:
     session_name: str = "crg-watch"
     """Logical daemon name (used in log messages and status output)."""
 
-    log_dir: Path = field(default_factory=lambda: Path.home() / ".code-review-graph" / "logs")
+    log_dir: Path = field(default_factory=default_log_dir)
     """Directory for per-repo log files."""
 
     poll_interval: int = 2
@@ -85,7 +141,7 @@ def load_config(path: Path | None = None) -> DaemonConfig:
     """Load daemon configuration from a TOML file.
 
     Args:
-        path: Explicit config path.  Falls back to :data:`CONFIG_PATH`.
+        path: Explicit config path.  Falls back to :func:`default_config_path`.
 
     Returns:
         A fully-validated :class:`DaemonConfig`.
@@ -99,7 +155,7 @@ def load_config(path: Path | None = None) -> DaemonConfig:
             "Install it with:  pip install tomli"
         )
 
-    config_path = path or CONFIG_PATH
+    config_path = path or default_config_path()
 
     if not config_path.exists():
         logger.info("Config file not found at %s — using defaults", config_path)
@@ -225,9 +281,9 @@ def save_config(config: DaemonConfig, path: Path | None = None) -> None:
 
     Args:
         config: The daemon configuration to persist.
-        path:   Explicit config path.  Falls back to :data:`CONFIG_PATH`.
+        path:   Explicit config path.  Falls back to :func:`default_config_path`.
     """
-    config_path = path or CONFIG_PATH
+    config_path = path or default_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(_serialize_toml(config), encoding="utf-8")
     logger.info("Config saved to %s", config_path)
@@ -248,7 +304,7 @@ def add_repo_to_config(
     Args:
         repo_path:   Path to the repository (will be resolved to absolute).
         alias:       Optional short name.  Derived from dirname if *None*.
-        config_path: Explicit config file path.  Falls back to :data:`CONFIG_PATH`.
+        config_path: Explicit config file path.  Falls back to :func:`default_config_path`.
 
     Returns:
         The updated :class:`DaemonConfig`.
@@ -294,7 +350,7 @@ def remove_repo_from_config(
 
     Args:
         path_or_alias: Either the absolute/relative repo path or its alias.
-        config_path:   Explicit config file path.  Falls back to :data:`CONFIG_PATH`.
+        config_path:   Explicit config file path.  Falls back to :func:`default_config_path`.
 
     Returns:
         The updated :class:`DaemonConfig`.
@@ -323,14 +379,14 @@ def remove_repo_from_config(
 
 def write_pid(pid: int | None = None, path: Path | None = None) -> None:
     """Write the current (or given) PID to the PID file."""
-    pid_path = path or PID_PATH
+    pid_path = path or default_pid_path()
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text(str(pid or os.getpid()), encoding="utf-8")
 
 
 def read_pid(path: Path | None = None) -> int | None:
     """Read the daemon PID from disk. Returns None if missing/invalid."""
-    pid_path = path or PID_PATH
+    pid_path = path or default_pid_path()
     if not pid_path.exists():
         return None
     try:
@@ -341,7 +397,7 @@ def read_pid(path: Path | None = None) -> int | None:
 
 def clear_pid(path: Path | None = None) -> None:
     """Remove the PID file."""
-    pid_path = path or PID_PATH
+    pid_path = path or default_pid_path()
     try:
         pid_path.unlink(missing_ok=True)
     except OSError:
@@ -455,7 +511,7 @@ def load_state(path: Path | None = None) -> dict[str, Any]:
     Returns a dict mapping alias to ``{"pid": int, "path": str}``.
     Returns an empty dict if the file is missing or corrupt.
     """
-    state_path = path or STATE_PATH
+    state_path = path or default_state_path()
     if not state_path.exists():
         return {}
     try:
@@ -599,8 +655,8 @@ class WatchDaemon:
         config_path: Path | None = None,
     ) -> None:
         self._config: DaemonConfig = config or load_config(config_path)
-        self._config_path: Path = config_path or CONFIG_PATH
-        self._state_path: Path = STATE_PATH
+        self._config_path: Path = config_path or default_config_path()
+        self._state_path: Path = default_state_path()
         self._children: dict[str, subprocess.Popen[bytes]] = {}
         self._current_repos: dict[str, WatchRepo] = {}
         self._config_watcher: ConfigWatcher | None = None

--- a/code_review_graph/eval/benchmarks/agent_baseline.py
+++ b/code_review_graph/eval/benchmarks/agent_baseline.py
@@ -180,10 +180,20 @@ def aggregate(results: list[dict]) -> dict:
     """Aggregate over rows where both sides of the comparison exist."""
     ok = [r for r in results if r.get("status") == "ok"]
     ratios = [float(r["baseline_to_graph_ratio"]) for r in ok]
+    no_graph = sum(1 for r in results if r.get("status") == "no_graph_results")
     return {
         "total_rows": len(results),
         "ok_rows": len(ok),
         "error_rows": sum(1 for r in results if r.get("status") == "error"),
+        # Excluded rows are reported, not just dropped: a run where the graph
+        # answered nothing must not be readable as "no result" when it is
+        # really "every query failed". A high no_graph_results_rows count
+        # against a populated graph means the vector index is missing —
+        # re-run the eval with --embed.
+        "no_graph_results_rows": no_graph,
+        "no_baseline_match_rows": sum(
+            1 for r in results if r.get("status") == "no_baseline_match"
+        ),
         "median_baseline_to_graph_ratio": (
             round(statistics.median(ratios), 1) if ratios else None
         ),

--- a/code_review_graph/eval/benchmarks/agent_baseline.py
+++ b/code_review_graph/eval/benchmarks/agent_baseline.py
@@ -147,7 +147,13 @@ def run(repo_path: Path, store, config: dict) -> list[dict]:
 
         try:
             from code_review_graph.search import hybrid_search
-            hits = hybrid_search(store, question, limit=5)
+            hits = hybrid_search(
+                store,
+                question,
+                limit=5,
+                provider=config.get("_embedding_provider"),
+                model=config.get("_embedding_model"),
+            )
         except Exception as exc:
             logger.warning("hybrid_search failed on %r: %s", question, exc)
             row["status"] = "error"

--- a/code_review_graph/eval/benchmarks/multi_hop_retrieval.py
+++ b/code_review_graph/eval/benchmarks/multi_hop_retrieval.py
@@ -61,7 +61,13 @@ def run(repo_path: Path, store, config: dict) -> list[dict]:
 
         # Step 1 — semantic search
         try:
-            hits = hybrid_search(store, nl_query, limit=k)
+            hits = hybrid_search(
+                store,
+                nl_query,
+                limit=k,
+                provider=config.get("_embedding_provider"),
+                model=config.get("_embedding_model"),
+            )
         except Exception as exc:  # noqa: BLE001 — benchmark must not abort the runner
             logger.warning("hybrid_search failed on %s: %s", task_id, exc)
             hits = []

--- a/code_review_graph/eval/benchmarks/search_quality.py
+++ b/code_review_graph/eval/benchmarks/search_quality.py
@@ -18,7 +18,13 @@ def run(repo_path: Path, store, config: dict) -> list[dict]:
 
         try:
             from code_review_graph.search import hybrid_search
-            search_results = hybrid_search(store, query, limit=20)
+            search_results = hybrid_search(
+                store,
+                query,
+                limit=20,
+                provider=config.get("_embedding_provider"),
+                model=config.get("_embedding_model"),
+            )
         except (ImportError, sqlite3.OperationalError) as exc:
             logger.debug("hybrid_search unavailable, using fallback: %s", exc)
             # Fallback to basic search

--- a/code_review_graph/eval/runner.py
+++ b/code_review_graph/eval/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import sqlite3
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -144,10 +145,99 @@ def write_csv(results: list[dict], path: Path) -> None:
         writer.writerows(results)
 
 
+#: Benchmarks that put a natural-language question through ``hybrid_search``.
+#: Without a vector index these fall back to FTS5, which scores a full
+#: sentence against no document and returns nothing.
+SEMANTIC_BENCHMARKS = frozenset(
+    {"agent_baseline", "search_quality", "multi_hop_retrieval"},
+)
+
+
+def _embedding_count(store) -> int | None:
+    """Return the number of stored vectors, or None if the table is absent.
+
+    Only a missing table is treated as "no index". A lock or a malformed
+    database is a different failure and must not be reported to the user as
+    "re-run with --embed", which would send them after the wrong problem.
+    """
+    try:
+        row = store._conn.execute("SELECT count(*) FROM embeddings").fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return None
+        raise
+    return int(row[0]) if row else 0
+
+
+def _build_embedding_index(
+    store,
+    db_path,
+    provider: str | None,
+    model: str | None,
+) -> None:
+    """Bootstrap the vector index for an already-built graph.
+
+    Mirrors ``tools.docs.embed_graph``, but reads the graph through the
+    runner's already-open ``GraphStore`` rather than opening a second one.
+    ``EmbeddingStore`` still opens its own connection to the same database —
+    that is safe here because the two are used sequentially, not
+    concurrently: vectors are written and orphans purged through the
+    embedding connection, then nodes are read back through the graph
+    connection. Both run in autocommit (``isolation_level=None``), so the
+    reads see committed data with no transaction snapshot in between.
+    """
+    from code_review_graph.embeddings import EmbeddingStore, embed_all_nodes
+
+    try:
+        emb_store = EmbeddingStore(db_path, provider=provider, model=model)
+    except ValueError as exc:
+        logger.error("  embedding index unavailable: %s", exc)
+        return
+
+    try:
+        if not emb_store.available:
+            logger.error(
+                "  embedding provider %r is not available — install "
+                "code-review-graph[embeddings] for the local provider, or "
+                "check the cloud provider's environment variables. "
+                "Semantic benchmarks will report no_graph_results.",
+                provider or "local",
+            )
+            return
+        embedded = embed_all_nodes(store, emb_store)
+        logger.info(
+            "  embedding index: %d new vector(s), %d total",
+            embedded,
+            emb_store.count(),
+        )
+    finally:
+        emb_store.close()
+
+
+def _warn_if_semantic_index_missing(store, benchmark_names: list[str]) -> None:
+    """Warn before running a semantic benchmark against an unindexed graph.
+
+    The failure is otherwise silent: rows come back ``no_graph_results`` and
+    ``aggregate()`` excludes them, so the run reports ``median: None`` rather
+    than an error.
+    """
+    requested = SEMANTIC_BENCHMARKS.intersection(benchmark_names)
+    if not requested or _embedding_count(store):
+        return
+    logger.warning(
+        "  no vector index — %s will score natural-language questions "
+        "against FTS5 alone and return zero hits. Re-run with --embed.",
+        ", ".join(sorted(requested)),
+    )
+
+
 def run_eval(
     repos: list[str] | None = None,
     benchmarks: list[str] | None = None,
     output_dir: str | Path | None = None,
+    embed: bool = False,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
 ) -> dict[str, list[dict]]:
     """Run evaluation benchmarks across repositories.
 
@@ -155,6 +245,14 @@ def run_eval(
         repos: List of repo config names to evaluate (None = all).
         benchmarks: List of benchmark names to run (None = all).
         output_dir: Directory for CSV output files.
+        embed: Build the vector index after the graph build. Default off,
+            because the local provider loads a model and cloud providers
+            transmit source-derived text and may incur API cost. Benchmarks
+            that put a natural-language question through ``hybrid_search``
+            (``agent_baseline``, ``search_quality``, ``multi_hop_retrieval``)
+            need this — FTS5 alone matches nothing on a full sentence.
+        embedding_provider: Provider for the index (default ``local``).
+        embedding_model: Exact model (default: provider's own default).
 
     Returns:
         Dict mapping ``{repo}_{benchmark}`` to list of result dicts.
@@ -201,6 +299,18 @@ def run_eval(
         pp_result = run_post_processing(store)
         for warning in pp_result.get("warnings", []):
             logger.warning("  postprocessing: %s", warning)
+
+        # run_post_processing's embedding step is a refresh, not a bootstrap:
+        # refresh_embeddings() returns early on a graph with no existing
+        # vectors, by design, so no build path can silently load a model or
+        # incur API cost. The eval framework therefore has to build the index
+        # explicitly, or every semantic query returns zero hits and the
+        # affected rows are dropped from the aggregate as "no_graph_results".
+        if embed:
+            _build_embedding_index(
+                store, db_path, embedding_provider, embedding_model,
+            )
+        _warn_if_semantic_index_missing(store, benchmark_names)
 
         for bench_name in benchmark_names:
             if bench_name not in BENCHMARK_REGISTRY:

--- a/code_review_graph/eval/runner.py
+++ b/code_review_graph/eval/runner.py
@@ -290,27 +290,40 @@ def run_eval(
         db_path = get_db_path(repo_path)
         store = GraphStore(db_path)
 
-        full_build(repo_path, store)
-        # full_build is the parsing-only primitive; the higher-level CLI/MCP
-        # wrappers run postprocessing on top. The eval framework bypasses
-        # those, so call it directly here. Without this, FTS5 stays empty
-        # and downstream benchmarks (token_efficiency, search_quality)
-        # silently produce useless results. See: search.rebuild_fts_index.
-        pp_result = run_post_processing(store)
-        for warning in pp_result.get("warnings", []):
-            logger.warning("  postprocessing: %s", warning)
+        try:
+            full_build(repo_path, store)
+            # full_build is the parsing-only primitive; the higher-level CLI/MCP
+            # wrappers run postprocessing on top. The eval framework bypasses
+            # those, so call it directly here. Without this, FTS5 stays empty
+            # and downstream benchmarks (token_efficiency, search_quality)
+            # silently produce useless results. See: search.rebuild_fts_index.
+            pp_result = run_post_processing(store)
+            for warning in pp_result.get("warnings", []):
+                logger.warning("  postprocessing: %s", warning)
 
-        # run_post_processing's embedding step is a refresh, not a bootstrap:
-        # refresh_embeddings() returns early on a graph with no existing
-        # vectors, by design, so no build path can silently load a model or
-        # incur API cost. The eval framework therefore has to build the index
-        # explicitly, or every semantic query returns zero hits and the
-        # affected rows are dropped from the aggregate as "no_graph_results".
+            # run_post_processing's embedding step is a refresh, not a bootstrap:
+            # refresh_embeddings() returns early on a graph with no existing
+            # vectors, by design, so no build path can silently load a model or
+            # incur API cost. The eval framework therefore has to build the index
+            # explicitly, or every semantic query returns zero hits and the
+            # affected rows are dropped from the aggregate as "no_graph_results".
+            if embed:
+                _build_embedding_index(
+                    store, db_path, embedding_provider, embedding_model,
+                )
+            _warn_if_semantic_index_missing(store, benchmark_names)
+        except BaseException:
+            store.close()
+            raise
+
+        # The embedding table is provider-scoped. A custom provider/model used
+        # to build the index must also be used by every semantic query, or the
+        # benchmark opens the same table under a different identity and sees
+        # zero vectors. Keep these run-only values out of the loaded config.
+        benchmark_config = dict(config)
         if embed:
-            _build_embedding_index(
-                store, db_path, embedding_provider, embedding_model,
-            )
-        _warn_if_semantic_index_missing(store, benchmark_names)
+            benchmark_config["_embedding_provider"] = embedding_provider
+            benchmark_config["_embedding_model"] = embedding_model
 
         for bench_name in benchmark_names:
             if bench_name not in BENCHMARK_REGISTRY:
@@ -320,7 +333,7 @@ def run_eval(
             logger.info("  Running %s...", bench_name)
             try:
                 bench_fn = BENCHMARK_REGISTRY[bench_name]
-                results = bench_fn(repo_path, store, config)
+                results = bench_fn(repo_path, store, benchmark_config)
 
                 key = f"{name}_{bench_name}"
                 all_results[key] = results

--- a/code_review_graph/registry.py
+++ b/code_review_graph/registry.py
@@ -13,22 +13,29 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
+from .constants import crg_home
+
 logger = logging.getLogger(__name__)
 
-# Default registry path
-_REGISTRY_DIR = Path.home() / ".code-review-graph"
-_REGISTRY_PATH = _REGISTRY_DIR / "registry.json"
+def default_registry_path() -> Path:
+    """Return the full path to ``registry.json``.
+
+    Lives under :func:`~code_review_graph.constants.crg_home`, so ``$CRG_HOME``
+    redirects it along with the rest of the per-user state.
+    """
+    return crg_home() / "registry.json"
 
 
 class Registry:
     """Manages a JSON-based registry of code-review-graph repositories.
 
     Each entry stores the repo path and an optional alias.
-    The registry lives at ``~/.code-review-graph/registry.json``.
+    The registry lives at ``~/.code-review-graph/registry.json``, or under
+    ``$CRG_HOME`` when that is set.
     """
 
     def __init__(self, path: Path | None = None) -> None:
-        self._path = path or _REGISTRY_PATH
+        self._path = path or default_registry_path()
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._repos: list[dict[str, str]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared test fixtures.
+
+Keeps code-review-graph's own per-user state out of the developer's real
+home directory. Scoped deliberately: the editor-integration installers in
+``skills.py`` write to other user-level locations (``~/.codex``,
+``~/.cursor``, ``~/.config/opencode``) that are outside CRG state and are
+not covered here — those tests patch ``Path.home()`` themselves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_crg_home(tmp_path_factory, monkeypatch):
+    """Redirect the per-user state directory into a temporary directory.
+
+    ``~/.code-review-graph`` holds ``registry.json``, ``watch.toml``,
+    ``daemon.pid``, ``daemon-state.json`` and ``logs/``. Two paths reached
+    the real one:
+
+    * ``Registry()`` defaults there, and ``incremental.get_data_dir()``
+      constructs one internally — so any test touching data-dir resolution
+      both read and wrote the registry of whoever ran the suite. That put
+      pytest tmp paths into a developer's home directory, and made those
+      tests depend on machine state: a developer with a registered repo
+      could get different results from one without.
+    * ``daemon`` built its config/PID/state paths from ``Path.home()``.
+
+    Autouse and unconditional: an opt-in fixture would silently stop
+    protecting a test the day someone forgets to request it.
+    """
+    home = tmp_path_factory.mktemp("crg-home")
+    monkeypatch.setenv("CRG_HOME", str(home))
+    return home

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1279,3 +1279,74 @@ class TestDaemonCLI:
             assert mock_print.call_count == 3
             printed_lines = [str(c.args[0]) for c in mock_print.call_args_list]
             assert printed_lines == ["line3", "line4", "line5"]
+
+
+class TestPerUserStateLocation:
+    """Daemon state must follow $CRG_HOME, not a frozen Path.home()."""
+
+    def test_defaults_live_under_crg_home(self, tmp_path, monkeypatch):
+        from code_review_graph import daemon
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "state"))
+
+        assert daemon.default_config_path() == tmp_path / "state" / "watch.toml"
+        assert daemon.default_pid_path() == tmp_path / "state" / "daemon.pid"
+        assert daemon.default_state_path() == tmp_path / "state" / "daemon-state.json"
+        assert daemon.default_log_dir() == tmp_path / "state" / "logs"
+
+    def test_defaults_are_not_frozen_at_import(self, tmp_path, monkeypatch):
+        """The original bug: a module constant captured $HOME at import time.
+
+        The autouse conftest fixture sets CRG_HOME before any test runs, so a
+        constant would already hold the wrong value and no later override
+        could move it.
+        """
+        from code_review_graph import daemon
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "first"))
+        first = daemon.default_pid_path()
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "second"))
+
+        assert daemon.default_pid_path() != first
+        assert daemon.default_pid_path() == tmp_path / "second" / "daemon.pid"
+
+    def test_legacy_constant_names_still_resolve(self, tmp_path, monkeypatch):
+        """CONFIG_PATH/PID_PATH/STATE_PATH kept working via the PEP 562 shim."""
+        from code_review_graph import daemon
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "state"))
+
+        assert daemon.CONFIG_PATH == tmp_path / "state" / "watch.toml"
+        assert daemon.PID_PATH == tmp_path / "state" / "daemon.pid"
+        assert daemon.STATE_PATH == tmp_path / "state" / "daemon-state.json"
+
+    def test_unknown_attribute_still_raises(self):
+        from code_review_graph import daemon
+
+        with pytest.raises(AttributeError, match="no attribute 'NOPE'"):
+            _ = daemon.NOPE
+
+    def test_bare_daemon_config_logs_under_crg_home(self, tmp_path, monkeypatch):
+        """DaemonConfig()'s default_factory must not point at the real home."""
+        from code_review_graph.daemon import DaemonConfig
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "state"))
+
+        assert DaemonConfig().log_dir == tmp_path / "state" / "logs"
+
+    def test_legacy_names_are_visible_to_dir(self):
+        """__getattr__ alone leaves the names invisible to introspection."""
+        from code_review_graph import daemon
+
+        names = dir(daemon)
+        assert "CONFIG_PATH" in names
+        assert "PID_PATH" in names
+        assert "STATE_PATH" in names
+        # The real module globals are still there too.
+        assert "WatchDaemon" in names
+
+    def test_legacy_names_work_through_from_import(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "state"))
+        from code_review_graph.daemon import CONFIG_PATH
+
+        assert CONFIG_PATH == tmp_path / "state" / "watch.toml"

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -963,3 +963,129 @@ def test_reporter_impact_f1_skips_error_and_co_change_rows():
     # the co-change row (different metric) must not pollute the column.
     assert "0.5" in tables
     assert "0.9" not in tables
+
+
+# -- Semantic index guard (agent_baseline and friends) ---------------------
+
+
+def test_agent_baseline_aggregate_reports_excluded_rows():
+    """A run where the graph answered nothing must not read as 'no result'.
+
+    ``ok_rows == 0`` with ``median is None`` is ambiguous on its own: it looks
+    the same whether zero questions were asked or every query came back empty.
+    The excluded-row counts disambiguate it.
+    """
+    from code_review_graph.eval.benchmarks import agent_baseline
+
+    results = [
+        {"status": "no_graph_results", "baseline_to_graph_ratio": ""},
+        {"status": "no_graph_results", "baseline_to_graph_ratio": ""},
+        {"status": "no_baseline_match", "baseline_to_graph_ratio": ""},
+    ]
+    agg = agent_baseline.aggregate(results)
+
+    assert agg["ok_rows"] == 0
+    assert agg["median_baseline_to_graph_ratio"] is None
+    assert agg["no_graph_results_rows"] == 2
+    assert agg["no_baseline_match_rows"] == 1
+
+
+def test_agent_baseline_aggregate_counts_zero_on_a_healthy_run():
+    from code_review_graph.eval.benchmarks import agent_baseline
+
+    agg = agent_baseline.aggregate([
+        {"status": "ok", "baseline_to_graph_ratio": "10.0"},
+        {"status": "ok", "baseline_to_graph_ratio": "20.0"},
+    ])
+
+    assert agg["ok_rows"] == 2
+    assert agg["no_graph_results_rows"] == 0
+    assert agg["no_baseline_match_rows"] == 0
+    assert agg["median_baseline_to_graph_ratio"] == 15.0
+
+
+def test_warns_when_semantic_benchmark_runs_without_a_vector_index(caplog):
+    """The silent-zero path must announce itself before the benchmark runs."""
+    import logging
+
+    from code_review_graph.eval.runner import _warn_if_semantic_index_missing
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = _make_repo(tmpdir)
+        store = _build_store(repo_path)
+        try:
+            with caplog.at_level(logging.WARNING):
+                _warn_if_semantic_index_missing(store, ["agent_baseline"])
+        finally:
+            store.close()
+
+    assert "no vector index" in caplog.text
+    assert "--embed" in caplog.text
+
+
+def test_no_warning_for_benchmarks_that_do_not_use_semantic_search(caplog):
+    import logging
+
+    from code_review_graph.eval.runner import _warn_if_semantic_index_missing
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = _make_repo(tmpdir)
+        store = _build_store(repo_path)
+        try:
+            with caplog.at_level(logging.WARNING):
+                _warn_if_semantic_index_missing(store, ["token_efficiency"])
+        finally:
+            store.close()
+
+    assert "no vector index" not in caplog.text
+
+
+def test_no_warning_once_the_index_is_populated(caplog, monkeypatch):
+    import logging
+
+    from code_review_graph.eval import runner
+
+    monkeypatch.setattr(runner, "_embedding_count", lambda store: 42)
+
+    with caplog.at_level(logging.WARNING):
+        runner._warn_if_semantic_index_missing(object(), ["agent_baseline"])
+
+    assert "no vector index" not in caplog.text
+
+
+def test_embedding_count_reraises_non_missing_table_errors():
+    """A lock or a corrupt database must not be reported as 'no index'.
+
+    Reclassifying it would tell the user to re-run with --embed and send
+    them after the wrong problem.
+    """
+    import sqlite3
+
+    from code_review_graph.eval.runner import _embedding_count
+
+    class _Boom:
+        class _Conn:
+            @staticmethod
+            def execute(*_args, **_kwargs):
+                raise sqlite3.OperationalError("database is locked")
+
+        _conn = _Conn()
+
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        _embedding_count(_Boom())
+
+
+def test_embedding_count_returns_none_for_a_missing_table():
+    import sqlite3
+
+    from code_review_graph.eval.runner import _embedding_count
+
+    class _NoTable:
+        class _Conn:
+            @staticmethod
+            def execute(*_args, **_kwargs):
+                raise sqlite3.OperationalError("no such table: embeddings")
+
+        _conn = _Conn()
+
+    assert _embedding_count(_NoTable()) is None

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -965,6 +965,188 @@ def test_reporter_impact_f1_skips_error_and_co_change_rows():
     assert "0.9" not in tables
 
 
+def test_eval_embed_bootstraps_vectors_and_returns_real_graph_results(
+    tmp_path,
+    monkeypatch,
+):
+    """The public eval path must build vectors that its semantic benchmark can use."""
+    from code_review_graph.eval import runner
+
+    repo_path = _make_repo(tmp_path)
+    helper = repo_path / "helper.py"
+    helper.write_text(
+        "# salutation_marker appears only in source text, not in graph node names\n"
+        + helper.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    config = _mock_config(
+        agent_questions=["Where is salutation_marker handled?"],
+    )
+    monkeypatch.setattr(runner, "load_config", lambda _name: config)
+    monkeypatch.setattr(runner, "clone_or_update", lambda _config: repo_path)
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+
+    state_dir = tmp_path / "state"
+    monkeypatch.setenv("CRG_HOME", str(state_dir))
+    from code_review_graph import registry as registry_module
+
+    monkeypatch.setattr(
+        registry_module,
+        "_REGISTRY_PATH",
+        state_dir / "registry.json",
+        raising=False,
+    )
+
+    class _StubProvider:
+        dimension = 2
+
+        def __init__(self, name):
+            self.name = name
+
+        @staticmethod
+        def embed(texts):
+            return [[float(len(text)), 1.0] for text in texts]
+
+        @staticmethod
+        def embed_query(_text):
+            return [1.0, 0.0]
+
+    monkeypatch.setattr(
+        "code_review_graph.embeddings.get_provider",
+        lambda provider=None, model=None: _StubProvider(
+            f"{provider or 'local'}:{model or 'default'}",
+        ),
+    )
+
+    results = runner.run_eval(
+        repos=["mock"],
+        benchmarks=["agent_baseline"],
+        output_dir=tmp_path / "results",
+        embed=True,
+        embedding_provider="local",
+        embedding_model="eval-test",
+    )
+
+    rows = results["mock_agent_baseline"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["graph_tokens"] > 0
+
+    from code_review_graph.graph import GraphStore
+    from code_review_graph.incremental import get_db_path
+
+    store = GraphStore(get_db_path(repo_path))
+    try:
+        assert runner._embedding_count(store) > 0
+    finally:
+        store.close()
+
+
+def test_search_quality_uses_the_index_provider_and_model(monkeypatch, tmp_path):
+    """A custom eval index is useless unless benchmark queries select that identity."""
+    from code_review_graph.eval.benchmarks import search_quality
+
+    observed = {}
+
+    def _search(_store, _query, *, limit, provider=None, model=None):
+        observed.update(provider=provider, model=model, limit=limit)
+        return []
+
+    monkeypatch.setattr("code_review_graph.search.hybrid_search", _search)
+    search_quality.run(
+        tmp_path,
+        object(),
+        {
+            "name": "mock",
+            "search_queries": [{"query": "natural language", "expected": "target"}],
+            "_embedding_provider": "google",
+            "_embedding_model": "text-embedding-test",
+        },
+    )
+
+    assert observed == {
+        "provider": "google",
+        "model": "text-embedding-test",
+        "limit": 20,
+    }
+
+
+def test_multi_hop_uses_the_index_provider_and_model(monkeypatch, tmp_path):
+    from code_review_graph.eval.benchmarks import multi_hop_retrieval
+
+    observed = {}
+
+    def _search(_store, _query, *, limit, provider=None, model=None):
+        observed.update(provider=provider, model=model, limit=limit)
+        return []
+
+    monkeypatch.setattr("code_review_graph.search.hybrid_search", _search)
+    multi_hop_retrieval.run(
+        tmp_path,
+        object(),
+        {
+            "name": "mock",
+            "multi_hop_tasks": [
+                {
+                    "id": "task",
+                    "nl_query": "natural language",
+                    "anchor_qualified_suffix": "::target",
+                    "k": 7,
+                },
+            ],
+            "_embedding_provider": "minimax",
+            "_embedding_model": "embedding-01",
+        },
+    )
+
+    assert observed == {
+        "provider": "minimax",
+        "model": "embedding-01",
+        "limit": 7,
+    }
+
+
+def test_eval_closes_graph_store_when_embedding_bootstrap_fails(
+    tmp_path,
+    monkeypatch,
+):
+    """A provider failure must not leave the evaluation database connection open."""
+    from code_review_graph.eval import runner
+    from code_review_graph.graph import GraphStore
+
+    repo_path = _make_repo(tmp_path)
+    config = _mock_config()
+    monkeypatch.setattr(runner, "load_config", lambda _name: config)
+    monkeypatch.setattr(runner, "clone_or_update", lambda _config: repo_path)
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    monkeypatch.setenv("CRG_HOME", str(tmp_path / "state"))
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(runner, "_build_embedding_index", _boom)
+    closed = []
+    original_close = GraphStore.close
+
+    def _track_close(self):
+        closed.append(self.db_path)
+        original_close(self)
+
+    monkeypatch.setattr(GraphStore, "close", _track_close)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        runner.run_eval(
+            repos=["mock"],
+            benchmarks=["agent_baseline"],
+            output_dir=tmp_path / "results",
+            embed=True,
+            embedding_provider="local",
+            embedding_model="eval-test",
+        )
+
+    assert closed
+
+
 # -- Semantic index guard (agent_baseline and friends) ---------------------
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -413,3 +413,77 @@ class TestRegistryNonAscii:
         raw = registry_path.read_text(encoding="utf-8")
         assert "基于STM32的项目" in raw
         assert "\\u" not in raw
+
+
+class TestRegistryLocationIsolation:
+    """The registry must never fall back to the real home directory in tests."""
+
+    def test_default_path_follows_the_env_override(self, tmp_path, monkeypatch):
+        from code_review_graph.registry import default_registry_path
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "elsewhere"))
+        assert default_registry_path() == tmp_path / "elsewhere" / "registry.json"
+
+    def test_override_is_read_per_call_not_at_import(self, tmp_path, monkeypatch):
+        """A module-level constant would freeze the value at first import.
+
+        The autouse fixture sets CRG_HOME before any test runs, so an
+        import-time constant would capture the wrong directory and every later
+        override would be ignored.
+        """
+        from code_review_graph.registry import default_registry_path
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "first"))
+        first = default_registry_path()
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "second"))
+        assert default_registry_path() != first
+        assert default_registry_path() == tmp_path / "second" / "registry.json"
+
+    def test_blank_override_falls_back_to_home(self, monkeypatch):
+        from code_review_graph.constants import crg_home
+
+        monkeypatch.setenv("CRG_HOME", "   ")
+        assert crg_home() == Path.home() / ".code-review-graph"
+
+    def test_bare_registry_writes_under_the_override(self, tmp_path, monkeypatch):
+        """Registry() with no path argument must land in the sandbox.
+
+        This is the leak that put pytest tmp paths into a developer's real
+        ~/.code-review-graph/registry.json.
+        """
+        # Point Path.home() at a fake home too, so the assertion that nothing
+        # was written there needs no access to the developer's real one.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        sandbox = tmp_path / "sandbox"
+        monkeypatch.setenv("CRG_HOME", str(sandbox))
+
+        repo = tmp_path / "project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        Registry().register(str(repo), alias="leaky")
+
+        sandboxed = sandbox / "registry.json"
+        assert sandboxed.exists()
+        assert "leaky" in sandboxed.read_text(encoding="utf-8")
+        assert not (fake_home / ".code-review-graph").exists()
+
+    def test_get_data_dir_uses_the_sandboxed_registry(self, tmp_path, monkeypatch):
+        """incremental.get_data_dir() builds its own Registry() internally."""
+        from code_review_graph.incremental import get_data_dir
+
+        monkeypatch.setenv("CRG_HOME", str(tmp_path / "sandbox"))
+        monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+
+        repo = tmp_path / "project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        external = tmp_path / "external"
+
+        Registry().set_data_dir(str(repo), str(external))
+
+        assert get_data_dir(repo) == external.resolve()
+        assert (tmp_path / "sandbox" / "registry.json").exists()


### PR DESCRIPTION
Integrates both contributor-authored commits from #710 against current `main`, preserving their original authors, then fixes the remaining end-to-end gaps found during maintainer validation.

The original branch built a custom provider/model index but benchmark searches still queried the default embedding identity, producing `no_graph_results`. It also left `GraphStore` open when embedding bootstrap failed. This integration propagates the exact provider/model through agent-baseline, search-quality, and multi-hop searches, closes the store on failure, and keeps both the Unicode registry tests and isolated-home behavior.

Exact-head validation:
- 203 focused eval, registry, CLI, incremental, and daemon tests passed
- the real multiprocessing parity test passed separately
- Ruff and diff checks passed
- serial graph build: 243 files, 4,732 nodes, 37,282 edges, zero errors

Incorporates #710.

Closes #711.
Closes #712.