### PR TITLE
fix(watch): reconcile graph lifecycle changes safely (#735)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -284,6 +284,34 @@ class GraphStore:
         self._conn.execute("DELETE FROM edges WHERE file_path = ?", (file_path,))
         self._invalidate_cache()
 
+    def remove_file_permanently(self, file_path: str) -> None:
+        """Remove a deleted file and every graph reference to its nodes."""
+        qualified_names = [
+            row["qualified_name"]
+            for row in self._conn.execute(
+                "SELECT qualified_name FROM nodes WHERE file_path = ?",
+                (file_path,),
+            ).fetchall()
+        ]
+        self.remove_file_data(file_path)
+        if qualified_names:
+            placeholders = ",".join("?" for _ in qualified_names)
+            self._conn.execute(  # nosec B608 - placeholders only
+                f"DELETE FROM edges WHERE source_qualified IN ({placeholders}) "
+                f"OR target_qualified IN ({placeholders})",
+                (*qualified_names, *qualified_names),
+            )
+        has_embeddings = self._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'embeddings'",
+        ).fetchone()
+        if has_embeddings is not None:
+            self._conn.executemany(
+                "DELETE FROM embeddings WHERE qualified_name = ?",
+                ((qualified_name,) for qualified_name in qualified_names),
+            )
+        self._invalidate_cache()
+
     def _begin_immediate(self) -> None:
         """Start an IMMEDIATE transaction, rolling back any prior uncommitted
         transaction first (regression guard for #135 / #489).

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -284,33 +284,48 @@ class GraphStore:
         self._conn.execute("DELETE FROM edges WHERE file_path = ?", (file_path,))
         self._invalidate_cache()
 
-    def remove_file_permanently(self, file_path: str) -> None:
-        """Remove a deleted file and every graph reference to its nodes."""
-        qualified_names = [
-            row["qualified_name"]
-            for row in self._conn.execute(
-                "SELECT qualified_name FROM nodes WHERE file_path = ?",
-                (file_path,),
-            ).fetchall()
-        ]
-        self.remove_file_data(file_path)
-        if qualified_names:
-            placeholders = ",".join("?" for _ in qualified_names)
-            self._conn.execute(  # nosec B608 - placeholders only
-                f"DELETE FROM edges WHERE source_qualified IN ({placeholders}) "
-                f"OR target_qualified IN ({placeholders})",
-                (*qualified_names, *qualified_names),
-            )
+    def remove_file_permanently(self, file_path: str) -> int:
+        """Remove one deleted file and every graph reference to its nodes."""
+        return self.remove_files_permanently([file_path])
+
+    def remove_files_permanently(self, file_paths: list[str]) -> int:
+        """Atomically remove deleted files and graph references to their nodes."""
+        changed = 0
         has_embeddings = self._conn.execute(
             "SELECT 1 FROM sqlite_master "
             "WHERE type = 'table' AND name = 'embeddings'",
         ).fetchone()
-        if has_embeddings is not None:
-            self._conn.executemany(
-                "DELETE FROM embeddings WHERE qualified_name = ?",
-                ((qualified_name,) for qualified_name in qualified_names),
-            )
+        self._begin_immediate()
+        try:
+            for file_path in dict.fromkeys(file_paths):
+                exists = self._conn.execute(
+                    "SELECT EXISTS(SELECT 1 FROM nodes WHERE file_path = ?) OR "
+                    "EXISTS(SELECT 1 FROM edges WHERE file_path = ?)",
+                    (file_path, file_path),
+                ).fetchone()[0]
+                if not exists:
+                    continue
+                changed += 1
+                if has_embeddings is not None:
+                    self._conn.execute(
+                        "DELETE FROM embeddings WHERE qualified_name IN "
+                        "(SELECT qualified_name FROM nodes WHERE file_path = ?)",
+                        (file_path,),
+                    )
+                self._conn.execute(
+                    "DELETE FROM edges WHERE file_path = ? OR source_qualified IN "
+                    "(SELECT qualified_name FROM nodes WHERE file_path = ?) OR "
+                    "target_qualified IN "
+                    "(SELECT qualified_name FROM nodes WHERE file_path = ?)",
+                    (file_path, file_path, file_path),
+                )
+                self._conn.execute("DELETE FROM nodes WHERE file_path = ?", (file_path,))
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
         self._invalidate_cache()
+        return changed
 
     def _begin_immediate(self) -> None:
         """Start an IMMEDIATE transaction, rolling back any prior uncommitted

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1082,6 +1082,7 @@ def incremental_update(
     store: GraphStore,
     base: str = "HEAD~1",
     changed_files: list[str] | None = None,
+    reconcile_stale: bool = True,
 ) -> dict:
     """Incremental update: re-parse changed + dependent files only."""
     parser = CodeParser(repo_root)
@@ -1113,7 +1114,7 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
-    stale_files = _reconcile_stale_files(repo_root, store)
+    stale_files = _reconcile_stale_files(repo_root, store) if reconcile_stale else []
 
     if not changed_files and not stale_files:
         return {
@@ -1123,6 +1124,7 @@ def incremental_update(
             "changed_files": [],
             "dependent_files": [],
             "stale_files_removed": 0,
+            "errors": [],
         }
 
     # Find dependent files (files that import from changed files)
@@ -1273,13 +1275,14 @@ def _create_watch_handler(
     from watchdog.utils.event_debouncer import EventDebouncer
 
     ignore_patterns = _load_ignore_patterns(repo_root)
+    parser = CodeParser(repo_root)
 
     class WatchBatchProcessor:
         def __init__(self) -> None:
             self.failure: BaseException | None = None
 
         def _relative_path(self, path: str) -> str | None:
-            candidate = Path(path)
+            candidate = Path(os.path.abspath(path))
             try:
                 relative = candidate.relative_to(repo_root)
             except ValueError:
@@ -1288,35 +1291,57 @@ def _create_watch_handler(
                 return None
             return str(relative)
 
+        def _stored_descendants(self, relative_directory: str) -> set[str]:
+            directory = str(repo_root / relative_directory) + os.sep
+            return {
+                str(Path(file_path).relative_to(repo_root))
+                for file_path in store.get_all_files()
+                if file_path.startswith(directory)
+            }
+
+        def _parseable_file(self, relative_path: str) -> bool:
+            absolute_path = repo_root / relative_path
+            return (
+                absolute_path.is_file()
+                and not absolute_path.is_symlink()
+                and parser.detect_language(absolute_path) is not None
+                and not _is_binary(absolute_path)
+            )
+
+        def _parseable_descendants(self, relative_directory: str) -> set[str]:
+            directory = repo_root / relative_directory
+            if not directory.is_dir() or directory.is_symlink():
+                return set()
+            return {
+                str(path.relative_to(repo_root))
+                for path in directory.rglob("*")
+                if self._parseable_file(str(path.relative_to(repo_root)))
+                and not _should_ignore(str(path.relative_to(repo_root)), ignore_patterns)
+            }
+
         def _event_paths(self, event: FileSystemEvent) -> set[str]:
             paths: set[str] = set()
             source = self._relative_path(os.fsdecode(event.src_path))
-            if source is not None:
-                paths.add(source)
             destination_path = getattr(event, "dest_path", "")
             destination = (
                 self._relative_path(os.fsdecode(destination_path))
                 if destination_path
                 else None
             )
-            if destination is not None:
-                destination_absolute = repo_root / destination
-                if event.is_directory and destination_absolute.is_dir():
-                    paths.update(
-                        str(path.relative_to(repo_root))
-                        for path in destination_absolute.rglob("*")
-                        if path.is_file() and not path.is_symlink()
-                    )
-                else:
+            if event.is_directory:
+                if source is not None and event.event_type in {"deleted", "moved"}:
+                    paths.update(self._stored_descendants(source))
+                if destination is not None:
+                    paths.update(self._parseable_descendants(destination))
+                elif source is not None and event.event_type == "created":
+                    paths.update(self._parseable_descendants(source))
+            else:
+                if source is not None and event.event_type in {"deleted", "moved"}:
+                    paths.add(source)
+                elif source is not None and self._parseable_file(source):
+                    paths.add(source)
+                if destination is not None and self._parseable_file(destination):
                     paths.add(destination)
-            elif event.is_directory and event.event_type == "created":
-                source_absolute = repo_root / source if source is not None else None
-                if source_absolute is not None and source_absolute.is_dir():
-                    paths.update(
-                        str(path.relative_to(repo_root))
-                        for path in source_absolute.rglob("*")
-                        if path.is_file() and not path.is_symlink()
-                    )
             return paths
 
         def process(self, events: list[FileSystemEvent]) -> None:
@@ -1324,7 +1349,16 @@ def _create_watch_handler(
                 changed_files = sorted(
                     {path for event in events for path in self._event_paths(event)}
                 )
-                result = incremental_update(repo_root, store, changed_files=changed_files)
+                if not changed_files:
+                    return
+                result = incremental_update(
+                    repo_root,
+                    store,
+                    changed_files=changed_files,
+                    reconcile_stale=False,
+                )
+                if result["errors"]:
+                    raise RuntimeError("incremental watch update reported parse errors")
                 if result["files_updated"] > 0 and on_files_updated is not None:
                     on_files_updated(store)
             except BaseException as exc:
@@ -1339,6 +1373,10 @@ def _create_watch_handler(
 
     class GraphUpdateHandler(FileSystemEventHandler):
         def dispatch(self, event: FileSystemEvent) -> None:
+            if event.event_type not in {"created", "modified", "deleted", "moved"}:
+                return
+            if event.is_directory and event.event_type == "modified":
+                return
             debouncer.handle_event(event)
 
         def start(self) -> None:
@@ -1364,7 +1402,7 @@ def watch(
 ) -> None:
     """Watch for file changes and auto-update the graph.
 
-    Uses a 300ms debounce to batch rapid-fire saves into a single update.
+    Uses a one-second debounce to batch rapid-fire saves into a single update.
 
     Args:
         repo_root: Repository root to watch.
@@ -1377,6 +1415,8 @@ def watch(
     from watchdog.observers import Observer
 
     initial = incremental_update(repo_root, store, changed_files=[])
+    if initial["errors"]:
+        raise RuntimeError("initial watch reconciliation reported parse errors")
     if initial["files_updated"] > 0 and on_files_updated is not None:
         on_files_updated(store)
     handler = _create_watch_handler(repo_root, store, on_files_updated)

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -846,6 +846,22 @@ def collect_all_files(
     return files
 
 
+def _reconcile_stale_files(
+    repo_root: Path,
+    store: GraphStore,
+    current_files: list[str] | None = None,
+) -> list[str]:
+    """Remove graph files absent from the current parseable repository inventory."""
+    files = current_files if current_files is not None else collect_all_files(repo_root)
+    current_paths = {str(repo_root / file_path) for file_path in files}
+    stale_files = sorted(set(store.get_all_files()) - current_paths)
+    for stale_file in stale_files:
+        store.remove_file_permanently(stale_file)
+    if stale_files:
+        store.commit()
+    return stale_files
+
+
 _MAX_DEPENDENT_HOPS = int(os.environ.get("CRG_DEPENDENT_HOPS", "2"))
 _MAX_DEPENDENT_FILES = 500
 
@@ -970,17 +986,7 @@ def full_build(
     """
     parser = CodeParser(repo_root)
     files = collect_all_files(repo_root, recurse_submodules)
-
-    # Purge stale data from files no longer on disk
-    existing_files = set(store.get_all_files())
-    current_abs = {str(repo_root / f) for f in files}
-    stale_files = existing_files - current_abs
-    for stale in stale_files:
-        store.remove_file_data(stale)
-    # Ensure deletions are persisted before store_file_nodes_edges()
-    # starts its own explicit transaction via BEGIN IMMEDIATE.
-    if stale_files:
-        store.commit()
+    stale_files = _reconcile_stale_files(repo_root, store, files)
 
     total_nodes = 0
     total_edges = 0
@@ -1058,6 +1064,7 @@ def full_build(
 
     return {
         "files_parsed": len(files),
+        "stale_files_removed": len(stale_files),
         "total_nodes": total_nodes,
         "total_edges": total_edges,
         "errors": errors,
@@ -1106,14 +1113,16 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
+    stale_files = _reconcile_stale_files(repo_root, store)
 
-    if not changed_files:
+    if not changed_files and not stale_files:
         return {
             "files_updated": 0,
             "total_nodes": 0,
             "total_edges": 0,
             "changed_files": [],
             "dependent_files": [],
+            "stale_files_removed": 0,
         }
 
     # Find dependent files (files that import from changed files)
@@ -1137,14 +1146,13 @@ def incremental_update(
 
     # Separate deleted/unparseable files from files that need re-parsing
     to_parse: list[str] = []
-    removed_any = False
     for rel_path in all_files:
         if _should_ignore(rel_path, ignore_patterns):
             continue
         abs_path = repo_root / rel_path
         if not abs_path.is_file():
-            store.remove_file_data(str(abs_path))
-            removed_any = True
+            if str(abs_path) not in stale_files:
+                store.remove_file_permanently(str(abs_path))
             continue
         if parser.detect_language(abs_path) is None:
             continue
@@ -1161,10 +1169,8 @@ def incremental_update(
 
     # Persist deletions before store_file_nodes_edges() opens its own
     # explicit transaction — avoids nested transaction errors.
-    if removed_any:
-        store.commit()
-
     use_serial = os.environ.get("CRG_SERIAL_PARSE", "") == "1"
+    parsed_files = 0
 
     if use_serial or len(to_parse) < 8:
         for rel_path in to_parse:
@@ -1174,6 +1180,7 @@ def incremental_update(
                 fhash = hashlib.sha256(source).hexdigest()
                 nodes, edges = parser.parse_bytes(abs_path, source)
                 store.store_file_nodes_edges(str(abs_path), nodes, edges, fhash)
+                parsed_files += 1
                 total_nodes += len(nodes)
                 total_edges += len(edges)
             except (OSError, PermissionError) as e:
@@ -1200,14 +1207,17 @@ def incremental_update(
                     edges,
                     fhash,
                 )
+                parsed_files += 1
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
-    store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
-    store.set_metadata("last_build_type", "incremental")
-    store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
-    _store_vcs_metadata(repo_root, store)
-    store.commit()
+    files_updated = parsed_files + len(stale_files)
+    if files_updated:
+        store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
+        store.set_metadata("last_build_type", "incremental")
+        store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+        _store_vcs_metadata(repo_root, store)
+        store.commit()
 
     # Only re-run language-specific resolvers when the relevant files changed.
     rescript_changed = any(
@@ -1229,11 +1239,12 @@ def incremental_update(
     scoped_stats = _run_scoped_resolver(store) if scoped_changed else None
 
     return {
-        "files_updated": len(all_files),
+        "files_updated": files_updated,
         "total_nodes": total_nodes,
         "total_edges": total_edges,
         "changed_files": list(changed_files),
         "dependent_files": list(dependent_files),
+        "stale_files_removed": len(stale_files),
         "errors": errors,
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
@@ -1249,7 +1260,101 @@ def incremental_update(
 # ---------------------------------------------------------------------------
 
 
-_DEBOUNCE_SECONDS = 0.3
+_DEBOUNCE_SECONDS = 1
+
+
+def _create_watch_handler(
+    repo_root: Path,
+    store: GraphStore,
+    on_files_updated: Optional[Callable],
+):
+    """Create the debounced watchdog handler for one repository."""
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.utils.event_debouncer import EventDebouncer
+
+    ignore_patterns = _load_ignore_patterns(repo_root)
+
+    class WatchBatchProcessor:
+        def __init__(self) -> None:
+            self.failure: BaseException | None = None
+
+        def _relative_path(self, path: str) -> str | None:
+            candidate = Path(path)
+            try:
+                relative = candidate.relative_to(repo_root)
+            except ValueError:
+                return None
+            if candidate.is_symlink() or _should_ignore(str(relative), ignore_patterns):
+                return None
+            return str(relative)
+
+        def _event_paths(self, event: FileSystemEvent) -> set[str]:
+            paths: set[str] = set()
+            source = self._relative_path(os.fsdecode(event.src_path))
+            if source is not None:
+                paths.add(source)
+            destination_path = getattr(event, "dest_path", "")
+            destination = (
+                self._relative_path(os.fsdecode(destination_path))
+                if destination_path
+                else None
+            )
+            if destination is not None:
+                destination_absolute = repo_root / destination
+                if event.is_directory and destination_absolute.is_dir():
+                    paths.update(
+                        str(path.relative_to(repo_root))
+                        for path in destination_absolute.rglob("*")
+                        if path.is_file() and not path.is_symlink()
+                    )
+                else:
+                    paths.add(destination)
+            elif event.is_directory and event.event_type == "created":
+                source_absolute = repo_root / source if source is not None else None
+                if source_absolute is not None and source_absolute.is_dir():
+                    paths.update(
+                        str(path.relative_to(repo_root))
+                        for path in source_absolute.rglob("*")
+                        if path.is_file() and not path.is_symlink()
+                    )
+            return paths
+
+        def process(self, events: list[FileSystemEvent]) -> None:
+            try:
+                changed_files = sorted(
+                    {path for event in events for path in self._event_paths(event)}
+                )
+                result = incremental_update(repo_root, store, changed_files=changed_files)
+                if result["files_updated"] > 0 and on_files_updated is not None:
+                    on_files_updated(store)
+            except BaseException as exc:
+                self.failure = exc
+
+        def raise_if_failed(self) -> None:
+            if self.failure is not None:
+                raise RuntimeError("watch update failed") from self.failure
+
+    processor = WatchBatchProcessor()
+    debouncer = EventDebouncer(_DEBOUNCE_SECONDS, processor.process)
+
+    class GraphUpdateHandler(FileSystemEventHandler):
+        def dispatch(self, event: FileSystemEvent) -> None:
+            debouncer.handle_event(event)
+
+        def start(self) -> None:
+            debouncer.start()
+
+        def stop(self) -> None:
+            debouncer.stop()
+            debouncer.join()
+
+        def process(self, events: list[FileSystemEvent]) -> None:
+            processor.process(events)
+
+        def raise_if_failed(self) -> None:
+            processor.raise_if_failed()
+
+    return GraphUpdateHandler()
 
 
 def watch(
@@ -1269,119 +1374,15 @@ def watch(
             only argument.  Used by the CLI to run post-processing
             (FTS, flows, communities) after watch updates.
     """
-    import threading
-
-    from watchdog.events import FileSystemEventHandler
     from watchdog.observers import Observer
 
-    parser = CodeParser(repo_root)
-    ignore_patterns = _load_ignore_patterns(repo_root)
-
-    class GraphUpdateHandler(FileSystemEventHandler):
-        def __init__(self):
-            self._pending: set[str] = set()
-            self._lock = threading.Lock()
-            self._timer: threading.Timer | None = None
-
-        def _should_handle(self, path: str) -> bool:
-            if Path(path).is_symlink():
-                return False
-            try:
-                rel = str(Path(path).relative_to(repo_root))
-            except ValueError:
-                return False
-            if _should_ignore(rel, ignore_patterns):
-                return False
-            if parser.detect_language(Path(path)) is None:
-                return False
-            return True
-
-        def on_modified(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_created(self, event):
-            if event.is_directory:
-                return
-            if self._should_handle(event.src_path):
-                self._schedule(event.src_path)
-
-        def on_deleted(self, event):
-            if event.is_directory:
-                return
-            # Only handle files we would normally track
-            try:
-                rel = str(Path(event.src_path).relative_to(repo_root))
-            except ValueError:
-                return
-            if _should_ignore(rel, ignore_patterns):
-                return
-            try:
-                store.remove_file_data(event.src_path)
-                store.commit()
-                logger.info("Removed: %s", rel)
-            except Exception as e:
-                logger.error("Error removing %s: %s", rel, e)
-
-        def _schedule(self, abs_path: str):
-            """Add file to pending set and reset the debounce timer."""
-            with self._lock:
-                self._pending.add(abs_path)
-                if self._timer is not None:
-                    self._timer.cancel()
-                self._timer = threading.Timer(_DEBOUNCE_SECONDS, self._flush)
-                self._timer.start()
-
-        def _flush(self):
-            """Process all pending files after the debounce window."""
-            with self._lock:
-                paths = list(self._pending)
-                self._pending.clear()
-                self._timer = None
-
-            updated = 0
-            for abs_path in paths:
-                if self._update_file(abs_path):
-                    updated += 1
-
-            if updated > 0 and on_files_updated is not None:
-                try:
-                    on_files_updated(store)
-                except Exception as e:
-                    logger.error("Post-update callback failed: %s", e)
-
-        def _update_file(self, abs_path: str) -> bool:
-            path = Path(abs_path)
-            if not path.is_file():
-                return False
-            if path.is_symlink():
-                return False
-            if _is_binary(path):
-                return False
-            try:
-                source = path.read_bytes()
-                fhash = hashlib.sha256(source).hexdigest()
-                nodes, edges = parser.parse_bytes(path, source)
-                store.store_file_nodes_edges(abs_path, nodes, edges, fhash)
-                store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
-                store.commit()
-                rel = str(path.relative_to(repo_root))
-                logger.info(
-                    "Updated: %s (%d nodes, %d edges)",
-                    rel,
-                    len(nodes),
-                    len(edges),
-                )
-                return True
-            except Exception as e:
-                logger.error("Error updating %s: %s", abs_path, e)
-                return False
-
-    handler = GraphUpdateHandler()
+    initial = incremental_update(repo_root, store, changed_files=[])
+    if initial["files_updated"] > 0 and on_files_updated is not None:
+        on_files_updated(store)
+    handler = _create_watch_handler(repo_root, store, on_files_updated)
     observer = Observer()
     observer.schedule(handler, str(repo_root), recursive=True)
+    handler.start()
     observer.start()
 
     logger.info("Watching %s for changes... (Ctrl+C to stop)", repo_root)
@@ -1390,9 +1391,13 @@ def watch(
 
         while True:
             _time.sleep(1)
+            handler.raise_if_failed()
     except KeyboardInterrupt:
         observer.stop()
-    observer.join()
+    finally:
+        observer.stop()
+        observer.join()
+        handler.stop()
     logger.info("Watch stopped.")
 
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1398,10 +1398,23 @@ def _create_watch_handler(
                     changed_files=changed_files,
                     reconcile_stale=False,
                 )
-                if result["errors"]:
-                    raise RuntimeError("incremental watch update reported parse errors")
+                errors = result.get("errors") or []
+                if errors:
+                    details = "; ".join(
+                        f"{error.get('file', 'unknown')}: "
+                        f"{error.get('error', 'unknown error')}"
+                        for error in errors
+                    )
+                    raise RuntimeError(f"incremental update reported errors: {details}")
                 if result["files_updated"] > 0 and on_files_updated is not None:
-                    on_files_updated(store)
+                    postprocess_result = on_files_updated(store)
+                    if isinstance(postprocess_result, dict):
+                        warnings = postprocess_result.get("warnings") or []
+                        if warnings:
+                            details = "; ".join(str(warning) for warning in warnings)
+                            raise RuntimeError(
+                                f"post-processing reported warnings: {details}"
+                            )
             except BaseException as exc:
                 self.failure = exc
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -855,10 +855,8 @@ def _reconcile_stale_files(
     files = current_files if current_files is not None else collect_all_files(repo_root)
     current_paths = {str(repo_root / file_path) for file_path in files}
     stale_files = sorted(set(store.get_all_files()) - current_paths)
-    for stale_file in stale_files:
-        store.remove_file_permanently(stale_file)
     if stale_files:
-        store.commit()
+        store.remove_files_permanently(stale_files)
     return stale_files
 
 
@@ -1145,6 +1143,7 @@ def incremental_update(
     total_nodes = 0
     total_edges = 0
     errors = []
+    missing_paths: set[str] = set()
 
     # Separate deleted/unparseable files from files that need re-parsing
     to_parse: list[str] = []
@@ -1154,7 +1153,7 @@ def incremental_update(
         abs_path = repo_root / rel_path
         if not abs_path.is_file():
             if str(abs_path) not in stale_files:
-                store.remove_file_permanently(str(abs_path))
+                missing_paths.add(str(abs_path))
             continue
         if parser.detect_language(abs_path) is None:
             continue
@@ -1213,7 +1212,8 @@ def incremental_update(
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
-    files_updated = parsed_files + len(stale_files)
+    removed_files = store.remove_files_permanently(sorted(missing_paths)) if missing_paths else 0
+    files_updated = parsed_files + len(stale_files) + removed_files
     if files_updated:
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
@@ -1276,6 +1276,8 @@ def _create_watch_handler(
 
     ignore_patterns = _load_ignore_patterns(repo_root)
     parser = CodeParser(repo_root)
+    lexical_root = Path(os.path.abspath(repo_root))
+    resolved_root = lexical_root.resolve()
 
     class WatchBatchProcessor:
         def __init__(self) -> None:
@@ -1284,10 +1286,25 @@ def _create_watch_handler(
         def _relative_path(self, path: str) -> str | None:
             candidate = Path(os.path.abspath(path))
             try:
-                relative = candidate.relative_to(repo_root)
+                relative = candidate.relative_to(lexical_root)
             except ValueError:
                 return None
-            if candidate.is_symlink() or _should_ignore(str(relative), ignore_patterns):
+            existing = candidate
+            while not existing.exists() and existing != lexical_root:
+                existing = existing.parent
+            try:
+                existing.resolve().relative_to(resolved_root)
+            except ValueError:
+                return None
+            if any(
+                component.is_symlink()
+                for component in [
+                    lexical_root / Path(*relative.parts[:index])
+                    for index in range(1, len(relative.parts) + 1)
+                ]
+            ):
+                return None
+            if _should_ignore(str(relative), ignore_patterns):
                 return None
             return str(relative)
 
@@ -1301,6 +1318,11 @@ def _create_watch_handler(
 
         def _parseable_file(self, relative_path: str) -> bool:
             absolute_path = repo_root / relative_path
+            resolved_path = absolute_path.resolve()
+            try:
+                resolved_path.relative_to(resolved_root)
+            except ValueError:
+                return False
             return (
                 absolute_path.is_file()
                 and not absolute_path.is_symlink()

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -853,12 +853,13 @@ def _reconcile_stale_files(
 ) -> list[str]:
     """Remove graph files absent from the current parseable repository inventory."""
     stored_files = set(store.get_all_files())
+    current_paths: set[str]
     if current_files is not None:
         current_paths = {str(repo_root / file_path) for file_path in current_files}
     else:
         ignore_patterns = _load_ignore_patterns(repo_root)
         parser = CodeParser(repo_root)
-        current_paths: set[str] = set()
+        current_paths = set()
         for stored_file in stored_files:
             path = Path(stored_file)
             try:

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1284,6 +1284,28 @@ def incremental_update(
 _DEBOUNCE_SECONDS = 1
 
 
+def _raise_watch_update_errors(result: dict, context: str) -> None:
+    """Fail the watch boundary when an incremental update reports errors."""
+    errors = result.get("errors") or []
+    if not errors:
+        return
+    details = "; ".join(
+        f"{error.get('file', 'unknown')}: {error.get('error', 'unknown error')}"
+        for error in errors
+    )
+    raise RuntimeError(f"{context} reported errors: {details}")
+
+
+def _raise_watch_postprocess_warnings(result: object) -> None:
+    """Treat structured post-processing warnings as a failed watch update."""
+    if not isinstance(result, dict):
+        return
+    warnings = result.get("warnings") or []
+    if warnings:
+        details = "; ".join(str(warning) for warning in warnings)
+        raise RuntimeError(f"post-processing reported warnings: {details}")
+
+
 def _create_watch_handler(
     repo_root: Path,
     store: GraphStore,
@@ -1398,23 +1420,10 @@ def _create_watch_handler(
                     changed_files=changed_files,
                     reconcile_stale=False,
                 )
-                errors = result.get("errors") or []
-                if errors:
-                    details = "; ".join(
-                        f"{error.get('file', 'unknown')}: "
-                        f"{error.get('error', 'unknown error')}"
-                        for error in errors
-                    )
-                    raise RuntimeError(f"incremental update reported errors: {details}")
+                _raise_watch_update_errors(result, "incremental update")
                 if result["files_updated"] > 0 and on_files_updated is not None:
                     postprocess_result = on_files_updated(store)
-                    if isinstance(postprocess_result, dict):
-                        warnings = postprocess_result.get("warnings") or []
-                        if warnings:
-                            details = "; ".join(str(warning) for warning in warnings)
-                            raise RuntimeError(
-                                f"post-processing reported warnings: {details}"
-                            )
+                    _raise_watch_postprocess_warnings(postprocess_result)
             except BaseException as exc:
                 self.failure = exc
 
@@ -1469,10 +1478,10 @@ def watch(
     from watchdog.observers import Observer
 
     initial = incremental_update(repo_root, store, changed_files=[])
-    if initial["errors"]:
-        raise RuntimeError("initial watch reconciliation reported parse errors")
+    _raise_watch_update_errors(initial, "initial watch reconciliation")
     if initial["files_updated"] > 0 and on_files_updated is not None:
-        on_files_updated(store)
+        postprocess_result = on_files_updated(store)
+        _raise_watch_postprocess_warnings(postprocess_result)
     handler = _create_watch_handler(repo_root, store, on_files_updated)
     observer = Observer()
     observer.schedule(handler, str(repo_root), recursive=True)

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -852,9 +852,28 @@ def _reconcile_stale_files(
     current_files: list[str] | None = None,
 ) -> list[str]:
     """Remove graph files absent from the current parseable repository inventory."""
-    files = current_files if current_files is not None else collect_all_files(repo_root)
-    current_paths = {str(repo_root / file_path) for file_path in files}
-    stale_files = sorted(set(store.get_all_files()) - current_paths)
+    stored_files = set(store.get_all_files())
+    if current_files is not None:
+        current_paths = {str(repo_root / file_path) for file_path in current_files}
+    else:
+        ignore_patterns = _load_ignore_patterns(repo_root)
+        parser = CodeParser(repo_root)
+        current_paths: set[str] = set()
+        for stored_file in stored_files:
+            path = Path(stored_file)
+            try:
+                relative = str(path.relative_to(repo_root))
+            except ValueError:
+                continue
+            if (
+                path.is_file()
+                and not path.is_symlink()
+                and not _should_ignore(relative, ignore_patterns)
+                and parser.detect_language(path) is not None
+                and not _is_binary(path)
+            ):
+                current_paths.add(stored_file)
+    stale_files = sorted(stored_files - current_paths)
     if stale_files:
         store.remove_files_permanently(stale_files)
     return stale_files

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -158,6 +158,116 @@ class TestGraphStore:
             "unrelated::orphan",
         ]
 
+    def test_remove_file_permanently_handles_more_than_sqlite_variable_limit(self):
+        deleted_path = "/test/large.py"
+        rows = [
+            (
+                "Function",
+                f"node_{index}",
+                f"{deleted_path}::node_{index}",
+                deleted_path,
+                index + 1,
+                index + 1,
+                "python",
+                0,
+                0.0,
+            )
+            for index in range(16_384)
+        ]
+        self.store._conn.executemany(
+            "INSERT INTO nodes "
+            "(kind, name, qualified_name, file_path, line_start, line_end, language, "
+            "is_test, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        self.store.commit()
+
+        changed = self.store.remove_file_permanently(deleted_path)
+
+        assert changed == 1
+        assert self.store.get_nodes_by_file(deleted_path) == []
+
+    def test_remove_files_permanently_rolls_back_every_table_on_failure(self):
+        deleted_path = "/test/deleted.py"
+        survivor_path = "/test/survivor.py"
+        deleted_qn = f"{deleted_path}::removed"
+        survivor_qn = f"{survivor_path}::caller"
+        self.store.store_file_nodes_edges(
+            deleted_path,
+            [self._make_file_node(deleted_path), self._make_func_node("removed", deleted_path)],
+            [
+                EdgeInfo(
+                    kind="CONTAINS",
+                    source=deleted_path,
+                    target=deleted_qn,
+                    file_path=deleted_path,
+                )
+            ],
+        )
+        self.store.store_file_nodes_edges(
+            survivor_path,
+            [self._make_file_node(survivor_path), self._make_func_node("caller", survivor_path)],
+            [
+                EdgeInfo(
+                    kind="CALLS",
+                    source=survivor_qn,
+                    target=deleted_qn,
+                    file_path=survivor_path,
+                )
+            ],
+        )
+        self.store._conn.execute(
+            "CREATE TABLE embeddings (qualified_name TEXT PRIMARY KEY, vector BLOB NOT NULL, "
+            "text_hash TEXT NOT NULL, provider TEXT NOT NULL)"
+        )
+        self.store._conn.execute(
+            "INSERT INTO embeddings VALUES (?, ?, ?, ?)",
+            (deleted_qn, b"deleted", "deleted", "test"),
+        )
+        self.store.commit()
+        before = {
+            "nodes": self.store._conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0],
+            "edges": self.store._conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0],
+            "embeddings": self.store._conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0],
+        }
+
+        self.store._conn.execute(
+            "CREATE TRIGGER fail_deleted_node BEFORE DELETE ON nodes "
+            f"WHEN OLD.file_path = '{deleted_path}' "
+            "BEGIN SELECT RAISE(ABORT, 'injected deletion failure'); END"
+        )
+        self.store.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="injected deletion failure"):
+            self.store.remove_files_permanently([deleted_path])
+
+        after = {
+            "nodes": self.store._conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0],
+            "edges": self.store._conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0],
+            "embeddings": self.store._conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0],
+        }
+        assert after == before
+
+    def test_remove_files_permanently_counts_changed_paths_and_commits_once(self):
+        paths = ["/test/first.py", "/test/second.py", "/test/missing.py"]
+        for path in paths[:2]:
+            self.store.store_file_nodes_edges(path, [self._make_file_node(path)], [])
+
+        commits = 0
+
+        def count_commits() -> int:
+            nonlocal commits
+            commits += 1
+            return 0
+
+        self.store._conn.set_trace_callback(
+            lambda statement: count_commits() if statement == "COMMIT" else None
+        )
+        changed = self.store.remove_files_permanently(paths)
+
+        assert changed == 2
+        assert commits == 1
+
     def test_replacement_preserves_incoming_edges_from_other_files(self):
         target_path = "/test/target.py"
         caller_path = "/test/caller.py"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -101,6 +101,106 @@ class TestGraphStore:
         assert self.store.get_node("/test/file.py") is None
         assert self.store.get_node("/test/file.py::my_func") is None
 
+    def test_remove_file_permanently_removes_references_and_same_db_embeddings(self):
+        deleted_path = "/test/deleted.py"
+        survivor_path = "/test/survivor.py"
+        deleted_qn = f"{deleted_path}::removed"
+        survivor_qn = f"{survivor_path}::caller"
+        self.store.store_file_nodes_edges(
+            deleted_path,
+            [
+                self._make_file_node(deleted_path),
+                self._make_func_node("removed", deleted_path),
+            ],
+            [],
+        )
+        self.store.store_file_nodes_edges(
+            survivor_path,
+            [
+                self._make_file_node(survivor_path),
+                self._make_func_node("caller", survivor_path),
+            ],
+            [
+                EdgeInfo(
+                    kind="CALLS",
+                    source=survivor_qn,
+                    target=deleted_qn,
+                    file_path=survivor_path,
+                ),
+            ],
+        )
+        self.store._conn.execute(
+            "CREATE TABLE embeddings ("
+            "qualified_name TEXT PRIMARY KEY, vector BLOB NOT NULL, "
+            "text_hash TEXT NOT NULL, provider TEXT NOT NULL)"
+        )
+        self.store._conn.executemany(
+            "INSERT INTO embeddings VALUES (?, ?, ?, ?)",
+            [
+                (deleted_qn, b"deleted", "deleted", "test"),
+                (survivor_qn, b"survivor", "survivor", "test"),
+                ("unrelated::orphan", b"orphan", "orphan", "test"),
+            ],
+        )
+        self.store.commit()
+
+        self.store.remove_file_permanently(deleted_path)
+        self.store.commit()
+
+        assert self.store.get_nodes_by_file(deleted_path) == []
+        assert self.store.get_node(survivor_qn) is not None
+        assert self.store.get_edges_by_source(survivor_qn) == []
+        embeddings = self.store._conn.execute(
+            "SELECT qualified_name FROM embeddings ORDER BY qualified_name"
+        ).fetchall()
+        assert [row["qualified_name"] for row in embeddings] == [
+            survivor_qn,
+            "unrelated::orphan",
+        ]
+
+    def test_replacement_preserves_incoming_edges_from_other_files(self):
+        target_path = "/test/target.py"
+        caller_path = "/test/caller.py"
+        target_qn = f"{target_path}::target"
+        caller_qn = f"{caller_path}::caller"
+        self.store.store_file_nodes_edges(
+            target_path,
+            [
+                self._make_file_node(target_path),
+                self._make_func_node("target", target_path),
+            ],
+            [],
+        )
+        self.store.store_file_nodes_edges(
+            caller_path,
+            [
+                self._make_file_node(caller_path),
+                self._make_func_node("caller", caller_path),
+            ],
+            [
+                EdgeInfo(
+                    kind="CALLS",
+                    source=caller_qn,
+                    target=target_qn,
+                    file_path=caller_path,
+                ),
+            ],
+        )
+
+        self.store.store_file_nodes_edges(
+            target_path,
+            [
+                self._make_file_node(target_path),
+                self._make_func_node("target", target_path),
+            ],
+            [],
+        )
+
+        incoming = self.store.get_edges_by_target(target_qn)
+        assert [(edge.source_qualified, edge.file_path) for edge in incoming] == [
+            (caller_qn, caller_path),
+        ]
+
     def test_store_file_nodes_edges(self):
         nodes = [self._make_file_node(), self._make_func_node()]
         edges = [

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1106,6 +1106,52 @@ class TestStartWatchThread:
 
 
 class TestWatchReconciliation:
+    @pytest.mark.parametrize(
+        "event_factory",
+        [
+            pytest.param("FileOpenedEvent", id="file-opened"),
+            pytest.param("FileClosedEvent", id="file-closed"),
+            pytest.param("FileClosedNoWriteEvent", id="file-closed-no-write"),
+            pytest.param("DirModifiedEvent", id="directory-modified"),
+        ],
+    )
+    def test_watch_dispatch_ignores_irrelevant_events(self, tmp_path, event_factory):
+        from watchdog import events
+
+        store = GraphStore(tmp_path / "graph.db")
+        debouncer = MagicMock()
+        with patch(
+            "watchdog.utils.event_debouncer.EventDebouncer",
+            return_value=debouncer,
+        ):
+            handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            event_type = getattr(events, event_factory)
+
+            handler.dispatch(event_type(str(tmp_path / "source.py")))
+
+            debouncer.handle_event.assert_not_called()
+        finally:
+            store.close()
+
+    def test_watch_file_batch_skips_repository_inventory(self, tmp_path):
+        source = tmp_path / "source.py"
+        source.write_text("def source():\n    return 1\n")
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import FileModifiedEvent
+
+            with patch(
+                "code_review_graph.incremental.collect_all_files",
+                side_effect=AssertionError("watch batch inventoried repository"),
+            ):
+                handler.process([FileModifiedEvent(str(source))])
+
+            assert store.get_nodes_by_file(str(source))
+        finally:
+            store.close()
+
     def test_watch_reconciles_before_observer_startup(self, tmp_path):
         deleted = tmp_path / "offline.py"
         deleted.write_text("def offline():\n    pass\n")
@@ -1204,7 +1250,11 @@ class TestWatchReconciliation:
         try:
             from watchdog.events import DirMovedEvent
 
-            handler.process([DirMovedEvent(str(source_dir), str(destination_dir))])
+            with patch(
+                "code_review_graph.incremental.collect_all_files",
+                side_effect=AssertionError("directory move inventoried repository"),
+            ):
+                handler.process([DirMovedEvent(str(source_dir), str(destination_dir))])
 
             assert store.get_nodes_by_file(str(source)) == []
             assert store.get_nodes_by_file(str(destination))
@@ -1224,7 +1274,11 @@ class TestWatchReconciliation:
         try:
             from watchdog.events import DirDeletedEvent
 
-            handler.process([DirDeletedEvent(str(package))])
+            with patch(
+                "code_review_graph.incremental.collect_all_files",
+                side_effect=AssertionError("directory delete inventoried repository"),
+            ):
+                handler.process([DirDeletedEvent(str(package))])
 
             assert store.get_nodes_by_file(str(source)) == []
         finally:
@@ -1289,6 +1343,8 @@ class TestWatchReconciliation:
             store.close()
 
     def test_watch_update_failure_propagates_to_boundary(self, tmp_path):
+        broken = tmp_path / "broken.py"
+        broken.write_text("def broken():\n    pass\n")
         store = GraphStore(tmp_path / "graph.db")
         handler = _create_watch_handler(tmp_path, store, None)
         try:
@@ -1298,7 +1354,7 @@ class TestWatchReconciliation:
                 "code_review_graph.incremental.incremental_update",
                 side_effect=RuntimeError("update failed"),
             ):
-                handler.process([FileCreatedEvent(str(tmp_path / "broken.py"))])
+                handler.process([FileCreatedEvent(str(broken))])
 
             with pytest.raises(RuntimeError, match="watch update failed"):
                 handler.raise_if_failed()
@@ -1321,6 +1377,47 @@ class TestWatchReconciliation:
 
             with pytest.raises(RuntimeError, match="watch update failed"):
                 handler.raise_if_failed()
+        finally:
+            store.close()
+
+    def test_watch_parse_errors_propagate_to_boundary(self, tmp_path):
+        broken = tmp_path / "broken.py"
+        broken.write_text("def broken():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        result = {
+            "files_updated": 0,
+            "errors": [{"file": "broken.py", "error": "parse failed"}],
+        }
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            with patch(
+                "code_review_graph.incremental.incremental_update",
+                return_value=result,
+            ):
+                handler.process([FileCreatedEvent(str(broken))])
+
+            with pytest.raises(RuntimeError, match="watch update failed"):
+                handler.raise_if_failed()
+        finally:
+            store.close()
+
+    @pytest.mark.parametrize("filename", ["unsupported.txt", "binary.py"])
+    def test_watch_unsupported_or_binary_paths_skip_postprocessing(self, tmp_path, filename):
+        source = tmp_path / filename
+        content = b"plain text" if filename.endswith(".txt") else b"\x00binary"
+        source.write_bytes(content)
+        store = GraphStore(tmp_path / "graph.db")
+        callback = MagicMock()
+        handler = _create_watch_handler(tmp_path, store, callback)
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            handler.process([FileCreatedEvent(str(source))])
+
+            callback.assert_not_called()
+            assert store.get_all_files() == []
         finally:
             store.close()
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1445,6 +1445,26 @@ class TestWatchReconciliation:
         finally:
             store.close()
 
+    def test_watch_incremental_error_result_propagates_to_boundary(self, tmp_path):
+        source = tmp_path / "source.py"
+        source.write_text("def source():\n    return 1\n")
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            with patch(
+                "code_review_graph.incremental.CodeParser.parse_bytes",
+                side_effect=RuntimeError("forced parse failure"),
+            ):
+                handler.process([FileCreatedEvent(str(source))])
+
+            with pytest.raises(RuntimeError, match="watch update failed") as exc_info:
+                handler.raise_if_failed()
+            assert "source.py: forced parse failure" in str(exc_info.value.__cause__)
+        finally:
+            store.close()
+
     def test_watch_callback_failure_propagates_to_boundary(self, tmp_path):
         source = tmp_path / "source.py"
         source.write_text("def source():\n    pass\n")
@@ -1502,6 +1522,30 @@ class TestWatchReconciliation:
 
             callback.assert_not_called()
             assert store.get_all_files() == []
+        finally:
+            store.close()
+
+    def test_watch_postprocess_warning_result_propagates_to_boundary(self, tmp_path):
+        import sqlite3
+
+        from watchdog.events import FileCreatedEvent
+
+        from code_review_graph.postprocessing import run_post_processing
+
+        source = tmp_path / "source.py"
+        source.write_text("def source():\n    return 1\n")
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, run_post_processing)
+        try:
+            with patch(
+                "code_review_graph.search.rebuild_fts_index",
+                side_effect=sqlite3.OperationalError("forced FTS failure"),
+            ):
+                handler.process([FileCreatedEvent(str(source))])
+
+            with pytest.raises(RuntimeError, match="watch update failed") as exc_info:
+                handler.raise_if_failed()
+            assert "FTS index rebuild failed" in str(exc_info.value.__cause__)
         finally:
             store.close()
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1220,6 +1220,24 @@ class TestWatchReconciliation:
         finally:
             store.close()
 
+    def test_watch_pure_file_deletion_counts_change_and_calls_callback_once(self, tmp_path):
+        source = tmp_path / "deleted.py"
+        source.write_text("def deleted():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["deleted.py"])
+        source.unlink()
+        callback = MagicMock()
+        handler = _create_watch_handler(tmp_path, store, callback)
+        try:
+            from watchdog.events import FileDeletedEvent
+
+            handler.process([FileDeletedEvent(str(source))])
+
+            callback.assert_called_once_with(store)
+            assert store.get_nodes_by_file(str(source)) == []
+        finally:
+            store.close()
+
     def test_watch_directory_create_indexes_parseable_descendants(self, tmp_path):
         store = GraphStore(tmp_path / "graph.db")
         handler = _create_watch_handler(tmp_path, store, None)
@@ -1306,6 +1324,33 @@ class TestWatchReconciliation:
             assert store.get_all_files() == []
         finally:
             store.close()
+
+    def test_watch_rejects_file_below_symlinked_ancestor_outside_repo(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        outside_file = outside / "escaped.py"
+        outside_file.write_text("def escaped():\n    pass\n")
+        linked_dir = tmp_path / "linked"
+        linked_dir.symlink_to(outside, target_is_directory=True)
+        store = GraphStore(tmp_path / "graph.db")
+        callback = MagicMock()
+        handler = _create_watch_handler(tmp_path, store, callback)
+        try:
+            from watchdog.events import DirCreatedEvent, FileCreatedEvent
+
+            handler.process(
+                [
+                    FileCreatedEvent(str(linked_dir / "escaped.py")),
+                    DirCreatedEvent(str(linked_dir)),
+                ]
+            )
+
+            callback.assert_not_called()
+            assert store.get_all_files() == []
+        finally:
+            store.close()
+            outside_file.unlink()
+            outside.rmdir()
 
     def test_watch_update_and_callback_never_overlap(self, tmp_path):
         source = tmp_path / "source.py"

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -3,10 +3,13 @@
 import subprocess
 from unittest.mock import MagicMock, call, patch  # noqa: F401 – used in tests
 
+import pytest
+
 import code_review_graph.incremental as incremental_module
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
     _decode_name_status_paths,
+    _create_watch_handler,
     _is_binary,
     _load_ignore_patterns,
     _parse_single_file,
@@ -23,6 +26,7 @@ from code_review_graph.incremental import (
     get_staged_and_unstaged,
     incremental_update,
     start_watch_thread,
+    watch,
 )
 
 
@@ -712,6 +716,35 @@ class TestFullBuild:
         finally:
             store.close()
 
+    def test_full_build_removes_offline_deleted_directory_tree(self, tmp_path):
+        package = tmp_path / "package"
+        package.mkdir()
+        first = package / "first.py"
+        second = package / "second.py"
+        first.write_text("def first():\n    pass\n")
+        second.write_text("def second():\n    pass\n")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["package/first.py", "package/second.py"],
+            ):
+                full_build(tmp_path, store)
+            first.unlink()
+            second.unlink()
+            package.rmdir()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=[],
+            ):
+                result = full_build(tmp_path, store)
+
+            assert result["stale_files_removed"] == 2
+            assert store.get_all_files() == []
+        finally:
+            store.close()
+
 
 class TestIncrementalUpdate:
     def test_incremental_with_no_changes(self, tmp_path):
@@ -720,6 +753,25 @@ class TestIncrementalUpdate:
         try:
             result = incremental_update(tmp_path, store, changed_files=[])
             assert result["files_updated"] == 0
+        finally:
+            store.close()
+
+    def test_empty_change_list_reconciles_offline_deletion_idempotently(self, tmp_path):
+        deleted = tmp_path / "offline.py"
+        deleted.write_text("def offline():\n    pass\n")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            incremental_update(tmp_path, store, changed_files=["offline.py"])
+            deleted.unlink()
+
+            first = incremental_update(tmp_path, store, changed_files=[])
+            second = incremental_update(tmp_path, store, changed_files=[])
+
+            assert first["stale_files_removed"] == 1
+            assert first["files_updated"] == 1
+            assert second["stale_files_removed"] == 0
+            assert second["files_updated"] == 0
+            assert store.get_all_files() == []
         finally:
             store.close()
 
@@ -1050,6 +1102,226 @@ class TestStartWatchThread:
             assert thread.is_alive()
         finally:
             barrier.set()
+            store.close()
+
+
+class TestWatchReconciliation:
+    def test_watch_reconciles_before_observer_startup(self, tmp_path):
+        deleted = tmp_path / "offline.py"
+        deleted.write_text("def offline():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["offline.py"])
+        deleted.unlink()
+        callback_count = 0
+
+        def on_files_updated(_store):
+            nonlocal callback_count
+            callback_count += 1
+
+        try:
+            with (
+                patch("watchdog.observers.Observer") as observer,
+                patch("time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                watch(tmp_path, store, on_files_updated=on_files_updated)
+            assert callback_count == 1
+            assert store.get_all_files() == []
+            observer.return_value.start.assert_called_once()
+        finally:
+            store.close()
+
+    def test_watch_file_move_runs_one_serialized_callback(self, tmp_path):
+        source = tmp_path / "source.py"
+        destination = tmp_path / "destination.py"
+        source.write_text("def moved():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["source.py"])
+        callback_count = 0
+        def on_files_updated(_store):
+            nonlocal callback_count
+            callback_count += 1
+
+        handler = _create_watch_handler(tmp_path, store, on_files_updated)
+        try:
+            from watchdog.events import FileMovedEvent
+
+            source.rename(destination)
+            handler.process([FileMovedEvent(str(source), str(destination))])
+            assert callback_count == 1
+            assert store.get_nodes_by_file(str(source)) == []
+            assert store.get_nodes_by_file(str(destination))
+        finally:
+            store.close()
+
+    def test_watch_noop_batch_does_not_call_callback(self, tmp_path):
+        source = tmp_path / "source.py"
+        source.write_text("def unchanged():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["source.py"])
+        callback_count = 0
+
+        def on_files_updated(_store):
+            nonlocal callback_count
+            callback_count += 1
+
+        handler = _create_watch_handler(tmp_path, store, on_files_updated)
+        try:
+            from watchdog.events import FileModifiedEvent
+
+            source.touch()
+            handler.process([FileModifiedEvent(str(source))])
+            assert callback_count == 0
+        finally:
+            store.close()
+
+    def test_watch_directory_create_indexes_parseable_descendants(self, tmp_path):
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        package = tmp_path / "package"
+        package.mkdir()
+        source = package / "created.py"
+        source.write_text("def created():\n    pass\n")
+        try:
+            from watchdog.events import DirCreatedEvent
+
+            handler.process([DirCreatedEvent(str(package))])
+
+            assert store.get_nodes_by_file(str(source))
+        finally:
+            store.close()
+
+    def test_watch_directory_move_replaces_source_tree(self, tmp_path):
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        source = source_dir / "moved.py"
+        source.write_text("def moved():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["source/moved.py"])
+        destination_dir = tmp_path / "destination"
+        source_dir.rename(destination_dir)
+        destination = destination_dir / "moved.py"
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import DirMovedEvent
+
+            handler.process([DirMovedEvent(str(source_dir), str(destination_dir))])
+
+            assert store.get_nodes_by_file(str(source)) == []
+            assert store.get_nodes_by_file(str(destination))
+        finally:
+            store.close()
+
+    def test_watch_directory_delete_reconciles_descendants(self, tmp_path):
+        package = tmp_path / "package"
+        package.mkdir()
+        source = package / "deleted.py"
+        source.write_text("def deleted():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["package/deleted.py"])
+        source.unlink()
+        package.rmdir()
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import DirDeletedEvent
+
+            handler.process([DirDeletedEvent(str(package))])
+
+            assert store.get_nodes_by_file(str(source)) == []
+        finally:
+            store.close()
+
+    def test_watch_symlink_events_are_rejected(self, tmp_path):
+        target = tmp_path / "target.py"
+        target.write_text("def target():\n    pass\n")
+        linked_file = tmp_path / "linked.py"
+        linked_file.symlink_to(target)
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "inside.py").write_text("def inside():\n    pass\n")
+        linked_dir = tmp_path / "linked_dir"
+        linked_dir.symlink_to(real_dir, target_is_directory=True)
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import DirCreatedEvent, FileCreatedEvent
+
+            handler.process(
+                [FileCreatedEvent(str(linked_file)), DirCreatedEvent(str(linked_dir))]
+            )
+
+            assert store.get_all_files() == []
+        finally:
+            store.close()
+
+    def test_watch_update_and_callback_never_overlap(self, tmp_path):
+        source = tmp_path / "source.py"
+        source.write_text("def source():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        active = False
+        phases = []
+
+        def callback(_store):
+            nonlocal active
+            assert active is False
+            phases.append("callback")
+
+        handler = _create_watch_handler(tmp_path, store, callback)
+        original_update = incremental_module.incremental_update
+
+        def tracked_update(*args, **kwargs):
+            nonlocal active
+            assert active is False
+            active = True
+            phases.append("update")
+            try:
+                return original_update(*args, **kwargs)
+            finally:
+                active = False
+
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            with patch("code_review_graph.incremental.incremental_update", tracked_update):
+                handler.process([FileCreatedEvent(str(source))])
+
+            assert phases == ["update", "callback"]
+        finally:
+            store.close()
+
+    def test_watch_update_failure_propagates_to_boundary(self, tmp_path):
+        store = GraphStore(tmp_path / "graph.db")
+        handler = _create_watch_handler(tmp_path, store, None)
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            with patch(
+                "code_review_graph.incremental.incremental_update",
+                side_effect=RuntimeError("update failed"),
+            ):
+                handler.process([FileCreatedEvent(str(tmp_path / "broken.py"))])
+
+            with pytest.raises(RuntimeError, match="watch update failed"):
+                handler.raise_if_failed()
+        finally:
+            store.close()
+
+    def test_watch_callback_failure_propagates_to_boundary(self, tmp_path):
+        source = tmp_path / "source.py"
+        source.write_text("def source():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+
+        def failing_callback(_store):
+            raise RuntimeError("callback failed")
+
+        handler = _create_watch_handler(tmp_path, store, failing_callback)
+        try:
+            from watchdog.events import FileCreatedEvent
+
+            handler.process([FileCreatedEvent(str(source))])
+
+            with pytest.raises(RuntimeError, match="watch update failed"):
+                handler.raise_if_failed()
+        finally:
             store.close()
 
     def test_returns_none_when_watchdog_unavailable(self, tmp_path):

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -8,8 +8,8 @@ import pytest
 import code_review_graph.incremental as incremental_module
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
-    _decode_name_status_paths,
     _create_watch_handler,
+    _decode_name_status_paths,
     _is_binary,
     _load_ignore_patterns,
     _parse_single_file,
@@ -1212,6 +1212,35 @@ class TestWatchReconciliation:
             assert callback_count == 1
             assert store.get_all_files() == []
             observer.return_value.start.assert_called_once()
+        finally:
+            store.close()
+
+    def test_watch_startup_postprocess_warning_prevents_observer_start(self, tmp_path):
+        import sqlite3
+
+        from code_review_graph.postprocessing import run_post_processing
+
+        deleted = tmp_path / "offline.py"
+        deleted.write_text("def offline():\n    pass\n")
+        store = GraphStore(tmp_path / "graph.db")
+        incremental_update(tmp_path, store, changed_files=["offline.py"])
+        deleted.unlink()
+        try:
+            with (
+                patch("watchdog.observers.Observer") as observer,
+                patch("time.sleep", side_effect=KeyboardInterrupt),
+                patch(
+                    "code_review_graph.search.rebuild_fts_index",
+                    side_effect=sqlite3.OperationalError("forced FTS failure"),
+                ),
+                pytest.raises(
+                    RuntimeError,
+                    match="post-processing reported warnings",
+                ),
+            ):
+                watch(tmp_path, store, on_files_updated=run_post_processing)
+
+            observer.assert_not_called()
         finally:
             store.close()
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -775,6 +775,45 @@ class TestIncrementalUpdate:
         finally:
             store.close()
 
+    def test_reconciliation_keeps_existing_untracked_files_in_git_repo(self, tmp_path):
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        tracked = tmp_path / "tracked.py"
+        tracked.write_text("def tracked():\n    return 1\n")
+        subprocess.run(
+            ["git", "add", "tracked.py"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        untracked = tmp_path / "untracked.py"
+        untracked.write_text("def untracked():\n    return 2\n")
+
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["tracked.py", "untracked.py"],
+            )
+            assert store.get_nodes_by_file(str(untracked))
+
+            tracked.write_text("def tracked():\n    return 3\n")
+            result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=["tracked.py"],
+            )
+
+            assert result["stale_files_removed"] == 0
+            assert store.get_nodes_by_file(str(untracked))
+        finally:
+            store.close()
+
     def test_incremental_with_changed_file(self, tmp_path):
         py_file = tmp_path / "mod.py"
         py_file.write_text("def greet():\n    return 'hi'\n")

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -303,8 +303,6 @@ class TestWatchCallbackIntegration:
         assert "on_files_updated" in sig.parameters
 
     def test_watch_callback_not_called_without_updates(self, tmp_path):
-        import threading
-
         from code_review_graph.incremental import watch
 
         (tmp_path / ".git").mkdir()
@@ -313,20 +311,16 @@ class TestWatchCallbackIntegration:
         callback = MagicMock()
 
         try:
+            with (
+                patch("watchdog.observers.Observer") as observer,
+                patch("time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                watch(tmp_path, store, on_files_updated=callback)
 
-            def run_watch():
-                try:
-                    watch(tmp_path, store, on_files_updated=callback)
-                except KeyboardInterrupt:
-                    pass
-
-            t = threading.Thread(target=run_watch, daemon=True)
-            t.start()
-
-            import time
-
-            time.sleep(0.5)
             callback.assert_not_called()
+            observer.return_value.start.assert_called_once()
+            observer.return_value.stop.assert_called()
+            observer.return_value.join.assert_called_once()
         finally:
             store.close()
 


### PR DESCRIPTION
Corrected integration of #735 against current main.

Contributor attribution is preserved in five Marlon Costa commits. The integration keeps the original precise deletion, lifecycle reconciliation, event coalescing, symlink rejection, and deterministic teardown work. It also adds three maintainer regressions/fixes so live untracked graph files are not deleted, incomplete updates fail closed, and startup post-processing failures stop the watcher instead of leaving a partially updated graph running.

Validation on current main:
- 399 focused graph/incremental/post-processing tests passed; 1 unrelated test skipped
- real process-pool parity passed
- Ruff and git diff checks passed
- full build: 246 files, 4,838 nodes, 38,798 edges
- post-processing: 185 flows, 207 communities, 4,793 FTS entries

Original contribution: #735