### PR TITLE
fix(parser): preserve user-site grammar access

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -440,6 +440,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PARSER_LOAD_TIMEOUT_SECONDS = 5.0
 _PARSER_PROBE_RESULTS: dict[str, bool] = {}
+_PARSER_PROBE_FAILURE_DETAILS: dict[str, str] = {}
 _PARSER_PROBE_LOCK = threading.Lock()
 _EXPECTED_PARSER_LOAD_ERRORS = (ImportError, LookupError, OSError, ValueError)
 
@@ -468,17 +469,32 @@ def _run_parser_load_probe(grammar: str, timeout_seconds: float) -> bool:
     )
     try:
         completed = subprocess.run(
-            [sys.executable, "-I", "-c", code, grammar],
+            [sys.executable, "-c", code, grammar],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             timeout=timeout_seconds,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
+        _PARSER_PROBE_FAILURE_DETAILS[grammar] = str(exc)
         logger.debug("tree-sitter parser probe failed for %s: %s", grammar, exc)
         return False
-    return completed.returncode == 0
+    if completed.returncode == 0:
+        _PARSER_PROBE_FAILURE_DETAILS.pop(grammar, None)
+        return True
+
+    raw_stderr = getattr(completed, "stderr", b"")
+    if isinstance(raw_stderr, bytes):
+        stderr = raw_stderr.decode("utf-8", errors="replace")
+    else:
+        stderr = str(raw_stderr)
+    detail = next(
+        (line.strip() for line in reversed(stderr.splitlines()) if line.strip()),
+        f"probe exited with status {completed.returncode}",
+    )
+    _PARSER_PROBE_FAILURE_DETAILS[grammar] = detail[:500]
+    return False
 
 
 def _parser_load_probe_succeeds(
@@ -503,10 +519,18 @@ def _parser_load_probe_succeeds(
         result = _run_parser_load_probe(grammar, timeout)
         _PARSER_PROBE_RESULTS[grammar] = result
         if not result:
-            logger.warning(
-                "Skipping unavailable tree-sitter parser for %s",
-                grammar,
-            )
+            detail = _PARSER_PROBE_FAILURE_DETAILS.get(grammar)
+            if detail:
+                logger.warning(
+                    "Skipping unavailable tree-sitter parser for %s: %s",
+                    grammar,
+                    detail,
+                )
+            else:
+                logger.warning(
+                    "Skipping unavailable tree-sitter parser for %s",
+                    grammar,
+                )
         return result
 
 
@@ -520,6 +544,7 @@ def _clear_parser_probe_cache() -> None:
     """Clear process-level probe state (used by focused tests)."""
     with _PARSER_PROBE_LOCK:
         _PARSER_PROBE_RESULTS.clear()
+        _PARSER_PROBE_FAILURE_DETAILS.clear()
 
 
 def _load_tree_sitter_parser(grammar: str):

--- a/tests/test_parser_load_probe.py
+++ b/tests/test_parser_load_probe.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -102,6 +105,66 @@ def test_nonzero_probe_skips_only_the_failing_grammar(monkeypatch):
     assert parser._get_parser("rust") is not None
     assert probe_calls == ["verilog", "rust"]
     assert language_pack.calls == ["rust"]
+
+
+def test_nonzero_probe_logs_the_subprocess_failure_reason(monkeypatch, caplog):
+    def fake_run(_command, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stderr=(
+                b"Traceback (most recent call last):\n"
+                b"ModuleNotFoundError: No module named "
+                b"'tree_sitter_language_pack'\n"
+            ),
+        )
+
+    monkeypatch.setattr(parser_module.subprocess, "run", fake_run)
+
+    with caplog.at_level("WARNING"):
+        assert not parser_module._parser_load_probe_succeeds("java")
+
+    assert (
+        "Skipping unavailable tree-sitter parser for java: "
+        "ModuleNotFoundError: No module named 'tree_sitter_language_pack'"
+        in caplog.text
+    )
+
+
+def test_probe_can_load_language_pack_from_user_site(tmp_path, monkeypatch):
+    """Regression for --user installs hidden by Python's isolated mode."""
+    base_executable = getattr(sys, "_base_executable", sys.executable)
+    env = os.environ.copy()
+    env["PYTHONUSERBASE"] = str(tmp_path / "user-base")
+    user_site_result = subprocess.run(
+        [
+            base_executable,
+            "-c",
+            "import site; print(site.ENABLE_USER_SITE); "
+            "print(site.getusersitepackages())",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    enabled, user_site = user_site_result.stdout.splitlines()
+    if enabled != "True":
+        pytest.skip("base interpreter has user-site packages disabled")
+
+    user_site_path = Path(user_site)
+    package_dir = user_site_path / "tree_sitter_language_pack"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text(
+        "def get_parser(grammar):\n"
+        "    assert grammar == 'user-site-only'\n"
+        "    return object()\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("PYTHONUSERBASE", env["PYTHONUSERBASE"])
+    monkeypatch.setattr(parser_module.sys, "executable", base_executable)
+
+    assert parser_module._run_parser_load_probe("user-site-only", 5.0)
 
 
 def test_expected_parent_load_failure_is_cached(monkeypatch):


### PR DESCRIPTION
Fix the shared parser-probe failure reported on Windows `pip install --user`, Nix, and macOS installs.

The disposable parser process no longer uses Python isolated mode, which hid user-site and runtime-visible packages from the probe even though the main process could import them. The subprocess remains isolated from native parser crashes. Failed probes now retain stderr and surface the final reason in the warning instead of only saying the grammar is unavailable.

Validation:
- new real user-site regression failed before the fix and passes after it
- 7 parser-probe tests passed
- 594 parser/multilanguage/custom-language tests passed
- real probes and parses passed for Python, Java, Bash, Nix, JavaScript, and TypeScript
- Ruff and diff checks passed
- full graph: 246 files, 4,795 nodes, 38,047 edges

Closes #751
Closes #753
Closes #756