### PR TITLE
fix(query): disambiguate bare inheritance types

### DIFF
--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -312,6 +312,16 @@ def query_graph(
                     if java_candidates is not None
                     else store.search_nodes(target, limit=20)
                 )
+                if pattern == "inheritors_of" and "::" not in target:
+                    exact_type_candidates = [
+                        candidate
+                        for candidate in candidates
+                        if candidate.name == target
+                        and candidate.kind
+                        in {"Class", "Interface", "Type", "Struct", "Enum", "Trait"}
+                    ]
+                    if exact_type_candidates:
+                        candidates = exact_type_candidates
                 if len(candidates) == 1:
                     node = candidates[0]
                     target = node.qualified_name

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,7 @@ import code_review_graph.tools.analysis_tools as analysis_module
 import code_review_graph.tools.docs as docs_module
 import code_review_graph.tools.query as query_module
 from code_review_graph.graph import GraphStore, _sanitize_name, node_to_dict
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import EdgeInfo, NodeInfo
 from code_review_graph.tools import (
     _validate_repo_root,
@@ -442,6 +443,38 @@ class TestQueryGraphCallTargetFallbacks:
             "TsChild",
             "JsxImplementer",
         }
+
+    def test_inheritors_of_bare_dart_class_ignores_member_matches(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Issue #87: Animal.speak must not make bare Animal ambiguous."""
+        source = tmp_path / "animals.dart"
+        source.write_text(
+            "class Animal {\n"
+            "  void speak() {}\n"
+            "}\n"
+            "class Dog extends Animal {\n"
+            "  @override\n"
+            "  void speak() {}\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        graph_dir = tmp_path / ".code-review-graph"
+        graph_dir.mkdir()
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+        with GraphStore(graph_dir / "graph.db") as store:
+            full_build(tmp_path, store)
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target="Animal",
+            repo_root=str(tmp_path),
+        )
+
+        assert result["status"] == "ok"
+        assert {item["name"] for item in result["results"]} == {"Dog"}
 
 
 def _seed_repo_relative_graph(root: Path) -> None:


### PR DESCRIPTION
Finish the remaining Dart query failure from #87.

Bare `inheritors_of("Animal")` previously searched all matching nodes and returned `ambiguous` because the result set contained both the `Animal` class and its `Animal.speak` member. In inheritance queries, exact class-like node matches are now preferred; genuinely duplicated classes remain ambiguous.

Validation:
- exact Dart parse → GraphStore → public `query_graph` regression failed before and passes after
- direct bare query now returns `Dog`
- 606 query, graph, and multilanguage tests passed; 1 skipped
- Ruff and diff checks passed
- full graph: 246 files, 4,839 nodes, 38,814 edges

This completes the third remaining item in #87; Dart CALLS and `package:` import resolution were already validated on main.

Closes #87