### PR TITLE
fix(graph): resolve Python imports safely (#749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- Resolved repository-local Python imports by unique module suffix after indexing,
-  so `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while
-  duplicate package candidates remain explicitly unresolved (#720).
+- Added a post-index Python import resolver using unique module suffixes, so
+  `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while duplicate
+  package candidates remain explicitly unresolved (#720).
 
 ## [2.3.7] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolved repository-local Python imports by unique module suffix after indexing,
+  so `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while
+  duplicate package candidates remain explicitly unresolved (#720).
+
 ## [2.3.7] - 2026-07-18
 
 **Maintainer-reconciliation release.** This release packages the verified work

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -687,6 +687,104 @@ class GraphStore:
         ]
         return supported[0] if len(supported) == 1 else None
 
+    def _resolve_python_import_targets(self) -> int:
+        """Resolve raw Python module imports against indexed repository files.
+
+        A module such as ``mypkg.runner`` may live below any source root
+        (``src/``, ``lib/``, or a monorepo package). Match by module suffix
+        after every file has been indexed, and only resolve a unique match.
+        """
+        conn = self._conn
+        python_files = [
+            row["file_path"]
+            for row in conn.execute(
+                "SELECT file_path FROM nodes "
+                "WHERE kind = 'File' AND language = 'python'"
+            ).fetchall()
+        ]
+        if not python_files:
+            return 0
+
+        modules: dict[str, set[str]] = {}
+        for file_path in python_files:
+            parts = [
+                part for part in file_path.replace("\\", "/").split("/")
+                if part
+            ]
+            if not parts:
+                continue
+            filename = parts[-1]
+            if filename == "__init__.py":
+                components = parts[:-1]
+            elif filename.endswith(".py"):
+                components = [*parts[:-1], filename[:-3]]
+            else:
+                continue
+            for start in range(len(components)):
+                modules.setdefault(
+                    ".".join(components[start:]), set(),
+                ).add(file_path)
+
+        rows = conn.execute(
+            "SELECT DISTINCT e.id, e.target_qualified, e.extra "
+            "FROM edges e JOIN nodes f "
+            "ON f.kind = 'File' AND f.file_path = e.file_path "
+            "WHERE e.kind = 'IMPORTS_FROM' AND f.language = 'python'"
+        ).fetchall()
+        changed = 0
+        python_file_set = set(python_files)
+        for edge in rows:
+            try:
+                extra = json.loads(edge["extra"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                extra = {}
+            if not isinstance(extra, dict):
+                extra = {}
+
+            raw_module = extra.get("python_module")
+            if not isinstance(raw_module, str):
+                raw_module = edge["target_qualified"]
+                if (
+                    raw_module in python_file_set
+                    or raw_module.startswith(".")
+                    or "/" in raw_module
+                    or "\\" in raw_module
+                ):
+                    continue
+
+            candidates = sorted(modules.get(raw_module, ()))
+            desired_extra = dict(extra)
+            desired_extra["python_module"] = raw_module
+            if len(candidates) == 1:
+                desired_target = candidates[0]
+                desired_extra["import_resolution"] = "repository_suffix"
+                desired_extra.pop("import_candidates", None)
+                desired_extra.pop("import_candidate_count", None)
+                desired_extra.pop("import_candidates_truncated", None)
+            else:
+                desired_target = raw_module
+                desired_extra["import_resolution"] = (
+                    "ambiguous" if candidates else "unresolved"
+                )
+                desired_extra["import_candidates"] = candidates[:20]
+                desired_extra["import_candidate_count"] = len(candidates)
+                desired_extra["import_candidates_truncated"] = len(candidates) > 20
+
+            if (
+                edge["target_qualified"] == desired_target
+                and extra == desired_extra
+            ):
+                continue
+            conn.execute(
+                "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
+                (desired_target, json.dumps(desired_extra, sort_keys=True), edge["id"]),
+            )
+            changed += 1
+
+        if changed:
+            conn.commit()
+        return changed
+
     def resolve_bare_call_targets(self) -> int:
         """Resolve bare CALLS targets backed by same-file or import evidence.
 
@@ -698,6 +796,7 @@ class GraphStore:
 
         Returns the number of resolved edges.
         """
+        self._resolve_python_import_targets()
         return self._resolve_bare_endpoints("CALLS", "target_qualified")
 
     def resolve_cpp_scoped_call_targets(self) -> int:
@@ -922,19 +1021,23 @@ class GraphStore:
     def _resolve_bare_endpoints(self, kind: str, endpoint: str) -> int:
         """Resolve a bare edge endpoint only when one candidate has evidence."""
         if endpoint == "target_qualified":
+            raw_key = "bare_call_target"
+            endpoint_column = "target_qualified"
             select_sql = (
                 "SELECT id, source_qualified, target_qualified, file_path, extra "
                 "FROM edges WHERE kind = ? "
-                "AND target_qualified NOT LIKE '%::%'"
+                "AND (target_qualified NOT LIKE '%::%' "
+                "OR extra LIKE '%\"bare_call_target\"%')"
             )
-            update_sql = "UPDATE edges SET target_qualified = ? WHERE id = ?"
         elif endpoint == "source_qualified":
+            raw_key = "bare_tested_by_source"
+            endpoint_column = "source_qualified"
             select_sql = (
                 "SELECT id, source_qualified, target_qualified, file_path, extra "
                 "FROM edges WHERE kind = ? "
-                "AND source_qualified NOT LIKE '%::%'"
+                "AND (source_qualified NOT LIKE '%::%' "
+                "OR extra LIKE '%\"bare_tested_by_source\"%')"
             )
-            update_sql = "UPDATE edges SET source_qualified = ? WHERE id = ?"
         else:
             raise ValueError(f"Invalid edge endpoint column: {endpoint!r}")
 
@@ -965,37 +1068,91 @@ class GraphStore:
             import_targets.setdefault(row["file_path"], set()).add(target_file)
 
         resolved = 0
+        changed = False
         for edge in bare_edges:
             try:
                 edge_extra = json.loads(edge["extra"] or "{}")
             except (TypeError, json.JSONDecodeError):
                 edge_extra = {}
-            if isinstance(edge_extra, dict) and (
+            if not isinstance(edge_extra, dict):
+                edge_extra = {}
+            if raw_key not in edge_extra and (
                 "ambiguous_targets" in edge_extra
                 or "unresolved_targets" in edge_extra
             ):
                 continue
 
-            bare_name = edge[endpoint]
-            candidates = node_lookup.get(bare_name, [])
-            if not candidates:
+            bare_name = edge_extra.get(raw_key, edge[endpoint])
+            if not isinstance(bare_name, str):
                 continue
+            candidates = node_lookup.get(bare_name, [])
 
             context_file = edge["file_path"]
             imported_files = import_targets.get(context_file, set())
-            qualified = self._select_evidence_backed_candidate(
-                candidates,
-                context_file,
-                imported_files,
-            )
-            if qualified is None:
+            supported = [
+                qualified
+                for qualified, candidate_file in candidates
+                if candidate_file == context_file or candidate_file in imported_files
+            ]
+            managed = raw_key in edge_extra
+            if len(supported) != 1 and not managed and len(supported) < 2:
                 continue
+            desired_extra = dict(edge_extra)
+            desired_extra[raw_key] = bare_name
+            if len(supported) == 1:
+                desired_endpoint = supported[0]
+                for key in (
+                    "ambiguous_targets",
+                    "ambiguous_target_count",
+                    "ambiguous_targets_truncated",
+                    "unresolved_targets",
+                    "unresolved_target_count",
+                    "unresolved_targets_truncated",
+                ):
+                    desired_extra.pop(key, None)
+            else:
+                desired_endpoint = bare_name
+                if len(supported) > 1:
+                    resolution = "ambiguous"
+                    resolution_candidates = supported
+                    other = "unresolved"
+                else:
+                    resolution = "unresolved"
+                    resolution_candidates = [
+                        qualified for qualified, _ in candidates
+                    ]
+                    other = "ambiguous"
+                for key in (
+                    f"{other}_targets",
+                    f"{other}_target_count",
+                    f"{other}_targets_truncated",
+                ):
+                    desired_extra.pop(key, None)
+                desired_extra.update({
+                    f"{resolution}_targets": resolution_candidates[:20],
+                    f"{resolution}_target_count": len(resolution_candidates),
+                    f"{resolution}_targets_truncated": (
+                        len(resolution_candidates) > 20
+                    ),
+                })
 
-            conn.execute(update_sql, (qualified, edge["id"]))
-            resolved += 1
+            serialized_extra = json.dumps(desired_extra, sort_keys=True)
+            if (
+                edge[endpoint] == desired_endpoint
+                and edge_extra == desired_extra
+            ):
+                continue
+            conn.execute(
+                f"UPDATE edges SET {endpoint_column} = ?, extra = ? WHERE id = ?",
+                (desired_endpoint, serialized_extra, edge["id"]),
+            )
+            changed = True
+            if len(supported) == 1 and edge[endpoint] != desired_endpoint:
+                resolved += 1
 
-        if resolved:
+        if changed:
             conn.commit()
+        if resolved:
             endpoint_label = (
                 "sources" if endpoint == "source_qualified" else "targets"
             )

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -687,104 +687,6 @@ class GraphStore:
         ]
         return supported[0] if len(supported) == 1 else None
 
-    def _resolve_python_import_targets(self) -> int:
-        """Resolve raw Python module imports against indexed repository files.
-
-        A module such as ``mypkg.runner`` may live below any source root
-        (``src/``, ``lib/``, or a monorepo package). Match by module suffix
-        after every file has been indexed, and only resolve a unique match.
-        """
-        conn = self._conn
-        python_files = [
-            row["file_path"]
-            for row in conn.execute(
-                "SELECT file_path FROM nodes "
-                "WHERE kind = 'File' AND language = 'python'"
-            ).fetchall()
-        ]
-        if not python_files:
-            return 0
-
-        modules: dict[str, set[str]] = {}
-        for file_path in python_files:
-            parts = [
-                part for part in file_path.replace("\\", "/").split("/")
-                if part
-            ]
-            if not parts:
-                continue
-            filename = parts[-1]
-            if filename == "__init__.py":
-                components = parts[:-1]
-            elif filename.endswith(".py"):
-                components = [*parts[:-1], filename[:-3]]
-            else:
-                continue
-            for start in range(len(components)):
-                modules.setdefault(
-                    ".".join(components[start:]), set(),
-                ).add(file_path)
-
-        rows = conn.execute(
-            "SELECT DISTINCT e.id, e.target_qualified, e.extra "
-            "FROM edges e JOIN nodes f "
-            "ON f.kind = 'File' AND f.file_path = e.file_path "
-            "WHERE e.kind = 'IMPORTS_FROM' AND f.language = 'python'"
-        ).fetchall()
-        changed = 0
-        python_file_set = set(python_files)
-        for edge in rows:
-            try:
-                extra = json.loads(edge["extra"] or "{}")
-            except (TypeError, json.JSONDecodeError):
-                extra = {}
-            if not isinstance(extra, dict):
-                extra = {}
-
-            raw_module = extra.get("python_module")
-            if not isinstance(raw_module, str):
-                raw_module = edge["target_qualified"]
-                if (
-                    raw_module in python_file_set
-                    or raw_module.startswith(".")
-                    or "/" in raw_module
-                    or "\\" in raw_module
-                ):
-                    continue
-
-            candidates = sorted(modules.get(raw_module, ()))
-            desired_extra = dict(extra)
-            desired_extra["python_module"] = raw_module
-            if len(candidates) == 1:
-                desired_target = candidates[0]
-                desired_extra["import_resolution"] = "repository_suffix"
-                desired_extra.pop("import_candidates", None)
-                desired_extra.pop("import_candidate_count", None)
-                desired_extra.pop("import_candidates_truncated", None)
-            else:
-                desired_target = raw_module
-                desired_extra["import_resolution"] = (
-                    "ambiguous" if candidates else "unresolved"
-                )
-                desired_extra["import_candidates"] = candidates[:20]
-                desired_extra["import_candidate_count"] = len(candidates)
-                desired_extra["import_candidates_truncated"] = len(candidates) > 20
-
-            if (
-                edge["target_qualified"] == desired_target
-                and extra == desired_extra
-            ):
-                continue
-            conn.execute(
-                "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
-                (desired_target, json.dumps(desired_extra, sort_keys=True), edge["id"]),
-            )
-            changed += 1
-
-        if changed:
-            conn.commit()
-        return changed
-
     def resolve_bare_call_targets(self) -> int:
         """Resolve bare CALLS targets backed by same-file or import evidence.
 
@@ -796,7 +698,6 @@ class GraphStore:
 
         Returns the number of resolved edges.
         """
-        self._resolve_python_import_targets()
         return self._resolve_bare_endpoints("CALLS", "target_qualified")
 
     def resolve_cpp_scoped_call_targets(self) -> int:

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -960,13 +960,35 @@ class GraphStore:
 
         # call-site file -> explicitly imported files
         import_targets: dict[str, set[str]] = {}
+        # Python's repository-suffix resolver keeps a raw import when multiple
+        # indexed modules match and records the candidate files in edge metadata.
+        # Carry that evidence into bare CALLS / TESTED_BY endpoints so a graph
+        # first built in the ambiguous state cannot fall back to a name-only
+        # caller match for every candidate.
+        ambiguous_import_targets: dict[str, set[str]] = {}
         for row in conn.execute(
-            "SELECT DISTINCT file_path, target_qualified FROM edges "
+            "SELECT DISTINCT file_path, target_qualified, extra FROM edges "
             "WHERE kind = 'IMPORTS_FROM'"
         ).fetchall():
             target = row["target_qualified"]
             target_file = target.split("::", 1)[0] if "::" in target else target
             import_targets.setdefault(row["file_path"], set()).add(target_file)
+            try:
+                import_extra = json.loads(row["extra"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                import_extra = {}
+            if (
+                isinstance(import_extra, dict)
+                and import_extra.get("import_resolution") == "ambiguous"
+                and isinstance(import_extra.get("import_candidates"), list)
+            ):
+                ambiguous_import_targets.setdefault(
+                    row["file_path"], set(),
+                ).update(
+                    candidate
+                    for candidate in import_extra["import_candidates"]
+                    if isinstance(candidate, str)
+                )
 
         resolved = 0
         changed = False
@@ -995,8 +1017,19 @@ class GraphStore:
                 for qualified, candidate_file in candidates
                 if candidate_file == context_file or candidate_file in imported_files
             ]
+            ambiguous_files = ambiguous_import_targets.get(context_file, set())
+            ambiguity_supported = [
+                qualified
+                for qualified, candidate_file in candidates
+                if candidate_file in ambiguous_files
+            ]
             managed = raw_key in edge_extra
-            if len(supported) != 1 and not managed and len(supported) < 2:
+            if (
+                len(supported) != 1
+                and not managed
+                and len(supported) < 2
+                and not ambiguity_supported
+            ):
                 continue
             desired_extra = dict(edge_extra)
             desired_extra[raw_key] = bare_name
@@ -1017,6 +1050,18 @@ class GraphStore:
                     resolution = "ambiguous"
                     resolution_candidates = supported
                     other = "unresolved"
+                elif ambiguity_supported:
+                    resolution = (
+                        "ambiguous"
+                        if len(ambiguity_supported) > 1
+                        else "unresolved"
+                    )
+                    resolution_candidates = ambiguity_supported
+                    other = (
+                        "unresolved"
+                        if resolution == "ambiguous"
+                        else "ambiguous"
+                    )
                 else:
                     resolution = "unresolved"
                     resolution_candidates = [

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1255,7 +1255,10 @@ def incremental_update(
         store.commit()
 
     # Only re-run language-specific resolvers when the relevant files changed.
-    python_changed = any(rp.endswith(".py") for rp in all_files)
+    python_changed = any(
+        path.endswith(".py")
+        for path in set(all_files) | set(stale_files) | missing_paths
+    )
     python_stats = _run_python_resolver(store) if python_changed else None
 
     rescript_changed = any(

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -76,6 +76,16 @@ CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
 
 
+def _run_python_resolver(store: GraphStore) -> Optional[dict]:
+    """Run repository-wide Python import resolution without failing a build."""
+    try:
+        from .python_resolver import resolve_python_imports
+        return resolve_python_imports(store)
+    except Exception as exc:  # noqa: BLE001 - best-effort post-pass
+        logger.warning("Python import resolver failed: %s", exc)
+        return None
+
+
 def _run_rescript_resolver(store: GraphStore) -> Optional[dict]:
     """Run the ReScript cross-module resolver, swallowing any failure so
     build never fails because of it. Returns stats or None on error.
@@ -1073,6 +1083,7 @@ def full_build(
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
+    python_stats = _run_python_resolver(store)
     rescript_stats = _run_rescript_resolver(store)
     spring_stats = _run_spring_resolver(store)
     spring_event_stats = _run_spring_event_resolver(store)
@@ -1086,6 +1097,7 @@ def full_build(
         "total_nodes": total_nodes,
         "total_edges": total_edges,
         "errors": errors,
+        "python_resolution": python_stats,
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
         "event_resolution": spring_event_stats,
@@ -1122,6 +1134,7 @@ def incremental_update(
             "dependent_files": [],
             "errors": rebuilt["errors"],
             "identity_rebuild": True,
+            "python_resolution": rebuilt["python_resolution"],
             "rescript_resolution": rebuilt["rescript_resolution"],
             "spring_resolution": rebuilt["spring_resolution"],
             "event_resolution": rebuilt["event_resolution"],
@@ -1242,6 +1255,9 @@ def incremental_update(
         store.commit()
 
     # Only re-run language-specific resolvers when the relevant files changed.
+    python_changed = any(rp.endswith(".py") for rp in all_files)
+    python_stats = _run_python_resolver(store) if python_changed else None
+
     rescript_changed = any(
         rp.endswith((".res", ".resi")) for rp in all_files
     )
@@ -1268,6 +1284,7 @@ def incremental_update(
         "dependent_files": list(dependent_files),
         "stale_files_removed": len(stale_files),
         "errors": errors,
+        "python_resolution": python_stats,
         "rescript_resolution": rescript_stats,
         "spring_resolution": spring_stats,
         "event_resolution": spring_event_stats,

--- a/code_review_graph/python_resolver.py
+++ b/code_review_graph/python_resolver.py
@@ -1,0 +1,123 @@
+"""Post-build resolution for repository-local Python imports."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .graph import GraphStore
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_python_imports(store: GraphStore) -> dict[str, int]:
+    """Resolve raw Python modules by unique repository-wide path suffix."""
+    conn = store._conn  # intentional: bounded post-build maintenance pass
+    python_files = [
+        row["file_path"]
+        for row in conn.execute(
+            "SELECT file_path FROM nodes "
+            "WHERE kind = 'File' AND language = 'python'"
+        ).fetchall()
+    ]
+    if not python_files:
+        return {
+            "files_indexed": 0,
+            "imports_updated": 0,
+            "imports_resolved": 0,
+            "imports_ambiguous": 0,
+        }
+
+    modules: dict[str, set[str]] = {}
+    for file_path in python_files:
+        parts = [
+            part for part in file_path.replace("\\", "/").split("/") if part
+        ]
+        if not parts:
+            continue
+        filename = parts[-1]
+        if filename == "__init__.py":
+            components = parts[:-1]
+        elif filename.endswith(".py"):
+            components = [*parts[:-1], filename[:-3]]
+        else:
+            continue
+        for start in range(len(components)):
+            modules.setdefault(".".join(components[start:]), set()).add(file_path)
+
+    updates: list[tuple[str, str, int]] = []
+    resolved = 0
+    ambiguous = 0
+    python_file_set = set(python_files)
+    for edge in conn.execute(
+        "SELECT DISTINCT e.id, e.target_qualified, e.extra "
+        "FROM edges e JOIN nodes f "
+        "ON f.kind = 'File' AND f.file_path = e.file_path "
+        "WHERE e.kind = 'IMPORTS_FROM' AND f.language = 'python'"
+    ).fetchall():
+        try:
+            extra = json.loads(edge["extra"] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            extra = {}
+        if not isinstance(extra, dict):
+            extra = {}
+
+        raw_module = extra.get("python_module")
+        if not isinstance(raw_module, str):
+            raw_module = edge["target_qualified"]
+            if (
+                raw_module in python_file_set
+                or raw_module.startswith(".")
+                or "/" in raw_module
+                or "\\" in raw_module
+            ):
+                continue
+
+        candidates = sorted(modules.get(raw_module, ()))
+        desired_extra = dict(extra)
+        desired_extra["python_module"] = raw_module
+        if len(candidates) == 1:
+            desired_target = candidates[0]
+            desired_extra["import_resolution"] = "repository_suffix"
+            desired_extra.pop("import_candidates", None)
+            desired_extra.pop("import_candidate_count", None)
+            desired_extra.pop("import_candidates_truncated", None)
+        else:
+            desired_target = raw_module
+            desired_extra["import_resolution"] = (
+                "ambiguous" if candidates else "unresolved"
+            )
+            desired_extra["import_candidates"] = candidates[:20]
+            desired_extra["import_candidate_count"] = len(candidates)
+            desired_extra["import_candidates_truncated"] = len(candidates) > 20
+
+        if edge["target_qualified"] == desired_target and extra == desired_extra:
+            continue
+        updates.append((
+            desired_target,
+            json.dumps(desired_extra, sort_keys=True),
+            edge["id"],
+        ))
+        if len(candidates) == 1:
+            resolved += 1
+        elif candidates:
+            ambiguous += 1
+
+    conn.executemany(
+        "UPDATE edges SET target_qualified = ?, extra = ? WHERE id = ?",
+        updates,
+    )
+    if updates:
+        conn.commit()
+        store._invalidate_cache()
+
+    result = {
+        "files_indexed": len(python_files),
+        "imports_updated": len(updates),
+        "imports_resolved": resolved,
+        "imports_ambiguous": ambiguous,
+    }
+    logger.info("Python import resolution: %s", result)
+    return result

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -389,7 +389,9 @@ def query_graph(
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
                         if caller:
-                            add_result(node_to_dict(caller), e)
+                            result = node_to_dict(caller)
+                            result["target_resolution"] = "unresolved"
+                            add_result(result, e)
 
         elif pattern == "callees_of":
             seen_targets: set[str] = set()
@@ -529,6 +531,7 @@ def query_graph(
                 if t.qualified_name not in seen and t.is_test:
                     result = node_to_dict(t)
                     result["indirect"] = False
+                    result["inferred_by"] = "naming_convention"
                     add_result(result)
                     seen.add(t.qualified_name)
 

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -389,9 +389,9 @@ def query_graph(
                         seen_sources.add(e.source_qualified)
                         caller = store.get_node(e.source_qualified)
                         if caller:
-                            result = node_to_dict(caller)
-                            result["target_resolution"] = "unresolved"
-                            add_result(result, e)
+                            caller_result = node_to_dict(caller)
+                            caller_result["target_resolution"] = "unresolved"
+                            add_result(caller_result, e)
 
         elif pattern == "callees_of":
             seen_targets: set[str] = set()

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -324,15 +324,8 @@ class TestToolBuildUsesSharedPipeline:
                 "code_review_graph.incremental.get_all_tracked_files",
                 return_value=tracked,
             ):
-                full_build(tmp_path, store)
-            run_post_processing(store)
-
-            production = f"{runner}::render_thing"
-            tests = store.get_transitive_tests(production, max_depth=0)
-            assert {test["name"] for test in tests} == {
-                "test_render_thing_basic",
-                "test_pipeline_uses_uppercase",
-            }
+                result = full_build(tmp_path, store)
+            assert result["python_resolution"]["imports_resolved"] == 1
             assert {
                 row["target_qualified"]
                 for row in store._conn.execute(
@@ -342,17 +335,23 @@ class TestToolBuildUsesSharedPipeline:
                 ).fetchall()
             } == {str(runner)}
 
+            run_post_processing(store)
+            production = f"{runner}::render_thing"
+            tests = store.get_transitive_tests(production, max_depth=0)
+            assert {test["name"] for test in tests} == {
+                "test_render_thing_basic",
+                "test_pipeline_uses_uppercase",
+            }
+
             duplicate = tmp_path / "packages" / "other" / "src" / "mypkg" / "runner.py"
             duplicate.parent.mkdir(parents=True)
             duplicate.write_text(runner.read_text())
-            incremental_update(
+            update = incremental_update(
                 tmp_path,
                 store,
                 changed_files=["packages/other/src/mypkg/runner.py"],
             )
-            run_post_processing(store)
-
-            assert store.get_transitive_tests(production, max_depth=0) == []
+            assert update["python_resolution"]["imports_ambiguous"] == 1
             imported = store._conn.execute(
                 "SELECT target_qualified, extra FROM edges "
                 "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
@@ -360,6 +359,30 @@ class TestToolBuildUsesSharedPipeline:
             ).fetchone()
             assert imported["target_qualified"] == "mypkg.runner"
             assert '"import_resolution": "ambiguous"' in imported["extra"]
+
+            run_post_processing(store)
+            assert store.get_transitive_tests(production, max_depth=0) == []
+
+            duplicate.unlink()
+            update = incremental_update(
+                tmp_path,
+                store,
+                changed_files=["packages/other/src/mypkg/runner.py"],
+            )
+            assert update["python_resolution"]["imports_resolved"] == 1
+            imported = store._conn.execute(
+                "SELECT target_qualified FROM edges "
+                "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                (str(test_file),),
+            ).fetchone()
+            assert imported["target_qualified"] == str(runner)
+
+            run_post_processing(store)
+            tests = store.get_transitive_tests(production, max_depth=0)
+            assert {test["name"] for test in tests} == {
+                "test_render_thing_basic",
+                "test_pipeline_uses_uppercase",
+            }
         finally:
             store.close()
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from code_review_graph.graph import GraphStore
-from code_review_graph.incremental import full_build
+from code_review_graph.incremental import full_build, incremental_update
 from code_review_graph.parser import EdgeInfo, NodeInfo
 from code_review_graph.postprocessing import run_post_processing
 
@@ -289,6 +289,77 @@ class TestToolBuildUsesSharedPipeline:
 
             assert len(unsigned_before_pp) > 0
             assert len(unsigned_after_pp) == 0
+        finally:
+            store.close()
+
+    def test_src_layout_imports_resolve_before_test_coverage(self, tmp_path):
+        runner = tmp_path / "src" / "mypkg" / "runner.py"
+        test_file = tmp_path / "tests" / "test_runner.py"
+        runner.parent.mkdir(parents=True)
+        test_file.parent.mkdir()
+        (runner.parent / "__init__.py").write_text("")
+        runner.write_text(
+            "def render_thing(code: str) -> str:\n"
+            "    return code.upper()\n"
+        )
+        test_file.write_text(
+            "from mypkg.runner import render_thing\n\n"
+            "def test_render_thing_basic():\n"
+            "    assert render_thing('a') == 'A'\n\n"
+            "def test_pipeline_uses_uppercase():\n"
+            "    assert render_thing('bc') == 'BC'\n"
+        )
+        (tmp_path / ".git").mkdir()
+        graph_dir = tmp_path / ".code-review-graph"
+        graph_dir.mkdir()
+
+        store = GraphStore(graph_dir / "graph.db")
+        try:
+            tracked = [
+                "src/mypkg/__init__.py",
+                "src/mypkg/runner.py",
+                "tests/test_runner.py",
+            ]
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=tracked,
+            ):
+                full_build(tmp_path, store)
+            run_post_processing(store)
+
+            production = f"{runner}::render_thing"
+            tests = store.get_transitive_tests(production, max_depth=0)
+            assert {test["name"] for test in tests} == {
+                "test_render_thing_basic",
+                "test_pipeline_uses_uppercase",
+            }
+            assert {
+                row["target_qualified"]
+                for row in store._conn.execute(
+                    "SELECT target_qualified FROM edges "
+                    "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                    (str(test_file),),
+                ).fetchall()
+            } == {str(runner)}
+
+            duplicate = tmp_path / "packages" / "other" / "src" / "mypkg" / "runner.py"
+            duplicate.parent.mkdir(parents=True)
+            duplicate.write_text(runner.read_text())
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["packages/other/src/mypkg/runner.py"],
+            )
+            run_post_processing(store)
+
+            assert store.get_transitive_tests(production, max_depth=0) == []
+            imported = store._conn.execute(
+                "SELECT target_qualified, extra FROM edges "
+                "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                (str(test_file),),
+            ).fetchone()
+            assert imported["target_qualified"] == "mypkg.runner"
+            assert '"import_resolution": "ambiguous"' in imported["extra"]
         finally:
             store.close()
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -386,6 +386,84 @@ class TestToolBuildUsesSharedPipeline:
         finally:
             store.close()
 
+    def test_initial_ambiguous_python_import_has_no_claimed_caller(self, tmp_path):
+        """A graph first built with duplicate module suffixes must stay ambiguous."""
+        from code_review_graph.tools.query import query_graph
+
+        production_files = []
+        for package in ("a", "b"):
+            runner = (
+                tmp_path
+                / "packages"
+                / package
+                / "src"
+                / "mypkg"
+                / "runner.py"
+            )
+            runner.parent.mkdir(parents=True)
+            runner.write_text(
+                "def render_thing(code: str) -> str:\n"
+                "    return code.upper()\n"
+            )
+            production_files.append(runner)
+
+        test_file = tmp_path / "tests" / "test_runner.py"
+        test_file.parent.mkdir()
+        test_file.write_text(
+            "from mypkg.runner import render_thing\n\n"
+            "def test_pipeline():\n"
+            "    assert render_thing('bc') == 'BC'\n"
+        )
+        (tmp_path / ".git").mkdir()
+        graph_dir = tmp_path / ".code-review-graph"
+        graph_dir.mkdir()
+        tracked = [
+            *(str(path.relative_to(tmp_path)) for path in production_files),
+            "tests/test_runner.py",
+        ]
+
+        store = GraphStore(graph_dir / "graph.db")
+        try:
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=tracked,
+            ):
+                result = full_build(tmp_path, store)
+            assert result["python_resolution"]["imports_ambiguous"] == 1
+            run_post_processing(store)
+
+            import_edge = store._conn.execute(
+                "SELECT target_qualified, extra FROM edges "
+                "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                (str(test_file),),
+            ).fetchone()
+            assert import_edge["target_qualified"] == "mypkg.runner"
+            assert '"import_resolution": "ambiguous"' in import_edge["extra"]
+
+            endpoint_edges = store._conn.execute(
+                "SELECT kind, extra FROM edges "
+                "WHERE kind IN ('CALLS', 'TESTED_BY') AND file_path = ?",
+                (str(test_file),),
+            ).fetchall()
+            assert {row["kind"] for row in endpoint_edges} == {
+                "CALLS",
+                "TESTED_BY",
+            }
+            assert all(
+                '"ambiguous_target_count": 2' in row["extra"]
+                for row in endpoint_edges
+            )
+
+            for runner in production_files:
+                callers = query_graph(
+                    pattern="callers_of",
+                    target=f"{runner}::render_thing",
+                    repo_root=str(tmp_path),
+                )
+                assert callers["results"] == []
+        finally:
+            store.close()
+
 
 class TestWatchCallbackIntegration:
     def test_watch_accepts_callback_parameter(self):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -418,6 +418,62 @@ class TestWatchCallbackIntegration:
         finally:
             store.close()
 
+    def test_watch_deletion_reresolves_python_imports(self, tmp_path):
+        from code_review_graph.incremental import full_build, watch
+
+        runner = tmp_path / "src" / "mypkg" / "runner.py"
+        duplicate = tmp_path / "packages" / "other" / "src" / "mypkg" / "runner.py"
+        test_file = tmp_path / "tests" / "test_runner.py"
+        runner.parent.mkdir(parents=True)
+        duplicate.parent.mkdir(parents=True)
+        test_file.parent.mkdir()
+        (runner.parent / "__init__.py").write_text("")
+        runner.write_text("def render_thing(code: str) -> str:\n    return code.upper()\n")
+        duplicate.write_text(runner.read_text())
+        test_file.write_text(
+            "from mypkg.runner import render_thing\n\n"
+            "def test_render_thing():\n"
+            "    assert render_thing('a') == 'A'\n"
+        )
+        (tmp_path / ".git").mkdir()
+        store = GraphStore(tmp_path / "graph.db")
+        observer = MagicMock()
+
+        try:
+            tracked = [
+                "src/mypkg/__init__.py",
+                "src/mypkg/runner.py",
+                "packages/other/src/mypkg/runner.py",
+                "tests/test_runner.py",
+            ]
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=tracked,
+            ):
+                full_build(tmp_path, store)
+            run_post_processing(store)
+            duplicate.unlink()
+
+            with (
+                patch("watchdog.observers.Observer", return_value=observer),
+                patch("time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                watch(tmp_path, store, on_files_updated=run_post_processing)
+
+            imported = store._conn.execute(
+                "SELECT target_qualified FROM edges "
+                "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                (str(test_file),),
+            ).fetchone()
+            assert imported["target_qualified"] == str(runner)
+            tests = store.get_transitive_tests(
+                f"{runner}::render_thing",
+                max_depth=0,
+            )
+            assert {test["name"] for test in tests} == {"test_render_thing"}
+        finally:
+            store.close()
+
 
 class TestResolveBareEndpointsStep:
     """The shared/watch pipeline resolves evidence-backed bare endpoints."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -319,6 +319,9 @@ class TestQueryGraphCallTargetFallbacks:
         names = {r["name"] for r in result["results"]}
         assert names == {"same_file_caller", "cross_file_caller"}
         assert len(result["results"]) == 2
+        by_name = {r["name"]: r for r in result["results"]}
+        assert "target_resolution" not in by_name["same_file_caller"]
+        assert by_name["cross_file_caller"]["target_resolution"] == "unresolved"
 
         edge_targets = {e["target"] for e in result["edges"]}
         assert edge_targets == {f"{self.target_file}::target_func", "target_func"}
@@ -595,6 +598,11 @@ class TestQueryGraphTestsFor:
             line_start=1, line_end=5, language="python", is_test=True,
         ))
         self.store.upsert_node(NodeInfo(
+            kind="Test", name="test_combine",
+            file_path="/tests/spec.py",
+            line_start=7, line_end=10, language="python", is_test=True,
+        ))
+        self.store.upsert_node(NodeInfo(
             kind="Function", name="shared_name", file_path="/src/first.py",
             line_start=1, line_end=5, language="python",
         ))
@@ -638,6 +646,18 @@ class TestQueryGraphTestsFor:
             "line_start", "line_end", "language", "parent_name", "is_test",
             "indirect",
         }
+
+    def test_query_graph_marks_naming_only_test_as_inferred(self):
+        from code_review_graph.tools import query_graph
+
+        result = query_graph(
+            pattern="tests_for",
+            target="/src/calc.py::combine",
+            repo_root=str(self.repo_root),
+        )
+
+        match = next(r for r in result["results"] if r["name"] == "test_combine")
+        assert match["inferred_by"] == "naming_convention"
 
     def test_query_graph_tests_for_finds_one_hop_indirect_test(self):
         from code_review_graph.tools import query_graph


### PR DESCRIPTION
Corrected integration of #749 on current main.

All four MerlinH contributor commits are preserved. The original resolver now works with the new serialized watch lifecycle and keeps src/, lib/, nested monorepo, and Windows-style paths. The maintainer correction fixes one safety gap found by end-to-end testing: if two matching modules exist from the initial full build, IMPORTS_FROM ambiguity is propagated to bare CALLS and TESTED_BY endpoints, so callers_of does not falsely attribute the same test to both production functions.

Validation:
- new initial-build ambiguity regression failed before the correction and passes after it
- unique↔ambiguous transitions and offline deletion pass
- 309 affected tests passed; 1 skipped where applicable
- real process-pool parity passed
- Ruff and diff checks passed
- full graph/post-process: 247 files, 4,845 nodes, 39,053 edges, 191 communities

Original contribution: #749

Closes #720