### PR TITLE
feat(parser): extract dbt model dependencies safely (#739)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2303,6 +2303,7 @@ class CodeParser:
 
     def __init__(self, repo_root: Optional[Path] = None) -> None:
         self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
+        self._dbt_model_paths_cache: dict[Path, tuple[Path, ...]] = {}
         self._parsers: dict[str, object] = {}
         self._module_file_cache: dict[str, Optional[str]] = {}
         self._export_symbol_cache: dict[str, Optional[str]] = {}
@@ -4068,10 +4069,11 @@ class CodeParser:
         Data dependencies (FROM/JOIN table references) are recorded as
         IMPORTS_FROM edges so the impact-radius query can follow them.
 
-        dbt models (detected by {{ ref() }} / {{ source() }} calls in the
-        file) use a dedicated extraction instead: one Class node per model,
-        named after the file stem, with IMPORTS_FROM edges from the Jinja
-        dependency calls.
+        dbt models use a dedicated extraction instead: one Class node per
+        model, named after the file stem, with IMPORTS_FROM edges from the
+        Jinja dependency calls. Within a dbt project, model membership comes
+        from ``model-paths`` in ``dbt_project.yml``; without project context,
+        a ``ref()`` / ``source()`` call remains a best-effort content signal.
         """
         text = source.decode("utf-8", errors="replace")
         file_path_str = str(path)
@@ -4096,7 +4098,8 @@ class CodeParser:
         # and the plain-SQL passes below would only pick up CTE names as
         # phantom IMPORTS_FROM targets. Handle it separately and skip them.
         dbt_refs = list(_DBT_REF_RE.finditer(text))
-        if dbt_refs:
+        dbt_model_path = self._is_dbt_model_path(path)
+        if dbt_model_path is True or (dbt_model_path is None and dbt_refs):
             self._extract_dbt_model(
                 path, text, dbt_refs, file_path_str, test_file, nodes, edges,
             )
@@ -4151,6 +4154,64 @@ class CodeParser:
 
         return nodes, edges
 
+    def _is_dbt_model_path(self, path: Path) -> Optional[bool]:
+        """Return whether *path* belongs to a configured dbt model directory.
+
+        ``None`` means there is no enclosing dbt project in this parser's
+        repository context, so callers may use content sniffing as a fallback.
+        """
+        if self._repo_root is None:
+            return None
+
+        resolved_path = path.resolve()
+        try:
+            resolved_path.relative_to(self._repo_root)
+        except ValueError:
+            return None
+
+        directory = resolved_path.parent
+        while True:
+            project_file = directory / "dbt_project.yml"
+            if project_file.is_file():
+                return any(
+                    resolved_path.is_relative_to(model_path)
+                    for model_path in self._dbt_model_paths(project_file)
+                )
+            if directory == self._repo_root:
+                return None
+            parent = directory.parent
+            if parent == directory or not parent.is_relative_to(self._repo_root):
+                return None
+            directory = parent
+
+    def _dbt_model_paths(self, project_file: Path) -> tuple[Path, ...]:
+        """Read and cache the model directories for one dbt project."""
+        cached = self._dbt_model_paths_cache.get(project_file)
+        if cached is not None:
+            return cached
+
+        configured_paths: object = ["models"]
+        if _yaml is not None:
+            try:
+                config = _yaml.safe_load(project_file.read_text(encoding="utf-8"))
+                if isinstance(config, dict):
+                    configured_paths = config.get("model-paths", ["models"])
+            except (OSError, _yaml.YAMLError):
+                configured_paths = ["models"]
+
+        if isinstance(configured_paths, str):
+            configured_paths = [configured_paths]
+        if not isinstance(configured_paths, list):
+            configured_paths = ["models"]
+
+        model_paths = tuple(
+            (project_file.parent / configured_path).resolve()
+            for configured_path in configured_paths
+            if isinstance(configured_path, str) and configured_path
+        )
+        self._dbt_model_paths_cache[project_file] = model_paths
+        return model_paths
+
     def _extract_dbt_model(
         self,
         path: Path,
@@ -4164,11 +4225,10 @@ class CodeParser:
         """Extract a dbt model file: one Class node plus its Jinja deps.
 
         dbt materializes each model file as a table or view named after the
-        file stem, and model names are unique project-wide, so the stem is
-        the node name — which lets a `{{ ref('other_model') }}` edge resolve
-        against the referenced model's node by bare name.
+        file stem, so the stem is the node name.
 
-        - `{{ ref('m') }}` / `{{ ref('pkg', 'm') }}` → IMPORTS_FROM target `m`
+        - `{{ ref('m') }}` → IMPORTS_FROM target `m`
+        - `{{ ref('pkg', 'm') }}` → IMPORTS_FROM target `pkg.m`
         - `{{ source('src', 'tbl') }}` → IMPORTS_FROM target `src.tbl`
           (kept qualified: sources are external tables, not project models,
           so the target must not collide with a model node of the same name)
@@ -4200,9 +4260,10 @@ class CodeParser:
                 if second_arg is None:
                     continue  # source() requires two args; malformed call
                 target = f"{first_arg}.{second_arg}"
+            elif second_arg is not None:
+                target = f"{first_arg}.{second_arg}"
             else:
-                # ref('model') or ref('package', 'model') — model is last.
-                target = second_arg if second_arg is not None else first_arg
+                target = first_arg
             if target and target != model_name and target not in seen_targets:
                 seen_targets.add(target)
                 edges.append(EdgeInfo(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -56,6 +56,16 @@ _SQL_TABLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# dbt model dependencies: {{ ref('model') }}, {{ ref('package', 'model') }}
+# and {{ source('source_name', 'table') }}. String-literal arguments only —
+# dynamic ref() calls cannot be resolved statically.
+_DBT_REF_RE = re.compile(
+    r"\{\{-?\s*(ref|source)\s*\(\s*"
+    r"['\"]([^'\"]+)['\"]"
+    r"(?:\s*,\s*['\"]([^'\"]+)['\"])?"
+    r"\s*\)",
+)
+
 _PYTHON_STAR_CACHE_MAX = 15_000
 _PYTHON_STAR_EXPORT_CACHE: dict[tuple[str, int, int], dict[str, str]] = {}
 _PYTHON_STAR_EXPORT_CACHE_LOCK = threading.RLock()
@@ -4057,6 +4067,11 @@ class CodeParser:
 
         Data dependencies (FROM/JOIN table references) are recorded as
         IMPORTS_FROM edges so the impact-radius query can follow them.
+
+        dbt models (detected by {{ ref() }} / {{ source() }} calls in the
+        file) use a dedicated extraction instead: one Class node per model,
+        named after the file stem, with IMPORTS_FROM edges from the Jinja
+        dependency calls.
         """
         text = source.decode("utf-8", errors="replace")
         file_path_str = str(path)
@@ -4074,6 +4089,18 @@ class CodeParser:
             language="sql",
             is_test=test_file,
         ))
+
+        # --- dbt model pass ---
+        # A dbt model has no DDL (dbt wraps the SELECT at build time), its
+        # dependencies live in Jinja calls the FROM/JOIN regex cannot see,
+        # and the plain-SQL passes below would only pick up CTE names as
+        # phantom IMPORTS_FROM targets. Handle it separately and skip them.
+        dbt_refs = list(_DBT_REF_RE.finditer(text))
+        if dbt_refs:
+            self._extract_dbt_model(
+                path, text, dbt_refs, file_path_str, test_file, nodes, edges,
+            )
+            return nodes, edges
 
         # --- tree-sitter pass ---
         parser = self._get_parser("sql")
@@ -4123,6 +4150,68 @@ class CodeParser:
                 ))
 
         return nodes, edges
+
+    def _extract_dbt_model(
+        self,
+        path: Path,
+        text: str,
+        dbt_refs: list[re.Match],
+        file_path_str: str,
+        test_file: bool,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+    ) -> None:
+        """Extract a dbt model file: one Class node plus its Jinja deps.
+
+        dbt materializes each model file as a table or view named after the
+        file stem, and model names are unique project-wide, so the stem is
+        the node name — which lets a `{{ ref('other_model') }}` edge resolve
+        against the referenced model's node by bare name.
+
+        - `{{ ref('m') }}` / `{{ ref('pkg', 'm') }}` → IMPORTS_FROM target `m`
+        - `{{ source('src', 'tbl') }}` → IMPORTS_FROM target `src.tbl`
+          (kept qualified: sources are external tables, not project models,
+          so the target must not collide with a model node of the same name)
+        """
+        model_name = path.stem
+        qualified = f"{file_path_str}::{model_name}"
+        nodes.append(NodeInfo(
+            kind="Class",
+            name=model_name,
+            file_path=file_path_str,
+            line_start=1,
+            line_end=text.count("\n") + 1,
+            language="sql",
+            is_test=test_file,
+            extra={"sql_kind": "dbt_model"},
+        ))
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=file_path_str,
+            target=qualified,
+            file_path=file_path_str,
+            line=1,
+        ))
+
+        seen_targets: set[str] = set()
+        for m in dbt_refs:
+            func, first_arg, second_arg = m.group(1), m.group(2), m.group(3)
+            if func == "source":
+                if second_arg is None:
+                    continue  # source() requires two args; malformed call
+                target = f"{first_arg}.{second_arg}"
+            else:
+                # ref('model') or ref('package', 'model') — model is last.
+                target = second_arg if second_arg is not None else first_arg
+            if target and target != model_name and target not in seen_targets:
+                seen_targets.add(target)
+                edges.append(EdgeInfo(
+                    kind="IMPORTS_FROM",
+                    source=file_path_str,
+                    target=target,
+                    file_path=file_path_str,
+                    line=text[: m.start()].count("\n") + 1,
+                ))
 
     def _walk_sql_tree(
         self,

--- a/tests/test_dbt_parser.py
+++ b/tests/test_dbt_parser.py
@@ -60,8 +60,21 @@ class TestDbtModelParsing:
         imports = {e.target for e in self.edges if e.kind == "IMPORTS_FROM"}
         assert imports == {
             "stg_orders",            # ref('stg_orders')
-            "dim_customers",         # ref('package', 'model') → model
+            "analytics_utils.dim_customers",  # ref('package', 'model')
             "core_db.payments",      # source() stays qualified
+        }
+
+    def test_package_qualified_refs_do_not_collide(self):
+        _, edges = self.parser.parse_bytes(
+            Path("models/package_refs.sql"),
+            b"select * from {{ ref('finance', 'dim_customers') }}\n"
+            b"union all\n"
+            b"select * from {{ ref('marketing', 'dim_customers') }}\n",
+        )
+        imports = {e.target for e in edges if e.kind == "IMPORTS_FROM"}
+        assert imports == {
+            "finance.dim_customers",
+            "marketing.dim_customers",
         }
 
     def test_cte_names_are_not_dependency_edges(self):
@@ -94,6 +107,11 @@ class TestDbtModelParsing:
 
 
 def test_full_build_links_dbt_models_by_ref(tmp_path: Path) -> None:
+    (tmp_path / "dbt_project.yml").write_text(
+        "name: analytics\n"
+        "config-version: 2\n",
+        encoding="utf-8",
+    )
     models = tmp_path / "models"
     models.mkdir()
     (models / "stg_orders.sql").write_text(
@@ -123,5 +141,47 @@ def test_full_build_links_dbt_models_by_ref(tmp_path: Path) -> None:
         }
         assert "stg_orders" in targets
         assert "orders" not in targets  # CTE name must not leak in
+    finally:
+        store.close()
+
+
+def test_full_build_includes_dbt_model_without_jinja_dependencies(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "dbt_project.yml").write_text(
+        "name: analytics\n"
+        "config-version: 2\n"
+        "model-paths: [warehouse_models]\n",
+        encoding="utf-8",
+    )
+    models = tmp_path / "warehouse_models"
+    models.mkdir()
+    base_model = models / "base_orders.sql"
+    base_model.write_text(
+        "select * from raw.orders\n",
+        encoding="utf-8",
+    )
+    outside_model_paths = tmp_path / "report.sql"
+    outside_model_paths.write_text(
+        "select * from {{ ref('base_orders') }}\n",
+        encoding="utf-8",
+    )
+
+    store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+    try:
+        full_build(tmp_path, store)
+
+        base_nodes = store.get_nodes_by_file(str(base_model))
+        assert any(
+            node.name == "base_orders"
+            and node.kind == "Class"
+            and node.extra.get("sql_kind") == "dbt_model"
+            for node in base_nodes
+        )
+        outside_nodes = store.get_nodes_by_file(str(outside_model_paths))
+        assert not any(
+            node.extra.get("sql_kind") == "dbt_model"
+            for node in outside_nodes
+        )
     finally:
         store.close()

--- a/tests/test_dbt_parser.py
+++ b/tests/test_dbt_parser.py
@@ -1,0 +1,127 @@
+"""dbt model SQL parser tests: {{ ref() }} / {{ source() }} extraction."""
+
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.parser import CodeParser
+
+DBT_MODEL = b"""\
+with
+
+source as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select * from {{ ref('analytics_utils', 'dim_customers') }}
+),
+
+payments as (
+    select * from {{ source('core_db', 'payments') }}
+),
+
+final as (
+    select
+        source.order_id,
+        customers.customer_id,
+        payments.amount
+    from source
+    left join customers on source.customer_id = customers.customer_id
+    left join payments on source.order_id = payments.order_id
+)
+
+select * from final
+"""
+
+
+class TestDbtModelParsing:
+    def setup_method(self):
+        self.parser = CodeParser()
+        self.nodes, self.edges = self.parser.parse_bytes(
+            Path("models/staging/fct_orders.sql"), DBT_MODEL,
+        )
+
+    def test_model_node_named_after_file_stem(self):
+        models = [
+            n for n in self.nodes
+            if n.kind == "Class" and n.extra.get("sql_kind") == "dbt_model"
+        ]
+        assert len(models) == 1
+        assert models[0].name == "fct_orders"
+        assert models[0].language == "sql"
+
+    def test_contains_edge(self):
+        contains = [e for e in self.edges if e.kind == "CONTAINS"]
+        targets = {e.target for e in contains}
+        assert "models/staging/fct_orders.sql::fct_orders" in targets
+
+    def test_ref_and_source_dependency_edges(self):
+        imports = {e.target for e in self.edges if e.kind == "IMPORTS_FROM"}
+        assert imports == {
+            "stg_orders",            # ref('stg_orders')
+            "dim_customers",         # ref('package', 'model') → model
+            "core_db.payments",      # source() stays qualified
+        }
+
+    def test_cte_names_are_not_dependency_edges(self):
+        # The FROM/JOIN regex pass must not run on dbt models: it would
+        # record the CTE names as phantom IMPORTS_FROM targets.
+        imports = {e.target for e in self.edges if e.kind == "IMPORTS_FROM"}
+        assert not imports & {"source", "customers", "payments", "final"}
+
+    def test_duplicate_refs_are_deduplicated(self):
+        nodes, edges = self.parser.parse_bytes(
+            Path("models/dupes.sql"),
+            b"select * from {{ ref('stg_orders') }}\n"
+            b"union all\n"
+            b"select * from {{ ref('stg_orders') }}\n",
+        )
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert [e.target for e in imports] == ["stg_orders"]
+
+    def test_plain_sql_without_jinja_keeps_ddl_extraction(self):
+        nodes, edges = self.parser.parse_bytes(
+            Path("schema.sql"),
+            b"CREATE TABLE users (id INT);\n"
+            b"CREATE VIEW active_users AS SELECT id FROM users;\n",
+        )
+        kinds = {n.extra.get("sql_kind") for n in nodes if n.kind == "Class"}
+        assert kinds == {"table", "view"}
+        assert not any(
+            n.extra.get("sql_kind") == "dbt_model" for n in nodes
+        )
+
+
+def test_full_build_links_dbt_models_by_ref(tmp_path: Path) -> None:
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "stg_orders.sql").write_text(
+        "select * from {{ source('core_db', 'orders') }}\n",
+        encoding="utf-8",
+    )
+    (models / "fct_orders.sql").write_text(
+        "with orders as (\n"
+        "    select * from {{ ref('stg_orders') }}\n"
+        ")\n"
+        "select * from orders\n",
+        encoding="utf-8",
+    )
+
+    store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+    try:
+        full_build(tmp_path, store)
+
+        model_names = {n.name for n in store.get_nodes_by_kind(["Class"])}
+        assert {"stg_orders", "fct_orders"} <= model_names
+
+        fct_file = str(models / "fct_orders.sql")
+        targets = {
+            e.target_qualified
+            for e in store.get_edges_by_source(fct_file)
+            if e.kind == "IMPORTS_FROM"
+        }
+        assert "stg_orders" in targets
+        assert "orders" not in targets  # CTE name must not leak in
+    finally:
+        store.close()


### PR DESCRIPTION
Corrected integration of #739 on current main.

The adamthuvesen contributor commit is preserved. The original dbt extraction is retained, with three correctness fixes found by end-to-end validation:
- `ref("package", "model")` keeps package identity instead of collapsing to a colliding bare model;
- every SQL model inside configured `model-paths` gets a dbt model node, even with no ref/source call;
- SQL outside dbt model paths is not misclassified merely because it contains a ref-like expression.

The parser reads the nearest dbt_project.yml and supports both default `models` and custom model paths. Direct content sniffing remains a fallback when no project context exists.

Validation:
- three regressions failed on the raw contributor commit and pass after correction
- 9 focused dbt tests passed
- 724 affected tests plus real process parity passed
- full suite: 2,205 passed, 1 skipped, 2 xpassed
- changed-file Ruff and diff checks passed
- exact-head graph: 247 files, 4,862 nodes, 39,027 edges

Original contribution: #739