### PR TITLE
fix(php): resolve PHPUnit coverage end to end (#747)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -530,10 +530,13 @@ class GraphStore:
         seen: set[str] = set()
         results: list[dict] = []
 
-        # If the input is a class, expand to its methods first.
+        # If the input is a class or file, expand to the production symbols it
+        # contains first. File targets are accepted by the public query tool,
+        # so tests_for("src/Foo.php") must cover methods nested under classes
+        # as well as top-level functions.
         input_qns = [qualified_name]
         row = conn.execute(
-            "SELECT kind FROM nodes WHERE qualified_name = ?",
+            "SELECT kind, file_path FROM nodes WHERE qualified_name = ?",
             (qualified_name,),
         ).fetchone()
         if row and row["kind"] == "Class":
@@ -543,6 +546,14 @@ class GraphStore:
                 (qualified_name,),
             ).fetchall():
                 input_qns.append(mrow["target_qualified"])
+        elif row and row["kind"] == "File":
+            for symbol in conn.execute(
+                "SELECT qualified_name FROM nodes "
+                "WHERE file_path = ? AND qualified_name != ? "
+                "AND kind IN ('Class', 'Function', 'Method')",
+                (row["file_path"], qualified_name),
+            ).fetchall():
+                input_qns.append(symbol["qualified_name"])
 
         def _node_dict(qn: str, indirect: bool) -> dict | None:
             row = conn.execute(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9627,6 +9627,9 @@ class CodeParser:
             decorators = tuple(deco_list)
 
         is_test = _is_test_function(name, file_path, decorators)
+        # PHPUnit's name convention is ``test*`` (not only ``test_*``).
+        if language == "php" and _is_test_file(file_path) and name.startswith("test"):
+            is_test = True
         kind = "Test" if is_test else "Function"
 
         parent_name = enclosing_class

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -9628,7 +9628,12 @@ class CodeParser:
 
         is_test = _is_test_function(name, file_path, decorators)
         # PHPUnit's name convention is ``test*`` (not only ``test_*``).
-        if language == "php" and _is_test_file(file_path) and name.startswith("test"):
+        if (
+            language == "php"
+            and child.type == "method_declaration"
+            and _is_test_file(file_path)
+            and name.startswith("test")
+        ):
             is_test = True
         kind = "Test" if is_test else "Function"
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4574,7 +4574,7 @@ class CodeParser:
         return resolved
 
     _TYPED_CALL_LANGUAGES = frozenset({
-        "python", "kotlin", "java", "javascript", "typescript", "tsx",
+        "python", "kotlin", "java", "javascript", "typescript", "tsx", "php",
     })
     _TRANSPARENT_TYPE_WRAPPERS = frozenset({"Annotated", "Optional", "Type"})
     _NON_RECEIVER_TYPE_NAMES = frozenset({
@@ -4595,9 +4595,11 @@ class CodeParser:
         """Collect evidence-backed targets for calls on typed receivers.
 
         The result is keyed by source line, receiver, and method so the normal
-        call extractor remains the single producer of CALLS edges. Only
-        repository-local imported types and same-file classes are qualified;
-        unknown or ambiguous types keep their existing bare targets.
+        call extractor remains the single producer of CALLS edges. Statically
+        typed receivers resolve directly when their class is repository-local.
+        PHP variables assigned from ``new Type`` retain a bare parse-time target
+        plus the constructed class scope for conservative graph-wide resolution.
+        Unknown or ambiguous types keep their existing bare targets.
         """
         if language not in self._TYPED_CALL_LANGUAGES:
             return {}
@@ -4611,6 +4613,7 @@ class CodeParser:
             "javascript": {"statement_block"},
             "typescript": {"statement_block"},
             "tsx": {"statement_block"},
+            "php": {"compound_statement"},
         }.get(language, set())
         targets: dict[tuple[int, str, str], tuple[str, str, str]] = {}
 
@@ -4647,11 +4650,18 @@ class CodeParser:
                 return
 
             new_bindings = self._typed_bindings_from_node(node, language)
-            if new_bindings:
+            assigned_names = (
+                self._php_assigned_variables(node)
+                if language == "php"
+                else set()
+            )
+            if new_bindings or assigned_names:
                 # Initializers are evaluated before their declaration becomes
                 # visible, so visit children with the previous environment.
                 for child in node.children:
                     walk(child, bindings, class_fields, depth + 1)
+                for name in assigned_names:
+                    bindings.pop(name, None)
                 bindings.update(new_bindings)
                 return
 
@@ -4661,7 +4671,11 @@ class CodeParser:
                 )
                 if receiver and method:
                     type_name = bindings.get(receiver)
-                    evidence = "typed_receiver"
+                    evidence = (
+                        "constructed_receiver"
+                        if language == "php"
+                        else "typed_receiver"
+                    )
                     if type_name is None and receiver[:1].isupper():
                         if receiver in import_map or receiver in defined_names:
                             type_name = receiver
@@ -4856,7 +4870,45 @@ class CodeParser:
                 node.child_by_field_name("type"),
             )
 
+        elif language == "php" and node.type == "assignment_expression":
+            name_node = node.child_by_field_name("left")
+            value_node = node.child_by_field_name("right")
+            if (
+                name_node is not None
+                and name_node.type == "variable_name"
+                and value_node is not None
+                and value_node.type == "object_creation_expression"
+            ):
+                type_node = next(
+                    (
+                        child
+                        for child in value_node.children
+                        if child.type in ("name", "qualified_name")
+                    ),
+                    None,
+                )
+                if type_node is not None:
+                    name = name_node.text.decode(
+                        "utf-8", errors="replace",
+                    )
+                    type_name = type_node.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip("\\")
+                    if name and type_name:
+                        result[name] = type_name
+
         return result
+
+    @staticmethod
+    def _php_assigned_variables(node) -> set[str]:
+        """Return simple PHP variables invalidated by one assignment."""
+        if node.type != "assignment_expression":
+            return set()
+        name_node = node.child_by_field_name("left")
+        if name_node is None or name_node.type != "variable_name":
+            return set()
+        name = name_node.text.decode("utf-8", errors="replace")
+        return {name} if name else set()
 
     @classmethod
     def _store_typed_binding(cls, result: dict[str, str], name_node, type_node) -> None:
@@ -4909,6 +4961,15 @@ class CodeParser:
         import_map: dict[str, str],
         defined_names: set[str],
     ) -> Optional[str]:
+        if language == "php":
+            normalized = type_name.strip("\\")
+            if not normalized:
+                return None
+            local_name = normalized.rsplit("\\", 1)[-1]
+            imported = import_map.get(local_name.casefold())
+            scope = imported or normalized
+            return f"{scope}::{method}"
+
         base_type = self._base_type_name(type_name)
         if not base_type:
             return None
@@ -4944,10 +5005,19 @@ class CodeParser:
                     "receiver_type": type_name,
                     "receiver_resolution": evidence_kind,
                 })
+                resolved_target = target
+                if evidence_kind == "constructed_receiver":
+                    # Keep PHP parse-only CALLS output backward-compatible
+                    # (bare method target) while preserving the constructed
+                    # class scope for the graph-wide resolver.
+                    scope, separator, _ = target.rpartition("::")
+                    if separator and scope:
+                        extra["receiver_scope"] = scope
+                    resolved_target = edge.target
                 edge = EdgeInfo(
                     kind=edge.kind,
                     source=edge.source,
-                    target=target,
+                    target=resolved_target,
                     file_path=edge.file_path,
                     line=edge.line,
                     extra=extra,
@@ -10099,6 +10169,22 @@ class CodeParser:
         receiver so class-field annotations can resolve them. More complex
         receiver expressions are deliberately left unresolved.
         """
+        if language == "php" and node.type in (
+            "member_call_expression",
+            "nullsafe_member_call_expression",
+        ):
+            receiver = node.child_by_field_name("object")
+            method = node.child_by_field_name("name")
+            if method is None:
+                return None, None
+            method_name = method.text.decode("utf-8", errors="replace")
+            if receiver is None or receiver.type != "variable_name":
+                return None, method_name
+            return (
+                receiver.text.decode("utf-8", errors="replace"),
+                method_name,
+            )
+
         if language == "rust" and node.type == "call_expression":
             callee = node.child_by_field_name("function")
             while callee is not None and callee.type == "generic_function":
@@ -12507,6 +12593,9 @@ class CodeParser:
             local_name = alias.strip() if separator else original.rsplit(".", 1)[-1]
             if local_name:
                 import_map[local_name] = original.strip()
+
+        elif language == "php":
+            import_map.update(self._php_import_bindings(node))
 
     def _collect_js_import_names(
         self, clause_node, module: str, import_map: dict[str, str],

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -1,4 +1,4 @@
-"""Post-build resolver for static/scoped ``Class::method`` calls.
+"""Post-build resolver for PHP/Rust scoped calls and constructed PHP receivers.
 
 Tree-sitter extraction records a scoped/static call such as ``Mailer::send($x)``
 (PHP) or ``Mailer::send(x)`` / ``Self::new()`` (Rust) as a ``CALLS`` edge whose
@@ -7,6 +7,11 @@ neither the canonical node key (``<file>::Class.method``) nor a bare method
 name, so ``callers_of``, ``get_impact_radius`` and ``tests_for`` never see the
 edge and report zero callers for a method that is obviously being called
 (GitHub #567).
+
+PHP instance calls keep their historical bare method target during parsing.
+When a local receiver was directly constructed (``$x = new Type(); $x->run()``),
+the parser stores the class as ``extra.receiver_scope`` and this pass uses that
+evidence to resolve the call without changing parse-only output (GitHub #745).
 
 This module runs after the graph is built and rewrites the resolvable
 ``Class::method`` targets to the canonical qualified name of the defined
@@ -217,7 +222,7 @@ def _scope_and_method(
 
 
 def resolve_scoped_calls(store: GraphStore) -> dict:
-    """Rewrite resolvable ``Class::method`` CALLS targets to node qualified names.
+    """Rewrite evidence-backed scoped CALLS targets to node qualified names.
 
     Safe to call repeatedly — rewritten edges start with a path head (and carry
     ``extra.scoped_resolved``), so they are no longer treated as candidates.
@@ -322,7 +327,7 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         return None
 
     calls_rows = conn.execute(
-        "SELECT id, source_qualified, target_qualified, extra, file_path "
+        "SELECT id, source_qualified, target_qualified, extra, file_path, line "
         "FROM edges WHERE kind = 'CALLS'"
     ).fetchall()
 
@@ -332,10 +337,26 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         if language is None:
             continue
         target = row["target_qualified"]
-        if not _is_unresolved_scoped_target(target):
+        try:
+            extra = json.loads(row["extra"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            extra = {}
+        if not isinstance(extra, dict):
+            extra = {}
+
+        resolution_target = target
+        receiver_scope = extra.get("receiver_scope")
+        if (
+            language == "php"
+            and "::" not in target
+            and isinstance(receiver_scope, str)
+            and receiver_scope
+        ):
+            resolution_target = f"{receiver_scope}::{target}"
+        elif not _is_unresolved_scoped_target(target):
             continue
 
-        parsed = _scope_and_method(target, language)
+        parsed = _scope_and_method(resolution_target, language)
         if parsed is None:
             continue
         class_name, method, needs_enclosing = parsed
@@ -364,22 +385,37 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
                 continue
             via = "import"
 
-        try:
-            extra = json.loads(row["extra"] or "{}")
-        except (json.JSONDecodeError, TypeError):
-            extra = {}
         extra["scoped_resolved"] = True
         extra["scoped_via"] = via
+        serialized_extra = json.dumps(extra)
 
         conn.execute(
             "UPDATE edges SET target_qualified = ?, extra = ?, "
             "confidence_tier = 'INFERRED' WHERE id = ?",
-            (new_target, json.dumps(extra), row["id"]),
+            (new_target, serialized_extra, row["id"]),
+        )
+        # The parser mirrors calls made by Test nodes as TESTED_BY edges.
+        # Keep that mirror aligned when a scoped target becomes canonical;
+        # otherwise public tests_for still sees the original Class::method
+        # source even though callers_of sees the resolved CALLS target.
+        conn.execute(
+            "UPDATE edges SET source_qualified = ?, extra = ?, "
+            "confidence_tier = 'INFERRED' "
+            "WHERE kind = 'TESTED_BY' AND source_qualified = ? "
+            "AND target_qualified = ? AND file_path = ? AND line = ?",
+            (
+                new_target,
+                serialized_extra,
+                target,
+                row["source_qualified"],
+                row["file_path"],
+                row["line"],
+            ),
         )
         resolved += 1
         logger.debug(
             "Scoped resolver: %s → %s (via %s)",
-            target, new_target, via,
+            resolution_target, new_target, via,
         )
 
     if resolved:

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -785,7 +785,8 @@ class TestPHPTestAnnotations:
     """
 
     def _parse(self, tmp_path):
-        p = tmp_path / "ExampleTest.php"
+        p = tmp_path / "tests" / "ExampleTest.php"
+        p.parent.mkdir()
         p.write_text(
             "<?php\n"
             "namespace Tests;\n\n"
@@ -797,6 +798,9 @@ class TestPHPTestAnnotations:
             "class ExampleTest extends TestCase\n"
             "{\n"
             "    public function test_prefixed_method_should_be_detected(): void\n"
+            "    {\n"
+            "    }\n\n"
+            "    public function testItAddsTwoNumbers(): void\n"
             "    {\n"
             "    }\n\n"
             "    /** @test */\n"
@@ -842,6 +846,12 @@ class TestPHPTestAnnotations:
     def test_name_prefix_still_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)
         m = next(n for n in nodes if n.name == "test_prefixed_method_should_be_detected")
+        assert m.kind == "Test"
+        assert m.is_test is True
+
+    def test_phpunit_camel_case_name_prefix_detected(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "testItAddsTwoNumbers")
         assert m.kind == "Test"
         assert m.is_test is True
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -838,6 +838,9 @@ class TestPHPTestAnnotations:
             "    public function helperNotATest(): void\n"
             "    {\n"
             "    }\n"
+            "}\n\n"
+            "function testDatabaseAvailable(): void\n"
+            "{\n"
             "}\n",
             encoding="utf-8",
         )
@@ -854,6 +857,12 @@ class TestPHPTestAnnotations:
         m = next(n for n in nodes if n.name == "testItAddsTwoNumbers")
         assert m.kind == "Test"
         assert m.is_test is True
+
+    def test_phpunit_name_prefix_does_not_mark_top_level_function(self, tmp_path):
+        nodes, _ = self._parse(tmp_path)
+        m = next(n for n in nodes if n.name == "testDatabaseAvailable")
+        assert m.kind == "Function"
+        assert m.is_test is False
 
     def test_docblock_annotation_detected(self, tmp_path):
         nodes, _ = self._parse(tmp_path)

--- a/tests/test_php_scoped_calls.py
+++ b/tests/test_php_scoped_calls.py
@@ -9,6 +9,7 @@ post-build scoped resolver rewrites the resolvable ones to the defining node.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from code_review_graph.graph import GraphStore
@@ -37,6 +38,198 @@ def _calls(store: GraphStore) -> list[dict]:
             "FROM edges WHERE kind = 'CALLS'"
         ).fetchall()
     ]
+
+
+def _build_phpunit_calculator(tmp_path: Path) -> GraphStore:
+    """Build the exact two-file PHPUnit reproduction from issue #745."""
+    return _build(
+        tmp_path,
+        {
+            "src/Calculator.php": (
+                "<?php\n"
+                "namespace App;\n"
+                "\n"
+                "class Calculator\n"
+                "{\n"
+                "    public function add(int $a, int $b): int\n"
+                "    {\n"
+                "        return $a + $b;\n"
+                "    }\n"
+                "}\n"
+            ),
+            "tests/CalculatorTest.php": (
+                "<?php\n"
+                "namespace App\\Tests;\n"
+                "\n"
+                "use App\\Calculator;\n"
+                "use PHPUnit\\Framework\\TestCase;\n"
+                "\n"
+                "class CalculatorTest extends TestCase\n"
+                "{\n"
+                "    public function testItAddsTwoNumbers(): void\n"
+                "    {\n"
+                "        $calculator = new Calculator();\n"
+                "        $this->assertSame(3, $calculator->add(1, 2));\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+
+def test_phpunit_instance_call_creates_canonical_tested_by_edge(
+    tmp_path: Path,
+) -> None:
+    store = _build_phpunit_calculator(tmp_path)
+    test_node = store._conn.execute(
+        "SELECT qualified_name, kind, is_test FROM nodes "
+        "WHERE name = 'testItAddsTwoNumbers'"
+    ).fetchone()
+    add_node = store._conn.execute(
+        "SELECT qualified_name FROM nodes "
+        "WHERE name = 'add' AND parent_name = 'Calculator'"
+    ).fetchone()
+
+    assert dict(test_node) == {
+        "qualified_name": (
+            f"{tmp_path}/tests/CalculatorTest.php"
+            "::CalculatorTest.testItAddsTwoNumbers"
+        ),
+        "kind": "Test",
+        "is_test": 1,
+    }
+    call = store._conn.execute(
+        "SELECT target_qualified, extra, confidence_tier FROM edges "
+        "WHERE kind = 'CALLS' AND source_qualified = ? AND target_qualified = ?",
+        (test_node["qualified_name"], add_node["qualified_name"]),
+    ).fetchone()
+    tested_by = store._conn.execute(
+        "SELECT source_qualified, target_qualified, confidence_tier FROM edges "
+        "WHERE kind = 'TESTED_BY' AND source_qualified = ? AND target_qualified = ?",
+        (add_node["qualified_name"], test_node["qualified_name"]),
+    ).fetchone()
+
+    assert call is not None
+    assert call["confidence_tier"] == "INFERRED"
+    assert json.loads(call["extra"]) == {
+        "receiver": "$calculator",
+        "receiver_resolution": "constructed_receiver",
+        "receiver_scope": "App\\Calculator",
+        "receiver_type": "Calculator",
+        "scoped_resolved": True,
+        "scoped_via": "single_match",
+    }
+    assert tested_by is not None
+    assert tested_by["confidence_tier"] == "INFERRED"
+
+
+def test_phpunit_instance_call_is_visible_through_public_tests_for(
+    tmp_path: Path,
+) -> None:
+    store = _build_phpunit_calculator(tmp_path)
+    add_qn = store._conn.execute(
+        "SELECT qualified_name FROM nodes "
+        "WHERE name = 'add' AND parent_name = 'Calculator'"
+    ).fetchone()["qualified_name"]
+
+    method_result = query_graph("tests_for", add_qn, repo_root=str(tmp_path))
+    file_result = query_graph(
+        "tests_for",
+        "src/Calculator.php",
+        repo_root=str(tmp_path),
+    )
+
+    assert method_result["status"] == "ok"
+    assert [
+        (result["name"], result["indirect"])
+        for result in method_result["results"]
+    ] == [("testItAddsTwoNumbers", False)]
+    assert file_result["status"] == "ok"
+    assert [
+        (result["name"], result["indirect"])
+        for result in file_result["results"]
+    ] == [("testItAddsTwoNumbers", False)]
+
+
+def test_php_instance_call_resolves_constructor_import_alias(
+    tmp_path: Path,
+) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/Calculator.php": (
+                "<?php\n"
+                "namespace App;\n"
+                "class Calculator {\n"
+                "    public function add(int $a, int $b): int { return $a + $b; }\n"
+                "}\n"
+            ),
+            "tests/CalculatorTest.php": (
+                "<?php\n"
+                "namespace App\\Tests;\n"
+                "use App\\Calculator as MathCalculator;\n"
+                "class CalculatorTest {\n"
+                "    public function testAlias(): void {\n"
+                "        $calculator = new MathCalculator();\n"
+                "        $calculator->add(1, 2);\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    target = store._conn.execute(
+        "SELECT qualified_name FROM nodes "
+        "WHERE name = 'add' AND parent_name = 'Calculator'"
+    ).fetchone()["qualified_name"]
+
+    call = store._conn.execute(
+        "SELECT extra FROM edges "
+        "WHERE kind = 'CALLS' AND target_qualified = ?",
+        (target,),
+    ).fetchone()
+
+    assert json.loads(call["extra"])["receiver_type"] == "MathCalculator"
+    assert json.loads(call["extra"])["scoped_resolved"] is True
+
+
+def test_php_reassignment_invalidates_constructed_receiver_type(
+    tmp_path: Path,
+) -> None:
+    store = _build(
+        tmp_path,
+        {
+            "src/Calculator.php": (
+                "<?php\n"
+                "class Calculator {\n"
+                "    public function add(int $a, int $b): int { return $a + $b; }\n"
+                "}\n"
+            ),
+            "tests/CalculatorTest.php": (
+                "<?php\n"
+                "class CalculatorTest {\n"
+                "    public function testReassigned(): void {\n"
+                "        $calculator = new Calculator();\n"
+                "        $calculator = makeCalculator();\n"
+                "        $calculator->add(1, 2);\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    canonical_target = store._conn.execute(
+        "SELECT qualified_name FROM nodes "
+        "WHERE name = 'add' AND parent_name = 'Calculator'"
+    ).fetchone()["qualified_name"]
+
+    assert store._conn.execute(
+        "SELECT 1 FROM edges "
+        "WHERE kind = 'CALLS' AND target_qualified = ?",
+        (canonical_target,),
+    ).fetchone() is None
+    assert store._conn.execute(
+        "SELECT 1 FROM edges "
+        "WHERE kind = 'CALLS' AND target_qualified = 'add'",
+    ).fetchone() is not None
 
 
 def test_path_tokens_normalizes_windows_separators() -> None:


### PR DESCRIPTION
Corrected integration of #747 on current main.

Both MerlinH contributor commits are preserved. PHPUnit `test*` method classification remains intact, and the integration completes the linked issue by resolving constructed PHP instance calls such as `$calculator = new Calculator(); $calculator->add()`.

The correction:
- tracks safely constructed receiver types and import aliases;
- invalidates inferred types after reassignment to avoid false links;
- keeps parse-only PHP call formatting backward compatible;
- canonicalizes CALLS and matching TESTED_BY edges;
- makes public `tests_for` work for the method and reported file target.

Validation:
- exact two-file issue regression returns `testItAddsTwoNumbers`
- 62 PHP/scoped/typed tests passed
- 219 graph/tool/post-processing tests passed; 1 skipped
- 425 complete multilanguage parser tests passed
- real process-pool parity passed
- Ruff and diff checks passed
- full graph/post-process: 246 files, 4,858 nodes, 39,066 edges; 185 flows, 194 communities

Original contribution: #747

Closes #745