### PR TITLE
fix(graph): make impact traversal directional (#291)

### DIFF
--- a/code_review_graph/constants.py
+++ b/code_review_graph/constants.py
@@ -66,6 +66,31 @@ IMPACT_EDGE_WEIGHTS: dict[str, float] = {
     "CONTAINS": 0.3,
 }
 IMPACT_DEFAULT_EDGE_WEIGHT = 0.5
+
+# Stored dependency edges point from the dependent to its dependency, so impact
+# normally propagates against the stored edge (target -> source). TESTED_BY is
+# intentionally stored in the opposite orientation (production -> test).
+# CONTAINS is not traversed: changing a file already seeds every node in it, and
+# following containment can bridge into unrelated structure through stale edges.
+IMPACT_DIRECTION_INCOMING = "incoming"
+IMPACT_DIRECTION_OUTGOING = "outgoing"
+IMPACT_DIRECTION_NONE = "none"
+IMPACT_EDGE_DIRECTIONS: dict[str, str] = {
+    "CALLS": IMPACT_DIRECTION_INCOMING,
+    "INHERITS": IMPACT_DIRECTION_INCOMING,
+    "OVERRIDES": IMPACT_DIRECTION_INCOMING,
+    "IMPLEMENTS": IMPACT_DIRECTION_INCOMING,
+    "TESTED_BY": IMPACT_DIRECTION_OUTGOING,
+    "REFERENCES": IMPACT_DIRECTION_INCOMING,
+    "DEPENDS_ON": IMPACT_DIRECTION_INCOMING,
+    "IMPORTS_FROM": IMPACT_DIRECTION_INCOMING,
+    "CONTAINS": IMPACT_DIRECTION_NONE,
+}
+# Unknown relationships conservatively follow the dominant graph convention:
+# source depends on target. This includes possible dependents without claiming
+# that a changed node's own unclassified dependency is impacted.
+IMPACT_DEFAULT_EDGE_DIRECTION = IMPACT_DIRECTION_INCOMING
+
 IMPACT_DEPTH_DECAY = _bounded_float_env(
     "CRG_IMPACT_DEPTH_DECAY", 0.6, lower=0.0, upper=1.0,
 )

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -22,8 +22,13 @@ import networkx as nx
 
 from .constants import (
     BFS_ENGINE,
+    IMPACT_DEFAULT_EDGE_DIRECTION,
     IMPACT_DEFAULT_EDGE_WEIGHT,
     IMPACT_DEPTH_DECAY,
+    IMPACT_DIRECTION_INCOMING,
+    IMPACT_DIRECTION_NONE,
+    IMPACT_DIRECTION_OUTGOING,
+    IMPACT_EDGE_DIRECTIONS,
     IMPACT_EDGE_WEIGHTS,
     IMPACT_SCORE_FLOOR,
     MAX_IMPACT_DEPTH,
@@ -1236,11 +1241,16 @@ class GraphStore:
         max_depth: int = MAX_IMPACT_DEPTH,
         max_nodes: int = MAX_IMPACT_NODES,
     ) -> dict[str, Any]:
-        """BFS from changed files to find all impacted nodes within depth N.
+        """Find dependents and tests impacted by changed files within depth N.
 
         Delegates to ``get_impact_radius_sql()`` by default (faster for
         large graphs).  Set ``CRG_BFS_ENGINE=networkx`` to use the legacy
         Python-side BFS via NetworkX.
+
+        Dependency-shaped edges propagate from target to source, while
+        TESTED_BY propagates from production source to test target. CONTAINS
+        does not expand the traversal because every node in a changed file is
+        already seeded.
 
         Returns dict with:
           - changed_nodes: nodes in changed files
@@ -1323,13 +1333,24 @@ class GraphStore:
         # many paths; these three bounded temp tables contain at most one row
         # per qualified name and each iteration scans the edge table once.
         self._conn.execute(
-            "CREATE TEMP TABLE IF NOT EXISTS _impact_weights "
-            "(kind TEXT PRIMARY KEY, weight REAL NOT NULL)"
+            "CREATE TEMP TABLE IF NOT EXISTS _impact_policies "
+            "(kind TEXT PRIMARY KEY, weight REAL NOT NULL, "
+            "direction TEXT NOT NULL)"
         )
-        self._conn.execute("DELETE FROM _impact_weights")
+        self._conn.execute("DELETE FROM _impact_policies")
         self._conn.executemany(
-            "INSERT INTO _impact_weights (kind, weight) VALUES (?, ?)",
-            list(IMPACT_EDGE_WEIGHTS.items()),
+            "INSERT INTO _impact_policies "
+            "(kind, weight, direction) VALUES (?, ?, ?)",
+            [
+                (
+                    kind,
+                    weight,
+                    IMPACT_EDGE_DIRECTIONS.get(
+                        kind, IMPACT_DEFAULT_EDGE_DIRECTION,
+                    ),
+                )
+                for kind, weight in IMPACT_EDGE_WEIGHTS.items()
+            ],
         )
         for table in ("_impact_best", "_impact_frontier", "_impact_next"):
             self._conn.execute(
@@ -1352,16 +1373,18 @@ class GraphStore:
         SELECT node_qn, MAX(score)
         FROM (
             SELECT e.target_qualified AS node_qn,
-                   f.score * COALESCE(w.weight, ?) * ? AS score
+                   f.score * COALESCE(p.weight, ?) * ? AS score
             FROM _impact_frontier f
             JOIN edges e ON e.source_qualified = f.node_qn
-            LEFT JOIN _impact_weights w ON w.kind = e.kind
+            LEFT JOIN _impact_policies p ON p.kind = e.kind
+            WHERE COALESCE(p.direction, ?) = ?
             UNION ALL
             SELECT e.source_qualified AS node_qn,
-                   f.score * COALESCE(w.weight, ?) * ? AS score
+                   f.score * COALESCE(p.weight, ?) * ? AS score
             FROM _impact_frontier f
             JOIN edges e ON e.target_qualified = f.node_qn
-            LEFT JOIN _impact_weights w ON w.kind = e.kind
+            LEFT JOIN _impact_policies p ON p.kind = e.kind
+            WHERE COALESCE(p.direction, ?) = ?
         ) candidates
         WHERE score > ?
         GROUP BY node_qn
@@ -1369,8 +1392,12 @@ class GraphStore:
         candidate_params = (
             IMPACT_DEFAULT_EDGE_WEIGHT,
             IMPACT_DEPTH_DECAY,
+            IMPACT_DEFAULT_EDGE_DIRECTION,
+            IMPACT_DIRECTION_OUTGOING,
             IMPACT_DEFAULT_EDGE_WEIGHT,
             IMPACT_DEPTH_DECAY,
+            IMPACT_DEFAULT_EDGE_DIRECTION,
+            IMPACT_DIRECTION_INCOMING,
             IMPACT_SCORE_FLOOR,
         )
         for _ in range(max_depth):
@@ -1487,16 +1514,15 @@ class GraphStore:
                 if qn not in nxg:
                     continue
                 neighbors = [
-                    (target, data)
+                    (target, data["impact_outgoing_weight"])
                     for _, target, data in nxg.out_edges(qn, data=True)
+                    if "impact_outgoing_weight" in data
                 ] + [
-                    (source, data)
+                    (source, data["impact_incoming_weight"])
                     for source, _, data in nxg.in_edges(qn, data=True)
+                    if "impact_incoming_weight" in data
                 ]
-                for other_qn, data in neighbors:
-                    weight = IMPACT_EDGE_WEIGHTS.get(
-                        data.get("kind", ""), IMPACT_DEFAULT_EDGE_WEIGHT,
-                    )
+                for other_qn, weight in neighbors:
                     new_score = score * weight * IMPACT_DEPTH_DECAY
                     if new_score <= IMPACT_SCORE_FLOOR:
                         continue
@@ -2020,7 +2046,7 @@ class GraphStore:
     # --- Internal helpers ---
 
     def _build_networkx_graph(self) -> nx.DiGraph:
-        """Build a directed graph, retaining the strongest parallel edge."""
+        """Build a directed graph with impact weights for both policies."""
         with self._cache_lock:
             if self._nxg_cache is not None:
                 return self._nxg_cache
@@ -2030,17 +2056,26 @@ class GraphStore:
                 source = r["source_qualified"]
                 target = r["target_qualified"]
                 kind = r["kind"]
-                if g.has_edge(source, target):
-                    existing = g[source][target].get("kind", "")
-                    existing_weight = IMPACT_EDGE_WEIGHTS.get(
-                        existing, IMPACT_DEFAULT_EDGE_WEIGHT,
+                candidate_weight = IMPACT_EDGE_WEIGHTS.get(
+                    kind, IMPACT_DEFAULT_EDGE_WEIGHT,
+                )
+                if not g.has_edge(source, target):
+                    g.add_edge(source, target, kind=kind)
+                data = g[source][target]
+                existing_weight = IMPACT_EDGE_WEIGHTS.get(
+                    data.get("kind", ""), IMPACT_DEFAULT_EDGE_WEIGHT,
+                )
+                if candidate_weight > existing_weight:
+                    data["kind"] = kind
+
+                direction = IMPACT_EDGE_DIRECTIONS.get(
+                    kind, IMPACT_DEFAULT_EDGE_DIRECTION,
+                )
+                if direction != IMPACT_DIRECTION_NONE:
+                    weight_key = f"impact_{direction}_weight"
+                    data[weight_key] = max(
+                        data.get(weight_key, 0.0), candidate_weight,
                     )
-                    candidate_weight = IMPACT_EDGE_WEIGHTS.get(
-                        kind, IMPACT_DEFAULT_EDGE_WEIGHT,
-                    )
-                    if candidate_weight <= existing_weight:
-                        continue
-                g.add_edge(source, target, kind=kind)
             self._nxg_cache = g
             return g
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -422,14 +422,14 @@ class TestGraphStore:
         assert "python" in stats.languages
 
     def test_impact_radius(self):
-        # Create a chain: file_a -> func_a -> (calls) -> func_b in file_b
+        # func_b depends on the changed func_a, so func_b is impacted.
         self.store.upsert_node(self._make_file_node("/a.py"))
         self.store.upsert_node(self._make_func_node("func_a", "/a.py"))
         self.store.upsert_node(self._make_file_node("/b.py"))
         self.store.upsert_node(self._make_func_node("func_b", "/b.py"))
         self.store.upsert_edge(EdgeInfo(
-            kind="CALLS", source="/a.py::func_a",
-            target="/b.py::func_b", file_path="/a.py", line=10,
+            kind="CALLS", source="/b.py::func_b",
+            target="/a.py::func_a", file_path="/b.py", line=10,
         ))
         self.store.commit()
 
@@ -620,7 +620,7 @@ class TestImpactRadiusSql:
         Path(self.tmp.name).unlink(missing_ok=True)
 
     def _build_chain(self):
-        """Build A -> B -> C -> D chain for testing."""
+        """Build D -> C -> B -> A dependency chain for testing."""
         for name, path in [
             ("func_a", "/a.py"), ("func_b", "/b.py"),
             ("func_c", "/c.py"), ("func_d", "/d.py"),
@@ -634,16 +634,16 @@ class TestImpactRadiusSql:
                 line_start=5, line_end=20, language="python",
             ))
         self.store.upsert_edge(EdgeInfo(
-            kind="CALLS", source="/a.py::func_a",
-            target="/b.py::func_b", file_path="/a.py", line=10,
-        ))
-        self.store.upsert_edge(EdgeInfo(
             kind="CALLS", source="/b.py::func_b",
-            target="/c.py::func_c", file_path="/b.py", line=10,
+            target="/a.py::func_a", file_path="/b.py", line=10,
         ))
         self.store.upsert_edge(EdgeInfo(
             kind="CALLS", source="/c.py::func_c",
-            target="/d.py::func_d", file_path="/c.py", line=10,
+            target="/b.py::func_b", file_path="/c.py", line=10,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/d.py::func_d",
+            target="/c.py::func_c", file_path="/d.py", line=10,
         ))
         self.store.commit()
 
@@ -654,6 +654,7 @@ class TestImpactRadiusSql:
 
         sql_qns = {n.qualified_name for n in sql_result["impacted_nodes"]}
         nx_qns = {n.qualified_name for n in nx_result["impacted_nodes"]}
+        assert sql_qns == {"/b.py::func_b", "/c.py::func_c"}
         assert sql_qns == nx_qns
 
     def test_max_nodes_truncation(self):
@@ -661,8 +662,9 @@ class TestImpactRadiusSql:
         result = self.store.get_impact_radius_sql(
             ["/a.py"], max_depth=3, max_nodes=2,
         )
-        # With 4 files in chain + file nodes, max_nodes=2 should limit
-        assert result["total_impacted"] <= 2 or result["truncated"]
+        assert result["truncated"] is True
+        assert result["total_impacted"] == 3
+        assert len(result["impacted_nodes"]) == 2
 
     def test_empty_changed_files(self):
         result = self.store.get_impact_radius_sql([], max_depth=2)
@@ -725,14 +727,60 @@ class TestWeightedImpactScoring:
     def _ordered_qns(result) -> list[str]:
         return [node.qualified_name for node in result["impacted_nodes"]]
 
-    def test_edge_weights_rank_best_path_and_engines_match(self):
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "CALLS",
+            "IMPORTS_FROM",
+            "DEPENDS_ON",
+            "REFERENCES",
+            "INHERITS",
+            "OVERRIDES",
+            "IMPLEMENTS",
+        ],
+    )
+    def test_dependency_edges_include_dependents_not_dependencies(self, kind):
         seed = self._add_func("seed", "/seed.py")
-        called = self._add_func("called", "/called.py")
-        imported = self._add_func("imported", "/imported.py")
-        indirect = self._add_func("indirect", "/indirect.py")
-        self._add_edge("CALLS", seed, called)
-        self._add_edge("IMPORTS_FROM", seed, imported)
-        self._add_edge("CALLS", called, indirect)
+        dependent = self._add_func("dependent", "/dependent.py")
+        dependency = self._add_func("dependency", "/dependency.py")
+        self._add_edge(kind, dependent, seed)
+        self._add_edge(kind, seed, dependency, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [dependent]
+        assert self._ordered_qns(nx_result) == [dependent]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_tested_by_traverses_from_production_to_test_only(self):
+        seed = self._add_func("seed", "/seed.py")
+        test = self._add_func("test_seed", "/test_seed.py")
+        unrelated_production = self._add_func(
+            "unrelated_production", "/unrelated.py",
+        )
+        self._add_edge("TESTED_BY", seed, test)
+        self._add_edge("TESTED_BY", unrelated_production, seed, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [test]
+        assert self._ordered_qns(nx_result) == [test]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_contains_edge_cannot_bridge_impact(self):
+        seed = self._add_func("seed", "/seed.py")
+        stale_container = "stale.py::Container"
+        dependent = self._add_func("dependent", "/dependent.py")
+        self._add_edge("CONTAINS", stale_container, seed)
+        self._add_edge("CALLS", dependent, stale_container, line=2)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
@@ -740,10 +788,51 @@ class TestWeightedImpactScoring:
             ["/seed.py"], max_depth=2,
         )
 
-        assert sql["impact_scores"][called] == pytest.approx(0.6)
-        assert sql["impact_scores"][indirect] == pytest.approx(0.36)
-        assert sql["impact_scores"][imported] == pytest.approx(0.3)
-        assert self._ordered_qns(sql) == [called, indirect, imported]
+        assert self._ordered_qns(sql) == []
+        assert self._ordered_qns(nx_result) == []
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_unknown_edge_kind_defaults_to_incoming_dependency_direction(self):
+        seed = self._add_func("seed", "/seed.py")
+        dependent = self._add_func("dependent", "/dependent.py")
+        dependency = self._add_func("dependency", "/dependency.py")
+        self._add_edge("UNKNOWN_KIND", dependent, seed)
+        self._add_edge("UNKNOWN_KIND", seed, dependency, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [dependent]
+        assert sql["impact_scores"][dependent] == pytest.approx(0.3)
+        assert self._ordered_qns(nx_result) == [dependent]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_edge_weights_rank_best_path_and_engines_match(self):
+        seed = self._add_func("seed", "/seed.py")
+        caller = self._add_func("caller", "/caller.py")
+        importer = self._add_func("importer", "/importer.py")
+        indirect_caller = self._add_func(
+            "indirect_caller", "/indirect_caller.py",
+        )
+        self._add_edge("CALLS", caller, seed)
+        self._add_edge("IMPORTS_FROM", importer, seed)
+        self._add_edge("CALLS", indirect_caller, caller)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=2,
+        )
+
+        assert sql["impact_scores"][caller] == pytest.approx(0.6)
+        assert sql["impact_scores"][indirect_caller] == pytest.approx(0.36)
+        assert sql["impact_scores"][importer] == pytest.approx(0.3)
+        assert self._ordered_qns(sql) == [
+            caller, indirect_caller, importer,
+        ]
         assert sql["impact_scores"] == nx_result["impact_scores"]
         assert self._ordered_qns(sql) == self._ordered_qns(nx_result)
 
@@ -751,9 +840,9 @@ class TestWeightedImpactScoring:
         seed = self._add_func("seed", "/seed.py")
         middle = self._add_func("middle", "/middle.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("CONTAINS", seed, target)
-        self._add_edge("CALLS", seed, middle, line=2)
-        self._add_edge("CALLS", middle, target, line=3)
+        self._add_edge("IMPORTS_FROM", target, seed)
+        self._add_edge("CALLS", middle, seed, line=2)
+        self._add_edge("CALLS", target, middle, line=3)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
@@ -769,7 +858,7 @@ class TestWeightedImpactScoring:
             self._add_func(f"node_{index}", f"/node_{index}.py")
             for index in range(8)
         ]
-        for index, (source, target) in enumerate(zip(qns, qns[1:])):
+        for index, (source, target) in enumerate(zip(qns[1:], qns)):
             self._add_edge("CALLS", source, target, line=index + 1)
         self.store.commit()
 
@@ -787,7 +876,7 @@ class TestWeightedImpactScoring:
     def test_unknown_edge_kind_uses_default_weight(self):
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("UNKNOWN_KIND", seed, target)
+        self._add_edge("UNKNOWN_KIND", target, seed)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
@@ -805,7 +894,7 @@ class TestWeightedImpactScoring:
             for index in range(3)
         ]
         for index, target in enumerate(targets):
-            self._add_edge("CALLS", seed, target, line=index + 1)
+            self._add_edge("CALLS", target, seed, line=index + 1)
         self.store.commit()
 
         exact = self.store.get_impact_radius_sql(
@@ -825,8 +914,8 @@ class TestWeightedImpactScoring:
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
         ghost = "external.package::ghost"
-        self._add_edge("CALLS", seed, ghost)
-        self._add_edge("CALLS", ghost, target, line=2)
+        self._add_edge("CALLS", ghost, seed)
+        self._add_edge("CALLS", target, ghost, line=2)
         self.store.commit()
 
         result = self.store.get_impact_radius_sql(
@@ -840,8 +929,8 @@ class TestWeightedImpactScoring:
     def test_parallel_edges_use_strongest_weight_in_both_engines(self):
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("CALLS", seed, target, line=1)
-        self._add_edge("CONTAINS", seed, target, line=2)
+        self._add_edge("CALLS", target, seed, line=1)
+        self._add_edge("IMPORTS_FROM", target, seed, line=2)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
@@ -850,6 +939,28 @@ class TestWeightedImpactScoring:
         )
         assert sql["impact_scores"][target] == pytest.approx(0.6)
         assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_parallel_edges_preserve_each_direction_in_both_engines(self):
+        source = self._add_func("source", "/source.py")
+        target = self._add_func("target", "/target.py")
+        self._add_edge("CALLS", source, target, line=1)
+        self._add_edge("TESTED_BY", source, target, line=2)
+        self.store.commit()
+
+        for path, expected_qn, expected_score in (
+            ("/source.py", target, 0.42),
+            ("/target.py", source, 0.6),
+        ):
+            sql = self.store.get_impact_radius_sql([path], max_depth=1)
+            nx_result = self.store._get_impact_radius_networkx(
+                [path], max_depth=1,
+            )
+
+            assert self._ordered_qns(sql) == [expected_qn]
+            assert sql["impact_scores"][expected_qn] == pytest.approx(
+                expected_score,
+            )
+            assert sql["impact_scores"] == nx_result["impact_scores"]
 
     def test_dense_mixed_cycle_is_bounded(self):
         qns = [self._add_func(f"node_{i}", f"/node_{i}.py") for i in range(12)]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,6 +10,7 @@ import pytest
 
 import code_review_graph.constants as constants_module
 from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import EdgeInfo, NodeInfo
 
 
@@ -671,6 +672,46 @@ class TestImpactRadiusSql:
         assert result["changed_nodes"] == []
         assert result["impacted_nodes"] == []
         assert result["total_impacted"] == 0
+
+
+def test_impact_radius_real_build_includes_importer_not_imported_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real parsed import graph follows impact toward dependents only."""
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    dependency = tmp_path / "dependency.py"
+    changed = tmp_path / "changed.py"
+    importer = tmp_path / "importer.py"
+    dependency.write_text("VALUE = 1\n", encoding="utf-8")
+    changed.write_text(
+        "from dependency import VALUE\n\n"
+        "def changed_value():\n"
+        "    return VALUE\n",
+        encoding="utf-8",
+    )
+    importer.write_text(
+        "from changed import changed_value\n\n"
+        "def consume():\n"
+        "    return changed_value()\n",
+        encoding="utf-8",
+    )
+
+    with GraphStore(tmp_path / "graph.db") as store:
+        built = full_build(tmp_path, store)
+        assert built["errors"] == []
+
+        sql = store.get_impact_radius_sql([str(changed)], max_depth=1)
+        networkx = store._get_impact_radius_networkx(
+            [str(changed)],
+            max_depth=1,
+        )
+
+    expected = {str(importer)}
+    assert set(sql["impacted_files"]) == expected
+    assert set(networkx["impacted_files"]) == expected
+    assert str(dependency) not in sql["impacted_files"]
+    assert sql["impact_scores"] == networkx["impact_scores"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2361,24 +2361,24 @@ def test_impact_radius_tool_exposes_best_first_scores(monkeypatch, tmp_path):
     """The public tool adds scores without changing the stored node schema."""
     store = GraphStore(tmp_path / "impact.db")
     seed = "/seed.py::seed"
-    called = "/called.py::called"
-    imported = "/imported.py::imported"
+    caller = "/caller.py::caller"
+    importer = "/importer.py::importer"
     for name, path in (
         ("seed", "/seed.py"),
-        ("called", "/called.py"),
-        ("imported", "/imported.py"),
+        ("caller", "/caller.py"),
+        ("importer", "/importer.py"),
     ):
         store.upsert_node(NodeInfo(
             kind="Function", name=name, file_path=path,
             line_start=1, line_end=3, language="python",
         ))
     store.upsert_edge(EdgeInfo(
-        kind="CALLS", source=seed, target=called,
-        file_path="/seed.py", line=1,
+        kind="CALLS", source=caller, target=seed,
+        file_path="/caller.py", line=1,
     ))
     store.upsert_edge(EdgeInfo(
-        kind="IMPORTS_FROM", source=seed, target=imported,
-        file_path="/seed.py", line=2,
+        kind="IMPORTS_FROM", source=importer, target=seed,
+        file_path="/importer.py", line=2,
     ))
     store.commit()
 
@@ -2396,7 +2396,7 @@ def test_impact_radius_tool_exposes_best_first_scores(monkeypatch, tmp_path):
     )
 
     assert [node["name"] for node in result["impacted_nodes"]] == [
-        "called", "imported",
+        "caller", "importer",
     ]
     scores = [node["impact_score"] for node in result["impacted_nodes"]]
     assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary

Fixes #291 by making impact-radius traversal follow dependency direction instead of walking every edge both ways.

- dependency-shaped edges propagate from the changed dependency to its dependents;
- `TESTED_BY` propagates from production code to tests;
- `CONTAINS` does not expand impact because changed-file seeding already includes contained nodes;
- unknown edge kinds use the documented dependency-shaped default;
- SQL and NetworkX share the same policy and preserve strongest parallel-edge weights in each permitted direction.

## Why the previous behavior was wrong

For an edge `importer -> imported`, changing the importer incorrectly reported the imported dependency as impacted. The same edge weight was used in both directions, so genuine importers and false dependency results were indistinguishable.

## Validation

- New direction regressions: passed.
- Real three-file full build: changing the middle module includes its importer and excludes its own imported dependency in both engines.
- Broad impact-related local suite: 318 passed, 1 skipped.
- Agent practical graph/tool suite before the final end-to-end addition: 359 passed, 1 skipped.
- Ruff: passed.
- Python compile check: passed.
- `git diff --check`: passed.

Full hosted Python, Windows, type, lint, schema, security, and CodeQL checks are still required before merge.
