### PR TITLE
feat(parser): index stable JS/TS member-assigned functions (#672)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -8467,15 +8467,17 @@ class CodeParser:
         # runtime scope, not to the module-level object namespace.  Without
         # lexical scope in the member name, identical assignments in sibling
         # functions would both become ``file::obj.method`` and produce
-        # duplicate CONTAINS targets.  Restrict this feature to module/class
-        # contexts, where the member path is a stable definition identity.
-        if enclosing_func:
+        # duplicate CONTAINS targets. Top-level lexical blocks have the same
+        # problem, so only direct program statements have a stable identity.
+        if (
+            enclosing_func
+            or child.parent is None
+            or child.parent.type != "program"
+        ):
             return False
 
-        member_name = left.text.decode("utf-8", errors="replace")
-        # Skip computed access (``obj[key] = fn``) and any multi-line/odd
-        # member paths that would produce a malformed qualified name.
-        if not member_name or "[" in member_name or "\n" in member_name:
+        member_name = self._get_js_static_member_path(left)
+        if member_name is None:
             return False
 
         is_test = _is_test_function(member_name, file_path)
@@ -8519,6 +8521,36 @@ class CodeParser:
             _depth=_depth + 1,
         )
         return True
+
+    @staticmethod
+    def _get_js_static_member_path(node) -> Optional[str]:
+        """Return a stable identifier-only JS/TS member path."""
+        if node.type != "member_expression":
+            return None
+        text = node.text.decode("utf-8", errors="replace")
+        if not text or "[" in text or "\n" in text:
+            return None
+
+        parts: list[str] = []
+        current = node
+        while current.type == "member_expression":
+            object_node = current.child_by_field_name("object")
+            property_node = current.child_by_field_name("property")
+            if (
+                object_node is None
+                or property_node is None
+                or property_node.type not in ("identifier", "property_identifier")
+            ):
+                return None
+            parts.append(
+                property_node.text.decode("utf-8", errors="replace"),
+            )
+            current = object_node
+
+        if current.type not in ("identifier", "this"):
+            return None
+        parts.append(current.text.decode("utf-8", errors="replace"))
+        return ".".join(reversed(parts))
 
     @staticmethod
     def _get_java_annotations(class_node) -> list[str]:
@@ -10474,13 +10506,7 @@ class CodeParser:
             callee = node.children[0]
         if callee is None or callee.type != "member_expression":
             return None
-        member_call = callee.text.decode("utf-8", errors="replace")
-        if not member_call or "[" in member_call or "\n" in member_call:
-            return None
-        # Optional property access has the same static member path as regular
-        # access: ``app?.handle()`` can target ``app.handle = fn`` whenever
-        # the receiver is present at runtime.
-        return member_call.replace("?.", ".")
+        return CodeParser._get_js_static_member_path(callee)
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -8463,6 +8463,15 @@ class CodeParser:
         if right.type not in self._JS_FUNC_VALUE_TYPES:
             return False
 
+        # An assignment nested in a function belongs to that function's
+        # runtime scope, not to the module-level object namespace.  Without
+        # lexical scope in the member name, identical assignments in sibling
+        # functions would both become ``file::obj.method`` and produce
+        # duplicate CONTAINS targets.  Restrict this feature to module/class
+        # contexts, where the member path is a stable definition identity.
+        if enclosing_func:
+            return False
+
         member_name = left.text.decode("utf-8", errors="replace")
         # Skip computed access (``obj[key] = fn``) and any multi-line/odd
         # member paths that would produce a malformed qualified name.

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4457,6 +4457,26 @@ class CodeParser:
                 continue
             receiver = edge.extra.get("receiver")
             has_receiver = bool(receiver)
+            if edge.kind in ("CALLS", "REFERENCES") and "::" not in edge.target:
+                # JS/TS calls retain their full member expression as evidence
+                # (``app.handle``) while keeping the method name (``handle``)
+                # as the fallback target for external calls. Prefer the full
+                # expression when it identifies a same-file member-assigned
+                # function; otherwise preserve the existing bare-name
+                # resolution behavior.
+                member_call = edge.extra.get("member_call")
+                member_candidates = symbols.get(member_call, [])
+                if member_candidates:
+                    edge = EdgeInfo(
+                        kind=edge.kind,
+                        source=edge.source,
+                        target=member_candidates[0][0],
+                        file_path=edge.file_path,
+                        line=edge.line,
+                        extra=edge.extra,
+                    )
+                    resolved.append(edge)
+                    continue
             cpp_lexical_receiver = is_cpp and receiver == "this"
             if (
                 is_cpp
@@ -10333,6 +10353,10 @@ class CodeParser:
             # uses this evidence during parsing, and the Spring DI resolver
             # consumes the same metadata for Java injected fields.
             call_extra: dict = {}
+            if language in ("javascript", "typescript", "tsx"):
+                member_call = self._get_js_member_call_name(child)
+                if member_call:
+                    call_extra["member_call"] = member_call
             if (
                 language in self._TYPED_CALL_LANGUAGES
                 or language in ("cpp", "rust")
@@ -10425,6 +10449,26 @@ class CodeParser:
             ))
 
         return False
+
+    @staticmethod
+    def _get_js_member_call_name(node) -> Optional[str]:
+        """Return a static JS/TS member-call expression, if present.
+
+        ``_get_call_name`` intentionally reduces ``app.handle()`` to
+        ``handle`` for general method-call handling. Retain ``app.handle`` as
+        supplemental evidence so the same-file resolver can link it to a
+        member-assigned definition without changing unresolved external calls.
+        Computed and multiline expressions are intentionally excluded.
+        """
+        callee = node.child_by_field_name("function")
+        if callee is None and node.children:
+            callee = node.children[0]
+        if callee is None or callee.type != "member_expression":
+            return None
+        member_call = callee.text.decode("utf-8", errors="replace")
+        if not member_call or "[" in member_call or "\n" in member_call:
+            return None
+        return member_call
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -10477,7 +10477,10 @@ class CodeParser:
         member_call = callee.text.decode("utf-8", errors="replace")
         if not member_call or "[" in member_call or "\n" in member_call:
             return None
-        return member_call
+        # Optional property access has the same static member path as regular
+        # access: ``app?.handle()`` can target ``app.handle = fn`` whenever
+        # the receiver is present at runtime.
+        return member_call.replace("?.", ".")
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -6071,6 +6071,18 @@ class CodeParser:
             ):
                 continue
 
+            # --- JS/TS member-assigned functions (app.handle = function () {}) ---
+            if (
+                language in ("javascript", "typescript", "tsx")
+                and node_type == "expression_statement"
+                and self._extract_js_member_functions(
+                    child, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names, _depth,
+                )
+            ):
+                continue
+
             # --- Functions ---
             if node_type in func_types and self._extract_functions(
                 child, source, language, file_path, nodes, edges,
@@ -8372,6 +8384,107 @@ class CodeParser:
             func_node, source, language, file_path, nodes, edges,
             enclosing_class=enclosing_class,
             enclosing_func=prop_name,
+            import_map=import_map,
+            defined_names=defined_names,
+            _depth=_depth + 1,
+        )
+        return True
+
+    def _extract_js_member_functions(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle JS/TS member-assigned functions.
+
+        Patterns handled (LHS is a ``member_expression``, RHS is a function):
+          app.handle = function handle(req, res) {}
+          Router.prototype.dispatch = (req) => {}
+          exports.render = function () {}
+
+        These prototype- and module-augmentation patterns carry the entire
+        public API of Express, Koa and many older JS modules, but were
+        previously invisible to the graph: only ``const x = fn``
+        (:func:`_extract_js_var_functions`) and class fields
+        (:func:`_extract_js_field_function`) produced Function nodes. The node
+        is qualified by its full member path (``file::app.handle``), matching
+        the ``file::Class.method`` shape used elsewhere.
+
+        Returns True if a function was extracted, so the caller can skip
+        generic recursion.
+        """
+        # ``child`` is the expression_statement wrapping the assignment.
+        assign = None
+        if child.type == "assignment_expression":
+            assign = child
+        else:
+            for sub in child.children:
+                if sub.type == "assignment_expression":
+                    assign = sub
+                    break
+        if assign is None:
+            return False
+
+        left = assign.child_by_field_name("left")
+        right = assign.child_by_field_name("right")
+        if left is None or right is None:
+            return False
+        if left.type != "member_expression":
+            return False
+        if right.type not in self._JS_FUNC_VALUE_TYPES:
+            return False
+
+        member_name = left.text.decode("utf-8", errors="replace")
+        # Skip computed access (``obj[key] = fn``) and any multi-line/odd
+        # member paths that would produce a malformed qualified name.
+        if not member_name or "[" in member_name or "\n" in member_name:
+            return False
+
+        is_test = _is_test_function(member_name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(member_name, file_path, enclosing_class)
+        params = self._get_params(right, language, source)
+        ret_type = self._get_return_type(right, language, source)
+
+        nodes.append(NodeInfo(
+            kind=kind,
+            name=member_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            params=params,
+            return_type=ret_type,
+            is_test=is_test,
+        ))
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class else file_path
+        )
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into the function body for calls, attributing them to the
+        # member function.
+        self._extract_from_tree(
+            right, source, language, file_path, nodes, edges,
+            enclosing_class=enclosing_class,
+            enclosing_func=member_name,
             import_map=import_map,
             defined_names=defined_names,
             _depth=_depth + 1,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2027,6 +2027,22 @@ class TestJsMemberAssignedFunctions:
         assert "app.settings" not in fns
         assert "app.locals" not in fns
 
+    def test_function_local_member_assignments_are_not_module_definitions(self):
+        """Sibling local assignments must not collide as ``file::x.run``."""
+        path = Path("/test/local_assignments.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"function a() { x.run = function () {}; }\n"
+            b"function b() { x.run = function () {}; }\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert {n.name for n in functions} == {"a", "b"}
+        assert all(n.name != "x.run" for n in functions)
+        assert all(
+            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            for e in edges
+        )
+
     def test_member_function_body_calls_still_attributed(self):
         """Calls inside a member-assigned function attribute to that function."""
         path = Path("/test/application.js")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2043,6 +2043,54 @@ class TestJsMemberAssignedFunctions:
             for e in edges
         )
 
+    def test_sibling_top_level_blocks_do_not_share_member_identity(self):
+        """Block-local objects must not collapse into one module definition."""
+        path = Path("/test/block_assignments.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"{ const x = {}; x.run = function () {}; }\n"
+            b"{ const x = {}; x.run = function () {}; }\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert all(n.name != "x.run" for n in functions)
+        assert all(
+            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            for e in edges
+        )
+
+    def test_dynamic_receiver_assignment_is_not_a_stable_definition(self):
+        """A fresh object returned by a call has no stable member identity."""
+        path = Path("/test/dynamic_assignment.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"factory().handle = function () {};\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert all(n.name != "factory().handle" for n in functions)
+        assert all(
+            not (
+                e.kind == "CONTAINS"
+                and e.target == f"{path}::factory().handle"
+            )
+            for e in edges
+        )
+
+    def test_dynamic_receiver_call_does_not_resolve_as_static_member(self):
+        """Separate factory calls must not be linked as one member."""
+        path = Path("/test/dynamic_call.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"factory().handle = function () {};\n"
+            b"function start() { factory().handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 2
+        handle_call = next(e for e in calls if e.target == "handle")
+        assert "member_call" not in handle_call.extra
+
     def test_member_function_body_calls_still_attributed(self):
         """Calls inside a member-assigned function attribute to that function."""
         path = Path("/test/application.js")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2044,3 +2044,18 @@ class TestJsMemberAssignedFunctions:
             and e.target.endswith("helper")
         ]
         assert len(calls) == 1
+
+    def test_member_call_resolves_to_member_assigned_function(self):
+        """A static member call resolves to its same-file member definition."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1957,3 +1957,90 @@ class TestCppScopedFunctionName:
         fns = [n for n in nodes if n.kind == "Function"]
         assert len(fns) == 1
         assert fns[0].name == "get_obj_fingerprint"
+
+
+class TestJsMemberAssignedFunctions:
+    """Member-assigned function expressions in JS/TS.
+
+    ``obj.method = function () {}`` / ``Foo.prototype.bar = () => {}`` are the
+    prototype- and module-augmentation patterns that Express, Koa and many
+    older JS libraries use for their entire public API. Only ``const x = fn``
+    (variable_declarator) and class fields were captured before, so these
+    definitions produced no Function node at all.
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def test_js_object_method_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/application.js"),
+            b"app.handle = function handle(req, res, next) {\n"
+            b"  next();\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.handle" in fns
+
+    def test_js_arrow_member_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/router.js"),
+            b"router.dispatch = (req, res) => {\n"
+            b"  return res;\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "router.dispatch" in fns
+
+    def test_ts_prototype_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/proto.ts"),
+            b"Router.prototype.handle = function (req: Request): void {\n"
+            b"  this.stack.forEach((layer) => layer.handle(req));\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "Router.prototype.handle" in fns
+
+    def test_member_function_qualified_name_and_contains(self):
+        """Qualified name is ``file::obj.method`` and a CONTAINS edge links it."""
+        path = Path("/test/application.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function handle(req, res) {};\n",
+        )
+        contains = [
+            e for e in edges
+            if e.kind == "CONTAINS" and e.target == f"{path}::app.handle"
+        ]
+        assert len(contains) == 1
+        assert contains[0].source == str(path)
+
+    def test_non_function_member_assignment_not_captured(self):
+        """``obj.prop = <non-function>`` must not create a Function node."""
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/config.js"),
+            b"app.settings = { trust_proxy: false };\n"
+            b"app.locals = {};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.settings" not in fns
+        assert "app.locals" not in fns
+
+    def test_member_function_body_calls_still_attributed(self):
+        """Calls inside a member-assigned function attribute to that function."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"function helper() { return 1; }\n"
+            b"app.handle = function handle() {\n"
+            b"  helper();\n"
+            b"};\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS"
+            and e.source == f"{path}::app.handle"
+            and e.target.endswith("helper")
+        ]
+        assert len(calls) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import CodeParser
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -2138,3 +2139,36 @@ class TestJsMemberAssignedFunctions:
         ]
         assert len(calls) == 1
         assert calls[0].target == f"{path}::app.handle"
+
+    def test_member_assignment_survives_full_build_with_resolved_caller(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """The definition and resolved call persist through a real graph build."""
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+        source = tmp_path / "application.js"
+        source.write_text(
+            "app.handle = function () { return 1; };\n"
+            "function start() { return app.handle(); }\n",
+            encoding="utf-8",
+        )
+        member_qn = f"{source}::app.handle"
+        caller_qn = f"{source}::start"
+
+        with GraphStore(tmp_path / "graph.db") as store:
+            built = full_build(tmp_path, store)
+            assert built["errors"] == []
+
+            member = store.get_node(member_qn)
+            callers = [
+                edge
+                for edge in store.get_edges_by_target(member_qn)
+                if edge.kind == "CALLS"
+            ]
+
+        assert member is not None
+        assert member.kind == "Function"
+        assert member.name == "app.handle"
+        assert len(callers) == 1
+        assert callers[0].source_qualified == caller_qn

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2075,3 +2075,18 @@ class TestJsMemberAssignedFunctions:
         ]
         assert len(calls) == 1
         assert calls[0].target == f"{path}::app.handle"
+
+    def test_optional_member_call_resolves_to_member_assigned_function(self):
+        """Optional chaining retains the same static member-call target."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app?.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"


### PR DESCRIPTION
## Summary

Corrected integration of contributor PR #672, preserving all four contributor commits and attribution.

This indexes stable top-level JavaScript/TypeScript member-assigned functions such as:

- `app.handle = function () {}`
- `router.dispatch = () => {}`
- `Router.prototype.handle = function () {}`

Static same-file calls, including optional chaining, resolve to those definitions.

## Maintainer corrections

The original branch also treated unstable runtime identities as module-level functions. This integration rejects:

- assignments inside functions;
- assignments inside sibling lexical blocks;
- dynamic receivers such as `factory().handle`.

These cases cannot safely share a file-level qualified name.

## Validation

- New blocker regressions failed 3/3 on the contributor-only state and passed after the correction.
- Broad parser/graph suite after rebase: 867 passed, 1 skipped.
- Full `tests/test_parser.py` after the final end-to-end addition: 147 passed.
- Real full-build regression proves the member function persists and its caller resolves after graph storage.
- Production Ruff: passed.
- Changed test code passes Ruff; the file has three unrelated pre-existing lint findings.
- `git diff --check`: passed.

Full hosted Python, Windows, type, lint, schema, security, and CodeQL checks are required before merge.
