### PR TITLE
fix(update): anchor incremental work to last-synced commit (#694)

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -755,7 +755,11 @@ def main() -> None:
 
     # update
     update_cmd = sub.add_parser("update", help="Incremental update (only changed files)")
-    update_cmd.add_argument("--base", default="HEAD~1", help="Git diff base (default: HEAD~1)")
+    update_cmd.add_argument(
+        "--base",
+        default=None,
+        help="Git diff base (default: the commit the graph was last built at)",
+    )
     update_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
     update_cmd.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     update_cmd.add_argument(
@@ -1686,15 +1690,26 @@ def main() -> None:
                 )
             finally:
                 logging.disable(previous_disable)
-            updated = result.get("files_updated", 0)
             nodes = result.get("total_nodes", 0)
             edges = result.get("total_edges", 0)
             if not args.quiet:
-                print(
-                    f"Incremental: {updated} files updated, "
-                    f"{nodes} nodes, {edges} edges"
-                    f" (postprocess={pp})"
-                )
+                if result.get("build_type") == "full":
+                    # No usable incremental base (fresh/legacy graph, or the
+                    # last-synced commit was lost to a rewrite/shallow clone),
+                    # so the update fell back to a full rebuild.
+                    parsed = result.get("files_parsed", 0)
+                    print(
+                        f"Full rebuild (no usable incremental base): "
+                        f"{parsed} files, {nodes} nodes, {edges} edges"
+                        f" (postprocess={pp})"
+                    )
+                else:
+                    updated = result.get("files_updated", 0)
+                    print(
+                        f"Incremental: {updated} files updated, "
+                        f"{nodes} nodes, {edges} edges"
+                        f" (postprocess={pp})"
+                    )
 
             # --brief: append a one-line change-impact summary with the same
             # estimated context-savings approximation that detect-changes uses.
@@ -1712,7 +1727,10 @@ def main() -> None:
                     get_staged_and_unstaged,
                 )
 
-                changed = get_changed_files(repo_root, args.base)
+                # Reuse the base the update actually resolved to (args.base is
+                # None by default now, which get_changed_files cannot accept).
+                brief_base = result.get("base_resolved") or "HEAD~1"
+                changed = get_changed_files(repo_root, brief_base)
                 if not changed:
                     changed = get_staged_and_unstaged(repo_root)
                 if changed:
@@ -1720,7 +1738,7 @@ def main() -> None:
                         store,
                         changed,
                         repo_root=str(repo_root),
-                        base=args.base,
+                        base=brief_base,
                     )
                     original_tokens = estimate_file_tokens(repo_root, changed)
                     attach_context_savings(

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -618,6 +618,55 @@ def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
             store.set_metadata("svn_revision", rev)
 
 
+def _commit_object_exists(repo_root: Path, ref: str) -> bool:
+    """Return True if *ref* resolves to a commit object present in the repo.
+
+    This is an object-existence check, not an ancestry check: a commit that is
+    only reachable from a branch we have since switched away from is still a
+    valid ``git diff`` base, so we must accept it. Any git failure (missing
+    binary, timeout, unknown ref) is treated as "not usable".
+    """
+    if not ref or ref.startswith("-") or not _SAFE_GIT_REF.fullmatch(ref):
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+            capture_output=True,
+            cwd=str(repo_root),
+            timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def resolve_incremental_base(repo_root: Path, store: "GraphStore") -> str | None:
+    """Resolve the automatic diff base for a default incremental update.
+
+    The graph records the commit it was last built at (``git_head_sha``). Using
+    that as the diff base lets a single ``update`` reconcile every change since
+    the graph was last in sync, instead of only the most recent commit, which
+    is what a fixed ``HEAD~1`` base does. That fixed base silently misses work
+    that arrived through a multi-commit pull, rebase, or branch switch.
+
+    Returns:
+        - the stored commit SHA when it is still a usable diff base;
+        - ``"HEAD~1"`` for SVN or non-git working copies, whose change
+          discovery ignores or reinterprets the base anyway;
+        - ``None`` for a git repo with no usable anchor (a fresh or legacy
+          database, or a stored commit lost to a history rewrite or shallow
+          clone), signalling the caller to do a full rebuild rather than
+          diff against a wrong base.
+    """
+    if detect_vcs(repo_root) != "git":
+        return "HEAD~1"
+    stored = store.get_metadata("git_head_sha")
+    if stored and _commit_object_exists(repo_root, stored):
+        return stored
+    return None
+
+
 def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
     """Get list of changed files via git diff or svn status.
 

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -100,7 +100,7 @@ mcp = FastMCP(
 async def build_or_update_graph_tool(
     full_rebuild: bool = False,
     repo_root: Optional[str] = None,
-    base: str = "HEAD~1",
+    base: Optional[str] = None,
     postprocess: str = "full",
     recurse_submodules: Optional[bool] = None,
     embedding_provider: Optional[str] = None,
@@ -122,7 +122,10 @@ async def build_or_update_graph_tool(
     Args:
         full_rebuild: If True, re-parse all files. Default: False (incremental).
         repo_root: Repository root path. Auto-detected from current directory if omitted.
-        base: Git ref to diff against for incremental updates. Default: HEAD~1.
+        base: Git ref to diff against for incremental updates. When omitted,
+            resolves automatically to the commit the graph was last built at,
+            so one update catches everything since the last sync (not just the
+            latest commit). Pass an explicit ref to override.
         postprocess: Post-processing level: "full" (default), "minimal" (signatures+FTS only),
                      or "none" (skip all post-processing). Use "minimal" for faster builds.
         recurse_submodules: If True, include files from git submodules.

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -7,7 +7,11 @@ import sqlite3
 import time
 from typing import Any
 
-from ..incremental import full_build, incremental_update
+from ..incremental import (
+    full_build,
+    incremental_update,
+    resolve_incremental_base,
+)
 from ._common import _get_store
 
 logger = logging.getLogger(__name__)
@@ -461,7 +465,7 @@ def _compute_summaries(store: Any) -> None:
 def build_or_update_graph(
     full_rebuild: bool = False,
     repo_root: str | None = None,
-    base: str = "HEAD~1",
+    base: str | None = None,
     postprocess: str = "full",
     recurse_submodules: bool | None = None,
     embedding_provider: str | None = None,
@@ -473,7 +477,11 @@ def build_or_update_graph(
         full_rebuild: If True, re-parse every file. If False (default),
                       only re-parse files changed since ``base``.
         repo_root: Path to the repository root. Auto-detected if omitted.
-        base: Git ref for incremental diff (default: HEAD~1).
+        base: Git ref for the incremental diff. When None (default), the base
+              is resolved automatically to the commit the graph was last built
+              at, so a single update reconciles everything since the last sync
+              rather than only the most recent commit. Pass an explicit ref to
+              override. Ignored when full_rebuild is True.
         postprocess: Post-processing level after build:
             ``"full"`` (default) — signatures, FTS, flows, communities.
             ``"minimal"`` — signatures + FTS only (fast, keeps search working).
@@ -494,31 +502,45 @@ def build_or_update_graph(
     """
     store, root = _get_store(repo_root)
     try:
+        # An automatic (base is None) incremental update resolves its diff base
+        # to the last-synced commit. When no usable anchor exists, fall back to
+        # a full rebuild rather than a wrong HEAD~1 diff that could report the
+        # graph as up to date while it is actually stale.
+        base_resolved: str | None = base
+        if not full_rebuild and base is None:
+            base_resolved = resolve_incremental_base(root, store)
+            if base_resolved is None:
+                full_rebuild = True
+
         if full_rebuild:
             result = full_build(root, store, recurse_submodules)
             build_result = {
+                **result,
                 "status": "ok",
                 "build_type": "full",
+                "base_resolved": None,
                 "summary": (
                     f"Full build complete: parsed {result['files_parsed']} files, "
                     f"created {result['total_nodes']} nodes and "
                     f"{result['total_edges']} edges."
                 ),
-                **result,
             }
         else:
-            result = incremental_update(root, store, base=base)
+            result = incremental_update(root, store, base=base_resolved)
             if result["files_updated"] == 0:
                 return {
+                    **result,
                     "status": "ok",
                     "build_type": "incremental",
+                    "base_resolved": base_resolved,
                     "summary": "No changes detected. Graph is up to date.",
                     "postprocess_level": postprocess,
-                    **result,
                 }
             build_result = {
+                **result,
                 "status": "ok",
                 "build_type": "incremental",
+                "base_resolved": base_resolved,
                 "summary": (
                     f"Incremental update: {result['files_updated']} files re-parsed, "
                     f"{result['total_nodes']} nodes and "
@@ -526,7 +548,6 @@ def build_or_update_graph(
                     f"Changed: {result['changed_files']}. "
                     f"Dependents also updated: {result['dependent_files']}."
                 ),
-                **result,
             }
 
         # Pass changed_files for incremental flow/community detection

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -29,7 +29,7 @@ Review a PR or branch diff.
 ```
 full_rebuild: bool = False           # True for full re-parse
 repo_root: str | None                # Auto-detected
-base: str = "HEAD~1"                 # VCS diff base for incremental updates
+base: str | None = None              # Diff base; None auto-resolves to the last-synced commit
 postprocess: str = "full"            # "full", "minimal", or "none"
 recurse_submodules: bool | None      # Falls back to CRG_RECURSE_SUBMODULES
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,13 +201,80 @@ class TestBuildUpdateCommands:
                         ) as mock_postprocess:
                             cli.main()
 
+        # With no explicit --base, the CLI forwards None so the shared seam
+        # can resolve the base to the last-synced commit.
         mock_build.assert_called_once_with(
             full_rebuild=False,
             repo_root="repo-root",
-            base="HEAD~1",
+            base=None,
             postprocess="minimal",
         )
         mock_postprocess.assert_not_called()
+
+    def test_update_forwards_explicit_base_verbatim(self):
+        argv = [
+            "code-review-graph",
+            "update",
+            "--base",
+            "HEAD~3",
+            "--skip-flows",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_updated": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "minimal",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ):
+                            cli.main()
+
+        assert mock_build.call_args.kwargs["base"] == "HEAD~3"
+
+    def test_update_reports_full_rebuild_fallback(self, capsys):
+        argv = ["code-review-graph", "update", "--repo", "repo-root"]
+        # build_or_update_graph falls back to a full rebuild when there is no
+        # usable incremental base; the CLI must say so rather than print
+        # "Incremental: 0 files updated", which reads as "nothing happened".
+        result = {
+            "status": "ok",
+            "build_type": "full",
+            "base_resolved": None,
+            "files_parsed": 2,
+            "total_nodes": 4,
+            "total_edges": 2,
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ):
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ):
+                            cli.main()
+
+        out = capsys.readouterr().out
+        assert "Full rebuild" in out
+        assert "Incremental:" not in out
 
 
 class TestDetectChangesCommand:

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -11,6 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 import inspect
+import json
 import subprocess
 import sys
 import tempfile
@@ -611,3 +612,161 @@ def test_cli_update_brief_default_base_does_not_crash(
     # It ran the incremental update and the brief impact summary without error.
     assert "Incremental:" in out
     assert "changed file" in out
+
+
+def test_update_auto_base_multi_commit_rename_matches_full_rebuild(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Three commits after the stored SHA converge exactly to a fresh graph.
+
+    The commits deliberately split a module rename, its importer update, and a
+    new importing file. A HEAD~1 update sees only the new file; the automatic
+    stored-SHA base must reconcile all three commits and purge the old path.
+    """
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    repo = tmp_path / "multi-commit-repo"
+    repo.mkdir()
+    _git_ok(repo, "init", "-b", "main")
+    _git_ok(repo, "config", "user.email", "test@test.com")
+    _git_ok(repo, "config", "user.name", "Test")
+
+    package = repo / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    old_module = package / "service.py"
+    old_module.write_text(
+        "def provide():\n"
+        "    return 'value'\n",
+        encoding="utf-8",
+    )
+    importer = repo / "app.py"
+    importer.write_text(
+        "from pkg.service import provide\n\n"
+        "def run():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", "initial graph state")
+    stored_sha = _git_ok(repo, "rev-parse", "HEAD").stdout.strip()
+
+    incremental_data = tmp_path / "incremental-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(incremental_data))
+    initial = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert initial["errors"] == []
+    with GraphStore(incremental_data / "graph.db") as stored:
+        assert stored.get_metadata("git_head_sha") == stored_sha
+        assert stored.get_nodes_by_file(str(old_module))
+
+    # Commit 1: rename the provider module.
+    new_module = package / "core.py"
+    _git_ok(repo, "mv", "pkg/service.py", "pkg/core.py")
+    _git_ok(repo, "commit", "-m", "rename provider module")
+
+    # Commit 2: update the existing importer.
+    importer.write_text(
+        "from pkg.core import provide\n\n"
+        "def run():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", "app.py")
+    _git_ok(repo, "commit", "-m", "update provider importer")
+
+    # Commit 3: add another importing file.
+    new_consumer = repo / "worker.py"
+    new_consumer.write_text(
+        "from pkg.core import provide\n\n"
+        "def work():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", "worker.py")
+    _git_ok(repo, "commit", "-m", "add provider worker")
+
+    commits_since_graph = _git_ok(
+        repo,
+        "rev-list",
+        "--count",
+        f"{stored_sha}..HEAD",
+    ).stdout.strip()
+    assert commits_since_graph == "3"
+    assert get_changed_files(repo, "HEAD~1") == ["worker.py"]
+
+    updated = build_or_update_graph(
+        full_rebuild=False,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert updated["build_type"] == "incremental"
+    assert updated["base_resolved"] == stored_sha
+    assert set(updated["changed_files"]) == {
+        "app.py",
+        "pkg/service.py",
+        "pkg/core.py",
+        "worker.py",
+    }
+    assert updated["errors"] == []
+
+    def node_snapshot(store: GraphStore) -> set[tuple[object, ...]]:
+        return {
+            (
+                node.kind,
+                node.name,
+                node.qualified_name,
+                node.file_path,
+                node.line_start,
+                node.line_end,
+                node.language,
+                node.parent_name,
+                node.params,
+                node.return_type,
+                node.is_test,
+                node.file_hash,
+                json.dumps(node.extra, sort_keys=True),
+            )
+            for node in store.get_all_nodes(exclude_files=False)
+        }
+
+    def edge_snapshot(store: GraphStore) -> set[tuple[object, ...]]:
+        return {
+            (
+                edge.kind,
+                edge.source_qualified,
+                edge.target_qualified,
+                edge.file_path,
+                edge.line,
+                json.dumps(edge.extra, sort_keys=True),
+                edge.confidence,
+                edge.confidence_tier,
+            )
+            for edge in store.get_all_edges()
+        }
+
+    with GraphStore(incremental_data / "graph.db") as incremental_store:
+        assert incremental_store.get_nodes_by_file(str(old_module)) == []
+        assert incremental_store.get_nodes_by_file(str(new_module))
+        incremental_nodes = node_snapshot(incremental_store)
+        incremental_edges = edge_snapshot(incremental_store)
+        assert all(
+            str(old_module) not in repr(edge)
+            for edge in incremental_edges
+        )
+
+    fresh_data = tmp_path / "fresh-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(fresh_data))
+    fresh = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert fresh["errors"] == []
+
+    with GraphStore(fresh_data / "graph.db") as fresh_store:
+        assert incremental_nodes == node_snapshot(fresh_store)
+        assert incremental_edges == edge_snapshot(fresh_store)

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -10,6 +10,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import inspect
 import subprocess
 import sys
 import tempfile
@@ -20,13 +21,16 @@ import pytest
 from code_review_graph.changes import parse_git_diff_ranges
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
+    _commit_object_exists,
     collect_all_files,
     full_build,
     get_all_tracked_files,
     get_changed_files,
     get_staged_and_unstaged,
     incremental_update,
+    resolve_incremental_base,
 )
+from code_review_graph.tools.build import build_or_update_graph
 from code_review_graph.wiki import get_wiki_page
 
 
@@ -39,6 +43,15 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         cwd=str(repo),
         timeout=10,
     )
+
+
+def _git_ok(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command and fail the test if it does not succeed."""
+    result = _git(repo, *args)
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed ({result.returncode}): {result.stderr.strip()}"
+    )
+    return result
 
 
 @pytest.fixture()
@@ -399,3 +412,202 @@ def test_incremental_rename_matches_a_fresh_full_rebuild(
         incremental_store.close()
         if full_store is not None:
             full_store.close()
+
+
+# ------------------------------------------------------------------
+# 6. Auto-resolved incremental base (last-synced commit, not HEAD~1)
+# ------------------------------------------------------------------
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """A git repo on branch ``main`` with one commit adding ``a.py``.
+
+    ``init -b main`` pins the branch name so tests that switch branches do not
+    depend on the host's ``init.defaultBranch`` (which may be ``master``).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_ok(repo, "init", "-b", "main")
+    _git_ok(repo, "config", "user.email", "test@test.com")
+    _git_ok(repo, "config", "user.name", "Test")
+    (repo / "a.py").write_text("def alpha():\n    return 1\n")
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", "c0")
+    return repo
+
+
+def _commit_file(repo: Path, name: str) -> None:
+    (repo / f"{name}.py").write_text(f"def {name}():\n    return 1\n")
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", name)
+
+
+def test_commit_object_exists(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert _commit_object_exists(repo, head) is True
+    assert _commit_object_exists(repo, "0" * 40) is False
+    # Injection-shaped refs are rejected before ever reaching git.
+    assert _commit_object_exists(repo, "--output=/tmp/evil") is False
+
+
+def test_resolve_incremental_base(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    store = GraphStore(str(repo / "graph.db"))
+    try:
+        # Usable anchor -> the stored SHA.
+        store.set_metadata("git_head_sha", head)
+        assert resolve_incremental_base(repo, store) == head
+        # Unreachable anchor (rewrite / shallow clone) -> None (full rebuild).
+        store.set_metadata("git_head_sha", "0" * 40)
+        assert resolve_incremental_base(repo, store) is None
+    finally:
+        store.close()
+
+    # No anchor at all (fresh / legacy database) -> None.
+    store2 = GraphStore(str(repo / "graph2.db"))
+    try:
+        assert resolve_incremental_base(repo, store2) is None
+    finally:
+        store2.close()
+
+
+def test_resolve_incremental_base_non_git(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    store = GraphStore(str(plain / "graph.db"))
+    try:
+        # Non-git working copies keep the concrete "HEAD~1" default so the
+        # SVN/plain change-discovery path never receives None.
+        assert resolve_incremental_base(plain, store) == "HEAD~1"
+    finally:
+        store.close()
+
+
+def test_update_auto_base_catches_commits_missed_by_head1(tmp_path: Path) -> None:
+    """The headline bug: after several out-of-band commits, a default update
+    must reconcile all of them, not only the newest."""
+    repo = _init_repo(tmp_path)
+    c0 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    for name in ("beta", "gamma", "delta"):
+        _commit_file(repo, name)
+
+    # Old behaviour, reproduced explicitly: HEAD~1 sees only the last commit.
+    head1 = get_changed_files(repo, "HEAD~1")
+    assert head1 == ["delta.py"]
+
+    # New behaviour: auto base resolves to c0 and catches every commit since.
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    assert res["base_resolved"] == c0
+    assert set(res["changed_files"]) == {"beta.py", "gamma.py", "delta.py"}
+
+
+def test_update_auto_base_across_divergent_branch_switch(tmp_path: Path) -> None:
+    """Build on one branch, then switch to a divergent branch whose HEAD~1 is
+    NOT the anchor. A fixed HEAD~1 base would miss the difference and leave the
+    other branch's files stale; the resolved anchor reconciles it.
+    """
+    repo = _init_repo(tmp_path)  # main @ c0 with a.py
+
+    # A sibling branch off c0 that adds its own file, then back to main.
+    _git_ok(repo, "checkout", "-b", "sibling")
+    _commit_file(repo, "sibling_only")
+    _git_ok(repo, "checkout", "main")
+
+    # Advance main by two commits and build the graph at main's tip.
+    _commit_file(repo, "main_one")
+    _commit_file(repo, "main_two")
+    main_tip = _git_ok(repo, "rev-parse", "HEAD").stdout.strip()
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    # Switch to the divergent sibling. Its HEAD~1 is c0, not main's tip, so a
+    # fixed-HEAD~1 update could never reconcile against where the graph is.
+    _git_ok(repo, "checkout", "sibling")
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    # The resolved base is the commit the graph was actually built at.
+    assert res["base_resolved"] == main_tip
+    assert res["build_type"] == "incremental"
+    # The diff main_tip..sibling adds sibling's file and drops main's files.
+    changed = set(res["changed_files"])
+    assert {"sibling_only.py", "main_one.py", "main_two.py"} <= changed
+
+
+def test_update_without_usable_anchor_falls_back_to_full_rebuild(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    # Corrupt the anchor to an unreachable SHA (as a history rewrite would).
+    from code_review_graph.incremental import get_db_path
+
+    store = GraphStore(str(get_db_path(repo)))
+    try:
+        store.set_metadata("git_head_sha", "0" * 40)
+    finally:
+        store.close()
+
+    _commit_file(repo, "epsilon")
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    assert res["build_type"] == "full"
+    assert res["base_resolved"] is None
+
+
+def test_update_explicit_base_bypasses_auto_resolution(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+    for name in ("beta", "gamma"):
+        _commit_file(repo, name)
+
+    # An explicit base is honoured verbatim and stays incremental.
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base="HEAD~1", postprocess="none"
+    )
+    assert res["build_type"] == "incremental"
+    assert res["base_resolved"] == "HEAD~1"
+    assert res["changed_files"] == ["gamma.py"]
+
+
+def test_mcp_tool_base_defaults_to_none() -> None:
+    """The MCP wrapper must default base to None so omitted-base calls reach
+    the auto-resolution path instead of a hardcoded HEAD~1."""
+    from code_review_graph.main import build_or_update_graph_tool
+
+    # FastMCP may wrap the tool; the underlying callable is stored on ``.fn``.
+    fn = getattr(build_or_update_graph_tool, "fn", build_or_update_graph_tool)
+    assert inspect.signature(fn).parameters["base"].default is None
+
+
+def test_cli_update_brief_default_base_does_not_crash(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    """`update --brief` with no explicit --base must not crash. The base now
+    defaults to None, which the brief impact path cannot pass to git directly;
+    it has to reuse the resolved base."""
+    from code_review_graph import cli
+
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+    _commit_file(repo, "brief_new")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["code-review-graph", "update", "--brief", "--repo", str(repo)],
+    )
+    cli.main()  # would raise AttributeError/TypeError on a None base before the fix
+
+    out = capsys.readouterr().out
+    # It ran the incremental update and the brief impact summary without error.
+    assert "Incremental:" in out
+    assert "changed file" in out


### PR DESCRIPTION
## Summary

Corrected integration of contributor PR #694, preserving Utku Özdemir’s patch and attribution.

The default incremental update base is now the commit at which the graph was last successfully built, instead of a fixed `HEAD~1`. This lets one update reconcile every commit since the graph was last in sync, including branch switches and multi-commit pulls.

If a fresh/legacy graph has no usable stored commit, or the commit was removed by a rewrite/shallow clone, the command performs a full rebuild rather than silently diffing from the wrong base. An explicit `--base` still overrides the automatic choice.

## Additional validation

The original contribution had good broad coverage but no exact regression combining the risky paths. The maintainer test splits these changes across three commits:

1. rename `pkg/service.py` to `pkg/core.py`;
2. update an existing importer;
3. add a new importing file.

It proves:

- `HEAD~1` sees only the newest file;
- the default stored-SHA update sees all four old/new paths;
- old nodes and edges are purged;
- complete node and edge snapshots match a fresh full rebuild.

## Results

- Exact multi-commit rename regression: passed.
- All 244 unique affected CLI/incremental/Git/forget/uninstall tests passed after rebasing on #766.
- The one process-pool test blocked by the local sandbox passed with a real two-worker process outside that sandbox.
- Production Ruff: passed.
- Affected test lint: passed.
- `git diff --check`: passed.
- Contributor patch and regression patch IDs are unchanged after rebase.

Full hosted Python, Windows, type, lint, schema, security, and CodeQL checks are required before merge.
