### PR TITLE
fix: reconcile directional impact, JS members, and incremental bases

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -755,7 +755,11 @@ def main() -> None:
 
     # update
     update_cmd = sub.add_parser("update", help="Incremental update (only changed files)")
-    update_cmd.add_argument("--base", default="HEAD~1", help="Git diff base (default: HEAD~1)")
+    update_cmd.add_argument(
+        "--base",
+        default=None,
+        help="Git diff base (default: the commit the graph was last built at)",
+    )
     update_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
     update_cmd.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     update_cmd.add_argument(
@@ -1686,15 +1690,26 @@ def main() -> None:
                 )
             finally:
                 logging.disable(previous_disable)
-            updated = result.get("files_updated", 0)
             nodes = result.get("total_nodes", 0)
             edges = result.get("total_edges", 0)
             if not args.quiet:
-                print(
-                    f"Incremental: {updated} files updated, "
-                    f"{nodes} nodes, {edges} edges"
-                    f" (postprocess={pp})"
-                )
+                if result.get("build_type") == "full":
+                    # No usable incremental base (fresh/legacy graph, or the
+                    # last-synced commit was lost to a rewrite/shallow clone),
+                    # so the update fell back to a full rebuild.
+                    parsed = result.get("files_parsed", 0)
+                    print(
+                        f"Full rebuild (no usable incremental base): "
+                        f"{parsed} files, {nodes} nodes, {edges} edges"
+                        f" (postprocess={pp})"
+                    )
+                else:
+                    updated = result.get("files_updated", 0)
+                    print(
+                        f"Incremental: {updated} files updated, "
+                        f"{nodes} nodes, {edges} edges"
+                        f" (postprocess={pp})"
+                    )
 
             # --brief: append a one-line change-impact summary with the same
             # estimated context-savings approximation that detect-changes uses.
@@ -1712,7 +1727,10 @@ def main() -> None:
                     get_staged_and_unstaged,
                 )
 
-                changed = get_changed_files(repo_root, args.base)
+                # Reuse the base the update actually resolved to (args.base is
+                # None by default now, which get_changed_files cannot accept).
+                brief_base = result.get("base_resolved") or "HEAD~1"
+                changed = get_changed_files(repo_root, brief_base)
                 if not changed:
                     changed = get_staged_and_unstaged(repo_root)
                 if changed:
@@ -1720,7 +1738,7 @@ def main() -> None:
                         store,
                         changed,
                         repo_root=str(repo_root),
-                        base=args.base,
+                        base=brief_base,
                     )
                     original_tokens = estimate_file_tokens(repo_root, changed)
                     attach_context_savings(

--- a/code_review_graph/constants.py
+++ b/code_review_graph/constants.py
@@ -66,6 +66,31 @@ IMPACT_EDGE_WEIGHTS: dict[str, float] = {
     "CONTAINS": 0.3,
 }
 IMPACT_DEFAULT_EDGE_WEIGHT = 0.5
+
+# Stored dependency edges point from the dependent to its dependency, so impact
+# normally propagates against the stored edge (target -> source). TESTED_BY is
+# intentionally stored in the opposite orientation (production -> test).
+# CONTAINS is not traversed: changing a file already seeds every node in it, and
+# following containment can bridge into unrelated structure through stale edges.
+IMPACT_DIRECTION_INCOMING = "incoming"
+IMPACT_DIRECTION_OUTGOING = "outgoing"
+IMPACT_DIRECTION_NONE = "none"
+IMPACT_EDGE_DIRECTIONS: dict[str, str] = {
+    "CALLS": IMPACT_DIRECTION_INCOMING,
+    "INHERITS": IMPACT_DIRECTION_INCOMING,
+    "OVERRIDES": IMPACT_DIRECTION_INCOMING,
+    "IMPLEMENTS": IMPACT_DIRECTION_INCOMING,
+    "TESTED_BY": IMPACT_DIRECTION_OUTGOING,
+    "REFERENCES": IMPACT_DIRECTION_INCOMING,
+    "DEPENDS_ON": IMPACT_DIRECTION_INCOMING,
+    "IMPORTS_FROM": IMPACT_DIRECTION_INCOMING,
+    "CONTAINS": IMPACT_DIRECTION_NONE,
+}
+# Unknown relationships conservatively follow the dominant graph convention:
+# source depends on target. This includes possible dependents without claiming
+# that a changed node's own unclassified dependency is impacted.
+IMPACT_DEFAULT_EDGE_DIRECTION = IMPACT_DIRECTION_INCOMING
+
 IMPACT_DEPTH_DECAY = _bounded_float_env(
     "CRG_IMPACT_DEPTH_DECAY", 0.6, lower=0.0, upper=1.0,
 )

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -22,8 +22,13 @@ import networkx as nx
 
 from .constants import (
     BFS_ENGINE,
+    IMPACT_DEFAULT_EDGE_DIRECTION,
     IMPACT_DEFAULT_EDGE_WEIGHT,
     IMPACT_DEPTH_DECAY,
+    IMPACT_DIRECTION_INCOMING,
+    IMPACT_DIRECTION_NONE,
+    IMPACT_DIRECTION_OUTGOING,
+    IMPACT_EDGE_DIRECTIONS,
     IMPACT_EDGE_WEIGHTS,
     IMPACT_SCORE_FLOOR,
     MAX_IMPACT_DEPTH,
@@ -1236,11 +1241,16 @@ class GraphStore:
         max_depth: int = MAX_IMPACT_DEPTH,
         max_nodes: int = MAX_IMPACT_NODES,
     ) -> dict[str, Any]:
-        """BFS from changed files to find all impacted nodes within depth N.
+        """Find dependents and tests impacted by changed files within depth N.
 
         Delegates to ``get_impact_radius_sql()`` by default (faster for
         large graphs).  Set ``CRG_BFS_ENGINE=networkx`` to use the legacy
         Python-side BFS via NetworkX.
+
+        Dependency-shaped edges propagate from target to source, while
+        TESTED_BY propagates from production source to test target. CONTAINS
+        does not expand the traversal because every node in a changed file is
+        already seeded.
 
         Returns dict with:
           - changed_nodes: nodes in changed files
@@ -1323,13 +1333,24 @@ class GraphStore:
         # many paths; these three bounded temp tables contain at most one row
         # per qualified name and each iteration scans the edge table once.
         self._conn.execute(
-            "CREATE TEMP TABLE IF NOT EXISTS _impact_weights "
-            "(kind TEXT PRIMARY KEY, weight REAL NOT NULL)"
+            "CREATE TEMP TABLE IF NOT EXISTS _impact_policies "
+            "(kind TEXT PRIMARY KEY, weight REAL NOT NULL, "
+            "direction TEXT NOT NULL)"
         )
-        self._conn.execute("DELETE FROM _impact_weights")
+        self._conn.execute("DELETE FROM _impact_policies")
         self._conn.executemany(
-            "INSERT INTO _impact_weights (kind, weight) VALUES (?, ?)",
-            list(IMPACT_EDGE_WEIGHTS.items()),
+            "INSERT INTO _impact_policies "
+            "(kind, weight, direction) VALUES (?, ?, ?)",
+            [
+                (
+                    kind,
+                    weight,
+                    IMPACT_EDGE_DIRECTIONS.get(
+                        kind, IMPACT_DEFAULT_EDGE_DIRECTION,
+                    ),
+                )
+                for kind, weight in IMPACT_EDGE_WEIGHTS.items()
+            ],
         )
         for table in ("_impact_best", "_impact_frontier", "_impact_next"):
             self._conn.execute(
@@ -1352,16 +1373,18 @@ class GraphStore:
         SELECT node_qn, MAX(score)
         FROM (
             SELECT e.target_qualified AS node_qn,
-                   f.score * COALESCE(w.weight, ?) * ? AS score
+                   f.score * COALESCE(p.weight, ?) * ? AS score
             FROM _impact_frontier f
             JOIN edges e ON e.source_qualified = f.node_qn
-            LEFT JOIN _impact_weights w ON w.kind = e.kind
+            LEFT JOIN _impact_policies p ON p.kind = e.kind
+            WHERE COALESCE(p.direction, ?) = ?
             UNION ALL
             SELECT e.source_qualified AS node_qn,
-                   f.score * COALESCE(w.weight, ?) * ? AS score
+                   f.score * COALESCE(p.weight, ?) * ? AS score
             FROM _impact_frontier f
             JOIN edges e ON e.target_qualified = f.node_qn
-            LEFT JOIN _impact_weights w ON w.kind = e.kind
+            LEFT JOIN _impact_policies p ON p.kind = e.kind
+            WHERE COALESCE(p.direction, ?) = ?
         ) candidates
         WHERE score > ?
         GROUP BY node_qn
@@ -1369,8 +1392,12 @@ class GraphStore:
         candidate_params = (
             IMPACT_DEFAULT_EDGE_WEIGHT,
             IMPACT_DEPTH_DECAY,
+            IMPACT_DEFAULT_EDGE_DIRECTION,
+            IMPACT_DIRECTION_OUTGOING,
             IMPACT_DEFAULT_EDGE_WEIGHT,
             IMPACT_DEPTH_DECAY,
+            IMPACT_DEFAULT_EDGE_DIRECTION,
+            IMPACT_DIRECTION_INCOMING,
             IMPACT_SCORE_FLOOR,
         )
         for _ in range(max_depth):
@@ -1487,16 +1514,15 @@ class GraphStore:
                 if qn not in nxg:
                     continue
                 neighbors = [
-                    (target, data)
+                    (target, data["impact_outgoing_weight"])
                     for _, target, data in nxg.out_edges(qn, data=True)
+                    if "impact_outgoing_weight" in data
                 ] + [
-                    (source, data)
+                    (source, data["impact_incoming_weight"])
                     for source, _, data in nxg.in_edges(qn, data=True)
+                    if "impact_incoming_weight" in data
                 ]
-                for other_qn, data in neighbors:
-                    weight = IMPACT_EDGE_WEIGHTS.get(
-                        data.get("kind", ""), IMPACT_DEFAULT_EDGE_WEIGHT,
-                    )
+                for other_qn, weight in neighbors:
                     new_score = score * weight * IMPACT_DEPTH_DECAY
                     if new_score <= IMPACT_SCORE_FLOOR:
                         continue
@@ -2020,7 +2046,7 @@ class GraphStore:
     # --- Internal helpers ---
 
     def _build_networkx_graph(self) -> nx.DiGraph:
-        """Build a directed graph, retaining the strongest parallel edge."""
+        """Build a directed graph with impact weights for both policies."""
         with self._cache_lock:
             if self._nxg_cache is not None:
                 return self._nxg_cache
@@ -2030,17 +2056,26 @@ class GraphStore:
                 source = r["source_qualified"]
                 target = r["target_qualified"]
                 kind = r["kind"]
-                if g.has_edge(source, target):
-                    existing = g[source][target].get("kind", "")
-                    existing_weight = IMPACT_EDGE_WEIGHTS.get(
-                        existing, IMPACT_DEFAULT_EDGE_WEIGHT,
+                candidate_weight = IMPACT_EDGE_WEIGHTS.get(
+                    kind, IMPACT_DEFAULT_EDGE_WEIGHT,
+                )
+                if not g.has_edge(source, target):
+                    g.add_edge(source, target, kind=kind)
+                data = g[source][target]
+                existing_weight = IMPACT_EDGE_WEIGHTS.get(
+                    data.get("kind", ""), IMPACT_DEFAULT_EDGE_WEIGHT,
+                )
+                if candidate_weight > existing_weight:
+                    data["kind"] = kind
+
+                direction = IMPACT_EDGE_DIRECTIONS.get(
+                    kind, IMPACT_DEFAULT_EDGE_DIRECTION,
+                )
+                if direction != IMPACT_DIRECTION_NONE:
+                    weight_key = f"impact_{direction}_weight"
+                    data[weight_key] = max(
+                        data.get(weight_key, 0.0), candidate_weight,
                     )
-                    candidate_weight = IMPACT_EDGE_WEIGHTS.get(
-                        kind, IMPACT_DEFAULT_EDGE_WEIGHT,
-                    )
-                    if candidate_weight <= existing_weight:
-                        continue
-                g.add_edge(source, target, kind=kind)
             self._nxg_cache = g
             return g
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -618,6 +618,55 @@ def _store_vcs_metadata(repo_root: Path, store: "GraphStore") -> None:
             store.set_metadata("svn_revision", rev)
 
 
+def _commit_object_exists(repo_root: Path, ref: str) -> bool:
+    """Return True if *ref* resolves to a commit object present in the repo.
+
+    This is an object-existence check, not an ancestry check: a commit that is
+    only reachable from a branch we have since switched away from is still a
+    valid ``git diff`` base, so we must accept it. Any git failure (missing
+    binary, timeout, unknown ref) is treated as "not usable".
+    """
+    if not ref or ref.startswith("-") or not _SAFE_GIT_REF.fullmatch(ref):
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+            capture_output=True,
+            cwd=str(repo_root),
+            timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def resolve_incremental_base(repo_root: Path, store: "GraphStore") -> str | None:
+    """Resolve the automatic diff base for a default incremental update.
+
+    The graph records the commit it was last built at (``git_head_sha``). Using
+    that as the diff base lets a single ``update`` reconcile every change since
+    the graph was last in sync, instead of only the most recent commit, which
+    is what a fixed ``HEAD~1`` base does. That fixed base silently misses work
+    that arrived through a multi-commit pull, rebase, or branch switch.
+
+    Returns:
+        - the stored commit SHA when it is still a usable diff base;
+        - ``"HEAD~1"`` for SVN or non-git working copies, whose change
+          discovery ignores or reinterprets the base anyway;
+        - ``None`` for a git repo with no usable anchor (a fresh or legacy
+          database, or a stored commit lost to a history rewrite or shallow
+          clone), signalling the caller to do a full rebuild rather than
+          diff against a wrong base.
+    """
+    if detect_vcs(repo_root) != "git":
+        return "HEAD~1"
+    stored = store.get_metadata("git_head_sha")
+    if stored and _commit_object_exists(repo_root, stored):
+        return stored
+    return None
+
+
 def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
     """Get list of changed files via git diff or svn status.
 

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -100,7 +100,7 @@ mcp = FastMCP(
 async def build_or_update_graph_tool(
     full_rebuild: bool = False,
     repo_root: Optional[str] = None,
-    base: str = "HEAD~1",
+    base: Optional[str] = None,
     postprocess: str = "full",
     recurse_submodules: Optional[bool] = None,
     embedding_provider: Optional[str] = None,
@@ -122,7 +122,10 @@ async def build_or_update_graph_tool(
     Args:
         full_rebuild: If True, re-parse all files. Default: False (incremental).
         repo_root: Repository root path. Auto-detected from current directory if omitted.
-        base: Git ref to diff against for incremental updates. Default: HEAD~1.
+        base: Git ref to diff against for incremental updates. When omitted,
+            resolves automatically to the commit the graph was last built at,
+            so one update catches everything since the last sync (not just the
+            latest commit). Pass an explicit ref to override.
         postprocess: Post-processing level: "full" (default), "minimal" (signatures+FTS only),
                      or "none" (skip all post-processing). Use "minimal" for faster builds.
         recurse_submodules: If True, include files from git submodules.

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -8467,15 +8467,17 @@ class CodeParser:
         # runtime scope, not to the module-level object namespace.  Without
         # lexical scope in the member name, identical assignments in sibling
         # functions would both become ``file::obj.method`` and produce
-        # duplicate CONTAINS targets.  Restrict this feature to module/class
-        # contexts, where the member path is a stable definition identity.
-        if enclosing_func:
+        # duplicate CONTAINS targets. Top-level lexical blocks have the same
+        # problem, so only direct program statements have a stable identity.
+        if (
+            enclosing_func
+            or child.parent is None
+            or child.parent.type != "program"
+        ):
             return False
 
-        member_name = left.text.decode("utf-8", errors="replace")
-        # Skip computed access (``obj[key] = fn``) and any multi-line/odd
-        # member paths that would produce a malformed qualified name.
-        if not member_name or "[" in member_name or "\n" in member_name:
+        member_name = self._get_js_static_member_path(left)
+        if member_name is None:
             return False
 
         is_test = _is_test_function(member_name, file_path)
@@ -8519,6 +8521,36 @@ class CodeParser:
             _depth=_depth + 1,
         )
         return True
+
+    @staticmethod
+    def _get_js_static_member_path(node) -> Optional[str]:
+        """Return a stable identifier-only JS/TS member path."""
+        if node.type != "member_expression":
+            return None
+        text = node.text.decode("utf-8", errors="replace")
+        if not text or "[" in text or "\n" in text:
+            return None
+
+        parts: list[str] = []
+        current = node
+        while current.type == "member_expression":
+            object_node = current.child_by_field_name("object")
+            property_node = current.child_by_field_name("property")
+            if (
+                object_node is None
+                or property_node is None
+                or property_node.type not in ("identifier", "property_identifier")
+            ):
+                return None
+            parts.append(
+                property_node.text.decode("utf-8", errors="replace"),
+            )
+            current = object_node
+
+        if current.type not in ("identifier", "this"):
+            return None
+        parts.append(current.text.decode("utf-8", errors="replace"))
+        return ".".join(reversed(parts))
 
     @staticmethod
     def _get_java_annotations(class_node) -> list[str]:
@@ -10474,13 +10506,7 @@ class CodeParser:
             callee = node.children[0]
         if callee is None or callee.type != "member_expression":
             return None
-        member_call = callee.text.decode("utf-8", errors="replace")
-        if not member_call or "[" in member_call or "\n" in member_call:
-            return None
-        # Optional property access has the same static member path as regular
-        # access: ``app?.handle()`` can target ``app.handle = fn`` whenever
-        # the receiver is present at runtime.
-        return member_call.replace("?.", ".")
+        return CodeParser._get_js_static_member_path(callee)
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -8463,6 +8463,15 @@ class CodeParser:
         if right.type not in self._JS_FUNC_VALUE_TYPES:
             return False
 
+        # An assignment nested in a function belongs to that function's
+        # runtime scope, not to the module-level object namespace.  Without
+        # lexical scope in the member name, identical assignments in sibling
+        # functions would both become ``file::obj.method`` and produce
+        # duplicate CONTAINS targets.  Restrict this feature to module/class
+        # contexts, where the member path is a stable definition identity.
+        if enclosing_func:
+            return False
+
         member_name = left.text.decode("utf-8", errors="replace")
         # Skip computed access (``obj[key] = fn``) and any multi-line/odd
         # member paths that would produce a malformed qualified name.

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -4457,6 +4457,26 @@ class CodeParser:
                 continue
             receiver = edge.extra.get("receiver")
             has_receiver = bool(receiver)
+            if edge.kind in ("CALLS", "REFERENCES") and "::" not in edge.target:
+                # JS/TS calls retain their full member expression as evidence
+                # (``app.handle``) while keeping the method name (``handle``)
+                # as the fallback target for external calls. Prefer the full
+                # expression when it identifies a same-file member-assigned
+                # function; otherwise preserve the existing bare-name
+                # resolution behavior.
+                member_call = edge.extra.get("member_call")
+                member_candidates = symbols.get(member_call, [])
+                if member_candidates:
+                    edge = EdgeInfo(
+                        kind=edge.kind,
+                        source=edge.source,
+                        target=member_candidates[0][0],
+                        file_path=edge.file_path,
+                        line=edge.line,
+                        extra=edge.extra,
+                    )
+                    resolved.append(edge)
+                    continue
             cpp_lexical_receiver = is_cpp and receiver == "this"
             if (
                 is_cpp
@@ -10333,6 +10353,10 @@ class CodeParser:
             # uses this evidence during parsing, and the Spring DI resolver
             # consumes the same metadata for Java injected fields.
             call_extra: dict = {}
+            if language in ("javascript", "typescript", "tsx"):
+                member_call = self._get_js_member_call_name(child)
+                if member_call:
+                    call_extra["member_call"] = member_call
             if (
                 language in self._TYPED_CALL_LANGUAGES
                 or language in ("cpp", "rust")
@@ -10425,6 +10449,26 @@ class CodeParser:
             ))
 
         return False
+
+    @staticmethod
+    def _get_js_member_call_name(node) -> Optional[str]:
+        """Return a static JS/TS member-call expression, if present.
+
+        ``_get_call_name`` intentionally reduces ``app.handle()`` to
+        ``handle`` for general method-call handling. Retain ``app.handle`` as
+        supplemental evidence so the same-file resolver can link it to a
+        member-assigned definition without changing unresolved external calls.
+        Computed and multiline expressions are intentionally excluded.
+        """
+        callee = node.child_by_field_name("function")
+        if callee is None and node.children:
+            callee = node.children[0]
+        if callee is None or callee.type != "member_expression":
+            return None
+        member_call = callee.text.decode("utf-8", errors="replace")
+        if not member_call or "[" in member_call or "\n" in member_call:
+            return None
+        return member_call
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -10477,7 +10477,10 @@ class CodeParser:
         member_call = callee.text.decode("utf-8", errors="replace")
         if not member_call or "[" in member_call or "\n" in member_call:
             return None
-        return member_call
+        # Optional property access has the same static member path as regular
+        # access: ``app?.handle()`` can target ``app.handle = fn`` whenever
+        # the receiver is present at runtime.
+        return member_call.replace("?.", ".")
 
     def _get_member_call_receiver_method(
         self,

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -6071,6 +6071,18 @@ class CodeParser:
             ):
                 continue
 
+            # --- JS/TS member-assigned functions (app.handle = function () {}) ---
+            if (
+                language in ("javascript", "typescript", "tsx")
+                and node_type == "expression_statement"
+                and self._extract_js_member_functions(
+                    child, source, language, file_path, nodes, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names, _depth,
+                )
+            ):
+                continue
+
             # --- Functions ---
             if node_type in func_types and self._extract_functions(
                 child, source, language, file_path, nodes, edges,
@@ -8372,6 +8384,107 @@ class CodeParser:
             func_node, source, language, file_path, nodes, edges,
             enclosing_class=enclosing_class,
             enclosing_func=prop_name,
+            import_map=import_map,
+            defined_names=defined_names,
+            _depth=_depth + 1,
+        )
+        return True
+
+    def _extract_js_member_functions(
+        self,
+        child,
+        source: bytes,
+        language: str,
+        file_path: str,
+        nodes: list[NodeInfo],
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+        _depth: int,
+    ) -> bool:
+        """Handle JS/TS member-assigned functions.
+
+        Patterns handled (LHS is a ``member_expression``, RHS is a function):
+          app.handle = function handle(req, res) {}
+          Router.prototype.dispatch = (req) => {}
+          exports.render = function () {}
+
+        These prototype- and module-augmentation patterns carry the entire
+        public API of Express, Koa and many older JS modules, but were
+        previously invisible to the graph: only ``const x = fn``
+        (:func:`_extract_js_var_functions`) and class fields
+        (:func:`_extract_js_field_function`) produced Function nodes. The node
+        is qualified by its full member path (``file::app.handle``), matching
+        the ``file::Class.method`` shape used elsewhere.
+
+        Returns True if a function was extracted, so the caller can skip
+        generic recursion.
+        """
+        # ``child`` is the expression_statement wrapping the assignment.
+        assign = None
+        if child.type == "assignment_expression":
+            assign = child
+        else:
+            for sub in child.children:
+                if sub.type == "assignment_expression":
+                    assign = sub
+                    break
+        if assign is None:
+            return False
+
+        left = assign.child_by_field_name("left")
+        right = assign.child_by_field_name("right")
+        if left is None or right is None:
+            return False
+        if left.type != "member_expression":
+            return False
+        if right.type not in self._JS_FUNC_VALUE_TYPES:
+            return False
+
+        member_name = left.text.decode("utf-8", errors="replace")
+        # Skip computed access (``obj[key] = fn``) and any multi-line/odd
+        # member paths that would produce a malformed qualified name.
+        if not member_name or "[" in member_name or "\n" in member_name:
+            return False
+
+        is_test = _is_test_function(member_name, file_path)
+        kind = "Test" if is_test else "Function"
+        qualified = self._qualify(member_name, file_path, enclosing_class)
+        params = self._get_params(right, language, source)
+        ret_type = self._get_return_type(right, language, source)
+
+        nodes.append(NodeInfo(
+            kind=kind,
+            name=member_name,
+            file_path=file_path,
+            line_start=child.start_point[0] + 1,
+            line_end=child.end_point[0] + 1,
+            language=language,
+            parent_name=enclosing_class,
+            params=params,
+            return_type=ret_type,
+            is_test=is_test,
+        ))
+        container = (
+            self._qualify(enclosing_class, file_path, None)
+            if enclosing_class else file_path
+        )
+        edges.append(EdgeInfo(
+            kind="CONTAINS",
+            source=container,
+            target=qualified,
+            file_path=file_path,
+            line=child.start_point[0] + 1,
+        ))
+
+        # Recurse into the function body for calls, attributing them to the
+        # member function.
+        self._extract_from_tree(
+            right, source, language, file_path, nodes, edges,
+            enclosing_class=enclosing_class,
+            enclosing_func=member_name,
             import_map=import_map,
             defined_names=defined_names,
             _depth=_depth + 1,

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -7,7 +7,11 @@ import sqlite3
 import time
 from typing import Any
 
-from ..incremental import full_build, incremental_update
+from ..incremental import (
+    full_build,
+    incremental_update,
+    resolve_incremental_base,
+)
 from ._common import _get_store
 
 logger = logging.getLogger(__name__)
@@ -461,7 +465,7 @@ def _compute_summaries(store: Any) -> None:
 def build_or_update_graph(
     full_rebuild: bool = False,
     repo_root: str | None = None,
-    base: str = "HEAD~1",
+    base: str | None = None,
     postprocess: str = "full",
     recurse_submodules: bool | None = None,
     embedding_provider: str | None = None,
@@ -473,7 +477,11 @@ def build_or_update_graph(
         full_rebuild: If True, re-parse every file. If False (default),
                       only re-parse files changed since ``base``.
         repo_root: Path to the repository root. Auto-detected if omitted.
-        base: Git ref for incremental diff (default: HEAD~1).
+        base: Git ref for the incremental diff. When None (default), the base
+              is resolved automatically to the commit the graph was last built
+              at, so a single update reconciles everything since the last sync
+              rather than only the most recent commit. Pass an explicit ref to
+              override. Ignored when full_rebuild is True.
         postprocess: Post-processing level after build:
             ``"full"`` (default) — signatures, FTS, flows, communities.
             ``"minimal"`` — signatures + FTS only (fast, keeps search working).
@@ -494,31 +502,45 @@ def build_or_update_graph(
     """
     store, root = _get_store(repo_root)
     try:
+        # An automatic (base is None) incremental update resolves its diff base
+        # to the last-synced commit. When no usable anchor exists, fall back to
+        # a full rebuild rather than a wrong HEAD~1 diff that could report the
+        # graph as up to date while it is actually stale.
+        base_resolved: str | None = base
+        if not full_rebuild and base is None:
+            base_resolved = resolve_incremental_base(root, store)
+            if base_resolved is None:
+                full_rebuild = True
+
         if full_rebuild:
             result = full_build(root, store, recurse_submodules)
             build_result = {
+                **result,
                 "status": "ok",
                 "build_type": "full",
+                "base_resolved": None,
                 "summary": (
                     f"Full build complete: parsed {result['files_parsed']} files, "
                     f"created {result['total_nodes']} nodes and "
                     f"{result['total_edges']} edges."
                 ),
-                **result,
             }
         else:
-            result = incremental_update(root, store, base=base)
+            result = incremental_update(root, store, base=base_resolved)
             if result["files_updated"] == 0:
                 return {
+                    **result,
                     "status": "ok",
                     "build_type": "incremental",
+                    "base_resolved": base_resolved,
                     "summary": "No changes detected. Graph is up to date.",
                     "postprocess_level": postprocess,
-                    **result,
                 }
             build_result = {
+                **result,
                 "status": "ok",
                 "build_type": "incremental",
+                "base_resolved": base_resolved,
                 "summary": (
                     f"Incremental update: {result['files_updated']} files re-parsed, "
                     f"{result['total_nodes']} nodes and "
@@ -526,7 +548,6 @@ def build_or_update_graph(
                     f"Changed: {result['changed_files']}. "
                     f"Dependents also updated: {result['dependent_files']}."
                 ),
-                **result,
             }
 
         # Pass changed_files for incremental flow/community detection

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -29,7 +29,7 @@ Review a PR or branch diff.
 ```
 full_rebuild: bool = False           # True for full re-parse
 repo_root: str | None                # Auto-detected
-base: str = "HEAD~1"                 # VCS diff base for incremental updates
+base: str | None = None              # Diff base; None auto-resolves to the last-synced commit
 postprocess: str = "full"            # "full", "minimal", or "none"
 recurse_submodules: bool | None      # Falls back to CRG_RECURSE_SUBMODULES
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,13 +201,80 @@ class TestBuildUpdateCommands:
                         ) as mock_postprocess:
                             cli.main()
 
+        # With no explicit --base, the CLI forwards None so the shared seam
+        # can resolve the base to the last-synced commit.
         mock_build.assert_called_once_with(
             full_rebuild=False,
             repo_root="repo-root",
-            base="HEAD~1",
+            base=None,
             postprocess="minimal",
         )
         mock_postprocess.assert_not_called()
+
+    def test_update_forwards_explicit_base_verbatim(self):
+        argv = [
+            "code-review-graph",
+            "update",
+            "--base",
+            "HEAD~3",
+            "--skip-flows",
+            "--repo",
+            "repo-root",
+        ]
+        result = {
+            "files_updated": 1,
+            "total_nodes": 2,
+            "total_edges": 1,
+            "postprocess_level": "minimal",
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ) as mock_build:
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ):
+                            cli.main()
+
+        assert mock_build.call_args.kwargs["base"] == "HEAD~3"
+
+    def test_update_reports_full_rebuild_fallback(self, capsys):
+        argv = ["code-review-graph", "update", "--repo", "repo-root"]
+        # build_or_update_graph falls back to a full rebuild when there is no
+        # usable incremental base; the CLI must say so rather than print
+        # "Incremental: 0 files updated", which reads as "nothing happened".
+        result = {
+            "status": "ok",
+            "build_type": "full",
+            "base_resolved": None,
+            "files_parsed": 2,
+            "total_nodes": 4,
+            "total_edges": 2,
+        }
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with patch(
+                        "code_review_graph.tools.build.build_or_update_graph",
+                        return_value=result,
+                    ):
+                        with patch(
+                            "code_review_graph.postprocessing.run_post_processing",
+                        ):
+                            cli.main()
+
+        out = capsys.readouterr().out
+        assert "Full rebuild" in out
+        assert "Incremental:" not in out
 
 
 class TestDetectChangesCommand:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -422,14 +422,14 @@ class TestGraphStore:
         assert "python" in stats.languages
 
     def test_impact_radius(self):
-        # Create a chain: file_a -> func_a -> (calls) -> func_b in file_b
+        # func_b depends on the changed func_a, so func_b is impacted.
         self.store.upsert_node(self._make_file_node("/a.py"))
         self.store.upsert_node(self._make_func_node("func_a", "/a.py"))
         self.store.upsert_node(self._make_file_node("/b.py"))
         self.store.upsert_node(self._make_func_node("func_b", "/b.py"))
         self.store.upsert_edge(EdgeInfo(
-            kind="CALLS", source="/a.py::func_a",
-            target="/b.py::func_b", file_path="/a.py", line=10,
+            kind="CALLS", source="/b.py::func_b",
+            target="/a.py::func_a", file_path="/b.py", line=10,
         ))
         self.store.commit()
 
@@ -620,7 +620,7 @@ class TestImpactRadiusSql:
         Path(self.tmp.name).unlink(missing_ok=True)
 
     def _build_chain(self):
-        """Build A -> B -> C -> D chain for testing."""
+        """Build D -> C -> B -> A dependency chain for testing."""
         for name, path in [
             ("func_a", "/a.py"), ("func_b", "/b.py"),
             ("func_c", "/c.py"), ("func_d", "/d.py"),
@@ -634,16 +634,16 @@ class TestImpactRadiusSql:
                 line_start=5, line_end=20, language="python",
             ))
         self.store.upsert_edge(EdgeInfo(
-            kind="CALLS", source="/a.py::func_a",
-            target="/b.py::func_b", file_path="/a.py", line=10,
-        ))
-        self.store.upsert_edge(EdgeInfo(
             kind="CALLS", source="/b.py::func_b",
-            target="/c.py::func_c", file_path="/b.py", line=10,
+            target="/a.py::func_a", file_path="/b.py", line=10,
         ))
         self.store.upsert_edge(EdgeInfo(
             kind="CALLS", source="/c.py::func_c",
-            target="/d.py::func_d", file_path="/c.py", line=10,
+            target="/b.py::func_b", file_path="/c.py", line=10,
+        ))
+        self.store.upsert_edge(EdgeInfo(
+            kind="CALLS", source="/d.py::func_d",
+            target="/c.py::func_c", file_path="/d.py", line=10,
         ))
         self.store.commit()
 
@@ -654,6 +654,7 @@ class TestImpactRadiusSql:
 
         sql_qns = {n.qualified_name for n in sql_result["impacted_nodes"]}
         nx_qns = {n.qualified_name for n in nx_result["impacted_nodes"]}
+        assert sql_qns == {"/b.py::func_b", "/c.py::func_c"}
         assert sql_qns == nx_qns
 
     def test_max_nodes_truncation(self):
@@ -661,8 +662,9 @@ class TestImpactRadiusSql:
         result = self.store.get_impact_radius_sql(
             ["/a.py"], max_depth=3, max_nodes=2,
         )
-        # With 4 files in chain + file nodes, max_nodes=2 should limit
-        assert result["total_impacted"] <= 2 or result["truncated"]
+        assert result["truncated"] is True
+        assert result["total_impacted"] == 3
+        assert len(result["impacted_nodes"]) == 2
 
     def test_empty_changed_files(self):
         result = self.store.get_impact_radius_sql([], max_depth=2)
@@ -725,14 +727,60 @@ class TestWeightedImpactScoring:
     def _ordered_qns(result) -> list[str]:
         return [node.qualified_name for node in result["impacted_nodes"]]
 
-    def test_edge_weights_rank_best_path_and_engines_match(self):
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "CALLS",
+            "IMPORTS_FROM",
+            "DEPENDS_ON",
+            "REFERENCES",
+            "INHERITS",
+            "OVERRIDES",
+            "IMPLEMENTS",
+        ],
+    )
+    def test_dependency_edges_include_dependents_not_dependencies(self, kind):
         seed = self._add_func("seed", "/seed.py")
-        called = self._add_func("called", "/called.py")
-        imported = self._add_func("imported", "/imported.py")
-        indirect = self._add_func("indirect", "/indirect.py")
-        self._add_edge("CALLS", seed, called)
-        self._add_edge("IMPORTS_FROM", seed, imported)
-        self._add_edge("CALLS", called, indirect)
+        dependent = self._add_func("dependent", "/dependent.py")
+        dependency = self._add_func("dependency", "/dependency.py")
+        self._add_edge(kind, dependent, seed)
+        self._add_edge(kind, seed, dependency, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [dependent]
+        assert self._ordered_qns(nx_result) == [dependent]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_tested_by_traverses_from_production_to_test_only(self):
+        seed = self._add_func("seed", "/seed.py")
+        test = self._add_func("test_seed", "/test_seed.py")
+        unrelated_production = self._add_func(
+            "unrelated_production", "/unrelated.py",
+        )
+        self._add_edge("TESTED_BY", seed, test)
+        self._add_edge("TESTED_BY", unrelated_production, seed, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [test]
+        assert self._ordered_qns(nx_result) == [test]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_contains_edge_cannot_bridge_impact(self):
+        seed = self._add_func("seed", "/seed.py")
+        stale_container = "stale.py::Container"
+        dependent = self._add_func("dependent", "/dependent.py")
+        self._add_edge("CONTAINS", stale_container, seed)
+        self._add_edge("CALLS", dependent, stale_container, line=2)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
@@ -740,10 +788,51 @@ class TestWeightedImpactScoring:
             ["/seed.py"], max_depth=2,
         )
 
-        assert sql["impact_scores"][called] == pytest.approx(0.6)
-        assert sql["impact_scores"][indirect] == pytest.approx(0.36)
-        assert sql["impact_scores"][imported] == pytest.approx(0.3)
-        assert self._ordered_qns(sql) == [called, indirect, imported]
+        assert self._ordered_qns(sql) == []
+        assert self._ordered_qns(nx_result) == []
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_unknown_edge_kind_defaults_to_incoming_dependency_direction(self):
+        seed = self._add_func("seed", "/seed.py")
+        dependent = self._add_func("dependent", "/dependent.py")
+        dependency = self._add_func("dependency", "/dependency.py")
+        self._add_edge("UNKNOWN_KIND", dependent, seed)
+        self._add_edge("UNKNOWN_KIND", seed, dependency, line=2)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=1,
+        )
+
+        assert self._ordered_qns(sql) == [dependent]
+        assert sql["impact_scores"][dependent] == pytest.approx(0.3)
+        assert self._ordered_qns(nx_result) == [dependent]
+        assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_edge_weights_rank_best_path_and_engines_match(self):
+        seed = self._add_func("seed", "/seed.py")
+        caller = self._add_func("caller", "/caller.py")
+        importer = self._add_func("importer", "/importer.py")
+        indirect_caller = self._add_func(
+            "indirect_caller", "/indirect_caller.py",
+        )
+        self._add_edge("CALLS", caller, seed)
+        self._add_edge("IMPORTS_FROM", importer, seed)
+        self._add_edge("CALLS", indirect_caller, caller)
+        self.store.commit()
+
+        sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
+        nx_result = self.store._get_impact_radius_networkx(
+            ["/seed.py"], max_depth=2,
+        )
+
+        assert sql["impact_scores"][caller] == pytest.approx(0.6)
+        assert sql["impact_scores"][indirect_caller] == pytest.approx(0.36)
+        assert sql["impact_scores"][importer] == pytest.approx(0.3)
+        assert self._ordered_qns(sql) == [
+            caller, indirect_caller, importer,
+        ]
         assert sql["impact_scores"] == nx_result["impact_scores"]
         assert self._ordered_qns(sql) == self._ordered_qns(nx_result)
 
@@ -751,9 +840,9 @@ class TestWeightedImpactScoring:
         seed = self._add_func("seed", "/seed.py")
         middle = self._add_func("middle", "/middle.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("CONTAINS", seed, target)
-        self._add_edge("CALLS", seed, middle, line=2)
-        self._add_edge("CALLS", middle, target, line=3)
+        self._add_edge("IMPORTS_FROM", target, seed)
+        self._add_edge("CALLS", middle, seed, line=2)
+        self._add_edge("CALLS", target, middle, line=3)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=2)
@@ -769,7 +858,7 @@ class TestWeightedImpactScoring:
             self._add_func(f"node_{index}", f"/node_{index}.py")
             for index in range(8)
         ]
-        for index, (source, target) in enumerate(zip(qns, qns[1:])):
+        for index, (source, target) in enumerate(zip(qns[1:], qns)):
             self._add_edge("CALLS", source, target, line=index + 1)
         self.store.commit()
 
@@ -787,7 +876,7 @@ class TestWeightedImpactScoring:
     def test_unknown_edge_kind_uses_default_weight(self):
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("UNKNOWN_KIND", seed, target)
+        self._add_edge("UNKNOWN_KIND", target, seed)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
@@ -805,7 +894,7 @@ class TestWeightedImpactScoring:
             for index in range(3)
         ]
         for index, target in enumerate(targets):
-            self._add_edge("CALLS", seed, target, line=index + 1)
+            self._add_edge("CALLS", target, seed, line=index + 1)
         self.store.commit()
 
         exact = self.store.get_impact_radius_sql(
@@ -825,8 +914,8 @@ class TestWeightedImpactScoring:
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
         ghost = "external.package::ghost"
-        self._add_edge("CALLS", seed, ghost)
-        self._add_edge("CALLS", ghost, target, line=2)
+        self._add_edge("CALLS", ghost, seed)
+        self._add_edge("CALLS", target, ghost, line=2)
         self.store.commit()
 
         result = self.store.get_impact_radius_sql(
@@ -840,8 +929,8 @@ class TestWeightedImpactScoring:
     def test_parallel_edges_use_strongest_weight_in_both_engines(self):
         seed = self._add_func("seed", "/seed.py")
         target = self._add_func("target", "/target.py")
-        self._add_edge("CALLS", seed, target, line=1)
-        self._add_edge("CONTAINS", seed, target, line=2)
+        self._add_edge("CALLS", target, seed, line=1)
+        self._add_edge("IMPORTS_FROM", target, seed, line=2)
         self.store.commit()
 
         sql = self.store.get_impact_radius_sql(["/seed.py"], max_depth=1)
@@ -850,6 +939,28 @@ class TestWeightedImpactScoring:
         )
         assert sql["impact_scores"][target] == pytest.approx(0.6)
         assert sql["impact_scores"] == nx_result["impact_scores"]
+
+    def test_parallel_edges_preserve_each_direction_in_both_engines(self):
+        source = self._add_func("source", "/source.py")
+        target = self._add_func("target", "/target.py")
+        self._add_edge("CALLS", source, target, line=1)
+        self._add_edge("TESTED_BY", source, target, line=2)
+        self.store.commit()
+
+        for path, expected_qn, expected_score in (
+            ("/source.py", target, 0.42),
+            ("/target.py", source, 0.6),
+        ):
+            sql = self.store.get_impact_radius_sql([path], max_depth=1)
+            nx_result = self.store._get_impact_radius_networkx(
+                [path], max_depth=1,
+            )
+
+            assert self._ordered_qns(sql) == [expected_qn]
+            assert sql["impact_scores"][expected_qn] == pytest.approx(
+                expected_score,
+            )
+            assert sql["impact_scores"] == nx_result["impact_scores"]
 
     def test_dense_mixed_cycle_is_bounded(self):
         qns = [self._add_func(f"node_{i}", f"/node_{i}.py") for i in range(12)]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,6 +10,7 @@ import pytest
 
 import code_review_graph.constants as constants_module
 from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import EdgeInfo, NodeInfo
 
 
@@ -671,6 +672,46 @@ class TestImpactRadiusSql:
         assert result["changed_nodes"] == []
         assert result["impacted_nodes"] == []
         assert result["total_impacted"] == 0
+
+
+def test_impact_radius_real_build_includes_importer_not_imported_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real parsed import graph follows impact toward dependents only."""
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    dependency = tmp_path / "dependency.py"
+    changed = tmp_path / "changed.py"
+    importer = tmp_path / "importer.py"
+    dependency.write_text("VALUE = 1\n", encoding="utf-8")
+    changed.write_text(
+        "from dependency import VALUE\n\n"
+        "def changed_value():\n"
+        "    return VALUE\n",
+        encoding="utf-8",
+    )
+    importer.write_text(
+        "from changed import changed_value\n\n"
+        "def consume():\n"
+        "    return changed_value()\n",
+        encoding="utf-8",
+    )
+
+    with GraphStore(tmp_path / "graph.db") as store:
+        built = full_build(tmp_path, store)
+        assert built["errors"] == []
+
+        sql = store.get_impact_radius_sql([str(changed)], max_depth=1)
+        networkx = store._get_impact_radius_networkx(
+            [str(changed)],
+            max_depth=1,
+        )
+
+    expected = {str(importer)}
+    assert set(sql["impacted_files"]) == expected
+    assert set(networkx["impacted_files"]) == expected
+    assert str(dependency) not in sql["impacted_files"]
+    assert sql["impact_scores"] == networkx["impact_scores"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -11,6 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 import inspect
+import json
 import subprocess
 import sys
 import tempfile
@@ -611,3 +612,161 @@ def test_cli_update_brief_default_base_does_not_crash(
     # It ran the incremental update and the brief impact summary without error.
     assert "Incremental:" in out
     assert "changed file" in out
+
+
+def test_update_auto_base_multi_commit_rename_matches_full_rebuild(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Three commits after the stored SHA converge exactly to a fresh graph.
+
+    The commits deliberately split a module rename, its importer update, and a
+    new importing file. A HEAD~1 update sees only the new file; the automatic
+    stored-SHA base must reconcile all three commits and purge the old path.
+    """
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    repo = tmp_path / "multi-commit-repo"
+    repo.mkdir()
+    _git_ok(repo, "init", "-b", "main")
+    _git_ok(repo, "config", "user.email", "test@test.com")
+    _git_ok(repo, "config", "user.name", "Test")
+
+    package = repo / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    old_module = package / "service.py"
+    old_module.write_text(
+        "def provide():\n"
+        "    return 'value'\n",
+        encoding="utf-8",
+    )
+    importer = repo / "app.py"
+    importer.write_text(
+        "from pkg.service import provide\n\n"
+        "def run():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", "initial graph state")
+    stored_sha = _git_ok(repo, "rev-parse", "HEAD").stdout.strip()
+
+    incremental_data = tmp_path / "incremental-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(incremental_data))
+    initial = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert initial["errors"] == []
+    with GraphStore(incremental_data / "graph.db") as stored:
+        assert stored.get_metadata("git_head_sha") == stored_sha
+        assert stored.get_nodes_by_file(str(old_module))
+
+    # Commit 1: rename the provider module.
+    new_module = package / "core.py"
+    _git_ok(repo, "mv", "pkg/service.py", "pkg/core.py")
+    _git_ok(repo, "commit", "-m", "rename provider module")
+
+    # Commit 2: update the existing importer.
+    importer.write_text(
+        "from pkg.core import provide\n\n"
+        "def run():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", "app.py")
+    _git_ok(repo, "commit", "-m", "update provider importer")
+
+    # Commit 3: add another importing file.
+    new_consumer = repo / "worker.py"
+    new_consumer.write_text(
+        "from pkg.core import provide\n\n"
+        "def work():\n"
+        "    return provide()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", "worker.py")
+    _git_ok(repo, "commit", "-m", "add provider worker")
+
+    commits_since_graph = _git_ok(
+        repo,
+        "rev-list",
+        "--count",
+        f"{stored_sha}..HEAD",
+    ).stdout.strip()
+    assert commits_since_graph == "3"
+    assert get_changed_files(repo, "HEAD~1") == ["worker.py"]
+
+    updated = build_or_update_graph(
+        full_rebuild=False,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert updated["build_type"] == "incremental"
+    assert updated["base_resolved"] == stored_sha
+    assert set(updated["changed_files"]) == {
+        "app.py",
+        "pkg/service.py",
+        "pkg/core.py",
+        "worker.py",
+    }
+    assert updated["errors"] == []
+
+    def node_snapshot(store: GraphStore) -> set[tuple[object, ...]]:
+        return {
+            (
+                node.kind,
+                node.name,
+                node.qualified_name,
+                node.file_path,
+                node.line_start,
+                node.line_end,
+                node.language,
+                node.parent_name,
+                node.params,
+                node.return_type,
+                node.is_test,
+                node.file_hash,
+                json.dumps(node.extra, sort_keys=True),
+            )
+            for node in store.get_all_nodes(exclude_files=False)
+        }
+
+    def edge_snapshot(store: GraphStore) -> set[tuple[object, ...]]:
+        return {
+            (
+                edge.kind,
+                edge.source_qualified,
+                edge.target_qualified,
+                edge.file_path,
+                edge.line,
+                json.dumps(edge.extra, sort_keys=True),
+                edge.confidence,
+                edge.confidence_tier,
+            )
+            for edge in store.get_all_edges()
+        }
+
+    with GraphStore(incremental_data / "graph.db") as incremental_store:
+        assert incremental_store.get_nodes_by_file(str(old_module)) == []
+        assert incremental_store.get_nodes_by_file(str(new_module))
+        incremental_nodes = node_snapshot(incremental_store)
+        incremental_edges = edge_snapshot(incremental_store)
+        assert all(
+            str(old_module) not in repr(edge)
+            for edge in incremental_edges
+        )
+
+    fresh_data = tmp_path / "fresh-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(fresh_data))
+    fresh = build_or_update_graph(
+        full_rebuild=True,
+        repo_root=str(repo),
+        postprocess="none",
+    )
+    assert fresh["errors"] == []
+
+    with GraphStore(fresh_data / "graph.db") as fresh_store:
+        assert incremental_nodes == node_snapshot(fresh_store)
+        assert incremental_edges == edge_snapshot(fresh_store)

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -10,6 +10,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import inspect
 import subprocess
 import sys
 import tempfile
@@ -20,13 +21,16 @@ import pytest
 from code_review_graph.changes import parse_git_diff_ranges
 from code_review_graph.graph import GraphStore
 from code_review_graph.incremental import (
+    _commit_object_exists,
     collect_all_files,
     full_build,
     get_all_tracked_files,
     get_changed_files,
     get_staged_and_unstaged,
     incremental_update,
+    resolve_incremental_base,
 )
+from code_review_graph.tools.build import build_or_update_graph
 from code_review_graph.wiki import get_wiki_page
 
 
@@ -39,6 +43,15 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         cwd=str(repo),
         timeout=10,
     )
+
+
+def _git_ok(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command and fail the test if it does not succeed."""
+    result = _git(repo, *args)
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed ({result.returncode}): {result.stderr.strip()}"
+    )
+    return result
 
 
 @pytest.fixture()
@@ -399,3 +412,202 @@ def test_incremental_rename_matches_a_fresh_full_rebuild(
         incremental_store.close()
         if full_store is not None:
             full_store.close()
+
+
+# ------------------------------------------------------------------
+# 6. Auto-resolved incremental base (last-synced commit, not HEAD~1)
+# ------------------------------------------------------------------
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """A git repo on branch ``main`` with one commit adding ``a.py``.
+
+    ``init -b main`` pins the branch name so tests that switch branches do not
+    depend on the host's ``init.defaultBranch`` (which may be ``master``).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_ok(repo, "init", "-b", "main")
+    _git_ok(repo, "config", "user.email", "test@test.com")
+    _git_ok(repo, "config", "user.name", "Test")
+    (repo / "a.py").write_text("def alpha():\n    return 1\n")
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", "c0")
+    return repo
+
+
+def _commit_file(repo: Path, name: str) -> None:
+    (repo / f"{name}.py").write_text(f"def {name}():\n    return 1\n")
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", name)
+
+
+def test_commit_object_exists(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert _commit_object_exists(repo, head) is True
+    assert _commit_object_exists(repo, "0" * 40) is False
+    # Injection-shaped refs are rejected before ever reaching git.
+    assert _commit_object_exists(repo, "--output=/tmp/evil") is False
+
+
+def test_resolve_incremental_base(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    store = GraphStore(str(repo / "graph.db"))
+    try:
+        # Usable anchor -> the stored SHA.
+        store.set_metadata("git_head_sha", head)
+        assert resolve_incremental_base(repo, store) == head
+        # Unreachable anchor (rewrite / shallow clone) -> None (full rebuild).
+        store.set_metadata("git_head_sha", "0" * 40)
+        assert resolve_incremental_base(repo, store) is None
+    finally:
+        store.close()
+
+    # No anchor at all (fresh / legacy database) -> None.
+    store2 = GraphStore(str(repo / "graph2.db"))
+    try:
+        assert resolve_incremental_base(repo, store2) is None
+    finally:
+        store2.close()
+
+
+def test_resolve_incremental_base_non_git(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    store = GraphStore(str(plain / "graph.db"))
+    try:
+        # Non-git working copies keep the concrete "HEAD~1" default so the
+        # SVN/plain change-discovery path never receives None.
+        assert resolve_incremental_base(plain, store) == "HEAD~1"
+    finally:
+        store.close()
+
+
+def test_update_auto_base_catches_commits_missed_by_head1(tmp_path: Path) -> None:
+    """The headline bug: after several out-of-band commits, a default update
+    must reconcile all of them, not only the newest."""
+    repo = _init_repo(tmp_path)
+    c0 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    for name in ("beta", "gamma", "delta"):
+        _commit_file(repo, name)
+
+    # Old behaviour, reproduced explicitly: HEAD~1 sees only the last commit.
+    head1 = get_changed_files(repo, "HEAD~1")
+    assert head1 == ["delta.py"]
+
+    # New behaviour: auto base resolves to c0 and catches every commit since.
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    assert res["base_resolved"] == c0
+    assert set(res["changed_files"]) == {"beta.py", "gamma.py", "delta.py"}
+
+
+def test_update_auto_base_across_divergent_branch_switch(tmp_path: Path) -> None:
+    """Build on one branch, then switch to a divergent branch whose HEAD~1 is
+    NOT the anchor. A fixed HEAD~1 base would miss the difference and leave the
+    other branch's files stale; the resolved anchor reconciles it.
+    """
+    repo = _init_repo(tmp_path)  # main @ c0 with a.py
+
+    # A sibling branch off c0 that adds its own file, then back to main.
+    _git_ok(repo, "checkout", "-b", "sibling")
+    _commit_file(repo, "sibling_only")
+    _git_ok(repo, "checkout", "main")
+
+    # Advance main by two commits and build the graph at main's tip.
+    _commit_file(repo, "main_one")
+    _commit_file(repo, "main_two")
+    main_tip = _git_ok(repo, "rev-parse", "HEAD").stdout.strip()
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    # Switch to the divergent sibling. Its HEAD~1 is c0, not main's tip, so a
+    # fixed-HEAD~1 update could never reconcile against where the graph is.
+    _git_ok(repo, "checkout", "sibling")
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    # The resolved base is the commit the graph was actually built at.
+    assert res["base_resolved"] == main_tip
+    assert res["build_type"] == "incremental"
+    # The diff main_tip..sibling adds sibling's file and drops main's files.
+    changed = set(res["changed_files"])
+    assert {"sibling_only.py", "main_one.py", "main_two.py"} <= changed
+
+
+def test_update_without_usable_anchor_falls_back_to_full_rebuild(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+
+    # Corrupt the anchor to an unreachable SHA (as a history rewrite would).
+    from code_review_graph.incremental import get_db_path
+
+    store = GraphStore(str(get_db_path(repo)))
+    try:
+        store.set_metadata("git_head_sha", "0" * 40)
+    finally:
+        store.close()
+
+    _commit_file(repo, "epsilon")
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base=None, postprocess="none"
+    )
+    assert res["build_type"] == "full"
+    assert res["base_resolved"] is None
+
+
+def test_update_explicit_base_bypasses_auto_resolution(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+    for name in ("beta", "gamma"):
+        _commit_file(repo, name)
+
+    # An explicit base is honoured verbatim and stays incremental.
+    res = build_or_update_graph(
+        full_rebuild=False, repo_root=str(repo), base="HEAD~1", postprocess="none"
+    )
+    assert res["build_type"] == "incremental"
+    assert res["base_resolved"] == "HEAD~1"
+    assert res["changed_files"] == ["gamma.py"]
+
+
+def test_mcp_tool_base_defaults_to_none() -> None:
+    """The MCP wrapper must default base to None so omitted-base calls reach
+    the auto-resolution path instead of a hardcoded HEAD~1."""
+    from code_review_graph.main import build_or_update_graph_tool
+
+    # FastMCP may wrap the tool; the underlying callable is stored on ``.fn``.
+    fn = getattr(build_or_update_graph_tool, "fn", build_or_update_graph_tool)
+    assert inspect.signature(fn).parameters["base"].default is None
+
+
+def test_cli_update_brief_default_base_does_not_crash(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    """`update --brief` with no explicit --base must not crash. The base now
+    defaults to None, which the brief impact path cannot pass to git directly;
+    it has to reuse the resolved base."""
+    from code_review_graph import cli
+
+    repo = _init_repo(tmp_path)
+    build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")
+    _commit_file(repo, "brief_new")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["code-review-graph", "update", "--brief", "--repo", str(repo)],
+    )
+    cli.main()  # would raise AttributeError/TypeError on a None base before the fix
+
+    out = capsys.readouterr().out
+    # It ran the incremental update and the brief impact summary without error.
+    assert "Incremental:" in out
+    assert "changed file" in out

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2027,6 +2027,22 @@ class TestJsMemberAssignedFunctions:
         assert "app.settings" not in fns
         assert "app.locals" not in fns
 
+    def test_function_local_member_assignments_are_not_module_definitions(self):
+        """Sibling local assignments must not collide as ``file::x.run``."""
+        path = Path("/test/local_assignments.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"function a() { x.run = function () {}; }\n"
+            b"function b() { x.run = function () {}; }\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert {n.name for n in functions} == {"a", "b"}
+        assert all(n.name != "x.run" for n in functions)
+        assert all(
+            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            for e in edges
+        )
+
     def test_member_function_body_calls_still_attributed(self):
         """Calls inside a member-assigned function attribute to that function."""
         path = Path("/test/application.js")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2043,6 +2043,54 @@ class TestJsMemberAssignedFunctions:
             for e in edges
         )
 
+    def test_sibling_top_level_blocks_do_not_share_member_identity(self):
+        """Block-local objects must not collapse into one module definition."""
+        path = Path("/test/block_assignments.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"{ const x = {}; x.run = function () {}; }\n"
+            b"{ const x = {}; x.run = function () {}; }\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert all(n.name != "x.run" for n in functions)
+        assert all(
+            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            for e in edges
+        )
+
+    def test_dynamic_receiver_assignment_is_not_a_stable_definition(self):
+        """A fresh object returned by a call has no stable member identity."""
+        path = Path("/test/dynamic_assignment.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"factory().handle = function () {};\n",
+        )
+        functions = [n for n in nodes if n.kind == "Function"]
+        assert all(n.name != "factory().handle" for n in functions)
+        assert all(
+            not (
+                e.kind == "CONTAINS"
+                and e.target == f"{path}::factory().handle"
+            )
+            for e in edges
+        )
+
+    def test_dynamic_receiver_call_does_not_resolve_as_static_member(self):
+        """Separate factory calls must not be linked as one member."""
+        path = Path("/test/dynamic_call.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"factory().handle = function () {};\n"
+            b"function start() { factory().handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 2
+        handle_call = next(e for e in calls if e.target == "handle")
+        assert "member_call" not in handle_call.extra
+
     def test_member_function_body_calls_still_attributed(self):
         """Calls inside a member-assigned function attribute to that function."""
         path = Path("/test/application.js")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2044,3 +2044,18 @@ class TestJsMemberAssignedFunctions:
             and e.target.endswith("helper")
         ]
         assert len(calls) == 1
+
+    def test_member_call_resolves_to_member_assigned_function(self):
+        """A static member call resolves to its same-file member definition."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1957,3 +1957,90 @@ class TestCppScopedFunctionName:
         fns = [n for n in nodes if n.kind == "Function"]
         assert len(fns) == 1
         assert fns[0].name == "get_obj_fingerprint"
+
+
+class TestJsMemberAssignedFunctions:
+    """Member-assigned function expressions in JS/TS.
+
+    ``obj.method = function () {}`` / ``Foo.prototype.bar = () => {}`` are the
+    prototype- and module-augmentation patterns that Express, Koa and many
+    older JS libraries use for their entire public API. Only ``const x = fn``
+    (variable_declarator) and class fields were captured before, so these
+    definitions produced no Function node at all.
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def test_js_object_method_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/application.js"),
+            b"app.handle = function handle(req, res, next) {\n"
+            b"  next();\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.handle" in fns
+
+    def test_js_arrow_member_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/router.js"),
+            b"router.dispatch = (req, res) => {\n"
+            b"  return res;\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "router.dispatch" in fns
+
+    def test_ts_prototype_assignment_captured(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/proto.ts"),
+            b"Router.prototype.handle = function (req: Request): void {\n"
+            b"  this.stack.forEach((layer) => layer.handle(req));\n"
+            b"};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "Router.prototype.handle" in fns
+
+    def test_member_function_qualified_name_and_contains(self):
+        """Qualified name is ``file::obj.method`` and a CONTAINS edge links it."""
+        path = Path("/test/application.js")
+        nodes, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function handle(req, res) {};\n",
+        )
+        contains = [
+            e for e in edges
+            if e.kind == "CONTAINS" and e.target == f"{path}::app.handle"
+        ]
+        assert len(contains) == 1
+        assert contains[0].source == str(path)
+
+    def test_non_function_member_assignment_not_captured(self):
+        """``obj.prop = <non-function>`` must not create a Function node."""
+        nodes, _ = self.parser.parse_bytes(
+            Path("/test/config.js"),
+            b"app.settings = { trust_proxy: false };\n"
+            b"app.locals = {};\n",
+        )
+        fns = {n.name for n in nodes if n.kind == "Function"}
+        assert "app.settings" not in fns
+        assert "app.locals" not in fns
+
+    def test_member_function_body_calls_still_attributed(self):
+        """Calls inside a member-assigned function attribute to that function."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"function helper() { return 1; }\n"
+            b"app.handle = function handle() {\n"
+            b"  helper();\n"
+            b"};\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS"
+            and e.source == f"{path}::app.handle"
+            and e.target.endswith("helper")
+        ]
+        assert len(calls) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import CodeParser
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -2138,3 +2139,36 @@ class TestJsMemberAssignedFunctions:
         ]
         assert len(calls) == 1
         assert calls[0].target == f"{path}::app.handle"
+
+    def test_member_assignment_survives_full_build_with_resolved_caller(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """The definition and resolved call persist through a real graph build."""
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+        source = tmp_path / "application.js"
+        source.write_text(
+            "app.handle = function () { return 1; };\n"
+            "function start() { return app.handle(); }\n",
+            encoding="utf-8",
+        )
+        member_qn = f"{source}::app.handle"
+        caller_qn = f"{source}::start"
+
+        with GraphStore(tmp_path / "graph.db") as store:
+            built = full_build(tmp_path, store)
+            assert built["errors"] == []
+
+            member = store.get_node(member_qn)
+            callers = [
+                edge
+                for edge in store.get_edges_by_target(member_qn)
+                if edge.kind == "CALLS"
+            ]
+
+        assert member is not None
+        assert member.kind == "Function"
+        assert member.name == "app.handle"
+        assert len(callers) == 1
+        assert callers[0].source_qualified == caller_qn

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2075,3 +2075,18 @@ class TestJsMemberAssignedFunctions:
         ]
         assert len(calls) == 1
         assert calls[0].target == f"{path}::app.handle"
+
+    def test_optional_member_call_resolves_to_member_assigned_function(self):
+        """Optional chaining retains the same static member-call target."""
+        path = Path("/test/application.js")
+        _, edges = self.parser.parse_bytes(
+            path,
+            b"app.handle = function () {};\n"
+            b"function start() { app?.handle(); }\n",
+        )
+        calls = [
+            e for e in edges
+            if e.kind == "CALLS" and e.source == f"{path}::start"
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == f"{path}::app.handle"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2361,24 +2361,24 @@ def test_impact_radius_tool_exposes_best_first_scores(monkeypatch, tmp_path):
     """The public tool adds scores without changing the stored node schema."""
     store = GraphStore(tmp_path / "impact.db")
     seed = "/seed.py::seed"
-    called = "/called.py::called"
-    imported = "/imported.py::imported"
+    caller = "/caller.py::caller"
+    importer = "/importer.py::importer"
     for name, path in (
         ("seed", "/seed.py"),
-        ("called", "/called.py"),
-        ("imported", "/imported.py"),
+        ("caller", "/caller.py"),
+        ("importer", "/importer.py"),
     ):
         store.upsert_node(NodeInfo(
             kind="Function", name=name, file_path=path,
             line_start=1, line_end=3, language="python",
         ))
     store.upsert_edge(EdgeInfo(
-        kind="CALLS", source=seed, target=called,
-        file_path="/seed.py", line=1,
+        kind="CALLS", source=caller, target=seed,
+        file_path="/caller.py", line=1,
     ))
     store.upsert_edge(EdgeInfo(
-        kind="IMPORTS_FROM", source=seed, target=imported,
-        file_path="/seed.py", line=2,
+        kind="IMPORTS_FROM", source=importer, target=seed,
+        file_path="/importer.py", line=2,
     ))
     store.commit()
 
@@ -2396,7 +2396,7 @@ def test_impact_radius_tool_exposes_best_first_scores(monkeypatch, tmp_path):
     )
 
     assert [node["name"] for node in result["impacted_nodes"]] == [
-        "called", "imported",
+        "caller", "importer",
     ]
     scores = [node["impact_score"] for node in result["impacted_nodes"]]
     assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## What changed

This integrates three independently reviewed fixes on the same current-main base:

- Make impact traversal directional, so dependents are included without incorrectly pulling in dependencies.
- Index stable module-scope JavaScript/TypeScript member-assigned functions and resolve their calls, while rejecting dynamic, function-local, and sibling-block identities.
- Anchor incremental updates to the last successfully synchronized commit, including multi-commit rename/import/new-file reconciliation.

## Why one integration PR

The three changes affect graph construction, parser identities, and incremental graph updates. Testing and merging their exact combined state avoids relying on three independently green heads that have never run together.

Contributor history and attribution are preserved:

- Avza's commits from #672 are included unchanged, followed by the maintainer stability correction and end-to-end storage/caller regression.
- utkuozdemir's commit from #694 is included unchanged, followed by the multi-commit rename reconciliation regression.

This supersedes the separately tested integration PRs #767, #768, and #769 after this PR's combined hosted matrix passes.

## Validation

- Combined targeted union: 1,129 passed, 1 skipped; the only initial failure was macOS sandbox denial of process semaphores.
- Exact process-pool regression outside the sandbox: 1 passed.
- Fresh combined core regression run: 490 passed, 1 skipped.
- Ruff on every changed production module: passed.
- `git diff --check`: passed.
- Full hosted matrices on #767, #768, and #769: Python 3.10–3.13, Windows daemon/file-handle tests, lint, type-check, security, schema sync, review, CodeQL, and GitGuardian all passed.

This PR must also pass its own complete hosted matrix before merge.

Fixes #291
