### PR TITLE
fix(parser): complete TypeScript type-reference support (#738)

### DIFF
--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -255,6 +255,7 @@ def query_graph_tool(
 
     Available patterns:
     - callers_of: Find functions that call the target
+    - references_to: Find nodes that reference the target
     - callees_of: Find functions called by the target
     - imports_of: Find what the target imports
     - importers_of: Find files that import the target

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -839,8 +839,19 @@ _TASK_META_KEYS: frozenset[str] = frozenset({
 _CLASS_TYPES: dict[str, list[str]] = {
     "python": ["class_definition"],
     "javascript": ["class_declaration", "class"],
-    "typescript": ["class_declaration", "class"],
-    "tsx": ["class_declaration", "class"],
+    # TS types are declarations, not just runtime classes: an interface or type
+    # alias is the thing callers depend on, so it needs a node of its own the way
+    # Java/C#/PHP interfaces do. Without them a types-only module (types.ts,
+    # *.d.ts) contributes zero symbol nodes and its blast radius collapses to
+    # whole-file IMPORTS_FROM fan-out. See: #737
+    "typescript": [
+        "class_declaration", "class",
+        "interface_declaration", "type_alias_declaration", "enum_declaration",
+    ],
+    "tsx": [
+        "class_declaration", "class",
+        "interface_declaration", "type_alias_declaration", "enum_declaration",
+    ],
     "go": ["type_declaration"],
     # impl_item is a scope for methods, not a second type definition. It is
     # dispatched separately so repeated impl blocks cannot overwrite structs.
@@ -908,6 +919,20 @@ _CLASS_TYPES: dict[str, list[str]] = {
     # _extract_hcl_constructs.
     "hcl": [],
 }
+
+# TS/TSX heritage clauses. Classes wrap theirs in class_heritage; interfaces use
+# extends_type_clause. A type_identifier inside one is already covered by an
+# INHERITS edge, so it must not also emit REFERENCES.
+_TS_HERITAGE_CLAUSES = frozenset({
+    "extends_clause", "implements_clause", "extends_type_clause",
+})
+
+# TS/TSX declarations whose ``name`` field is a type_identifier. That occurrence
+# is the definition site, not a use of the type.
+_TS_TYPE_DECLARATIONS = frozenset({
+    "class_declaration", "abstract_class_declaration", "interface_declaration",
+    "type_alias_declaration", "enum_declaration",
+})
 
 _FUNCTION_TYPES: dict[str, list[str]] = {
     "python": ["function_definition"],
@@ -6137,6 +6162,14 @@ class CodeParser:
                 and node_type in ("jsx_opening_element", "jsx_self_closing_element")
             ):
                 self._extract_jsx_component_call(
+                    child, language, file_path, edges,
+                    enclosing_class, enclosing_func,
+                    import_map, defined_names,
+                )
+
+            # --- TS type-position references ---
+            if language in ("typescript", "tsx") and node_type == "type_identifier":
+                self._extract_ts_type_reference(
                     child, language, file_path, edges,
                     enclosing_class, enclosing_func,
                     import_map, defined_names,
@@ -11520,6 +11553,62 @@ class CodeParser:
         "self", "this", "cls", "super",
     })
 
+    def _extract_ts_type_reference(
+        self,
+        child,
+        language: str,
+        file_path: str,
+        edges: list[EdgeInfo],
+        enclosing_class: Optional[str],
+        enclosing_func: Optional[str],
+        import_map: Optional[dict[str, str]],
+        defined_names: Optional[set[str]],
+    ) -> None:
+        """Emit a ``REFERENCES`` edge for a type used in a TS type position.
+
+        ``function summarize(items: Finding[])`` is a real dependency on
+        ``Finding``, but a type annotation is not call syntax, so neither
+        _extract_calls nor _extract_value_references sees it and callers_of on
+        an interface stays empty.
+
+        ``REFERENCES`` (0.6 in IMPACT_EDGE_WEIGHTS) rather than ``CALLS`` (1.0):
+        a type use is a weaker signal than an invocation, and folding the two
+        together would let type churn outrank call churn in impact ranking.
+        """
+        parent = child.parent
+        if parent is not None:
+            # The declaration's own name is a definition, not a use. Compare by
+            # byte span: child_by_field_name returns a fresh wrapper object, so
+            # identity/equality checks against *child* are unreliable.
+            if parent.type in _TS_TYPE_DECLARATIONS:
+                name_node = parent.child_by_field_name("name")
+                if (
+                    name_node is not None
+                    and name_node.start_byte == child.start_byte
+                    and name_node.end_byte == child.end_byte
+                ):
+                    return
+            # extends/implements are already covered by INHERITS edges.
+            if parent.type in _TS_HERITAGE_CLAUSES:
+                return
+
+        # Attribute to the enclosing function, else the enclosing type, else the
+        # file — so `interface Wrapper { nested: Verdict }` names Wrapper as the
+        # dependent rather than collapsing to the whole module.
+        if enclosing_func:
+            caller = self._qualify(enclosing_func, file_path, enclosing_class)
+        elif enclosing_class:
+            caller = self._qualify(enclosing_class, file_path, None)
+        else:
+            caller = file_path
+
+        self._emit_reference_if_known(
+            child.text.decode("utf-8", errors="replace"),
+            language, file_path, caller, edges,
+            import_map or {}, defined_names or set(),
+            line=child.start_point[0] + 1,
+        )
+
     def _extract_value_references(
         self,
         child,
@@ -14521,12 +14610,28 @@ class CodeParser:
                         if sub.type == "type_identifier":
                             bases.append(sub.text.decode("utf-8", errors="replace"))
         elif language in ("typescript", "javascript", "tsx"):
-            # extends clause
+            # Classes nest their heritage one level down, under class_heritage
+            # (`class C extends B implements I`); interfaces carry
+            # extends_type_clause as a direct child. Scanning only direct
+            # children therefore missed every class base.
+            clauses: list = []
             for child in node.children:
-                if child.type in ("extends_clause", "implements_clause"):
-                    for sub in child.children:
-                        if sub.type in ("identifier", "type_identifier", "nested_identifier"):
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                if child.type == "class_heritage":
+                    clauses.extend(child.children)
+                else:
+                    clauses.append(child)
+            for clause in clauses:
+                if clause.type not in _TS_HERITAGE_CLAUSES:
+                    continue
+                for sub in clause.children:
+                    if sub.type in ("identifier", "type_identifier", "nested_identifier"):
+                        bases.append(sub.text.decode("utf-8", errors="replace"))
+                    elif sub.type == "generic_type":
+                        # `extends Base<T>` — the base is the generic's head.
+                        for ident in sub.children:
+                            if ident.type in ("type_identifier", "nested_type_identifier"):
+                                bases.append(ident.text.decode("utf-8", errors="replace"))
+                                break
         elif language == "solidity":
             # contract Foo is Bar, Baz { ... }
             for child in node.children:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1238,6 +1238,7 @@ _SPRING_EVENT_LISTENER_ANNOTATIONS = frozenset({"EventListener"})
 _SPRING_EVENT_PUBLISH_METHODS = frozenset({"publishEvent"})
 _JAVA_PACKAGE_KEY = "__crg_java_package__"
 _SPRING_REQUEST_PREFIX_KEY = "__crg_spring_request_prefix__:"
+_JS_IMPORT_ORIGINAL_PREFIX_KEY = "__crg_js_import_original__:"
 _SPRING_REQUEST_MAPPINGS = {
     "DeleteMapping": ("DELETE",),
     "GetMapping": ("GET",),
@@ -5175,7 +5176,7 @@ class CodeParser:
             return None
         if base_type in import_map:
             resolved = self._resolve_imported_symbol(
-                base_type,
+                self._js_imported_symbol_name(base_type, import_map),
                 import_map[base_type],
                 file_path,
                 language,
@@ -11588,9 +11589,22 @@ class CodeParser:
                     and name_node.end_byte == child.end_byte
                 ):
                     return
-            # extends/implements are already covered by INHERITS edges.
-            if parent.type in _TS_HERITAGE_CLAUSES:
-                return
+            # extends/implements are already covered by INHERITS edges. Generic
+            # bases add a ``generic_type`` wrapper, so walk up to the clause.
+            # Do not suppress a separate imported type used as a type argument:
+            # ``extends Base<Dependency>`` inherits Base but references Dependency.
+            ancestor = parent
+            inside_type_arguments = False
+            while ancestor is not None:
+                if ancestor.type == "type_arguments":
+                    inside_type_arguments = True
+                if ancestor.type in _TS_HERITAGE_CLAUSES:
+                    if not inside_type_arguments:
+                        return
+                    break
+                if ancestor.type in _TS_TYPE_DECLARATIONS:
+                    break
+                ancestor = ancestor.parent
 
         # Attribute to the enclosing function, else the enclosing type, else the
         # file — so `interface Wrapper { nested: Verdict }` names Wrapper as the
@@ -13053,6 +13067,8 @@ class CodeParser:
                 for spec in child.children:
                     if spec.type == "import_specifier":
                         # Could be: name or name as alias
+                        imported_node = spec.child_by_field_name("name")
+                        alias_node = spec.child_by_field_name("alias")
                         names = [
                             s.text.decode("utf-8", errors="replace")
                             for s in spec.children
@@ -13060,7 +13076,30 @@ class CodeParser:
                         ]
                         # Last identifier is the local name
                         if names:
-                            import_map[names[-1]] = module
+                            local_name = names[-1]
+                            import_map[local_name] = module
+                            imported_name = (
+                                imported_node.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                                if imported_node is not None
+                                else names[0]
+                            )
+                            if alias_node is not None and imported_name != local_name:
+                                import_map[
+                                    f"{_JS_IMPORT_ORIGINAL_PREFIX_KEY}{local_name}"
+                                ] = imported_name
+
+    @staticmethod
+    def _js_imported_symbol_name(
+        local_name: str,
+        import_map: dict[str, str],
+    ) -> str:
+        """Return the exported name behind a local JS/TS import alias."""
+        return import_map.get(
+            f"{_JS_IMPORT_ORIGINAL_PREFIX_KEY}{local_name}",
+            local_name,
+        )
 
     def exclude_files(self, paths: set[str]) -> None:
         """Treat these files as absent when resolving imports.
@@ -13718,7 +13757,10 @@ class CodeParser:
             if language == "julia":
                 return import_map[call_name]
             resolved = self._resolve_imported_symbol(
-                call_name, import_map[call_name], file_path, language,
+                self._js_imported_symbol_name(call_name, import_map),
+                import_map[call_name],
+                file_path,
+                language,
             )
             if resolved:
                 return resolved

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 _QUERY_PATTERNS = {
     "callers_of": "Find all functions that call a given function",
+    "references_to": "Find all nodes that reference a given symbol",
     "callees_of": "Find all functions called by a given function",
     "imports_of": "Find all imports of a given file or module",
     "importers_of": "Find all files that import a given file or module",
@@ -234,8 +235,8 @@ def query_graph(
     """Run a predefined graph query.
 
     Args:
-        pattern: Query pattern. One of: callers_of, callees_of, imports_of,
-                 importers_of, children_of, tests_for, inheritors_of,
+        pattern: Query pattern. One of: callers_of, references_to, callees_of,
+                 imports_of, importers_of, children_of, tests_for, inheritors_of,
                  triggers_of, triggered_by, publishers_of, listeners_of,
                  handlers_of, endpoints_for, consumers_of, file_summary.
         target: The node name, qualified name, or file path to query about.
@@ -402,6 +403,16 @@ def query_graph(
                             caller_result = node_to_dict(caller)
                             caller_result["target_resolution"] = "unresolved"
                             add_result(caller_result, e)
+
+        elif pattern == "references_to":
+            seen_sources: set[str] = set()
+            for e in store.iter_edges_by_target(qn):
+                if e.kind != "REFERENCES" or e.source_qualified in seen_sources:
+                    continue
+                source = store.get_node(e.source_qualified)
+                if source:
+                    seen_sources.add(e.source_qualified)
+                    add_result(node_to_dict(source), e)
 
         elif pattern == "callees_of":
             seen_targets: set[str] = set()

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -405,13 +405,16 @@ def query_graph(
                             add_result(caller_result, e)
 
         elif pattern == "references_to":
-            seen_sources: set[str] = set()
+            seen_reference_sources: set[str] = set()
             for e in store.iter_edges_by_target(qn):
-                if e.kind != "REFERENCES" or e.source_qualified in seen_sources:
+                if (
+                    e.kind != "REFERENCES"
+                    or e.source_qualified in seen_reference_sources
+                ):
                     continue
                 source = store.get_node(e.source_qualified)
                 if source:
-                    seen_sources.add(e.source_qualified)
+                    seen_reference_sources.add(e.source_qualified)
                     add_result(node_to_dict(source), e)
 
         elif pattern == "callees_of":

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -62,7 +62,7 @@ Relevant responses may include compact estimated `context_savings` metadata.
 
 #### `query_graph_tool`
 ```
-pattern: str    # callers_of, callees_of, imports_of, importers_of,
+pattern: str    # callers_of, references_to, callees_of, imports_of, importers_of,
                 # children_of, tests_for, inheritors_of, file_summary
 target: str     # Node name, qualified name, or file path
 repo_root: str | None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2242,6 +2242,35 @@ class TestTypeScriptTypeDeclarations:
             assert (f"{use}::summarize", f"{types.resolve()}::Finding") in refs
             assert (f"{use}::summarize", f"{types.resolve()}::Verdict") in refs
 
+    def test_aliased_type_import_resolves_to_exported_symbol(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, _ = self._project(root)
+            use = root / "aliased.ts"
+            use.write_text(
+                "import type { Finding as ImportedFinding } from './types';\n\n"
+                "export function summarize(item: ImportedFinding): string {\n"
+                "  return item.id;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(use)
+
+            refs = {
+                (edge.source, edge.target)
+                for edge in edges
+                if edge.kind == "REFERENCES"
+            }
+            assert (
+                f"{use}::summarize",
+                f"{types.resolve()}::Finding",
+            ) in refs
+            assert not any(
+                target == f"{types.resolve()}::ImportedFinding"
+                for _, target in refs
+            )
+
     def test_type_argument_inside_a_generic_is_a_reference(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -2358,6 +2387,44 @@ class TestTypeScriptTypeDeclarations:
 
             bare = {e.target.split("::")[-1] for e in edges if e.kind == "REFERENCES"}
             assert "Findable" not in bare
+
+    def test_generic_heritage_does_not_double_emit_a_reference(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text(
+                "export interface Box<T> { value: T }\n"
+                "export interface Payload { value: string }\n",
+                encoding="utf-8",
+            )
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Box, Payload } from './base';\n\n"
+                "export class BoxImpl implements Box<Payload> {\n"
+                "  value = { value: 'x' };\n"
+                "}\n\n"
+                "export interface StringBox extends Box<string> {}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            inherits = [
+                edge for edge in edges
+                if edge.kind == "INHERITS" and edge.target == "Box"
+            ]
+            references = [
+                edge for edge in edges
+                if edge.kind == "REFERENCES"
+                and edge.target == f"{base.resolve()}::Box"
+            ]
+            assert len(inherits) == 2
+            assert references == []
+            assert any(
+                edge.kind == "REFERENCES"
+                and edge.target == f"{base.resolve()}::Payload"
+                for edge in edges
+            )
 
     def test_tsx_type_positions_are_also_covered(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2172,3 +2172,211 @@ class TestJsMemberAssignedFunctions:
         assert member.name == "app.handle"
         assert len(callers) == 1
         assert callers[0].source_qualified == caller_qn
+class TestTypeScriptTypeDeclarations:
+    """TS interfaces / type aliases / enums are graph nodes, and type positions
+    are dependencies.
+
+    Before this, ``_CLASS_TYPES`` covered only ``class_declaration`` for TS, so a
+    types-only module produced zero symbol nodes and its blast radius collapsed
+    to whole-file ``IMPORTS_FROM`` fan-out. Java/C#/PHP already indexed
+    ``interface_declaration``. See: #737
+    """
+
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def _project(self, root: Path) -> tuple[Path, Path]:
+        types = root / "types.ts"
+        types.write_text(
+            "export interface Finding {\n"
+            "  id: string;\n"
+            "}\n\n"
+            "export type Verdict = 'ok' | 'bad';\n\n"
+            "export enum Severity {\n"
+            "  Low,\n"
+            "  High,\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        use = root / "use.ts"
+        use.write_text(
+            "import { Finding, Verdict, Severity } from './types';\n\n"
+            "export function summarize(items: Finding[]): Verdict {\n"
+            "  const cache: Map<string, Severity> = new Map();\n"
+            "  return cache.size ? 'bad' : 'ok';\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        return types, use
+
+    def test_interface_type_alias_and_enum_become_nodes(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            types, _ = self._project(Path(tmp_dir))
+
+            nodes, _ = self.parser.parse_file(types)
+
+            names = {n.name for n in nodes if n.kind == "Class"}
+            assert {"Finding", "Verdict", "Severity"} <= names
+
+    def test_declaration_name_is_not_a_reference_to_itself(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            types, _ = self._project(Path(tmp_dir))
+
+            _, edges = self.parser.parse_file(types)
+
+            refs = [e for e in edges if e.kind == "REFERENCES"]
+            assert not [e for e in refs if e.source == e.target]
+
+    def test_type_annotation_emits_reference_to_the_declaring_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            refs = {
+                (e.source, e.target)
+                for e in edges
+                if e.kind == "REFERENCES"
+            }
+            assert (f"{use}::summarize", f"{types.resolve()}::Finding") in refs
+            assert (f"{use}::summarize", f"{types.resolve()}::Verdict") in refs
+
+    def test_type_argument_inside_a_generic_is_a_reference(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            # Severity appears only as Map<string, Severity>.
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{use}::summarize"
+                and e.target == f"{types.resolve()}::Severity"
+                for e in edges
+            )
+
+    def test_unknown_and_builtin_types_do_not_emit_references(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _, use = self._project(root)
+
+            _, edges = self.parser.parse_file(use)
+
+            bare = {e.target.split("::")[-1] for e in edges if e.kind == "REFERENCES"}
+            # Neither a predefined type nor an unimported global becomes an edge.
+            assert "string" not in bare
+            assert "Map" not in bare
+
+    def test_interface_member_attributes_to_the_interface_not_the_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, _ = self._project(root)
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Verdict } from './types';\n\n"
+                "export interface Wrapper {\n"
+                "  nested: Verdict;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{wrapper}::Wrapper"
+                and e.target == f"{types.resolve()}::Verdict"
+                for e in edges
+            )
+
+    def test_class_heritage_emits_inherits_edges(self):
+        """`class C extends B implements I` nests its clauses under
+        class_heritage, so scanning only direct children found no bases at all.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text(
+                "export class Base {}\n"
+                "export interface Findable { id: string }\n",
+                encoding="utf-8",
+            )
+            impl = root / "impl.ts"
+            impl.write_text(
+                "import { Base, Findable } from './base';\n\n"
+                "export class Impl extends Base implements Findable {\n"
+                "  id = 'x';\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(impl)
+
+            inherits = {
+                (e.source, e.target) for e in edges if e.kind == "INHERITS"
+            }
+            assert (f"{impl}::Impl", "Base") in inherits
+            assert (f"{impl}::Impl", "Findable") in inherits
+
+    def test_interface_extends_emits_inherits_edge(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text("export interface Findable { id: string }\n", encoding="utf-8")
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Findable } from './base';\n\n"
+                "export interface Wrapper extends Findable {\n"
+                "  extra: string;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            inherits = {(e.source, e.target) for e in edges if e.kind == "INHERITS"}
+            assert (f"{wrapper}::Wrapper", "Findable") in inherits
+
+    def test_heritage_does_not_double_emit_a_reference(self):
+        """A base is already an INHERITS edge; it must not also be REFERENCES."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            base = root / "base.ts"
+            base.write_text("export interface Findable { id: string }\n", encoding="utf-8")
+            wrapper = root / "wrapper.ts"
+            wrapper.write_text(
+                "import { Findable } from './base';\n\n"
+                "export interface Wrapper extends Findable {\n"
+                "  extra: string;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(wrapper)
+
+            bare = {e.target.split("::")[-1] for e in edges if e.kind == "REFERENCES"}
+            assert "Findable" not in bare
+
+    def test_tsx_type_positions_are_also_covered(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            types, _ = self._project(root)
+            panel = root / "Panel.tsx"
+            panel.write_text(
+                "import { Finding } from './types';\n\n"
+                "export function Panel({ finding }: { finding: Finding }) {\n"
+                "  return null;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            _, edges = self.parser.parse_file(panel)
+
+            assert any(
+                e.kind == "REFERENCES"
+                and e.source == f"{panel}::Panel"
+                and e.target == f"{types.resolve()}::Finding"
+                for e in edges
+            )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -327,6 +327,47 @@ class TestQueryGraphCallTargetFallbacks:
         edge_targets = {e["target"] for e in result["edges"]}
         assert edge_targets == {f"{self.target_file}::target_func", "target_func"}
 
+    def test_references_to_returns_type_dependents(self, monkeypatch):
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+        type_path = self.root / "types.ts"
+        use_path = self.root / "use.ts"
+        alias_path = self.root / "alias.ts"
+        type_path.write_text(
+            "export interface Finding { id: string }\n",
+            encoding="utf-8",
+        )
+        use_path.write_text(
+            "import type { Finding } from './types';\n"
+            "export function summarize(item: Finding): string { return item.id; }\n",
+            encoding="utf-8",
+        )
+        alias_path.write_text(
+            "import type { Finding as ImportedFinding } from './types';\n"
+            "export function summarizeAlias(item: ImportedFinding): string {\n"
+            "  return item.id;\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        with GraphStore(self.db_path) as store:
+            build = full_build(self.root, store)
+            assert build["errors"] == []
+
+        type_qn = f"{type_path}::Finding"
+        direct_qn = f"{use_path}::summarize"
+        alias_qn = f"{alias_path}::summarizeAlias"
+        result = query_graph(
+            pattern="references_to",
+            target=type_qn,
+            repo_root=str(self.root),
+        )
+
+        assert result["status"] == "ok"
+        assert {node["qualified_name"] for node in result["results"]} == {
+            direct_qn,
+            alias_qn,
+        }
+        assert {edge["kind"] for edge in result["edges"]} == {"REFERENCES"}
+
     def test_callees_of_includes_resolved_and_bare_target_callees(self):
         result = query_graph(
             pattern="callees_of",


### PR DESCRIPTION
## What changed

This preserves nhatvu148's TypeScript/TSX type-declaration work from #738 and completes the missing end-to-end behavior:

- Index interfaces, type aliases, and enums as graph nodes.
- Emit `REFERENCES` edges for known types used in annotations and generic arguments.
- Preserve the exported symbol behind aliased type imports.
- Emit one inheritance relationship for generic heritage without duplicating the base as a reference, while retaining references to its type arguments.
- Add the public `references_to` query for type dependents.

The rebase conflict was limited to appended parser tests. Both #770's JS member-function regressions and this contribution's type regressions are preserved.

## Attribution

The contributor patch is preserved as commit `f28862e`, authored by `nhatvu148 <nhatvu148@gmail.com>`. The following maintainer commit contains only the corrections and missing regressions found during review.

## Validation

- TDD: alias identity, generic-heritage deduplication, and `references_to` first failed on the contributed patch, then passed after the correction.
- Fresh local parser/query/graph/tsconfig suite: 363 passed, 1 skipped.
- Real full build, persisted graph, and `references_to` query cover both direct and aliased consumers.
- Ruff on every changed production module: passed.
- `git diff --check`: passed.

This PR must pass its complete hosted Python, Windows, lint, type, security, schema, review, CodeQL, and GitGuardian matrix before merge.

Fixes #737
Supersedes #738
