### PR TITLE
fix(platform): detect installed GitHub Copilot clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- GitHub Copilot auto-detection now requires the Copilot extension and also
+  recognizes the extension bundled with released VS Code installations.
 - Added a post-index Python import resolver using unique module suffixes, so
   `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while duplicate
   package candidates remain explicitly unresolved (#720).

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -32,6 +32,92 @@ def _zed_settings_path() -> Path:
     return Path.home() / ".config" / "zed" / "settings.json"
 
 
+def _copilot_vscode_detected() -> bool:
+    """Return whether a GitHub Copilot extension is installed for VS Code."""
+    home = Path.home()
+    extension_dirs = [
+        home / ".vscode" / "extensions",
+        home / ".vscode-insiders" / "extensions",
+    ]
+
+    system = platform.system()
+    if system == "Darwin":
+        for applications_dir in (Path("/Applications"), home / "Applications"):
+            for app_name in (
+                "Visual Studio Code.app",
+                "Visual Studio Code - Insiders.app",
+            ):
+                extension_dirs.append(
+                    applications_dir
+                    / app_name
+                    / "Contents"
+                    / "Resources"
+                    / "app"
+                    / "extensions"
+                )
+    elif system == "Windows":
+        for env_name in ("LOCALAPPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)"):
+            if install_root := os.environ.get(env_name):
+                for app_name in ("Microsoft VS Code", "Microsoft VS Code Insiders"):
+                    extension_dirs.append(
+                        Path(install_root)
+                        / app_name
+                        / "resources"
+                        / "app"
+                        / "extensions"
+                    )
+    elif system == "Linux":
+        extension_dirs.extend(
+            [
+                Path("/usr/share/code/resources/app/extensions"),
+                Path("/usr/share/code-insiders/resources/app/extensions"),
+                Path("/usr/lib/code/resources/app/extensions"),
+                Path("/opt/visual-studio-code/resources/app/extensions"),
+                Path("/snap/code/current/usr/share/code/resources/app/extensions"),
+            ]
+        )
+
+    for command in ("code", "code-insiders"):
+        if executable := shutil.which(command):
+            try:
+                parents = Path(executable).resolve().parents[:6]
+            except OSError:
+                continue
+            for parent in parents:
+                extension_dirs.extend(
+                    [
+                        parent / "extensions",
+                        parent / "resources" / "app" / "extensions",
+                        parent / "Resources" / "app" / "extensions",
+                    ]
+                )
+
+    for extensions_dir in dict.fromkeys(extension_dirs):
+        try:
+            extension_paths = list(extensions_dir.iterdir())
+        except OSError:
+            continue
+        for extension_path in extension_paths:
+            name = extension_path.name.lower()
+            if name.startswith("github.copilot-"):
+                return True
+            if "copilot" not in name:
+                continue
+            try:
+                manifest = json.loads(
+                    (extension_path / "package.json").read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (
+                str(manifest.get("publisher", "")).lower() == "github"
+                and str(manifest.get("name", "")).lower()
+                in {"copilot", "copilot-chat"}
+            ):
+                return True
+    return False
+
+
 def _opencode_config_path(repo_root: Path) -> Path:
     """Return OpenCode's existing project config, preferring JSONC."""
     for name in ("opencode.jsonc", "opencode.json"):
@@ -142,7 +228,7 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "name": "GitHub Copilot",
         "config_path": lambda root: root / ".vscode" / "mcp.json",
         "key": "servers",
-        "detect": lambda: (Path.home() / ".vscode").exists(),
+        "detect": _copilot_vscode_detected,
         "format": "object",
         "needs_type": True,
     },

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -19,6 +19,7 @@ from code_review_graph import skills as skills_module
 from code_review_graph.skills import (
     _CLAUDE_MD_SECTION_MARKER,
     PLATFORMS,
+    _copilot_vscode_detected,
     _cursor_hook_scripts,
     _detect_serve_command,
     _in_poetry_project,
@@ -1669,14 +1670,58 @@ class TestCopilotPlatform:
         assert not (tmp_path / "QODER.md").exists()
 
     def test_copilot_included_in_all_when_detected(self, tmp_path):
-        """install_platform_configs with target='all' includes Copilot when ~/.vscode exists."""
+        """Auto-detection requires the Copilot extension, not only VS Code."""
         fake_home = tmp_path / "fakehome"
-        (fake_home / ".vscode").mkdir(parents=True)
-        with patch("code_review_graph.skills.Path.home", return_value=fake_home):
+        (fake_home / ".vscode" / "extensions" / "github.copilot-1.2.3").mkdir(
+            parents=True
+        )
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.platform.system", return_value="Unknown"),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
             configured = install_platform_configs(tmp_path, target="all")
         assert "GitHub Copilot" in configured
         config_path = tmp_path / ".vscode" / "mcp.json"
         assert config_path.exists()
+
+    def test_copilot_detects_vscode_bundled_extension(self, tmp_path):
+        """Current VS Code bundles Copilot under its application extensions."""
+        fake_home = tmp_path / "fakehome"
+        app_root = tmp_path / "vscode" / "resources" / "app"
+        code_cli = app_root / "bin" / "code"
+        code_cli.parent.mkdir(parents=True)
+        code_cli.write_text("", encoding="utf-8")
+        manifest = app_root / "extensions" / "copilot" / "package.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps({"publisher": "GitHub", "name": "copilot-chat"}),
+            encoding="utf-8",
+        )
+
+        def _which(command):
+            return str(code_cli) if command == "code" else None
+
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.shutil.which", side_effect=_which),
+        ):
+            assert _copilot_vscode_detected() is True
+
+    def test_copilot_not_detected_from_vscode_alone(self, tmp_path):
+        """An unrelated VS Code install must not trigger Copilot configuration."""
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".vscode" / "extensions" / "ms-python.python-1.0.0").mkdir(
+            parents=True
+        )
+        with (
+            patch("code_review_graph.skills.Path.home", return_value=fake_home),
+            patch("code_review_graph.skills.platform.system", return_value="Unknown"),
+            patch("code_review_graph.skills.shutil.which", return_value=None),
+        ):
+            configured = install_platform_configs(tmp_path, target="all")
+        assert "GitHub Copilot" not in configured
+        assert not (tmp_path / ".vscode" / "mcp.json").exists()
 
 
 class TestCopilotCLIPlatform:


### PR DESCRIPTION
## What changed

Extract only the validated GitHub Copilot detection fix from draft #658:

- Require a real Copilot extension instead of treating any `~/.vscode` directory as Copilot.
- Detect user-installed and bundled Copilot/Copilot Chat extensions.
- Cover released VS Code application layouts and executable-relative extension paths.

No Google Antigravity behavior from #658 is included.

## Attribution and client evidence

The commit credits `npkriami18 <pranaynannuri@gmail.com>` as co-author.

The original #658 validation used released VS Code 1.127 with bundled Copilot Chat 0.55: detection succeeded and the generated workspace MCP configuration loaded without a parse error. Copilot CLI discovery, invocation, idempotent reinstall, and surgical uninstall were also validated there. This PR isolates only the detection portion that applies to current main.

## Validation

- Fresh local platform/install/uninstall suite: 241 passed.
- Ruff on changed implementation/tests: passed.
- `git diff --check`: passed.

This PR must pass its complete hosted Python, Windows, lint, type, security, schema, review, CodeQL, and GitGuardian matrix before merge.

Extracted from #658
