### PR TITLE
fix(parser): index C++ and Qt headers correctly

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -752,6 +752,21 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".yaml": "yaml",
 }
 
+# ``.h`` is shared by C and C++. Keep C as the extension default, then promote
+# a header only when the C++ grammar finds syntax that C cannot express. Weak
+# compatibility markers such as ``__cplusplus`` and ``extern "C"`` are
+# deliberately excluded because they are common in otherwise-C headers.
+_CPP_HEADER_EVIDENCE_TYPES = frozenset({
+    "access_specifier",
+    "alias_declaration",
+    "base_class_clause",
+    "class_specifier",
+    "concept_definition",
+    "namespace_definition",
+    "template_declaration",
+    "using_declaration",
+})
+
 # Shebang interpreter → language mapping for extension-less Unix scripts.
 # Each key is the **basename** of the interpreter path as it appears after
 # ``#!`` (or after ``#!/usr/bin/env``).  Only languages already registered
@@ -2522,6 +2537,17 @@ class CodeParser:
         if not language:
             return [], []
 
+        parser = None
+        tree = None
+        if language == "c" and path.suffix.lower() == ".h":
+            cpp_parser = self._get_parser("cpp")
+            if cpp_parser is not None:
+                cpp_tree = cpp_parser.parse(source)
+                if self._has_cpp_header_evidence(cpp_tree.root_node):
+                    language = "cpp"
+                    parser = cpp_parser
+                    tree = cpp_tree
+
         if language == "blade":
             return self._parse_blade(path, source)
 
@@ -2592,11 +2618,13 @@ class CodeParser:
         if language == "yaml":
             return [], []
 
-        parser = self._get_parser(language)
+        if parser is None:
+            parser = self._get_parser(language)
         if not parser:
             return [], []
 
-        tree = parser.parse(source)
+        if tree is None:
+            tree = parser.parse(source)
         nodes: list[NodeInfo] = []
         edges: list[EdgeInfo] = []
         file_path_str = str(path)
@@ -2683,6 +2711,17 @@ class CodeParser:
                     ))
 
         return nodes, edges
+
+    @staticmethod
+    def _has_cpp_header_evidence(root) -> bool:
+        """Return whether a parsed ``.h`` tree contains C++-only syntax."""
+        pending = [root]
+        while pending:
+            node = pending.pop()
+            if node.type in _CPP_HEADER_EVIDENCE_TYPES:
+                return True
+            pending.extend(node.named_children)
+        return False
 
     @classmethod
     def _mask_blade_comments(cls, text: str) -> str:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -762,10 +762,16 @@ _CPP_HEADER_EVIDENCE_TYPES = frozenset({
     "base_class_clause",
     "class_specifier",
     "concept_definition",
+    "lambda_expression",
     "namespace_definition",
+    "noexcept",
+    "placeholder_type_specifier",
     "template_declaration",
+    "trailing_return_type",
     "using_declaration",
 })
+
+_CPP_HEADER_EVIDENCE_QUALIFIERS = frozenset({b"constexpr", b"consteval", b"constinit"})
 
 _CPP_QT_STRUCTURAL_MACRO_REPLACEMENTS = {
     b"QT_BEGIN_NAMESPACE": b" " * len(b"QT_BEGIN_NAMESPACE"),
@@ -2732,7 +2738,29 @@ class CodeParser:
         pending = [root]
         while pending:
             node = pending.pop()
+            if node.type == "ERROR" or _is_in_static_dead_guard(node):
+                continue
+
+            previous = node.prev_named_sibling
+            recovered_after_error = (
+                previous is not None
+                and previous.type == "ERROR"
+                and previous.end_byte == node.start_byte
+            )
+            if recovered_after_error:
+                continue
+
             if node.type in _CPP_HEADER_EVIDENCE_TYPES:
+                return True
+            if (
+                node.type == "enum_specifier"
+                and any(child.type in ("class", "struct") for child in node.children)
+            ):
+                return True
+            if (
+                node.type == "type_qualifier"
+                and node.text in _CPP_HEADER_EVIDENCE_QUALIFIERS
+            ):
                 return True
             pending.extend(node.named_children)
         return False

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14114,7 +14114,7 @@ class CodeParser:
         if language == "cpp" and kind == "function":
             declarator = node.child_by_field_name("declarator")
             if node.type in ("declaration", "field_declaration"):
-                if self._cpp_find_function_declarator(declarator) is None:
+                if not self._cpp_is_callable_declaration(declarator):
                     return None
                 return self._cpp_callable_name(declarator)
             cpp_name = self._cpp_callable_name(declarator)
@@ -14487,6 +14487,24 @@ class CodeParser:
             if found is not None:
                 return found
         return None
+
+    def _cpp_is_callable_declaration(self, declarator) -> bool:
+        """Return whether a declaration names a function, not a function pointer."""
+        function_declarator = self._cpp_find_function_declarator(declarator)
+        if function_declarator is None:
+            return False
+
+        callable_declarator = function_declarator.child_by_field_name("declarator")
+        if (
+            callable_declarator is None
+            or callable_declarator.type != "parenthesized_declarator"
+        ):
+            return True
+
+        # ``void (*callback)(int)`` has no nested function declarator inside
+        # the parentheses.  A real function returning a function pointer,
+        # such as ``void (*factory())(int)``, does.
+        return self._cpp_find_function_declarator(callable_declarator) is not None
 
     def _cpp_find_qualified_identifier(self, declarator):
         """Find the callable's qualified identifier outside its parameters."""

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -765,13 +765,12 @@ _CPP_HEADER_EVIDENCE_TYPES = frozenset({
     "lambda_expression",
     "namespace_definition",
     "noexcept",
-    "placeholder_type_specifier",
     "template_declaration",
     "trailing_return_type",
     "using_declaration",
 })
 
-_CPP_HEADER_EVIDENCE_QUALIFIERS = frozenset({b"constexpr", b"consteval", b"constinit"})
+_CPP_HEADER_EVIDENCE_QUALIFIERS = frozenset({b"consteval", b"constinit"})
 
 _CPP_QT_STRUCTURAL_MACRO_REPLACEMENTS = {
     b"QT_BEGIN_NAMESPACE": b" " * len(b"QT_BEGIN_NAMESPACE"),

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14229,7 +14229,10 @@ class CodeParser:
         if language == "cpp" and kind == "function":
             declarator = node.child_by_field_name("declarator")
             if node.type in ("declaration", "field_declaration"):
-                if not self._cpp_is_callable_declaration(declarator):
+                if (
+                    not self._cpp_declaration_has_callable_scope(node)
+                    or not self._cpp_is_callable_declaration(declarator)
+                ):
                     return None
                 return self._cpp_callable_name(declarator)
             cpp_name = self._cpp_callable_name(declarator)
@@ -14620,6 +14623,26 @@ class CodeParser:
         # the parentheses.  A real function returning a function pointer,
         # such as ``void (*factory())(int)``, does.
         return self._cpp_find_function_declarator(callable_declarator) is not None
+
+    @staticmethod
+    def _cpp_declaration_has_callable_scope(declaration) -> bool:
+        """Limit callable declarations to file, namespace, and class scopes."""
+        scope = declaration.parent
+        while scope is not None:
+            if scope.type in (
+                "translation_unit",
+                "namespace_definition",
+                "field_declaration_list",
+            ):
+                return not _is_in_static_dead_guard(declaration)
+            if scope.type in (
+                "compound_statement",
+                "function_definition",
+                "lambda_expression",
+            ):
+                return False
+            scope = scope.parent
+        return False
 
     def _cpp_find_qualified_identifier(self, declarator):
         """Find the callable's qualified identifier outside its parameters."""

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -767,9 +767,14 @@ _CPP_HEADER_EVIDENCE_TYPES = frozenset({
     "using_declaration",
 })
 
-_CPP_QT_STRUCTURAL_MACRO_RE = re.compile(
-    rb"\b(?:QT_BEGIN_NAMESPACE|QT_END_NAMESPACE|Q_OBJECT|Q_SIGNALS|Q_SLOTS|Q_EMIT)\b",
-)
+_CPP_QT_STRUCTURAL_MACRO_REPLACEMENTS = {
+    b"QT_BEGIN_NAMESPACE": b" " * len(b"QT_BEGIN_NAMESPACE"),
+    b"QT_END_NAMESPACE": b" " * len(b"QT_END_NAMESPACE"),
+    b"Q_OBJECT": b" " * len(b"Q_OBJECT"),
+    b"Q_SIGNALS": b"public" + b" " * (len(b"Q_SIGNALS") - len(b"public")),
+    b"Q_SLOTS": b" " * len(b"Q_SLOTS"),
+    b"Q_EMIT": b" " * len(b"Q_EMIT"),
+}
 
 # Shebang interpreter → language mapping for extension-less Unix scripts.
 # Each key is the **basename** of the interpreter path as it appears after
@@ -2735,13 +2740,95 @@ class CodeParser:
     @staticmethod
     def _mask_cpp_qt_macros(source: bytes) -> bytes:
         """Shield structural Qt macros without changing byte or line offsets."""
-        def replacement(match: re.Match[bytes]) -> bytes:
-            token = match.group(0)
-            if token == b"Q_SIGNALS":
-                return b"public" + b" " * (len(token) - len(b"public"))
-            return b" " * len(token)
+        masked = bytearray(source)
+        length = len(source)
+        index = 0
+        line_start = 0
 
-        return _CPP_QT_STRUCTURAL_MACRO_RE.sub(replacement, source)
+        def skip_quoted(start: int, quote: int) -> int:
+            cursor = start + 1
+            while cursor < length:
+                if source[cursor] == ord("\\"):
+                    cursor += 2
+                elif source[cursor] == quote:
+                    return cursor + 1
+                else:
+                    cursor += 1
+            return length
+
+        def raw_string_end(start: int) -> Optional[int]:
+            for prefix in (b'u8R"', b'LR"', b'UR"', b'uR"', b'R"'):
+                if not source.startswith(prefix, start):
+                    continue
+                delimiter_start = start + len(prefix)
+                opening = source.find(b"(", delimiter_start, delimiter_start + 17)
+                if opening == -1:
+                    return None
+                delimiter = source[delimiter_start:opening]
+                if any(byte in b" ()\\\t\r\n" for byte in delimiter):
+                    return None
+                closing = source.find(b")" + delimiter + b'"', opening + 1)
+                return length if closing == -1 else closing + len(delimiter) + 2
+            return None
+
+        while index < length:
+            byte = source[index]
+            if byte == ord("\n"):
+                line_start = index + 1
+                index += 1
+                continue
+
+            if source.startswith(b"//", index):
+                newline = source.find(b"\n", index + 2)
+                index = length if newline == -1 else newline
+                continue
+            if source.startswith(b"/*", index):
+                closing = source.find(b"*/", index + 2)
+                index = length if closing == -1 else closing + 2
+                continue
+
+            if byte == ord("#") and not source[line_start:index].strip(b" \t\v\f\r"):
+                cursor = index
+                while cursor < length:
+                    newline = source.find(b"\n", cursor)
+                    if newline == -1:
+                        cursor = length
+                        break
+                    previous = newline - 1
+                    if previous >= cursor and source[previous] == ord("\r"):
+                        previous -= 1
+                    if previous < cursor or source[previous] != ord("\\"):
+                        cursor = newline
+                        break
+                    cursor = newline + 1
+                index = cursor
+                continue
+
+            raw_end = raw_string_end(index)
+            if raw_end is not None:
+                index = raw_end
+                continue
+            if byte in (ord('"'), ord("'")):
+                index = skip_quoted(index, byte)
+                continue
+
+            if byte == ord("_") or chr(byte).isalpha():
+                end = index + 1
+                while end < length:
+                    candidate = source[end]
+                    if candidate != ord("_") and not chr(candidate).isalnum():
+                        break
+                    end += 1
+                token = source[index:end]
+                replacement = _CPP_QT_STRUCTURAL_MACRO_REPLACEMENTS.get(token)
+                if replacement is not None:
+                    masked[index:end] = replacement
+                index = end
+                continue
+
+            index += 1
+
+        return bytes(masked)
 
     @classmethod
     def _mask_blade_comments(cls, text: str) -> str:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -962,7 +962,7 @@ _FUNCTION_TYPES: dict[str, list[str]] = {
     "rust": ["function_item", "function_signature_item"],
     "java": ["method_declaration", "constructor_declaration"],
     "c": ["function_definition"],
-    "cpp": ["function_definition"],
+    "cpp": ["function_definition", "declaration", "field_declaration"],
     "csharp": ["method_declaration", "constructor_declaration"],
     "ruby": ["method", "singleton_method"],
     "r": ["function_definition"],
@@ -14113,6 +14113,10 @@ class CodeParser:
 
         if language == "cpp" and kind == "function":
             declarator = node.child_by_field_name("declarator")
+            if node.type in ("declaration", "field_declaration"):
+                if self._cpp_find_function_declarator(declarator) is None:
+                    return None
+                return self._cpp_callable_name(declarator)
             cpp_name = self._cpp_callable_name(declarator)
             if cpp_name:
                 return cpp_name

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2770,7 +2770,7 @@ class CodeParser:
         masked = bytearray(source)
         length = len(source)
         index = 0
-        line_start = 0
+        line_has_code = False
 
         def skip_quoted(start: int, quote: int) -> int:
             cursor = start + 1
@@ -2801,7 +2801,7 @@ class CodeParser:
         while index < length:
             byte = source[index]
             if byte == ord("\n"):
-                line_start = index + 1
+                line_has_code = False
                 index += 1
                 continue
 
@@ -2811,10 +2811,13 @@ class CodeParser:
                 continue
             if source.startswith(b"/*", index):
                 closing = source.find(b"*/", index + 2)
-                index = length if closing == -1 else closing + 2
+                comment_end = length if closing == -1 else closing + 2
+                if b"\n" in source[index:comment_end]:
+                    line_has_code = False
+                index = comment_end
                 continue
 
-            if byte == ord("#") and not source[line_start:index].strip(b" \t\v\f\r"):
+            if byte == ord("#") and not line_has_code:
                 cursor = index
                 while cursor < length:
                     newline = source.find(b"\n", cursor)
@@ -2833,9 +2836,11 @@ class CodeParser:
 
             raw_end = raw_string_end(index)
             if raw_end is not None:
+                line_has_code = True
                 index = raw_end
                 continue
             if byte in (ord('"'), ord("'")):
+                line_has_code = True
                 index = skip_quoted(index, byte)
                 continue
 
@@ -2850,9 +2855,12 @@ class CodeParser:
                 replacement = _CPP_QT_STRUCTURAL_MACRO_REPLACEMENTS.get(token)
                 if replacement is not None:
                     masked[index:end] = replacement
+                line_has_code = True
                 index = end
                 continue
 
+            if byte not in b" \t\v\f\r":
+                line_has_code = True
             index += 1
 
         return bytes(masked)

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -767,6 +767,10 @@ _CPP_HEADER_EVIDENCE_TYPES = frozenset({
     "using_declaration",
 })
 
+_CPP_QT_STRUCTURAL_MACRO_RE = re.compile(
+    rb"\b(?:QT_BEGIN_NAMESPACE|QT_END_NAMESPACE|Q_OBJECT|Q_SIGNALS|Q_SLOTS|Q_EMIT)\b",
+)
+
 # Shebang interpreter → language mapping for extension-less Unix scripts.
 # Each key is the **basename** of the interpreter path as it appears after
 # ``#!`` (or after ``#!/usr/bin/env``).  Only languages already registered
@@ -2539,14 +2543,19 @@ class CodeParser:
 
         parser = None
         tree = None
+        parse_source = source
         if language == "c" and path.suffix.lower() == ".h":
             cpp_parser = self._get_parser("cpp")
             if cpp_parser is not None:
-                cpp_tree = cpp_parser.parse(source)
+                cpp_source = self._mask_cpp_qt_macros(source)
+                cpp_tree = cpp_parser.parse(cpp_source)
                 if self._has_cpp_header_evidence(cpp_tree.root_node):
                     language = "cpp"
                     parser = cpp_parser
                     tree = cpp_tree
+                    parse_source = cpp_source
+        elif language == "cpp":
+            parse_source = self._mask_cpp_qt_macros(source)
 
         if language == "blade":
             return self._parse_blade(path, source)
@@ -2624,7 +2633,7 @@ class CodeParser:
             return [], []
 
         if tree is None:
-            tree = parser.parse(source)
+            tree = parser.parse(parse_source)
         nodes: list[NodeInfo] = []
         edges: list[EdgeInfo] = []
         file_path_str = str(path)
@@ -2722,6 +2731,17 @@ class CodeParser:
                 return True
             pending.extend(node.named_children)
         return False
+
+    @staticmethod
+    def _mask_cpp_qt_macros(source: bytes) -> bytes:
+        """Shield structural Qt macros without changing byte or line offsets."""
+        def replacement(match: re.Match[bytes]) -> bytes:
+            token = match.group(0)
+            if token == b"Q_SIGNALS":
+                return b"public" + b" " * (len(token) - len(b"public"))
+            return b" " * len(token)
+
+        return _CPP_QT_STRUCTURAL_MACRO_RE.sub(replacement, source)
 
     @classmethod
     def _mask_blade_comments(cls, text: str) -> str:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14597,6 +14597,11 @@ class CodeParser:
         if declarator is None:
             return None
         if declarator.type in ("function_declarator", "abstract_function_declarator"):
+            nested = self._cpp_find_function_declarator(
+                declarator.child_by_field_name("declarator"),
+            )
+            if nested is not None:
+                return nested
             return declarator
         for child in declarator.named_children:
             if child.type in ("parameter_list", "template_argument_list"):

--- a/tests/fixtures/cpp_qt_headers/MyWidget.cpp
+++ b/tests/fixtures/cpp_qt_headers/MyWidget.cpp
@@ -1,0 +1,12 @@
+#include "MyWidget.h"
+
+MyWidget::MyWidget(QWidget* parent) : QMainWindow(parent) {}
+MyWidget::~MyWidget() {}
+void MyWidget::doSomething() { onReset(); }
+int MyWidget::calculateValue(int a, int b) { return a + b; }
+void MyWidget::onButtonClicked() { Q_EMIT dataReady(calculateValue(1, 2)); }
+void MyWidget::onDataReceived(int value) {
+  if (value < 0) { Q_EMIT errorOccurred("err"); return; }
+  doSomething();
+}
+void MyWidget::onReset() { Q_EMIT dataReady(0); }

--- a/tests/fixtures/cpp_qt_headers/MyWidget.h
+++ b/tests/fixtures/cpp_qt_headers/MyWidget.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <QMainWindow>
+
+QT_BEGIN_NAMESPACE namespace Ui { class MyWidgetClass; };
+QT_END_NAMESPACE
+
+class MyWidget : public QMainWindow {
+  Q_OBJECT
+
+ public:
+  MyWidget(QWidget* parent = nullptr);
+  ~MyWidget();
+  void doSomething();
+  int calculateValue(int a, int b);
+
+ protected Q_SLOTS:
+  void onButtonClicked();
+  void onDataReceived(int value);
+
+ public Q_SLOTS:
+  void onReset();
+
+ Q_SIGNALS:
+  void dataReady(int result);
+  void errorOccurred(const QString& msg);
+};

--- a/tests/fixtures/cpp_qt_headers/MyWidgetPlain.cpp
+++ b/tests/fixtures/cpp_qt_headers/MyWidgetPlain.cpp
@@ -1,0 +1,10 @@
+#include "MyWidgetPlain.h"
+
+MyWidgetPlain::MyWidgetPlain() {}
+MyWidgetPlain::~MyWidgetPlain() {}
+
+void MyWidgetPlain::doSomething() { onReset(); }
+int MyWidgetPlain::calculateValue(int a, int b) { return a + b; }
+void MyWidgetPlain::onButtonClicked() { int result = calculateValue(1, 2); }
+void MyWidgetPlain::onDataReceived(int value) { if (value < 0) return; doSomething(); }
+void MyWidgetPlain::onReset() {}

--- a/tests/fixtures/cpp_qt_headers/MyWidgetPlain.h
+++ b/tests/fixtures/cpp_qt_headers/MyWidgetPlain.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class MyWidgetPlain {
+ public:
+  MyWidgetPlain();
+  ~MyWidgetPlain();
+  void doSomething();
+  int calculateValue(int a, int b);
+
+ protected:
+  void onButtonClicked();
+  void onDataReceived(int value);
+  void onReset();
+};

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -234,6 +234,9 @@ void (*factory())(int);
 
     function_names = [node.name for node in nodes if node.kind == "Function"]
     assert function_names == ["run", "free_function", "factory"]
+    factory = next(node for node in nodes if node.name == "factory")
+    assert factory.identity_name == "factory()"
+    assert factory.params == "()"
 
 
 def test_cpp_local_function_prototypes_are_not_indexed(tmp_path: Path) -> None:

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -4,6 +4,31 @@ from pathlib import Path
 
 from code_review_graph.parser import CodeParser
 
+QT_HEADER = """#pragma once
+#include <QMainWindow>
+
+QT_BEGIN_NAMESPACE namespace Ui { class MyWidgetClass; };
+QT_END_NAMESPACE
+
+class MyWidget : public QMainWindow {
+  Q_OBJECT
+
+ public:
+  MyWidget(QWidget* parent = nullptr);
+  ~MyWidget();
+
+ protected Q_SLOTS:
+  void onButtonClicked();
+
+ public Q_SLOTS:
+  void onReset();
+
+ Q_SIGNALS:
+  void dataReady(int result);
+  void errorOccurred(const QString& msg);
+};
+"""
+
 
 def _parse(tmp_path: Path, name: str, source: str):
     path = tmp_path / name
@@ -68,3 +93,30 @@ int library_version(void);
     )
 
     assert _file_language(nodes) == "c"
+
+
+def test_qt_structural_macros_do_not_hide_classes_or_become_functions(
+    tmp_path: Path,
+) -> None:
+    _, nodes, _ = _parse(tmp_path, "MyWidget.hpp", QT_HEADER)
+
+    class_names = {node.name for node in nodes if node.kind == "Class"}
+    function_names = {node.name for node in nodes if node.kind == "Function"}
+
+    assert {"MyWidget", "MyWidgetClass"} <= class_names
+    assert function_names.isdisjoint({
+        "QT_BEGIN_NAMESPACE",
+        "QT_END_NAMESPACE",
+        "Q_OBJECT",
+        "Q_SLOTS",
+        "Q_SIGNALS",
+    })
+
+
+def test_qt_macro_shielding_preserves_class_source_span(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(tmp_path, "MyWidget.hpp", QT_HEADER)
+
+    widget = next(
+        node for node in nodes if node.kind == "Class" and node.name == "MyWidget"
+    )
+    assert (widget.line_start, widget.line_end) == (7, 23)

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -151,6 +151,29 @@ extern int global_value;
     assert "global_value" not in function_names
 
 
+def test_cpp_function_pointer_variables_are_not_indexed_as_functions(
+    tmp_path: Path,
+) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "Callbacks.hpp",
+        """class Callbacks {
+ public:
+  void run(int value);
+  void (*callback)(int);
+  void (Callbacks::*handler)(int);
+};
+
+void free_function(int value);
+void (*global_callback)(int);
+void (*factory())(int);
+""",
+    )
+
+    function_names = [node.name for node in nodes if node.kind == "Function"]
+    assert function_names == ["run", "free_function", "factory"]
+
+
 def test_qt_member_declarations_survive_macro_shielding(tmp_path: Path) -> None:
     _, nodes, _ = _parse(tmp_path, "MyWidget.hpp", QT_HEADER)
 

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -236,6 +236,21 @@ void (*factory())(int);
     assert function_names == ["run", "free_function", "factory"]
 
 
+def test_cpp_local_function_prototypes_are_not_indexed(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "LocalPrototype.cpp",
+        """void outer() {
+  void local_prototype(int value);
+  local_prototype(1);
+}
+""",
+    )
+
+    function_names = [node.name for node in nodes if node.kind == "Function"]
+    assert function_names == ["outer"]
+
+
 def test_qt_member_declarations_survive_macro_shielding(tmp_path: Path) -> None:
     _, nodes, _ = _parse(tmp_path, "MyWidget.hpp", QT_HEADER)
 

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -120,3 +120,41 @@ def test_qt_macro_shielding_preserves_class_source_span(tmp_path: Path) -> None:
         node for node in nodes if node.kind == "Class" and node.name == "MyWidget"
     )
     assert (widget.line_start, widget.line_end) == (7, 23)
+
+
+def test_cpp_callable_declarations_are_indexed_without_variables(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "Widget.hpp",
+        """class Widget {
+ public:
+  Widget();
+  ~Widget();
+  void reset();
+  int value() const;
+  int count;
+};
+
+void top_level(int value);
+extern int global_value;
+""",
+    )
+
+    function_names = [node.name for node in nodes if node.kind == "Function"]
+    assert function_names == ["Widget", "~Widget", "reset", "value", "top_level"]
+    assert "count" not in function_names
+    assert "global_value" not in function_names
+
+
+def test_qt_member_declarations_survive_macro_shielding(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(tmp_path, "MyWidget.hpp", QT_HEADER)
+
+    function_names = {node.name for node in nodes if node.kind == "Function"}
+    assert {
+        "MyWidget",
+        "~MyWidget",
+        "onButtonClicked",
+        "onReset",
+        "dataReady",
+        "errorOccurred",
+    } <= function_names

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -1,8 +1,13 @@
 """Regression coverage for C++ and Qt header indexing (issue #463)."""
 
+import shutil
 from pathlib import Path
 
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
 from code_review_graph.parser import CodeParser
+
+FIXTURES = Path(__file__).parent / "fixtures" / "cpp_qt_headers"
 
 QT_HEADER = """#pragma once
 #include <QMainWindow>
@@ -158,3 +163,80 @@ def test_qt_member_declarations_survive_macro_shielding(tmp_path: Path) -> None:
         "dataReady",
         "errorOccurred",
     } <= function_names
+
+
+def test_four_file_cpp_qt_fixture_survives_full_build(tmp_path: Path) -> None:
+    for fixture in FIXTURES.iterdir():
+        shutil.copy2(fixture, tmp_path / fixture.name)
+
+    expected_functions = {
+        "MyWidgetPlain.h": {
+            "MyWidgetPlain",
+            "~MyWidgetPlain",
+            "doSomething",
+            "calculateValue",
+            "onButtonClicked",
+            "onDataReceived",
+            "onReset",
+        },
+        "MyWidgetPlain.cpp": {
+            "MyWidgetPlain",
+            "~MyWidgetPlain",
+            "doSomething",
+            "calculateValue",
+            "onButtonClicked",
+            "onDataReceived",
+            "onReset",
+        },
+        "MyWidget.h": {
+            "MyWidget",
+            "~MyWidget",
+            "doSomething",
+            "calculateValue",
+            "onButtonClicked",
+            "onDataReceived",
+            "onReset",
+            "dataReady",
+            "errorOccurred",
+        },
+        "MyWidget.cpp": {
+            "MyWidget",
+            "~MyWidget",
+            "doSomething",
+            "calculateValue",
+            "onButtonClicked",
+            "onDataReceived",
+            "onReset",
+        },
+    }
+
+    with GraphStore(":memory:") as store:
+        result = full_build(tmp_path, store)
+
+        assert result["errors"] == []
+        assert result["files_parsed"] == 4
+        for filename, expected in expected_functions.items():
+            path = tmp_path / filename
+            stored = store.get_nodes_by_file(str(path))
+            assert {node.name for node in stored if node.kind == "Function"} == expected
+            assert all(node.language == "cpp" for node in stored)
+
+        qt_header_nodes = store.get_nodes_by_file(str(tmp_path / "MyWidget.h"))
+        widget = next(
+            node
+            for node in qt_header_nodes
+            if node.kind == "Class" and node.name == "MyWidget"
+        )
+        assert (widget.line_start, widget.line_end) == (7, 26)
+        assert all(
+            node.name
+            not in {
+                "QT_BEGIN_NAMESPACE",
+                "QT_END_NAMESPACE",
+                "Q_OBJECT",
+                "Q_SLOTS",
+                "Q_SIGNALS",
+                "Q_EMIT",
+            }
+            for node in store.get_all_nodes()
+        )

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -1,0 +1,70 @@
+"""Regression coverage for C++ and Qt header indexing (issue #463)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse(tmp_path: Path, name: str, source: str):
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path, *CodeParser().parse_file(path)
+
+
+def _file_language(nodes) -> str:
+    return next(node.language for node in nodes if node.kind == "File")
+
+
+def test_h_file_uses_cpp_when_source_has_strong_cpp_evidence(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "MyWidgetPlain.h",
+        """#pragma once
+
+class MyWidgetPlain {
+ public:
+  void reset();
+};
+""",
+    )
+
+    assert _file_language(nodes) == "cpp"
+    assert any(node.kind == "Class" and node.name == "MyWidgetPlain" for node in nodes)
+
+
+def test_h_file_without_cpp_evidence_remains_c(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "plain.h",
+        """#pragma once
+
+typedef struct record {
+  int value;
+} record;
+
+int read_record(const record *value);
+""",
+    )
+
+    assert _file_language(nodes) == "c"
+
+
+def test_c_header_cpp_compatibility_guard_is_not_cpp_evidence(tmp_path: Path) -> None:
+    _, nodes, _ = _parse(
+        tmp_path,
+        "compat.h",
+        """#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int library_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+""",
+    )
+
+    assert _file_language(nodes) == "c"

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -183,6 +183,8 @@ def test_qt_macro_shielding_leaves_literals_comments_and_directives_unchanged(
 constexpr auto marker = R"tag(Q_SIGNALS \" Q_EMIT)tag";
 // Q_SLOTS
 /* QT_BEGIN_NAMESPACE */
+/* multiline comment
+*/#define Q_SIGNALS custom_signals
 class Widget {
   Q_OBJECT
  Q_SIGNALS:
@@ -194,6 +196,7 @@ class Widget {
 
     assert len(masked) == len(source)
     assert masked.splitlines()[:5] == source.splitlines()[:5]
+    assert b"*/#define Q_SIGNALS custom_signals" in masked
     assert b"  Q_OBJECT\n" not in masked
     assert b" Q_SIGNALS:\n" not in masked
 

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -100,6 +100,39 @@ int library_version(void);
     assert _file_language(nodes) == "c"
 
 
+def test_h_file_uses_cpp_for_scoped_enums_and_modern_function_syntax(
+    tmp_path: Path,
+) -> None:
+    sources = {
+        "ScopedEnum.h": "enum class Color { Red, Blue };\n",
+        "Constexpr.h": "constexpr int answer() noexcept;\n",
+        "TrailingReturn.h": "auto answer() -> int;\n",
+    }
+
+    for name, source in sources.items():
+        _, nodes, _ = _parse(tmp_path, name, source)
+        assert _file_language(nodes) == "cpp", name
+
+
+def test_inactive_or_recovered_cpp_syntax_does_not_promote_c_headers(
+    tmp_path: Path,
+) -> None:
+    sources = {
+        "disabled.h": """#if 0
+class Disabled {};
+#endif
+typedef int value;
+""",
+        "objective_c.h": """@class Forward;
+typedef int value;
+""",
+    }
+
+    for name, source in sources.items():
+        _, nodes, _ = _parse(tmp_path, name, source)
+        assert _file_language(nodes) == "c", name
+
+
 def test_qt_structural_macros_do_not_hide_classes_or_become_functions(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -127,6 +127,35 @@ def test_qt_macro_shielding_preserves_class_source_span(tmp_path: Path) -> None:
     assert (widget.line_start, widget.line_end) == (7, 23)
 
 
+def test_qt_macro_shielding_leaves_literals_comments_and_directives_unchanged(
+    tmp_path: Path,
+) -> None:
+    source = b'''#define Q_OBJECT custom_object
+#include "Q_OBJECT"
+constexpr auto marker = R"tag(Q_SIGNALS \" Q_EMIT)tag";
+// Q_SLOTS
+/* QT_BEGIN_NAMESPACE */
+class Widget {
+  Q_OBJECT
+ Q_SIGNALS:
+  void ready();
+};
+'''
+
+    masked = CodeParser._mask_cpp_qt_macros(source)
+
+    assert len(masked) == len(source)
+    assert masked.splitlines()[:5] == source.splitlines()[:5]
+    assert b"  Q_OBJECT\n" not in masked
+    assert b" Q_SIGNALS:\n" not in masked
+
+    path = tmp_path / "Widget.hpp"
+    nodes, edges = CodeParser().parse_bytes(path, source)
+    imports = [edge.target for edge in edges if edge.kind == "IMPORTS_FROM"]
+    assert imports == ["Q_OBJECT"]
+    assert any(node.kind == "Class" and node.name == "Widget" for node in nodes)
+
+
 def test_cpp_callable_declarations_are_indexed_without_variables(tmp_path: Path) -> None:
     _, nodes, _ = _parse(
         tmp_path,

--- a/tests/test_cpp_qt_headers.py
+++ b/tests/test_cpp_qt_headers.py
@@ -133,6 +133,21 @@ typedef int value;
         assert _file_language(nodes) == "c", name
 
 
+def test_c_auto_and_c23_constexpr_are_not_cpp_evidence(tmp_path: Path) -> None:
+    sources = {
+        "auto_storage.h": "auto int value;\n",
+        "c23_constexpr.h": """constexpr int limit = 16;
+typedef struct item {
+  int value;
+} item;
+""",
+    }
+
+    for name, source in sources.items():
+        _, nodes, _ = _parse(tmp_path, name, source)
+        assert _file_language(nodes) == "c", name
+
+
 def test_qt_structural_macros_do_not_hide_classes_or_become_functions(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Problem

`.h` files currently default to the C parser, so normal C++ class headers lose their classes and member declarations. Qt's structural macros can also push the C++ grammar into error recovery, hiding the real class and surfacing macro names as functions.

## What changed

- promote ambiguous `.h` files only when the C++ tree contains strong language evidence, while keeping ordinary C and C23 headers on the C path
- shield the Qt structural macros from #463 with same-length replacements limited to real code, so comments, literals, directives, and source positions stay intact
- index callable C++ declarations without treating fields, local prototypes, or function-pointer variables as functions
- add the exact four-file plain/Qt fixture as an end-to-end `full_build` regression

## Validation

- `uv run pytest tests/test_cpp_qt_headers.py tests/test_parser.py tests/test_multilang.py tests/test_cpp_overload_identity.py -q` (`627 passed`)
- `uv run pytest tests/ --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65` (`2319 passed`, `82.23%` coverage)
- `uv run ruff check code_review_graph/ tests/test_cpp_qt_headers.py`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- `uv run --with bandit bandit -r code_review_graph/ -c pyproject.toml -q`

Closes #463
