### PR TITLE
feat: add Hermes Agent install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ code-review-graph install --platform kiro         # configure only Kiro
 code-review-graph install --platform copilot      # configure only GitHub Copilot (VS Code)
 code-review-graph install --platform copilot-cli  # configure only GitHub Copilot CLI
 code-review-graph install --platform codebuddy    # configure only CodeBuddy Code
+code-review-graph install --platform hermes       # configure only Hermes Agent
 ```
 
 Requires Python 3.10+. For the best experience, install [uv](https://docs.astral.sh/uv/) (the MCP config will use `uvx` if available, otherwise falls back to the `code-review-graph` command directly).
@@ -687,5 +688,5 @@ MIT. See [LICENSE](LICENSE).
 <br>
 <a href="https://code-review-graph.com">code-review-graph.com</a><br><br>
 <code>pip install code-review-graph && code-review-graph install</code><br>
-<sub>Works with Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, GitHub Copilot, and GitHub Copilot CLI</sub>
+<sub>Works with Codex, Claude Code, CodeBuddy Code, Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity, Gemini CLI, Qwen, Qoder, Kiro, GitHub Copilot, GitHub Copilot CLI, and Hermes Agent</sub>
 </p>

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_CHOICES = [
     "codex", "claude", "claude-code", "cursor", "windsurf", "zed",
     "continue", "opencode", "antigravity", "gemini-cli", "qwen", "kiro", "qoder",
-    "copilot", "copilot-cli", "codebuddy", "all",
+    "copilot", "copilot-cli", "codebuddy", "hermes", "all",
 ]
 
 
@@ -315,6 +315,7 @@ def _handle_init(args: argparse.Namespace) -> None:
         install_gemini_cli_hooks,
         install_gemini_cli_skills,
         install_git_hook,
+        install_hermes_skills,
         install_hooks,
         install_opencode_plugin,
         install_qoder_skills,
@@ -335,6 +336,11 @@ def _handle_init(args: argparse.Namespace) -> None:
         if target in ("codebuddy", "all"):
             codebuddy_skills_dir = install_codebuddy_skills(repo_root)
             print(f"Installed CodeBuddy skills in {codebuddy_skills_dir}")
+
+        # Hermes Agent discovers skills under <HERMES_HOME>/skills/.
+        if target == "hermes" or (target == "all" and PLATFORMS["hermes"]["detect"]()):
+            hermes_skills_dir = install_hermes_skills(repo_root)
+            print(f"Installed Hermes Agent skills in {hermes_skills_dir}")
 
     # Confirm before writing instruction files (#173). --yes skips the
     # prompt; --no-instructions skips the whole block.

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -118,6 +118,28 @@ def _copilot_vscode_detected() -> bool:
     return False
 
 
+def _hermes_home() -> Path:
+    """Return the Hermes Agent home directory.
+
+    Mirrors Hermes' own resolution order: the ``HERMES_HOME`` environment
+    variable wins, otherwise the platform-native default (``%LOCALAPPDATA%\\hermes``
+    on Windows, ``~/.hermes`` elsewhere).
+    """
+    override = os.environ.get("HERMES_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    if platform.system() == "Windows":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        return base / "hermes"
+    return Path.home() / ".hermes"
+
+
+def _hermes_config_path() -> Path:
+    """Return the Hermes Agent config file (``config.yaml``)."""
+    return _hermes_home() / "config.yaml"
+
+
 def _opencode_config_path(repo_root: Path) -> Path:
     """Return OpenCode's existing project config, preferring JSONC."""
     for name in ("opencode.jsonc", "opencode.json"):
@@ -246,6 +268,14 @@ PLATFORMS: dict[str, dict[str, Any]] = {
         "server_type": "local",
         "entry_fields": {"tools": ["*"]},
     },
+    "hermes": {
+        "name": "Hermes Agent",
+        "config_path": lambda root: _hermes_config_path(),
+        "key": "mcp_servers",
+        "detect": lambda: _hermes_home().exists(),
+        "format": "yaml",
+        "needs_type": False,
+    },
     "codebuddy": {
         "name": "CodeBuddy Code",
         "config_path": lambda root: root / ".mcp.json",
@@ -350,6 +380,12 @@ def _build_server_entry(
         return {"type": "local", "command": opencode_command}
 
     entry: dict[str, Any] = {"command": command, "args": args}
+    if key == "hermes":
+        # Hermes' mcp_servers schema has no ``cwd``; the repo root must be
+        # passed to the server itself so it finds the right graph database.
+        if repo_root is not None:
+            entry["args"] = [*args, "--repo", str(repo_root)]
+        return entry
     # Include cwd so the MCP server can find the graph database
     if repo_root is not None:
         entry["cwd"] = str(repo_root)
@@ -423,6 +459,154 @@ def _merge_toml_mcp_server(
             prefix += "\n"
     config_path.write_text(prefix + section, encoding="utf-8")
     return True
+
+
+def _yaml_section_bounds(lines: list[str], key: str) -> tuple[int, int] | None:
+    """Return ``(header_index, end_index)`` for a top-level block mapping ``key``.
+
+    ``end_index`` is the index just past the last line belonging to the block
+    (blank lines and comments trailing the block are excluded so an insertion
+    lands inside it). Returns ``None`` when the key is absent or is not a
+    block mapping (e.g. ``key: {}`` written in flow style).
+    """
+    header = None
+    for index, line in enumerate(lines):
+        if line.startswith((" ", "\t", "#")) or not line.strip():
+            continue
+        name, sep, value = line.partition(":")
+        if sep and name.strip() == key:
+            if value.strip() and not value.strip().startswith("#"):
+                return None  # inline/flow value — refuse to edit
+            header = index
+            break
+    if header is None:
+        return None
+    end = header + 1
+    last_content = header + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip() and not line.startswith((" ", "\t")):
+            break
+        if line.strip() and not line.lstrip().startswith("#"):
+            last_content = end + 1
+        end += 1
+    return header, last_content
+
+
+def _yaml_block_indent(lines: list[str], start: int, end: int) -> int:
+    """Return the child indentation used inside a block, defaulting to 2."""
+    for line in lines[start:end]:
+        stripped = line.lstrip()
+        if stripped and not stripped.startswith("#"):
+            return len(line) - len(stripped)
+    return 2
+
+
+def _merge_yaml_mcp_server(
+    config_path: Path,
+    server_key: str,
+    server_name: str,
+    server_entry: dict[str, Any],
+    dry_run: bool = False,
+) -> bool | None:
+    """Add an MCP server to a YAML config without reformatting the rest.
+
+    The file is edited as text rather than round-tripped through a YAML
+    dumper: Hermes' ``config.yaml`` is hand-edited and full of comments,
+    anchors, and deliberate ordering that a dump would destroy. The parsed
+    document is only used to decide *whether* an edit is needed, and the
+    result is re-parsed before writing so a malformed edit is never saved.
+
+    Returns True when the file was (or would be) modified, False when the
+    entry is already present, and None when the edit was refused to avoid
+    data loss (the reason is printed).
+    """
+    import yaml
+
+    raw = ""
+    if config_path.exists():
+        raw = config_path.read_text(encoding="utf-8", errors="replace")
+        try:
+            parsed = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            print(
+                f"  {config_path} contains unparseable YAML ({exc.__class__.__name__})"
+                f" — skipping to avoid data loss. Please add the MCP config manually."
+            )
+            return None
+        if parsed is not None and not isinstance(parsed, dict):
+            print(
+                f"  {config_path} is valid YAML but not a top-level mapping "
+                f"({type(parsed).__name__}) — skipping to avoid data loss. "
+                f"Please add the MCP config manually."
+            )
+            return None
+        existing_servers = (parsed or {}).get(server_key)
+        if existing_servers is not None and not isinstance(existing_servers, dict):
+            print(
+                f"  {config_path} setting {server_key!r} is "
+                f"{type(existing_servers).__name__}; expected a mapping — "
+                f"skipping to avoid data loss."
+            )
+            return None
+        if isinstance(existing_servers, dict) and server_name in existing_servers:
+            return False
+
+    lines = raw.splitlines(keepends=True)
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    bounds = _yaml_section_bounds(lines, server_key)
+    if bounds is None and raw and server_key in (yaml.safe_load(raw) or {}):
+        # The key exists but is not an editable block mapping (flow style).
+        print(
+            f"  {config_path} setting {server_key!r} is not a block mapping — "
+            f"skipping to avoid data loss. Please add the MCP config manually."
+        )
+        return None
+
+    body = yaml.safe_dump(
+        {server_name: server_entry},
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    if bounds is None:
+        indent = 2
+        prefix = "" if not lines or lines[-1].strip() == "" else "\n"
+        block = prefix + f"{server_key}:\n" + _indent_block(body, indent)
+        new_lines = lines + [block]
+    else:
+        header, insert_at = bounds
+        indent = _yaml_block_indent(lines, header + 1, insert_at)
+        new_lines = lines[:insert_at] + [_indent_block(body, indent)] + lines[insert_at:]
+
+    rewritten = "".join(new_lines)
+    try:
+        reparsed = yaml.safe_load(rewritten)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive validation
+        print(
+            f"  {config_path}: safe YAML edit failed "
+            f"({exc.__class__.__name__}) — left unchanged."
+        )
+        return None
+    if not isinstance(reparsed, dict) or server_name not in (reparsed.get(server_key) or {}):
+        print(f"  {config_path}: safe YAML edit did not take effect — left unchanged.")
+        return None
+
+    if not dry_run:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(rewritten, encoding="utf-8")
+    return True
+
+
+def _indent_block(text: str, indent: int) -> str:
+    """Indent every non-empty line of ``text`` by ``indent`` spaces."""
+    pad = " " * indent
+    return "".join(
+        f"{pad}{line}" if line.strip() else line
+        for line in text.splitlines(keepends=True)
+    )
 
 
 def _strip_jsonc(text: str) -> str:
@@ -560,13 +744,25 @@ def install_platform_configs(
         server_key = plat["key"]
         server_entry = _build_server_entry(plat, key=key, repo_root=repo_root)
 
-        if plat["format"] == "toml":
-            changed = _merge_toml_mcp_server(
-                config_path,
-                "code-review-graph",
-                server_entry,
-                dry_run=dry_run,
-            )
+        if plat["format"] in ("toml", "yaml"):
+            if plat["format"] == "toml":
+                changed = _merge_toml_mcp_server(
+                    config_path,
+                    "code-review-graph",
+                    server_entry,
+                    dry_run=dry_run,
+                )
+            else:
+                changed = _merge_yaml_mcp_server(
+                    config_path,
+                    server_key,
+                    "code-review-graph",
+                    server_entry,
+                    dry_run=dry_run,
+                )
+            if changed is None:
+                # Refused to avoid data loss; the reason was already printed.
+                continue
             if not changed:
                 print(f"  {plat['name']}: already configured in {config_path}")
                 _record_configured(key, plat)
@@ -1273,7 +1469,7 @@ def inject_claude_md(repo_root: Path) -> None:
 # Used to filter writes when the user passes --platform <X>: only files
 # whose owner set includes the target (or "all") are written.
 _PLATFORM_INSTRUCTION_FILES: dict[str, tuple[str, ...]] = {
-    "AGENTS.md": ("cursor", "opencode", "antigravity", "codex"),
+    "AGENTS.md": ("cursor", "opencode", "antigravity", "codex", "hermes"),
     "GEMINI.md": ("antigravity", "gemini-cli"),
     ".cursorrules": ("cursor",),
     ".windsurfrules": ("windsurf",),
@@ -1754,6 +1950,17 @@ def install_qoder_skills(repo_root: Path) -> Path | None:
         logger.info("Installed %d skill(s) to %s", installed_count, qoder_skills_dir)
         return qoder_skills_dir
     return None
+
+
+def install_hermes_skills(repo_root: Path) -> Path:
+    """Install skills into Hermes Agent's user-level skills directory.
+
+    Hermes discovers skills at ``<HERMES_HOME>/skills/<category>/<name>/SKILL.md``
+    and uses the same ``name``/``description`` frontmatter as Claude Code, so
+    :func:`generate_skills` writes them directly under a ``code-review-graph``
+    category.
+    """
+    return generate_skills(repo_root, skills_dir=_hermes_home() / "skills" / "code-review-graph")
 
 
 # --- OpenCode plugin ---

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -381,10 +381,12 @@ def _build_server_entry(
 
     entry: dict[str, Any] = {"command": command, "args": args}
     if key == "hermes":
-        # Hermes' mcp_servers schema has no ``cwd``; the repo root must be
-        # passed to the server itself so it finds the right graph database.
-        if repo_root is not None:
-            entry["args"] = [*args, "--repo", str(repo_root)]
+        # No repo is pinned here, deliberately. Hermes Agent is a long-lived
+        # assistant that moves between projects, and its stdio schema has no
+        # ``cwd``, so a baked-in ``--repo`` would silently answer every
+        # question about whichever repo happened to be installed from. Every
+        # tool takes an explicit ``repo_root``; without a default, omitting it
+        # fails loudly instead of returning another project's graph.
         return entry
     # Include cwd so the MCP server can find the graph database
     if repo_root is not None:

--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -523,7 +523,7 @@ def _merge_yaml_mcp_server(
     entry is already present, and None when the edit was refused to avoid
     data loss (the reason is printed).
     """
-    import yaml
+    import yaml  # type: ignore[import-untyped]
 
     raw = ""
     if config_path.exists():

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -539,7 +539,7 @@ def _remove_yaml_entry(
     byte-for-byte; the parsed document is used only to locate the entry and to
     validate the result before writing.
     """
-    import yaml
+    import yaml  # type: ignore[import-untyped]
 
     if not path.exists() or not _safe_path(path, boundary, report):
         return

--- a/code_review_graph/uninstall.py
+++ b/code_review_graph/uninstall.py
@@ -525,6 +525,106 @@ def _remove_toml_entry(
     )
 
 
+def _remove_yaml_entry(
+    path: Path,
+    key: str,
+    boundary: Path,
+    report: UninstallReport,
+    *,
+    dry_run: bool,
+) -> None:
+    """Delete ``<key>.code-review-graph`` from a YAML config, text-surgically.
+
+    The rest of the document — comments, ordering, formatting — is preserved
+    byte-for-byte; the parsed document is used only to locate the entry and to
+    validate the result before writing.
+    """
+    import yaml
+
+    if not path.exists() or not _safe_path(path, boundary, report):
+        return
+    raw = _read_text(path, report)
+    if raw is None:
+        return
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        report.skipped_paths.append(f"{path} (YAML parse failed; left unchanged: {exc})")
+        return
+    if not isinstance(parsed, dict):
+        return
+    container = parsed.get(key)
+    if not isinstance(container, dict) or _ENTRY_NAME not in container:
+        return
+
+    lines = raw.splitlines(keepends=True)
+    bounds = skills._yaml_section_bounds(lines, key)
+    if bounds is None:
+        report.skipped_paths.append(
+            f"{path} ({key} is not a block mapping; left unchanged)"
+        )
+        return
+    header, section_end = bounds
+    child_indent = skills._yaml_block_indent(lines, header + 1, section_end)
+    entry_prefix = f"{' ' * child_indent}{_ENTRY_NAME}:"
+    start = next(
+        (
+            index
+            for index in range(header + 1, section_end)
+            if lines[index].rstrip("\n") == entry_prefix.rstrip()
+            or lines[index].startswith(entry_prefix)
+        ),
+        None,
+    )
+    if start is None:
+        report.skipped_paths.append(
+            f"{path} (could not locate {_ENTRY_NAME} block; left unchanged)"
+        )
+        return
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip() and (len(line) - len(line.lstrip())) <= child_indent:
+            break
+        end += 1
+    # Blank lines after the block separate it from what follows and belong to
+    # the user's formatting, not to our entry. Leave them in place.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+
+    rewritten = "".join(lines[:start] + lines[end:])
+    try:
+        reparsed = yaml.safe_load(rewritten)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive validation
+        report.skipped_paths.append(f"{path} (safe YAML edit failed; left unchanged: {exc})")
+        return
+    if not isinstance(reparsed, dict):
+        report.skipped_paths.append(f"{path} (safe YAML edit failed; left unchanged)")
+        return
+    remaining = reparsed.get(key)
+    if _ENTRY_NAME in (remaining or {}):
+        report.skipped_paths.append(f"{path} (safe YAML edit failed; left unchanged)")
+        return
+    # Every other setting must survive the edit untouched.
+    expected = copy.deepcopy(parsed)
+    del expected[key][_ENTRY_NAME]
+    if not expected[key]:
+        # An emptied mapping is written as ``key:`` (None) rather than ``{}``.
+        expected[key] = None
+    if reparsed != expected:
+        report.skipped_paths.append(
+            f"{path} (safe YAML edit changed unrelated settings; left unchanged)"
+        )
+        return
+    _write_text(
+        path,
+        rewritten,
+        report,
+        detail=f"removed {key}.{_ENTRY_NAME}",
+        dry_run=dry_run,
+    )
+
+
 def _commands(value: Any) -> set[str]:
     found: set[str] = set()
     if isinstance(value, dict):
@@ -904,6 +1004,13 @@ def _scope_for_config(path: Path, repo_root: Path, home: Path) -> tuple[str, Pat
         return "repo", repo_root
     if _is_lexical_child(path, home):
         return "user", home
+    # ``HERMES_HOME`` may relocate the Hermes Agent config outside the user's
+    # home directory. That directory is then the user-scope boundary for its
+    # own config, otherwise install would write a file uninstall refuses to
+    # clean up.
+    hermes_home = _absolute(skills._hermes_home())
+    if _is_lexical_child(path, hermes_home):
+        return "user", hermes_home
     return None
 
 
@@ -947,6 +1054,10 @@ def _process_platform_configs(
             seen.add(identity)
             if format_name == "toml":
                 _remove_toml_entry(
+                    path, entry_key, boundary, report, dry_run=dry_run
+                )
+            elif format_name == "yaml":
+                _remove_yaml_entry(
                     path, entry_key, boundary, report, dry_run=dry_run
                 )
             elif format_name in {"object", "array"}:
@@ -1184,6 +1295,15 @@ def _process_user(
         report,
         dry_run=dry_run,
     )
+
+    hermes_skills = skills._hermes_home() / "skills" / "code-review-graph"
+    for slug in _generated_skill_slugs():
+        _remove_skill_file(
+            hermes_skills / slug / "SKILL.md",
+            hermes_skills,
+            report,
+            dry_run=dry_run,
+        )
 
 
 def _registry_repo_paths(home: Path, report: UninstallReport) -> list[Path]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,4 +33,10 @@ def isolated_crg_home(tmp_path_factory, monkeypatch):
     """
     home = tmp_path_factory.mktemp("crg-home")
     monkeypatch.setenv("CRG_HOME", str(home))
+    # The Hermes Agent installer resolves its config from ``HERMES_HOME``,
+    # falling back to ``~/.hermes``. That fallback reaches the real user
+    # config in any test that does not also patch ``Path.home()``, so pin
+    # the variable to a temp directory instead of merely clearing it:
+    # unset, a miss would be silently destructive; set, it cannot be.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path_factory.mktemp("hermes-home")))
     return home

--- a/tests/test_hermes_install.py
+++ b/tests/test_hermes_install.py
@@ -1,0 +1,287 @@
+"""Hermes Agent install/uninstall: YAML preservation regressions.
+
+Hermes' ``config.yaml`` is a hand-edited file full of comments, ordering, and
+settings CRG knows nothing about. Every test here asserts the same contract:
+CRG may add or remove exactly its own ``mcp_servers.code-review-graph`` entry
+and must leave every other byte of the file alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from code_review_graph import skills, uninstall
+from code_review_graph.skills import (
+    PLATFORMS,
+    _detect_serve_command,
+    _hermes_config_path,
+    _hermes_home,
+    install_platform_configs,
+)
+
+# A realistic slice of a real Hermes config: comments, nested mappings, a
+# sibling MCP server, and settings after the mcp_servers block.
+_REAL_CONFIG = """\
+# Hermes Agent configuration
+model:
+  default: claude-opus-5   # trailing comment
+  provider: copilot
+
+# Servers exposing extra tools
+mcp_servers:
+  browsermcp:
+    command: npx
+    args:
+      - '@browsermcp/mcp@latest'
+  wanderlog:
+    command: npx
+    args: [-y, wanderlog-mcp]
+    env:
+      WANDERLOG_COOKIE: s%3Asecret
+
+tool_output:
+  max_bytes: 50000
+"""
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A fake user home, so the real ~/.hermes is unreachable from this suite."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
+
+
+@pytest.fixture
+def hermes_home(fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point HERMES_HOME at a temp dir under the fake home."""
+    home = fake_home / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo root that is a sibling of the fake home, never a parent of it."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+def _install(repo_root: Path) -> list[str]:
+    return install_platform_configs(repo_root, target="hermes")
+
+
+def _entry(config_path: Path) -> dict:
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    return data["mcp_servers"]["code-review-graph"]
+
+
+class TestSuiteSafety:
+    """The suite must never be able to reach a real Hermes config.
+
+    A parametrized test walks every ``PLATFORMS`` entry and calls its
+    ``config_path``. Unlike the other platforms, Hermes resolves to an
+    absolute user path that ignores ``Path.home()`` patching, so a missing
+    guard here silently overwrites the developer's own ``config.yaml``.
+    """
+
+    def test_hermes_home_is_pinned_to_a_temp_dir(self, tmp_path_factory) -> None:
+        resolved = _hermes_home().resolve()
+        real = (Path.home() / ".hermes").resolve()
+        assert resolved != real
+        assert resolved.is_relative_to(
+            Path(tmp_path_factory.getbasetemp()).resolve().parent
+        )
+
+
+class TestHermesHome:
+    def test_env_override_wins(self, hermes_home: Path) -> None:
+        assert _hermes_home() == hermes_home
+        assert _hermes_config_path() == hermes_home / "config.yaml"
+
+    def test_defaults_to_dot_hermes(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # fake_home patches Path.home(), so clearing the override here still
+        # cannot reach the developer's real ~/.hermes.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(skills.platform, "system", lambda: "Darwin")
+        assert _hermes_home() == fake_home / ".hermes"
+
+
+class TestInstall:
+    def test_creates_config_when_absent(self, repo: Path, hermes_home: Path) -> None:
+        configured = _install(repo)
+        assert "Hermes Agent" in configured
+
+        entry = _entry(hermes_home / "config.yaml")
+        expected_command, expected_args = _detect_serve_command()
+        assert entry["command"] == expected_command
+        # Hermes has no ``cwd``: the repo root must ride along in args.
+        assert entry["args"] == [*expected_args, "--repo", str(repo)]
+        assert "cwd" not in entry
+        assert "type" not in entry
+
+    def test_preserves_comments_and_other_settings(
+        self, repo: Path, hermes_home: Path
+    ) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        _install(repo)
+
+        text = config.read_text(encoding="utf-8")
+        # Every comment survives byte-for-byte.
+        assert "# Hermes Agent configuration" in text
+        assert "default: claude-opus-5   # trailing comment" in text
+        assert "# Servers exposing extra tools" in text
+
+        data = yaml.safe_load(text)
+        assert data["model"] == {"default": "claude-opus-5", "provider": "copilot"}
+        assert data["tool_output"] == {"max_bytes": 50000}
+        assert data["mcp_servers"]["browsermcp"]["command"] == "npx"
+        assert data["mcp_servers"]["wanderlog"]["env"]["WANDERLOG_COOKIE"] == "s%3Asecret"
+        assert "code-review-graph" in data["mcp_servers"]
+
+    def test_is_idempotent(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        _install(repo)
+        first = config.read_text(encoding="utf-8")
+        _install(repo)
+        assert config.read_text(encoding="utf-8") == first
+        assert first.count("code-review-graph:") == 1
+
+    def test_appends_block_when_key_absent(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text("model:\n  default: gpt-5.5\n", encoding="utf-8")
+        _install(repo)
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert data["model"]["default"] == "gpt-5.5"
+        assert "code-review-graph" in data["mcp_servers"]
+
+    def test_dry_run_writes_nothing(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        install_platform_configs(repo, target="hermes", dry_run=True)
+        assert config.read_text(encoding="utf-8") == _REAL_CONFIG
+
+    def test_refuses_unparseable_yaml(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        broken = "mcp_servers:\n  a: [1, 2\n   bad: :\n"
+        config.write_text(broken, encoding="utf-8")
+        configured = _install(repo)
+        assert configured == []
+        assert config.read_text(encoding="utf-8") == broken
+
+    def test_refuses_non_mapping_mcp_servers(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        hostile = "mcp_servers:\n  - not-a-mapping\n"
+        config.write_text(hostile, encoding="utf-8")
+        configured = _install(repo)
+        assert configured == []
+        assert config.read_text(encoding="utf-8") == hostile
+
+    def test_refuses_flow_style_mcp_servers(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        flow = "mcp_servers: {other: {command: npx}}\n"
+        config.write_text(flow, encoding="utf-8")
+        configured = _install(repo)
+        assert configured == []
+        assert config.read_text(encoding="utf-8") == flow
+
+    def test_detect_requires_hermes_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+        assert PLATFORMS["hermes"]["detect"]() is False
+        (tmp_path / "nope").mkdir()
+        assert PLATFORMS["hermes"]["detect"]() is True
+
+
+class TestUninstall:
+    def _uninstall(self, repo_root: Path, home: Path, *, dry_run: bool = False):
+        report = uninstall.UninstallReport()
+        uninstall._process_platform_configs(
+            repo_root,
+            home,
+            report,
+            scope="user",
+            dry_run=dry_run,
+            platforms=frozenset({"hermes"}),
+        )
+        return report
+
+    def test_removes_only_its_own_entry(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        _install(repo)
+
+        self._uninstall(repo, hermes_home)
+
+        text = config.read_text(encoding="utf-8")
+        assert "code-review-graph" not in text
+        # The original file is restored byte-for-byte.
+        assert text == _REAL_CONFIG
+
+    def test_dry_run_writes_nothing(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        _install(repo)
+        installed = config.read_text(encoding="utf-8")
+
+        report = self._uninstall(repo, hermes_home, dry_run=True)
+
+        assert config.read_text(encoding="utf-8") == installed
+        assert report.edited_paths
+
+    def test_noop_when_entry_absent(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+        report = self._uninstall(repo, hermes_home)
+        assert config.read_text(encoding="utf-8") == _REAL_CONFIG
+        assert not report.edited_paths
+
+    def test_leaves_unparseable_yaml_alone(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        broken = "mcp_servers:\n  code-review-graph: [1, 2\n   bad: :\n"
+        config.write_text(broken, encoding="utf-8")
+        report = self._uninstall(repo, hermes_home)
+        assert config.read_text(encoding="utf-8") == broken
+        assert not report.edited_paths
+
+    def test_relocated_hermes_home_is_still_cleanable(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HERMES_HOME may sit outside the user's home directory.
+
+        Install honours it, so uninstall must too — otherwise CRG writes a
+        file it then refuses to clean up.
+        """
+        elsewhere = tmp_path / "elsewhere" / "hermes"
+        elsewhere.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(elsewhere))
+        config = elsewhere / "config.yaml"
+        config.write_text(_REAL_CONFIG, encoding="utf-8")
+
+        _install(repo)
+        assert "code-review-graph" in config.read_text(encoding="utf-8")
+
+        self._uninstall(repo, Path.home())
+        assert config.read_text(encoding="utf-8") == _REAL_CONFIG
+
+    def test_round_trip_when_only_entry(self, repo: Path, hermes_home: Path) -> None:
+        config = hermes_home / "config.yaml"
+        original = "model:\n  default: gpt-5.5\n"
+        config.write_text(original, encoding="utf-8")
+        _install(repo)
+        self._uninstall(repo, hermes_home)
+
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert data["model"]["default"] == "gpt-5.5"
+        assert not data.get("mcp_servers")

--- a/tests/test_hermes_install.py
+++ b/tests/test_hermes_install.py
@@ -123,8 +123,13 @@ class TestInstall:
         entry = _entry(hermes_home / "config.yaml")
         expected_command, expected_args = _detect_serve_command()
         assert entry["command"] == expected_command
-        # Hermes has no ``cwd``: the repo root must ride along in args.
-        assert entry["args"] == [*expected_args, "--repo", str(repo)]
+        # No repo is pinned. Hermes has no ``cwd`` and outlives any single
+        # project, so a baked-in default would answer questions about the
+        # wrong repo without saying so. Callers pass ``repo_root`` per tool
+        # call; omitting it must fail loudly instead.
+        assert entry["args"] == expected_args
+        assert "--repo" not in entry["args"]
+        assert str(repo) not in entry["args"]
         assert "cwd" not in entry
         assert "type" not in entry
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -36,6 +36,10 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: home)
+    # conftest pins HERMES_HOME to its own temp dir so no test can reach the
+    # real config. Re-point it inside this fake home so the Hermes platform
+    # is exercised within the user-scope boundary uninstall enforces.
+    monkeypatch.setenv("HERMES_HOME", str(home / ".hermes"))
     return home
 
 
@@ -64,6 +68,16 @@ def test_uninstall_removes_mcp_entry_for_every_current_platform_spec(
             "command = \"code-review-graph\"\n\n"
             "[mcp_servers.other]\ncommand = \"other\"\n",
         )
+    elif spec["format"] == "yaml":
+        _write(
+            config_path,
+            "theme: dark\n\n"
+            f"{spec['key']}:\n"
+            "  code-review-graph:\n"
+            "    command: code-review-graph\n"
+            "  other:\n"
+            "    url: https://example.test/mcp\n",
+        )
     else:
         if spec["format"] == "array":
             container: object = [
@@ -85,6 +99,12 @@ def test_uninstall_removes_mcp_entry_for_every_current_platform_spec(
         assert "[mcp_servers.code-review-graph]" not in text
         assert "[mcp_servers.other]" in text
         assert 'theme = "dark"' in text
+    elif spec["format"] == "yaml":
+        import yaml
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert set(data[spec["key"]]) == {"other"}
+        assert data["theme"] == "dark"
     else:
         data = _read_jsonc(config_path)
         container = data[spec["key"]]


### PR DESCRIPTION
Closes #588.

Adds `--platform hermes` for [Hermes Agent](https://hermes-agent.nousresearch.com/docs), the first YAML-configured platform.

## Why this needed new install machinery

Hermes reads `<HERMES_HOME>/config.yaml` (default `~/.hermes/config.yaml`) under a top-level `mcp_servers` key. The installer previously handled `object`, `array`, and `toml` — this adds `yaml` alongside them, driven by the same `PLATFORMS` table so install and uninstall stay in sync automatically.

That config is hand-edited and full of comments, ordering, and settings CRG knows nothing about. **Neither install nor uninstall round-trips it through a YAML dumper**, which would reformat the entire file. Both edit it as text; the parsed document is used only to decide whether an edit is needed and to validate the result before writing. Uninstall additionally diffs the reparsed document against the expected one and refuses to write if any unrelated setting moved.

When the file cannot be edited safely (unparseable YAML, `mcp_servers` in flow style, `mcp_servers` not a mapping), the installer refuses and says why rather than guessing. Refusal is distinct from "already configured" internally, so the CLI never reports a platform as configured when it declined to touch it.

## No `--repo` in the entry — deliberate

The first draft modelled the Hermes entry on OpenCode and appended `--repo <root>` to args. That analogy is wrong, and testing on a real install showed why.

An IDE window is scoped to one project, so a baked-in repo matches what the user is looking at. Hermes Agent is a long-lived assistant that moves between projects, and its stdio schema has no `cwd`, so the pinned repo is whichever one happened to run `install`.

The result was a silent wrong answer. Asked about the codebase in one project, the agent called `get_minimal_context_tool` without `repo_root` — the tool docs say it is auto-detected — and `--repo` resolved the call against a completely different repo. Stats, risk score, and review priorities all came back for the wrong project, with nothing to indicate it.

All 30 tools take an explicit `repo_root`, so dropping the default costs no capability. Without it the same call fails with `repo_root does not look like a project root`, which the agent sees and corrects by passing the path. A loud failure beats a confident wrong answer.

## Skills, instructions, hooks

Skills install to `<HERMES_HOME>/skills/code-review-graph/<name>/SKILL.md`, reusing `generate_skills` since Hermes uses the same frontmatter as Claude Code. Hermes also reads project `AGENTS.md`, so it joins that file's owner set.

Hooks are not wired up. Hermes' hook model differs from the `settings.json` shape used by Claude and Qoder, and MCP plus skills already cover proactive graph use. Happy to follow up separately if you want it.

## Test isolation fix (please read)

`test_uninstall_removes_mcp_entry_for_every_current_platform_spec` walks every `PLATFORMS` entry and calls its `config_path`. For every other platform that lands under a patched `Path.home()`. Hermes resolves an absolute path from `HERMES_HOME`, which ignores `Path.home()` patching — so on a machine where a contributor actually uses Hermes, **the suite would have overwritten their real `config.yaml`**. It did exactly that to mine while developing this.

`tests/conftest.py` now pins `HERMES_HOME` to a temp directory for the whole suite. Pinning rather than clearing is deliberate: cleared, the fallback still reaches the real home in any test that forgets to patch it. `TestSuiteSafety` asserts the pin holds so nobody can quietly remove it.

## Verification

Verified end to end against a real Hermes Agent install, not just fixtures:

- `hermes mcp test code-review-graph` → **Connected, 30 tools discovered**
- `get_minimal_context_tool` invoked **through Hermes**, returned real graph data
- install → uninstall restored a **763-line** config **byte for byte**
- the wrong-repo scenario above reproduced before the fix and confirmed to fail loudly after

Full suite: **2324 passed**, 5 skipped, 2 xpassed. `ruff` clean on changed files.

Round-tripping caught two real bugs that unit tests alone missed: removal ate the blank line separating the block from the next section, and `_scope_for_config` rejected a relocated `HERMES_HOME` as outside the home/repo boundary — meaning install honoured the variable while uninstall refused to clean up the file it had written. Both fixed, both covered.

## Commits

Kept as two commits so the reasoning is visible: the feature, then the `--repo` correction with its rationale. Squash if you prefer.
