### PR TITLE
fix(skills): align tool names with exported MCP schema

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -680,20 +680,20 @@ _SKILLS: dict[str, dict[str, str]] = {
             "## Explore Codebase\n\n"
             "Use the code-review-graph MCP tools to explore and understand the codebase.\n\n"
             "### Steps\n\n"
-            "1. Run `list_graph_stats` to see overall codebase metrics.\n"
+            "1. Run `list_graph_stats_tool` to see overall codebase metrics.\n"
             "2. Run `get_architecture_overview_tool` for high-level community structure.\n"
-            "3. Use `list_communities_tool` to find major modules, then `get_community` "
+            "3. Use `list_communities_tool` to find major modules, then `get_community_tool` "
             "for details.\n"
             "4. Use `semantic_search_nodes_tool` to find specific functions or classes.\n"
             "5. Use `query_graph_tool` with patterns like `callers_of`, `callees_of`, "
             "`imports_of` to trace relationships.\n"
-            "6. Use `list_flows` and `get_flow` to understand execution paths.\n\n"
+            "6. Use `list_flows_tool` and `get_flow_tool` to understand execution paths.\n\n"
             "### Tips\n\n"
             "- Start broad (stats, architecture) then narrow down to specific areas.\n"
             "- Use `children_of` on a file to see all its functions and classes.\n"
-            "- Use `find_large_functions` to identify complex code.\n\n"
+            "- Use `find_large_functions_tool` to identify complex code.\n\n"
             "## Token Efficiency Rules\n"
-            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
+            '- ALWAYS start with `get_minimal_context_tool(task="<your task>")` '
             "before any other graph tool.\n"
             '- Use `detail_level="minimal"` on all calls. Only escalate to '
             '"standard" when minimal is insufficient.\n'
@@ -721,7 +721,7 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Suggested improvements\n"
             "- Overall merge recommendation\n\n"
             "## Token Efficiency Rules\n"
-            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
+            '- ALWAYS start with `get_minimal_context_tool(task="<your task>")` '
             "before any other graph tool.\n"
             '- Use `detail_level="minimal"` on all calls. Only escalate to '
             '"standard" when minimal is insufficient.\n'
@@ -739,7 +739,7 @@ _SKILLS: dict[str, dict[str, str]] = {
             "1. Use `semantic_search_nodes_tool` to find code related to the issue.\n"
             "2. Use `query_graph_tool` with `callers_of` and `callees_of` to trace "
             "call chains.\n"
-            "3. Use `get_flow` to see full execution paths through suspected areas.\n"
+            "3. Use `get_flow_tool` to see full execution paths through suspected areas.\n"
             "4. Run `detect_changes_tool` to check if recent changes caused the issue.\n"
             "5. Use `get_impact_radius_tool` on suspected files to see what else is affected.\n\n"
             "### Tips\n\n"
@@ -747,7 +747,7 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Look at affected flows to find the entry point that triggers the bug.\n"
             "- Recent changes are the most common source of new issues.\n\n"
             "## Token Efficiency Rules\n"
-            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
+            '- ALWAYS start with `get_minimal_context_tool(task="<your task>")` '
             "before any other graph tool.\n"
             '- Use `detail_level="minimal"` on all calls. Only escalate to '
             '"standard" when minimal is insufficient.\n'
@@ -773,9 +773,9 @@ _SKILLS: dict[str, dict[str, str]] = {
             "- Always preview before applying (rename mode gives you an edit list).\n"
             "- Check `get_impact_radius_tool` before major refactors.\n"
             "- Use `get_affected_flows_tool` to ensure no critical paths are broken.\n"
-            "- Run `find_large_functions` to identify decomposition targets.\n\n"
+            "- Run `find_large_functions_tool` to identify decomposition targets.\n\n"
             "## Token Efficiency Rules\n"
-            '- ALWAYS start with `get_minimal_context(task="<your task>")` '
+            '- ALWAYS start with `get_minimal_context_tool(task="<your task>")` '
             "before any other graph tool.\n"
             '- Use `detail_level="minimal"` on all calls. Only escalate to '
             '"standard" when minimal is insufficient.\n'

--- a/skills/debug-issue/SKILL.md
+++ b/skills/debug-issue/SKILL.md
@@ -11,7 +11,7 @@ Use the knowledge graph to systematically trace and debug issues.
 
 1. Use `semantic_search_nodes_tool` to find code related to the issue.
 2. Use `query_graph_tool` with `callers_of` and `callees_of` to trace call chains.
-3. Use `get_flow` to see full execution paths through suspected areas.
+3. Use `get_flow_tool` to see full execution paths through suspected areas.
 4. Run `detect_changes_tool` to check if recent changes caused the issue.
 5. Use `get_impact_radius_tool` on suspected files to see what else is affected.
 
@@ -22,6 +22,6 @@ Use the knowledge graph to systematically trace and debug issues.
 - Recent changes are the most common source of new issues.
 
 ## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- ALWAYS start with `get_minimal_context_tool(task="<your task>")` before any other graph tool.
 - Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
 - Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/skills/explore-codebase/SKILL.md
+++ b/skills/explore-codebase/SKILL.md
@@ -9,20 +9,20 @@ Use the code-review-graph MCP tools to explore and understand the codebase.
 
 ### Steps
 
-1. Run `list_graph_stats` to see overall codebase metrics.
+1. Run `list_graph_stats_tool` to see overall codebase metrics.
 2. Run `get_architecture_overview_tool` for high-level community structure.
-3. Use `list_communities_tool` to find major modules, then `get_community` for details.
+3. Use `list_communities_tool` to find major modules, then `get_community_tool` for details.
 4. Use `semantic_search_nodes_tool` to find specific functions or classes.
 5. Use `query_graph_tool` with patterns like `callers_of`, `callees_of`, `imports_of` to trace relationships.
-6. Use `list_flows` and `get_flow` to understand execution paths.
+6. Use `list_flows_tool` and `get_flow_tool` to understand execution paths.
 
 ### Tips
 
 - Start broad (stats, architecture) then narrow down to specific areas.
 - Use `children_of` on a file to see all its functions and classes.
-- Use `find_large_functions` to identify complex code.
+- Use `find_large_functions_tool` to identify complex code.
 
 ## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- ALWAYS start with `get_minimal_context_tool(task="<your task>")` before any other graph tool.
 - Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
 - Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/skills/refactor-safely/SKILL.md
+++ b/skills/refactor-safely/SKILL.md
@@ -20,9 +20,9 @@ Use the knowledge graph to plan and execute refactoring with confidence.
 - Always preview before applying (rename mode gives you an edit list).
 - Check `get_impact_radius_tool` before major refactors.
 - Use `get_affected_flows_tool` to ensure no critical paths are broken.
-- Run `find_large_functions` to identify decomposition targets.
+- Run `find_large_functions_tool` to identify decomposition targets.
 
 ## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- ALWAYS start with `get_minimal_context_tool(task="<your task>")` before any other graph tool.
 - Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
 - Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/skills/review-changes/SKILL.md
+++ b/skills/review-changes/SKILL.md
@@ -24,6 +24,6 @@ Provide findings grouped by risk level (high/medium/low) with:
 - Overall merge recommendation
 
 ## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- ALWAYS start with `get_minimal_context_tool(task="<your task>")` before any other graph tool.
 - Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
 - Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -170,13 +170,48 @@ class TestGenerateSkills:
         assert len(list(result.iterdir())) == 4
 
     def test_skill_content_includes_get_minimal_context(self, tmp_path):
-        """Every skill template must reference get_minimal_context."""
+        """Every skill template must reference get_minimal_context_tool."""
         skills_dir = generate_skills(tmp_path)
         for subdir in skills_dir.iterdir():
             content = (subdir / "SKILL.md").read_text()
-            assert "get_minimal_context" in content, (
-                f"{subdir.name} missing get_minimal_context reference"
+            assert "get_minimal_context_tool" in content, (
+                f"{subdir.name} missing get_minimal_context_tool reference"
             )
+
+    def test_skill_templates_use_exported_tool_names(self, tmp_path):
+        generated = generate_skills(tmp_path)
+        bundled = Path(__file__).parents[1] / "skills"
+
+        expected_tools = {
+            "explore-codebase": [
+                "get_minimal_context_tool",
+                "list_graph_stats_tool",
+                "get_community_tool",
+                "list_flows_tool",
+                "get_flow_tool",
+                "find_large_functions_tool",
+            ],
+            "refactor-safely": ["get_minimal_context_tool", "find_large_functions_tool"],
+        }
+        legacy_tools = [
+            "get_minimal_context",
+            "list_graph_stats",
+            "get_community",
+            "list_flows",
+            "get_flow",
+            "find_large_functions",
+        ]
+
+        for skill_name, tool_names in expected_tools.items():
+            for skill_file in (
+                generated / skill_name / "SKILL.md",
+                bundled / skill_name / "SKILL.md",
+            ):
+                content = skill_file.read_text(encoding="utf-8")
+                for tool_name in tool_names:
+                    assert tool_name in content, skill_file
+                for legacy_tool in legacy_tools:
+                    assert f"`{legacy_tool}`" not in content, skill_file
 
     def test_skill_content_includes_detail_level(self, tmp_path):
         """Every skill template must reference detail_level."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -191,6 +191,8 @@ class TestGenerateSkills:
                 "get_flow_tool",
                 "find_large_functions_tool",
             ],
+            "review-changes": ["get_minimal_context_tool", "get_affected_flows_tool"],
+            "debug-issue": ["get_minimal_context_tool", "get_flow_tool"],
             "refactor-safely": ["get_minimal_context_tool", "find_large_functions_tool"],
         }
         legacy_tools = [


### PR DESCRIPTION
Summary:
- Align generated and bundled skill templates with the MCP tool names exported by the server.
- Keep the skills consistent with the current schema for Codex and Claude Code instructions.
- Add a regression test that fails if the old bare names reappear.

Validation:
- .venv/bin/pytest tests/test_skills.py -q
- 192 passed

Notes:
- This fixes stale skill/template references to bare names such as get_minimal_context, list_graph_stats, list_flows, get_flow, and find_large_functions.
- The MCP server already exported the corresponding *_tool names; the bug was in the instructions/templates layer.
