### PR TITLE
Fix #777: status/update no longer create empty graph.db on repos with no graph

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1607,7 +1607,10 @@ def main() -> None:
         _handle_data_dir_option(args, repo_root)
 
     db_path = get_db_path(repo_root)
-    if args.command in ("dead-code", "forget") and not db_path.exists():
+    # Read-only commands must not materialise the database as a side effect of
+    # opening the store. A 0-node graph reads as "built" to every later command
+    # while actually holding nothing (#777).
+    if args.command in ("dead-code", "forget", "status") and not db_path.exists():
         print(
             f"No graph found at {db_path}. Run `code-review-graph build` first.",
             file=sys.stderr,

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -475,7 +475,9 @@ def build_or_update_graph(
 
     Args:
         full_rebuild: If True, re-parse every file. If False (default),
-                      only re-parse files changed since ``base``.
+                      only re-parse files changed since ``base`` — except on an
+                      empty graph, which is rebuilt in full so a missing or
+                      previously emptied database repairs itself.
         repo_root: Path to the repository root. Auto-detected if omitted.
         base: Git ref for the incremental diff. When None (default), the base
               is resolved automatically to the commit the graph was last built
@@ -507,10 +509,17 @@ def build_or_update_graph(
         # a full rebuild rather than a wrong HEAD~1 diff that could report the
         # graph as up to date while it is actually stale.
         base_resolved: str | None = base
-        if not full_rebuild and base is None:
-            base_resolved = resolve_incremental_base(root, store)
-            if base_resolved is None:
+        if not full_rebuild:
+            # An empty graph has nothing to update incrementally: the diff only
+            # covers files touched since the base, so everything else stays
+            # missing — and the resulting graph then anchors every later
+            # update, so it stays missing forever (#777).
+            if store.get_stats().total_nodes == 0:
                 full_rebuild = True
+            elif base is None:
+                base_resolved = resolve_incremental_base(root, store)
+                if base_resolved is None:
+                    full_rebuild = True
 
         if full_rebuild:
             result = full_build(root, store, recurse_submodules)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ import sys
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from code_review_graph import cli
 
 
@@ -580,3 +582,121 @@ class TestGraphToolExplicitRepoResolution:
                 cli.main()
 
         assert mock_run.call_args.args[1] == module.resolve()
+
+
+class TestMissingGraph:
+    """Issue #777: on a repo with no graph, ``status`` and ``update`` left
+    behind a 0-node graph.db that read as "built" to every later command.
+
+    ``status`` now behaves like the other read-only commands (``query``,
+    ``search``, ``dead-code``) and ``update`` falls back to a full build.
+    """
+
+    @staticmethod
+    def _git(repo, *args):
+        import subprocess
+
+        subprocess.run(
+            ["git", "-C", str(repo), "-c", "user.email=t@example.com",
+             "-c", "user.name=Test", "-c", "commit.gpgsign=false", *args],
+            check=True,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+
+    def _make_repo(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+        monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "app.py").write_text(
+            "def greet(name):\n"
+            "    return 'hi ' + name\n",
+            encoding="utf-8",
+        )
+        self._git(repo, "init", "-q")
+        self._git(repo, "add", ".")
+        self._git(repo, "commit", "-q", "-m", "initial")
+        return repo
+
+    @staticmethod
+    def _node_count(db_path):
+        from code_review_graph.graph import GraphStore
+
+        store = GraphStore(db_path)
+        try:
+            return store.get_stats().total_nodes
+        finally:
+            store.close()
+
+    def test_status_without_graph_exits_without_creating_db(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        repo = self._make_repo(tmp_path, monkeypatch)
+        db_path = repo / ".code-review-graph" / "graph.db"
+
+        argv = ["code-review-graph", "status", "--repo", str(repo)]
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+        assert exc_info.value.code == 1
+        assert not db_path.exists()
+        assert "No graph found" in capsys.readouterr().err
+
+    def test_update_without_graph_runs_a_full_build(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        repo = self._make_repo(tmp_path, monkeypatch)
+        db_path = repo / ".code-review-graph" / "graph.db"
+
+        argv = ["code-review-graph", "update", "--repo", str(repo)]
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+        assert "Full rebuild" in capsys.readouterr().out
+        assert db_path.exists()
+        assert self._node_count(db_path) > 0
+
+    def test_update_repairs_an_already_emptied_graph(
+        self, tmp_path, monkeypatch,
+    ):
+        """The 0-node database left by an older version must not persist."""
+        from code_review_graph.graph import GraphStore
+
+        repo = self._make_repo(tmp_path, monkeypatch)
+        db_path = repo / ".code-review-graph" / "graph.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        GraphStore(db_path).close()
+        assert self._node_count(db_path) == 0
+
+        argv = ["code-review-graph", "update", "--repo", str(repo)]
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+        assert self._node_count(db_path) > 0
+
+    def test_status_with_existing_graph_reports_stats(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.incremental import full_build, get_db_path
+
+        repo = self._make_repo(tmp_path, monkeypatch)
+        store = GraphStore(get_db_path(repo))
+        try:
+            full_build(repo, store)
+        finally:
+            store.close()
+
+        argv = ["code-review-graph", "status", "--repo", str(repo)]
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+        out = capsys.readouterr().out
+        assert "Nodes: " in out
+        assert "Edges: " in out
+        assert "Files: " in out


### PR DESCRIPTION
Fixes #777

## Problem

Running `status` or `update` on a repository with no graph created an empty `graph.db` (0 nodes) and exited 0. Subsequent `update` calls never repaired it — they only incrementally added files changed after that moment. The graph then answered queries confidently and wrongly (`callers_of X` returns `not_found` for symbols that are genuinely called).

Read-only commands (`query`, `search`, `dead-code`) already handled this correctly by exiting non-zero without creating the database. `status` and `update` did not.

## Fix

Two changes:

1. **`status` now behaves like other read-only commands** — added it to the no-graph guard alongside `dead-code` and `forget`. When no graph exists, it prints `"No graph found at <path>. Run code-review-graph build first."` to stderr and exits 1, without creating the database.

2. **`update` on a missing/empty graph performs a full build** — when the graph has 0 nodes, `build_or_update_graph` falls back to a full rebuild instead of an incremental pass. This also repairs graphs that were already poisoned by the old behavior (a 0-node database from a previous version will self-heal on the next `update`).

## Files changed

- `code_review_graph/cli.py` — added `status` to the no-graph early-exit guard
- `code_review_graph/tools/build.py` — empty graph triggers full rebuild in `build_or_update_graph`
- `tests/test_cli.py` — 4 new tests in `TestMissingGraph`:
  - `status` on no graph exits 1 without creating `graph.db`
  - `update` on no graph runs a full build (non-empty `graph.db`)
  - `update` repairs an already-emptied (0-node) graph
  - `status` with an existing graph still reports stats as before

## How this was made

This fix was produced by **[skep](https://github.com/anmolnoor/skep)** — a local-first autonomous coding supervisor — with **Claude Code** as the worker agent. Skep dispatched Claude Code into an isolated git worktree to implement and verify the fix. The patch landed through skep's human-approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)