### PR TITLE
Fix #776: resolve jsconfig.json path aliases in JS projects

### DIFF
--- a/code_review_graph/tsconfig_resolver.py
+++ b/code_review_graph/tsconfig_resolver.py
@@ -18,8 +18,11 @@ logger = logging.getLogger(__name__)
 # Extensions probed when resolving an alias target
 _PROBE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".vue"]
 
-# Tsconfig filenames to look for when walking up the directory tree
-_TSCONFIG_NAMES = ["tsconfig.json", "tsconfig.app.json"]
+# Tsconfig filenames to look for when walking up the directory tree.
+# ``jsconfig.json`` uses the same schema for ``compilerOptions.paths`` and is the
+# convention in plain-JS projects (Vue, Nuxt, Vite); it is checked last so that
+# ``tsconfig.json`` wins when both are present.
+_TSCONFIG_NAMES = ["tsconfig.json", "tsconfig.app.json", "jsconfig.json"]
 
 
 class TsconfigResolver:

--- a/tests/test_tsconfig_resolver.py
+++ b/tests/test_tsconfig_resolver.py
@@ -47,6 +47,41 @@ class TestTsconfigResolver:
             result = self.resolver.resolve_alias("@/foo", file_path)
         assert result is None
 
+    def test_resolve_alias_from_jsconfig(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "jsconfig.json").write_text(
+                '{"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["./src/*"]}}}',
+                encoding="utf-8",
+            )
+            (root / "src").mkdir()
+            (root / "src" / "utils.js").write_text("export const a = 1;\n", encoding="utf-8")
+
+            result = self.resolver.resolve_alias("@/utils", str(root / "main.js"))
+
+        assert result is not None
+        assert result.endswith("utils.js")
+
+    def test_tsconfig_takes_precedence_over_jsconfig(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "tsconfig.json").write_text(
+                '{"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["./ts-src/*"]}}}',
+                encoding="utf-8",
+            )
+            (root / "jsconfig.json").write_text(
+                '{"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["./js-src/*"]}}}',
+                encoding="utf-8",
+            )
+            for sub, ext in (("ts-src", ".ts"), ("js-src", ".js")):
+                (root / sub).mkdir()
+                (root / sub / f"utils{ext}").write_text("export const a = 1;\n", encoding="utf-8")
+
+            result = self.resolver.resolve_alias("@/utils", str(root / "main.ts"))
+
+        assert result is not None
+        assert result.endswith(str(Path("ts-src") / "utils.ts"))
+
     def test_caching(self):
         importer = str(FIXTURES / "alias_importer.ts")
         self.resolver.resolve_alias("@/lib/utils", importer)


### PR DESCRIPTION
Fixes #776

## Problem

`TsConfigResolver` only looked for `tsconfig.json` and `tsconfig.app.json`. Plain-JavaScript projects (Vue, Nuxt, plain Vite) conventionally declare path aliases in `jsconfig.json` instead. On those projects every aliased import stayed unresolved, and the failure was silent — the graph built successfully and looked healthy while missing 71%+ of internal imports.

## Fix

Added `jsconfig.json` to the `_TSCONFIG_NAMES` list in `code_review_graph/tsconfig_resolver.py`. `jsconfig.json` uses the same `compilerOptions.paths` schema as `tsconfig.json`, so the existing parser handles it without any other changes. Ordering ensures `tsconfig.json` takes precedence when both files exist.

## Tests

Two new tests in `tests/test_tsconfig_resolver.py`:
- `test_resolve_alias_from_jsconfig` — verifies aliases from `jsconfig.json` resolve correctly
- `test_tsconfig_takes_precedence_over_jsconfig` — verifies `tsconfig.json` wins when both are present

## How this was made

This fix was produced by **[skep](https://github.com/anmolnoor/skep)** — a local-first autonomous coding supervisor — with **Claude Code** as the worker agent. Skep dispatched Claude Code into an isolated git worktree to implement and verify the fix. The patch landed through skep's human-approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)