### PR TITLE
fix(cli): prevent missing graphs from poisoning updates

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1617,7 +1617,8 @@ def main() -> None:
         legacy_db = repo_root / ".code-review-graph.db"
         default_db = repo_root / ".code-review-graph" / "graph.db"
         if (
-            not db_path.exists()
+            not status_data_dir
+            and not db_path.exists()
             and db_path.resolve() == default_db.resolve()
             and legacy_db.exists()
         ):

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1606,8 +1606,8 @@ def main() -> None:
     if args.command in _data_dir_cmds:
         _handle_data_dir_option(args, repo_root)
 
-    db_path = get_db_path(repo_root)
-    if args.command in ("dead-code", "forget") and not db_path.exists():
+    db_path = get_db_path(repo_root, read_only=args.command == "status")
+    if args.command in ("dead-code", "forget", "status") and not db_path.exists():
         print(
             f"No graph found at {db_path}. Run `code-review-graph build` first.",
             file=sys.stderr,

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1609,7 +1609,12 @@ def main() -> None:
     if args.command == "status":
         db_path = get_db_path(repo_root, read_only=True)
         legacy_db = repo_root / ".code-review-graph.db"
-        if not db_path.exists() and legacy_db.exists():
+        default_db = repo_root / ".code-review-graph" / "graph.db"
+        if (
+            not db_path.exists()
+            and db_path.resolve() == default_db.resolve()
+            and legacy_db.exists()
+        ):
             # Preserve the established one-time legacy migration, but do not
             # materialize graph state when neither database exists.
             db_path = get_db_path(repo_root)

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1603,11 +1603,17 @@ def main() -> None:
         "wiki",
         "dead-code",
     )
-    if args.command in _data_dir_cmds:
+    status_data_dir = (
+        args.command == "status" and bool(getattr(args, "data_dir", None))
+    )
+    if args.command in _data_dir_cmds and not status_data_dir:
         _handle_data_dir_option(args, repo_root)
 
     if args.command == "status":
-        db_path = get_db_path(repo_root, read_only=True)
+        if status_data_dir:
+            db_path = Path(args.data_dir).expanduser().resolve() / "graph.db"
+        else:
+            db_path = get_db_path(repo_root, read_only=True)
         legacy_db = repo_root / ".code-review-graph.db"
         default_db = repo_root / ".code-review-graph" / "graph.db"
         if (

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1606,7 +1606,15 @@ def main() -> None:
     if args.command in _data_dir_cmds:
         _handle_data_dir_option(args, repo_root)
 
-    db_path = get_db_path(repo_root, read_only=args.command == "status")
+    if args.command == "status":
+        db_path = get_db_path(repo_root, read_only=True)
+        legacy_db = repo_root / ".code-review-graph.db"
+        if not db_path.exists() and legacy_db.exists():
+            # Preserve the established one-time legacy migration, but do not
+            # materialize graph state when neither database exists.
+            db_path = get_db_path(repo_root)
+    else:
+        db_path = get_db_path(repo_root)
     if args.command in ("dead-code", "forget", "status") and not db_path.exists():
         print(
             f"No graph found at {db_path}. Run `code-review-graph build` first.",

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -386,6 +386,10 @@ class GraphStore:
         row = self._conn.execute("SELECT value FROM metadata WHERE key=?", (key,)).fetchone()
         return row["value"] if row else None
 
+    def has_nodes(self) -> bool:
+        row = self._conn.execute("SELECT 1 FROM nodes LIMIT 1").fetchone()
+        return row is not None
+
     def has_nodes_for_language(self, language: str) -> bool:
         row = self._conn.execute(
             "SELECT 1 FROM nodes WHERE language = ? LIMIT 1",

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -9,11 +9,10 @@ from typing import Any
 
 from ..incremental import (
     full_build,
-    get_db_path,
     incremental_update,
     resolve_incremental_base,
 )
-from ._common import _get_store, _resolve_root
+from ._common import _get_store
 
 logger = logging.getLogger(__name__)
 
@@ -501,14 +500,9 @@ def build_or_update_graph(
     Returns:
         Summary with files_parsed/updated, node/edge counts, and errors.
     """
-    root = _resolve_root(repo_root)
-    graph_exists = get_db_path(root, read_only=True).exists()
-    store, root = _get_store(str(root))
+    store, root = _get_store(repo_root)
     try:
-        if (
-            not full_rebuild
-            and (not graph_exists or store.get_stats().total_nodes == 0)
-        ):
+        if not full_rebuild and not store.has_nodes():
             full_rebuild = True
 
         # An automatic (base is None) incremental update resolves its diff base

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -505,7 +505,10 @@ def build_or_update_graph(
     graph_exists = get_db_path(root, read_only=True).exists()
     store, root = _get_store(str(root))
     try:
-        if not full_rebuild and not graph_exists:
+        if (
+            not full_rebuild
+            and (not graph_exists or store.get_stats().total_nodes == 0)
+        ):
             full_rebuild = True
 
         # An automatic (base is None) incremental update resolves its diff base

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -9,10 +9,11 @@ from typing import Any
 
 from ..incremental import (
     full_build,
+    get_db_path,
     incremental_update,
     resolve_incremental_base,
 )
-from ._common import _get_store
+from ._common import _get_store, _resolve_root
 
 logger = logging.getLogger(__name__)
 
@@ -500,8 +501,13 @@ def build_or_update_graph(
     Returns:
         Summary with files_parsed/updated, node/edge counts, and errors.
     """
-    store, root = _get_store(repo_root)
+    root = _resolve_root(repo_root)
+    graph_exists = get_db_path(root, read_only=True).exists()
+    store, root = _get_store(str(root))
     try:
+        if not full_rebuild and not graph_exists:
+            full_rebuild = True
+
         # An automatic (base is None) incremental update resolves its diff base
         # to the last-synced commit. When no usable anchor exists, fall back to
         # a full rebuild rather than a wrong HEAD~1 diff that could report the

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -172,6 +172,29 @@ def test_status_preserves_legacy_graph_migration(tmp_path, monkeypatch, capsys):
     assert (repo / ".code-review-graph" / "graph.db").exists()
 
 
+def test_status_external_data_dir_does_not_migrate_unrelated_legacy_graph(
+    tmp_path, monkeypatch, capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    legacy_db = repo / ".code-review-graph.db"
+    with code_review_graph.graph.GraphStore(legacy_db):
+        pass
+    data_dir = tmp_path / "external-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(data_dir))
+    argv = ["code-review-graph", "status", "--repo", str(repo)]
+
+    with patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert legacy_db.exists()
+    assert not data_dir.exists()
+
+
 def test_enrich_command_reads_stdin_and_respects_external_data_dir(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -195,6 +195,48 @@ def test_status_external_data_dir_does_not_migrate_unrelated_legacy_graph(
     assert not data_dir.exists()
 
 
+def test_status_data_dir_option_is_read_only(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    data_dir = tmp_path / "explicit-data"
+    registry_path = tmp_path / "registry" / "registry.json"
+    monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+    argv = [
+        "code-review-graph",
+        "status",
+        "--repo",
+        str(repo),
+        "--data-dir",
+        str(data_dir),
+    ]
+
+    with patch(
+        "code_review_graph.registry.default_registry_path",
+        return_value=registry_path,
+    ):
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not data_dir.exists()
+    assert not registry_path.exists()
+
+    with code_review_graph.graph.GraphStore(data_dir / "graph.db"):
+        pass
+    with patch(
+        "code_review_graph.registry.default_registry_path",
+        return_value=registry_path,
+    ):
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+    assert "Nodes: 0" in capsys.readouterr().out
+    assert not registry_path.exists()
+
+
 def test_enrich_command_reads_stdin_and_respects_external_data_dir(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -237,6 +237,36 @@ def test_status_data_dir_option_is_read_only(tmp_path, monkeypatch, capsys):
     assert not registry_path.exists()
 
 
+def test_status_default_data_dir_override_does_not_migrate_legacy_graph(
+    tmp_path, monkeypatch, capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    legacy_db = repo / ".code-review-graph.db"
+    with code_review_graph.graph.GraphStore(legacy_db):
+        pass
+    data_dir = repo / ".code-review-graph"
+    monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+    argv = [
+        "code-review-graph",
+        "status",
+        "--repo",
+        str(repo),
+        "--data-dir",
+        str(data_dir),
+    ]
+
+    with patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert legacy_db.exists()
+    assert not data_dir.exists()
+
+
 def test_enrich_command_reads_stdin_and_respects_external_data_dir(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -131,6 +131,25 @@ def test_status_quiet_prints_nothing(capsys):
     assert capsys.readouterr().out == ""
 
 
+def test_status_missing_graph_exits_without_creating_data_tree(
+    tmp_path, monkeypatch, capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    data_dir = tmp_path / "missing-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(data_dir))
+    argv = ["code-review-graph", "status", "--repo", str(repo)]
+
+    with patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not data_dir.exists()
+
+
 def test_enrich_command_reads_stdin_and_respects_external_data_dir(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -150,6 +150,28 @@ def test_status_missing_graph_exits_without_creating_data_tree(
     assert not data_dir.exists()
 
 
+def test_status_preserves_legacy_graph_migration(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    legacy_db = repo / ".code-review-graph.db"
+    with code_review_graph.graph.GraphStore(legacy_db):
+        pass
+    monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+    argv = ["code-review-graph", "status", "--repo", str(repo)]
+
+    with patch(
+        "code_review_graph.registry.default_registry_path",
+        return_value=tmp_path / "missing-registry.json",
+    ):
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+    assert "Nodes: 0" in capsys.readouterr().out
+    assert not legacy_db.exists()
+    assert (repo / ".code-review-graph" / "graph.db").exists()
+
+
 def test_enrich_command_reads_stdin_and_respects_external_data_dir(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -422,6 +422,13 @@ class TestGraphStore:
         assert stats.nodes_by_kind["Class"] == 1
         assert "python" in stats.languages
 
+    def test_has_nodes(self):
+        assert self.store.has_nodes() is False
+
+        self.store.upsert_node(self._make_file_node())
+
+        assert self.store.has_nodes() is True
+
     def test_impact_radius(self):
         # func_b depends on the changed func_a, so func_b is impacted.
         self.store.upsert_node(self._make_file_node("/a.py"))

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -564,6 +564,27 @@ def test_update_without_usable_anchor_falls_back_to_full_rebuild(
     assert res["base_resolved"] is None
 
 
+def test_update_missing_graph_ignores_explicit_incremental_base(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_file(repo, "beta")
+
+    res = build_or_update_graph(
+        full_rebuild=False,
+        repo_root=str(repo),
+        base="HEAD~1",
+        postprocess="none",
+    )
+
+    assert res["build_type"] == "full"
+    assert res["base_resolved"] is None
+    assert res["files_parsed"] == 2
+    with GraphStore(repo / ".code-review-graph" / "graph.db") as store:
+        assert store.get_nodes_by_file(str(repo / "a.py"))
+        assert store.get_nodes_by_file(str(repo / "beta.py"))
+
+
 def test_update_explicit_base_bypasses_auto_resolution(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -585,6 +585,30 @@ def test_update_missing_graph_ignores_explicit_incremental_base(
         assert store.get_nodes_by_file(str(repo / "beta.py"))
 
 
+def test_update_repairs_existing_empty_graph(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    graph_path = repo / ".code-review-graph" / "graph.db"
+    with GraphStore(graph_path):
+        pass
+    _commit_file(repo, "beta")
+
+    res = build_or_update_graph(
+        full_rebuild=False,
+        repo_root=str(repo),
+        base="HEAD~1",
+        postprocess="none",
+    )
+
+    assert res["build_type"] == "full"
+    assert res["base_resolved"] is None
+    assert res["files_parsed"] == 2
+    with GraphStore(graph_path) as store:
+        assert store.get_nodes_by_file(str(repo / "a.py"))
+        assert store.get_nodes_by_file(str(repo / "beta.py"))
+
+
 def test_update_explicit_base_bypasses_auto_resolution(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -609,6 +609,76 @@ def test_update_repairs_existing_empty_graph(
         assert store.get_nodes_by_file(str(repo / "beta.py"))
 
 
+def test_status_then_update_builds_complete_queryable_graph(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    from code_review_graph import cli
+    from code_review_graph.tools.query import query_graph
+
+    repo = tmp_path / "queryable-repo"
+    repo.mkdir()
+    _git_ok(repo, "init", "-b", "main")
+    _git_ok(repo, "config", "user.email", "test@test.com")
+    _git_ok(repo, "config", "user.name", "Test")
+    (repo / "provider.py").write_text(
+        "def target():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (repo / "stable.py").write_text(
+        "from provider import target\n\ndef stable():\n    return target()\n",
+        encoding="utf-8",
+    )
+    recent = repo / "recent.py"
+    recent.write_text(
+        "from provider import target\n\ndef recent():\n    return target()\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", ".")
+    _git_ok(repo, "commit", "-m", "initial callers")
+
+    data_dir = tmp_path / "queryable-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(data_dir))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["code-review-graph", "status", "--repo", str(repo)],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 1
+    assert not data_dir.exists()
+    capsys.readouterr()
+
+    recent.write_text(
+        "from provider import target\n\ndef recent():\n    return target() + 1\n",
+        encoding="utf-8",
+    )
+    _git_ok(repo, "add", "recent.py")
+    _git_ok(repo, "commit", "-m", "change recent caller")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "code-review-graph",
+            "update",
+            "--repo",
+            str(repo),
+            "--base",
+            "HEAD~1",
+            "--skip-postprocess",
+        ],
+    )
+    cli.main()
+
+    assert "Full rebuild" in capsys.readouterr().out
+    result = query_graph("callers_of", "target", repo_root=str(repo))
+    assert result["status"] == "ok"
+    assert {item["name"] for item in result["results"]} == {"recent", "stable"}
+
+
 def test_update_explicit_base_bypasses_auto_resolution(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     build_or_update_graph(full_rebuild=True, repo_root=str(repo), postprocess="none")


### PR DESCRIPTION
## What changed

- make `status` resolve missing graphs without creating a database, data directory, or registry entry
- make `update` fall back to a full build when the graph is missing or has zero nodes
- keep the existing default-path legacy migration while isolating external and explicit data-dir lookups
- use a cheap node-existence query instead of collecting full graph statistics on every update
- cover the original three-file failure end to end, including the `callers_of` result

## Why

An empty database could previously look like a valid graph. Later incremental updates would then parse only changed files, leaving the graph incomplete and queries confidently wrong.

## Validation

- `2314 passed, 5 skipped, 2 xpassed` with 82.20% coverage
- Ruff
- mypy
- Bandit
- focused CLI, graph, and git-integration regressions

Closes #777
