### PR TITLE
Add Voyage embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,13 @@ pip install "code-review-graph[all]"                 # All optional dependencies
 | `CRG_TOOLS` | Comma-separated allowlist of MCP tools to expose when serving | - |
 | `GOOGLE_API_KEY` | API key for Google Gemini embeddings | - |
 | `MINIMAX_API_KEY` | API key for MiniMax embeddings | - |
+| `VOYAGE_API_KEY` | API key for Voyage embeddings | - |
+| `CRG_VOYAGE_MODEL` | Model name for Voyage embeddings | `voyage-code-3` |
+| `CRG_VOYAGE_OUTPUT_DIMENSION` | Output dimension for Voyage embeddings | `1024` |
+| `CRG_VOYAGE_OUTPUT_DTYPE` | Output dtype for Voyage embeddings | `float` |
+| `CRG_VOYAGE_BASE_URL` | Voyage embeddings endpoint | `https://api.voyageai.com/v1` |
+| `CRG_VOYAGE_BATCH_SIZE` | Batch size for Voyage embedding requests | `100` |
+| `CRG_VOYAGE_MIN_INTERVAL_SEC` | Minimum delay between Voyage requests | `0` |
 | `CRG_OPENAI_BASE_URL` | OpenAI-compatible embeddings endpoint | - |
 | `CRG_OPENAI_API_KEY` | API key for OpenAI-compatible embeddings | - |
 | `CRG_OPENAI_MODEL` | Model name for OpenAI-compatible embeddings | - |
@@ -565,6 +572,15 @@ export CRG_OPENAI_BATCH_SIZE=100                        # lower for gateways wit
 
 The cloud-egress warning is auto-skipped when the base URL points to localhost
 (`127.0.0.1`, `localhost`, `0.0.0.0`, `::1`).
+
+Voyage embeddings need no extra install. Set `VOYAGE_API_KEY` and pass
+`provider="voyage"` to `embed_graph`; the default model is `voyage-code-3`:
+
+```bash
+export VOYAGE_API_KEY=pa-...
+export CRG_ACCEPT_CLOUD_EMBEDDINGS=1
+code-review-graph embed --provider voyage --model voyage-code-3
+```
 
 > **Model selection tip.** Avoid `-preview` / `-beta` / `-exp` model IDs
 > (e.g. `google/gemini-embedding-2-preview`) for anything you plan to keep

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -968,7 +968,7 @@ def main() -> None:
     )
     eval_cmd.add_argument(
         "--embed-provider",
-        choices=["local", "openai", "google", "minimax"],
+        choices=["local", "openai", "google", "minimax", "voyage"],
         default=None,
         help="Provider for --embed (default: local, needs "
              "code-review-graph[embeddings])",

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -430,7 +430,7 @@ def _add_embedding_refresh_args(command) -> None:
     """Add explicit, provider-scoped refresh options to a CLI command."""
     command.add_argument(
         "--embedding-provider",
-        choices=["local", "openai", "google", "minimax"],
+        choices=["local", "openai", "google", "minimax", "voyage"],
         default=None,
         help=(
             "Explicitly refresh an existing embedding index with this provider; "
@@ -821,7 +821,7 @@ def main() -> None:
     embed_cmd.add_argument("--repo", default=None, help="Repository root (auto-detected)")
     embed_cmd.add_argument(
         "--provider",
-        choices=["local", "openai", "google", "minimax"],
+        choices=["local", "openai", "google", "minimax", "voyage"],
         default=None,
         help="Embedding provider (default: local, needs code-review-graph[embeddings])",
     )
@@ -829,7 +829,7 @@ def main() -> None:
         "--model",
         default=None,
         help="Embedding model. For local: HuggingFace ID (default all-MiniLM-L6-v2); "
-             "for openai/google/minimax: provider-specific model ID.",
+             "for openai/google/minimax/voyage: provider-specific model ID.",
     )
     embed_cmd.add_argument(
         "--data-dir",

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -1204,20 +1204,27 @@ class EmbeddingStore:
         if not to_embed:
             return 0
 
-        # Encode in batches
-        texts = [t for _, t, _ in to_embed]
-        vectors = self.provider.embed(texts)
+        embedded = 0
+        for i in range(0, len(to_embed), batch_size):
+            batch = to_embed[i:i + batch_size]
+            texts = [t for _, t, _ in batch]
+            vectors = self.provider.embed(texts)
 
-        for (node, _text, text_hash), vec in zip(to_embed, vectors):
-            blob = _encode_vector(vec)
-            self._conn.execute(
-                """INSERT OR REPLACE INTO embeddings (qualified_name, vector, text_hash, provider)
-                   VALUES (?, ?, ?, ?)""",
-                (node.qualified_name, blob, text_hash, provider_name),
-            )
+            for (node, _text, text_hash), vec in zip(batch, vectors):
+                blob = _encode_vector(vec)
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO embeddings
+                        (qualified_name, vector, text_hash, provider)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (node.qualified_name, blob, text_hash, provider_name),
+                )
+                embedded += 1
 
-        self._conn.commit()
-        return len(to_embed)
+            self._conn.commit()
+
+        return embedded
 
     def search(self, query: str, limit: int = 20) -> list[tuple[str, float]]:
         """Search for nodes by semantic similarity."""

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -895,6 +895,7 @@ def get_provider(
                CRG_EMBEDDING_MODEL env var, then to all-MiniLM-L6-v2.
                For Google provider this is a Gemini model ID.
                For OpenAI provider this overrides CRG_OPENAI_MODEL.
+               For Voyage provider this overrides CRG_VOYAGE_MODEL.
 
     Raises:
         ValueError: If the provider name is not one of the known providers,
@@ -972,7 +973,6 @@ def get_provider(
         resolved_model = (
             model
             or os.environ.get("CRG_VOYAGE_MODEL")
-            or os.environ.get("CRG_EMBEDDING_MODEL")
             or VoyageEmbeddingProvider._DEFAULT_MODEL
         )
         dim_env = os.environ.get("CRG_VOYAGE_OUTPUT_DIMENSION")

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -6,6 +6,7 @@ Supports multiple providers:
 3. MiniMax (embo-01) - High-quality 1536-dim cloud embeddings. Requires MINIMAX_API_KEY.
 4. OpenAI-compatible - Any endpoint speaking OpenAI /v1/embeddings (real OpenAI,
    Azure OpenAI, self-hosted gateways like new-api / LiteLLM / vLLM / LocalAI / Ollama).
+5. Voyage AI - Code retrieval embeddings via the Voyage embeddings API.
 """
 
 from __future__ import annotations
@@ -625,7 +626,189 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         return f"openai:{self._model}@{self._host_key}"
 
 
-CLOUD_PROVIDERS = {"google", "minimax", "openai"}
+class VoyageEmbeddingProvider(EmbeddingProvider):
+    """Voyage AI embedding provider.
+
+    Uses Voyage's embeddings API with document/query input types so indexed
+    source-derived node text and search queries are embedded with the task hint
+    Voyage expects. Provider identity includes model, dimension, dtype, and
+    endpoint to avoid mixing incompatible vector spaces.
+    """
+
+    _DEFAULT_BASE_URL = "https://api.voyageai.com/v1"
+    _DEFAULT_MODEL = "voyage-code-3"
+    _DEFAULT_DIMENSION = 1024
+    _DEFAULT_OUTPUT_DTYPE = "float"
+    _DEFAULT_BATCH_SIZE = 100
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str | None = None,
+        model: str | None = None,
+        output_dimension: int | None = None,
+        output_dtype: str | None = None,
+        timeout: int = 120,
+        batch_size: int | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = (base_url or self._DEFAULT_BASE_URL).rstrip("/")
+        self._model = model or self._DEFAULT_MODEL
+        self._output_dimension = output_dimension or self._DEFAULT_DIMENSION
+        self._output_dtype = output_dtype or self._DEFAULT_OUTPUT_DTYPE
+        self._timeout = timeout
+        self._batch_size = batch_size or self._DEFAULT_BATCH_SIZE
+        self._host_key = OpenAIEmbeddingProvider._make_host_key(self._base_url)
+
+    def _call_api(self, texts: list[str], input_type: str) -> list[list[float]]:
+        import http.client
+        import json as _json
+        import socket
+        import ssl
+        import urllib.error
+        import urllib.request
+
+        body: dict[str, Any] = {
+            "model": self._model,
+            "input": texts,
+            "input_type": input_type,
+            "output_dimension": self._output_dimension,
+            "output_dtype": self._output_dtype,
+        }
+
+        payload = _json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self._base_url}/embeddings",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._api_key}",
+                "User-Agent": _USER_AGENT,
+                "Accept": "application/json",
+            },
+        )
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                _ssl_ctx = ssl.create_default_context()
+                try:
+                    with urllib.request.urlopen(  # nosec B310
+                        req, timeout=self._timeout, context=_ssl_ctx,
+                    ) as resp:
+                        raw = resp.read().decode("utf-8")
+                except urllib.error.HTTPError as http_err:
+                    if http_err.code == 429 or 500 <= http_err.code < 600:
+                        raise
+                    try:
+                        err_body = http_err.read().decode("utf-8", errors="replace")
+                    except Exception:
+                        err_body = ""
+                    err_msg = err_body or str(http_err)
+                    try:
+                        parsed = _json.loads(err_body)
+                        if isinstance(parsed, dict) and "error" in parsed:
+                            err_obj = parsed["error"]
+                            err_msg = (
+                                err_obj.get("message", err_msg)
+                                if isinstance(err_obj, dict) else str(err_obj)
+                            )
+                    except Exception:  # nosec B110
+                        pass
+                    raise RuntimeError(
+                        f"Voyage API HTTP {http_err.code}: {err_msg}"
+                    ) from http_err
+
+                response = _json.loads(raw)
+
+                if "error" in response:
+                    err = response["error"]
+                    msg = err.get("message", "unknown") if isinstance(err, dict) else str(err)
+                    raise RuntimeError(f"Voyage API error: {msg}")
+
+                data = response.get("data", [])
+                if not data:
+                    raise RuntimeError("Voyage API returned empty data")
+
+                any_has_index = any("index" in item for item in data)
+                all_int_index = all(
+                    isinstance(item.get("index"), int) for item in data
+                )
+                if all_int_index:
+                    expected = set(range(len(texts)))
+                    indices = [int(item["index"]) for item in data]
+                    if len(set(indices)) != len(indices) or set(indices) != expected:
+                        raise RuntimeError(
+                            "Voyage API returned malformed indices "
+                            f"(got {indices}, expected permutation of "
+                            f"0..{len(texts) - 1}) — refusing to misalign vectors."
+                        )
+                    data = sorted(data, key=lambda item: int(item["index"]))
+                elif not any_has_index:
+                    if len(data) != len(texts):
+                        raise RuntimeError(
+                            f"Voyage API returned {len(data)} embeddings for "
+                            f"{len(texts)} inputs with no index field — "
+                            "refusing to misalign vectors."
+                        )
+                else:
+                    raise RuntimeError(
+                        "Voyage API returned mixed indexed/unindexed data — "
+                        "refusing to misalign vectors."
+                    )
+
+                return [item["embedding"] for item in data]
+
+            except Exception as e:
+                is_retryable = False
+                if isinstance(e, urllib.error.HTTPError):
+                    is_retryable = e.code == 429 or 500 <= e.code < 600
+                elif isinstance(e, (
+                    urllib.error.URLError,
+                    socket.timeout,
+                    TimeoutError,
+                    ConnectionError,
+                    ssl.SSLError,
+                    http.client.IncompleteRead,
+                    http.client.BadStatusLine,
+                    http.client.RemoteDisconnected,
+                )):
+                    is_retryable = True
+                if not is_retryable or attempt == max_retries - 1:
+                    raise
+                wait = 2 ** attempt
+                logger.warning(
+                    "Voyage embeddings API error (attempt %d/%d), retrying in %ds: %s",
+                    attempt + 1, max_retries, wait, e,
+                )
+                time.sleep(wait)
+
+        return []  # unreachable
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        results: list[list[float]] = []
+        for i in range(0, len(texts), self._batch_size):
+            results.extend(self._call_api(texts[i:i + self._batch_size], "document"))
+        return results
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._call_api([text], "query")[0]
+
+    @property
+    def dimension(self) -> int:
+        return self._output_dimension
+
+    @property
+    def name(self) -> str:
+        return (
+            f"voyage:{self._model}:dim{self._output_dimension}:"
+            f"{self._output_dtype}@{self._host_key}"
+        )
+
+
+CLOUD_PROVIDERS = {"google", "minimax", "openai", "voyage"}
 
 
 def _is_localhost_url(url: str) -> bool:
@@ -668,7 +851,7 @@ def _warn_cloud_egress(provider_name: str) -> None:
     )
 
 
-_VALID_PROVIDERS = {"local", "openai", "google", "minimax"}
+_VALID_PROVIDERS = {"local", "openai", "google", "minimax", "voyage"}
 
 
 def get_provider(
@@ -678,17 +861,18 @@ def get_provider(
     """Get an embedding provider by name.
 
     Args:
-        provider: Provider name. One of "local", "google", "minimax", "openai",
-                  or None. When omitted, configured OpenAI-compatible
-                  credentials select OpenAI; otherwise the local provider is
-                  used. Names are case-insensitive and surrounding whitespace
-                  is ignored; unknown names raise ValueError instead of
-                  silently falling back to the local provider.
-                  Google requires GOOGLE_API_KEY env var and explicit opt-in.
-                  MiniMax requires MINIMAX_API_KEY env var and explicit opt-in.
-                  OpenAI requires CRG_OPENAI_API_KEY + CRG_OPENAI_BASE_URL +
-                  CRG_OPENAI_MODEL env vars (or the ``model`` arg). The egress
-                  warning is skipped when the base URL points to localhost.
+        provider: Provider name. One of "local", "google", "minimax",
+                  "openai", "voyage", or None. When omitted, configured
+                  OpenAI-compatible credentials select OpenAI; otherwise the
+                  local provider is used. Names are case-insensitive and
+                  surrounding whitespace is ignored; unknown names raise
+                  ValueError instead of silently falling back to the local
+                  provider. Google requires GOOGLE_API_KEY env var and explicit
+                  opt-in. MiniMax requires MINIMAX_API_KEY env var and explicit
+                  opt-in. Voyage requires VOYAGE_API_KEY. OpenAI requires
+                  CRG_OPENAI_API_KEY + CRG_OPENAI_BASE_URL + CRG_OPENAI_MODEL
+                  env vars (or the ``model`` arg). The egress warning is
+                  skipped when the base URL points to localhost.
                   Cloud providers emit a one-time stderr warning before use
                   unless ``CRG_ACCEPT_CLOUD_EMBEDDINGS=1`` is set. See: #174
         model: Model name/path to use. For local provider this is any
@@ -705,7 +889,7 @@ def get_provider(
     if name and name not in _VALID_PROVIDERS:
         raise ValueError(
             f"Unknown embedding provider '{name}'. "
-            "Valid: local, openai, google, minimax"
+            "Valid: local, openai, google, minimax, voyage"
         )
 
     # When no explicit provider is given but OpenAI-compatible env vars are
@@ -758,6 +942,42 @@ def get_provider(
             )
         _warn_cloud_egress("minimax")
         return MiniMaxEmbeddingProvider(api_key=api_key)
+
+    if name == "voyage":
+        api_key = os.environ.get("VOYAGE_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "VOYAGE_API_KEY environment variable is required for "
+                "the Voyage embedding provider."
+            )
+        base_url = (
+            os.environ.get("CRG_VOYAGE_BASE_URL")
+            or VoyageEmbeddingProvider._DEFAULT_BASE_URL
+        )
+        resolved_model = (
+            model
+            or os.environ.get("CRG_VOYAGE_MODEL")
+            or os.environ.get("CRG_EMBEDDING_MODEL")
+            or VoyageEmbeddingProvider._DEFAULT_MODEL
+        )
+        dim_env = os.environ.get("CRG_VOYAGE_OUTPUT_DIMENSION")
+        output_dimension = int(dim_env) if dim_env else VoyageEmbeddingProvider._DEFAULT_DIMENSION
+        output_dtype = (
+            os.environ.get("CRG_VOYAGE_OUTPUT_DTYPE")
+            or VoyageEmbeddingProvider._DEFAULT_OUTPUT_DTYPE
+        )
+        batch_env = os.environ.get("CRG_VOYAGE_BATCH_SIZE")
+        batch_size = int(batch_env) if batch_env else None
+        if not _is_localhost_url(base_url):
+            _warn_cloud_egress("voyage")
+        return VoyageEmbeddingProvider(
+            api_key=api_key,
+            base_url=base_url,
+            model=resolved_model,
+            output_dimension=output_dimension,
+            output_dtype=output_dtype,
+            batch_size=batch_size,
+        )
 
     if name == "google":
         api_key = os.environ.get("GOOGLE_API_KEY")

--- a/code_review_graph/embeddings.py
+++ b/code_review_graph/embeddings.py
@@ -650,6 +650,7 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         output_dtype: str | None = None,
         timeout: int = 120,
         batch_size: int | None = None,
+        min_interval_sec: float = 0.0,
     ) -> None:
         self._api_key = api_key
         self._base_url = (base_url or self._DEFAULT_BASE_URL).rstrip("/")
@@ -658,7 +659,20 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         self._output_dtype = output_dtype or self._DEFAULT_OUTPUT_DTYPE
         self._timeout = timeout
         self._batch_size = batch_size or self._DEFAULT_BATCH_SIZE
+        self._min_interval_sec = max(0.0, min_interval_sec)
+        self._last_request_at = 0.0
         self._host_key = OpenAIEmbeddingProvider._make_host_key(self._base_url)
+
+    def _wait_for_rate_limit_slot(self) -> None:
+        if self._min_interval_sec <= 0:
+            return
+        now = time.monotonic()
+        if self._last_request_at > 0:
+            wait = self._min_interval_sec - (now - self._last_request_at)
+            if wait > 0:
+                time.sleep(wait)
+                now = time.monotonic()
+        self._last_request_at = now
 
     def _call_api(self, texts: list[str], input_type: str) -> list[list[float]]:
         import http.client
@@ -693,6 +707,7 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
             try:
                 _ssl_ctx = ssl.create_default_context()
                 try:
+                    self._wait_for_rate_limit_slot()
                     with urllib.request.urlopen(  # nosec B310
                         req, timeout=self._timeout, context=_ssl_ctx,
                     ) as resp:
@@ -968,6 +983,8 @@ def get_provider(
         )
         batch_env = os.environ.get("CRG_VOYAGE_BATCH_SIZE")
         batch_size = int(batch_env) if batch_env else None
+        min_interval_env = os.environ.get("CRG_VOYAGE_MIN_INTERVAL_SEC")
+        min_interval_sec = float(min_interval_env) if min_interval_env else 0.0
         if not _is_localhost_url(base_url):
             _warn_cloud_egress("voyage")
         return VoyageEmbeddingProvider(
@@ -977,6 +994,7 @@ def get_provider(
             output_dimension=output_dimension,
             output_dtype=output_dtype,
             batch_size=batch_size,
+            min_interval_sec=min_interval_sec,
         )
 
     if name == "google":

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -332,9 +332,9 @@ def semantic_search_nodes_tool(
 
     Uses vector embeddings for semantic search when available (run embed_graph_tool
     first, with a provider of your choice: "local" needs sentence-transformers,
-    "openai" / "google" / "minimax" need their respective env vars). Falls back
-    to FTS5 / keyword matching when no matching embeddings exist for the given
-    provider.
+    "openai" / "google" / "minimax" / "voyage" need their respective env vars).
+    Falls back to FTS5 / keyword matching when no matching embeddings exist for
+    the given provider.
 
     Args:
         query: Search string to match against node names.
@@ -343,9 +343,10 @@ def semantic_search_nodes_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         model: Embedding model for query vectors. Must match the model used
                during embed_graph. Falls back to CRG_EMBEDDING_MODEL env var
-               (local) or CRG_OPENAI_MODEL (openai).
+               (local), CRG_OPENAI_MODEL (openai), or CRG_VOYAGE_MODEL (voyage).
         provider: Embedding provider: "local" (default), "openai", "google",
-                  or "minimax". Must match the provider used during embed_graph.
+                  "minimax", or "voyage". Must match the provider used during
+                  embed_graph.
         detail_level: "standard" for full output, "minimal" for compact summary. Default: standard.
     """
     root = _resolve_repo_root(repo_root)
@@ -367,7 +368,7 @@ async def embed_graph_tool(
     cloud providers use stdlib urllib).
     Default provider: local. Default model: all-MiniLM-L6-v2.
     Override provider via `provider` param, model via `model` param or
-    CRG_EMBEDDING_MODEL / CRG_OPENAI_MODEL env vars.
+    CRG_EMBEDDING_MODEL / CRG_OPENAI_MODEL / CRG_VOYAGE_MODEL env vars.
     Changing the model or provider re-embeds all nodes automatically.
 
     After running this, semantic_search_nodes_tool will use vector similarity
@@ -382,12 +383,15 @@ async def embed_graph_tool(
         repo_root: Repository root path. Auto-detected if omitted.
         model: Embedding model. For local: HuggingFace ID/path; for openai:
                model ID (e.g. "text-embedding-3-small"); for google: Gemini
-               model ID. Falls back to CRG_EMBEDDING_MODEL / CRG_OPENAI_MODEL
-               env vars as appropriate.
-        provider: "local" (default), "openai", "google", or "minimax".
+               model ID; for voyage: Voyage model ID (e.g. "voyage-code-3").
+               Falls back to CRG_EMBEDDING_MODEL / CRG_OPENAI_MODEL /
+               CRG_VOYAGE_MODEL env vars as appropriate.
+        provider: "local" (default), "openai", "google", "minimax", or "voyage".
                   "openai" requires CRG_OPENAI_BASE_URL + CRG_OPENAI_API_KEY +
                   CRG_OPENAI_MODEL env vars and accepts any OpenAI-compatible
                   endpoint (real OpenAI, Azure, new-api, LiteLLM, vLLM, etc.).
+                  "voyage" requires VOYAGE_API_KEY and defaults to voyage-code-3
+                  unless a model arg or CRG_VOYAGE_MODEL is supplied.
     """
     root = _resolve_repo_root(repo_root)
 

--- a/code_review_graph/tools/docs.py
+++ b/code_review_graph/tools/docs.py
@@ -25,9 +25,11 @@ def embed_graph(
     """Compute vector embeddings for all graph nodes to enable semantic search.
 
     Requires: ``pip install code-review-graph[embeddings]`` (local provider only;
-    cloud providers like ``openai`` / ``google`` / ``minimax`` use stdlib ``urllib``).
+    cloud providers like ``openai`` / ``google`` / ``minimax`` / ``voyage`` use
+    stdlib ``urllib``).
     Default model: all-MiniLM-L6-v2. Override via ``model`` param or
-    CRG_EMBEDDING_MODEL env var.
+    provider-specific env vars such as CRG_EMBEDDING_MODEL, CRG_OPENAI_MODEL, or
+    CRG_VOYAGE_MODEL.
     Changing the model or provider re-embeds all nodes automatically.
 
     Only embeds nodes that don't already have up-to-date embeddings.
@@ -36,13 +38,17 @@ def embed_graph(
         repo_root: Repository root path. Auto-detected if omitted.
         model: Embedding model name. For local: HuggingFace ID or path;
                for openai: model ID (e.g. ``text-embedding-3-small``);
-               for google: Gemini model ID. Falls back to
-               CRG_EMBEDDING_MODEL / CRG_OPENAI_MODEL env vars as appropriate.
+               for google: Gemini model ID; for voyage: Voyage model ID
+               (e.g. ``voyage-code-3``). Falls back to CRG_EMBEDDING_MODEL /
+               CRG_OPENAI_MODEL / CRG_VOYAGE_MODEL env vars as appropriate.
         provider: Provider name: ``local`` (default), ``openai``, ``google``,
-                  or ``minimax``. ``openai`` requires CRG_OPENAI_BASE_URL +
+                  ``minimax``, or ``voyage``. ``openai`` requires CRG_OPENAI_BASE_URL +
                   CRG_OPENAI_API_KEY + CRG_OPENAI_MODEL env vars and accepts
                   any OpenAI-compatible endpoint (real OpenAI, Azure, new-api,
                   LiteLLM, vLLM, LocalAI, Ollama openai-mode, etc.).
+                  ``voyage`` requires VOYAGE_API_KEY and defaults to
+                  voyage-code-3 unless a model arg or CRG_VOYAGE_MODEL is
+                  supplied.
 
     Returns:
         Number of nodes embedded and total embedding count.
@@ -59,7 +65,7 @@ def embed_graph(
             return {"status": "error", "error": str(exc)}
         try:
             if not emb_store.available:
-                if provider in ("openai", "google", "minimax"):
+                if provider in ("openai", "google", "minimax", "voyage"):
                     err = (
                         f"The '{provider}' embedding provider is not available. "
                         "Check the required environment variables "
@@ -70,7 +76,8 @@ def embed_graph(
                     err = (
                         "The local embedding provider needs sentence-transformers. "
                         "Install with: pip install code-review-graph[embeddings] — "
-                        "or switch provider to 'openai' / 'google' / 'minimax'."
+                        "or switch provider to 'openai' / 'google' / 'minimax' "
+                        "/ 'voyage'."
                     )
                 return {"status": "error", "error": err}
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -96,8 +96,8 @@ query: str           # Search string
 kind: str | None     # File, Class, Function, Type, Test
 limit: int = 20
 repo_root: str | None
-model: str | None    # Embedding model (falls back to CRG_EMBEDDING_MODEL env var)
-provider: str | None # local, openai, google, minimax
+model: str | None    # Embedding model (falls back to provider-specific env vars)
+provider: str | None # local, openai, google, minimax, voyage
 detail_level: str = "standard"
 ```
 
@@ -105,7 +105,7 @@ detail_level: str = "standard"
 ```
 repo_root: str | None
 model: str | None    # Embedding model name
-provider: str | None # local, openai, google, minimax
+provider: str | None # local, openai, google, minimax, voyage
 ```
 Local embeddings require: `pip install "code-review-graph[embeddings]"`. Cloud providers use stdlib HTTP clients and require their provider environment variables.
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -7,7 +7,7 @@
 - All graph data stored locally in `.code-review-graph/graph.db`
 - Core graph build, review, search, and CLI/MCP workflows run locally
 - Optional local embeddings may download a sentence-transformers model from HuggingFace when first used
-- Optional cloud embedding providers (`openai`, `google`, `minimax`) send embedded source snippets to the configured provider only when explicitly selected
+- Optional cloud embedding providers (`openai`, `google`, `minimax`, `voyage`) send embedded source snippets to the configured provider only when explicitly selected
 - Remote embedding providers print an egress warning unless `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` is set
 - Streamable HTTP MCP transport binds to localhost by default
 

--- a/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -45,8 +45,8 @@ Or use PostToolUse (Write|Edit|Bash) hooks for automatic background updates.
 Optional: pip install "code-review-graph[embeddings]"
 Then call embed_graph_tool to compute vectors.
 semantic_search_nodes_tool auto-uses vectors when available, falls back to keyword + FTS5.
-Providers: local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, and MiniMax.
-Configure via provider/model parameters, CRG_EMBEDDING_MODEL for local, or CRG_OPENAI_* for OpenAI-compatible endpoints.
+Providers: local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, MiniMax, and Voyage.
+Configure via provider/model parameters, CRG_EMBEDDING_MODEL for local, CRG_OPENAI_* for OpenAI-compatible endpoints, or VOYAGE_API_KEY plus optional CRG_VOYAGE_MODEL for Voyage.
 </section>
 
 <section name="languages">

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -87,7 +87,7 @@ pip install "code-review-graph[embeddings]"
 ```
 Then use `embed_graph_tool` to compute vectors. `semantic_search_nodes_tool` automatically uses vector similarity when matching embeddings are available and falls back to keyword/FTS search otherwise.
 
-Embedding providers are local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, and MiniMax. Local embeddings use `CRG_EMBEDDING_MODEL`; OpenAI-compatible providers use `CRG_OPENAI_BASE_URL`, `CRG_OPENAI_API_KEY`, and `CRG_OPENAI_MODEL`. Cloud providers are opt-in and print an egress warning unless `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` is set.
+Embedding providers are local sentence-transformers, OpenAI-compatible endpoints, Google Gemini, MiniMax, and Voyage. Local embeddings use `CRG_EMBEDDING_MODEL`; OpenAI-compatible providers use `CRG_OPENAI_BASE_URL`, `CRG_OPENAI_API_KEY`, and `CRG_OPENAI_MODEL`; Voyage uses `VOYAGE_API_KEY` and optionally `CRG_VOYAGE_MODEL`. Cloud providers are opt-in and print an egress warning unless `CRG_ACCEPT_CLOUD_EMBEDDINGS=1` is set.
 
 Function/class documentation summaries are included in embedding text. For a
 graph created by an older release, run a full build once before re-embedding so

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -111,6 +111,24 @@ class TestNodeToText:
 
 
 class TestEmbeddingStore:
+    def _make_node(self, index: int) -> GraphNode:
+        return GraphNode(
+            id=index,
+            kind="Function",
+            name=f"func_{index}",
+            qualified_name=f"file.py::func_{index}",
+            file_path="file.py",
+            line_start=index,
+            line_end=index + 1,
+            language="python",
+            parent_name=None,
+            params=None,
+            return_type=None,
+            is_test=False,
+            file_hash=None,
+            extra={},
+        )
+
     def test_store_initializes(self, tmp_path):
         db = tmp_path / "embeddings.db"
         with patch("code_review_graph.embeddings.get_provider", return_value=None):
@@ -147,6 +165,69 @@ class TestEmbeddingStore:
             store = EmbeddingStore(db)
             # Should not raise even if node doesn't exist
             store.remove_node("nonexistent::func")
+            store.close()
+
+    def test_embed_nodes_commits_each_batch(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+
+        class Provider:
+            name = "test:provider"
+
+            def __init__(self):
+                self.calls = []
+
+            def embed(self, texts):
+                self.calls.append(list(texts))
+                return [[float(len(self.calls)), 0.0] for _ in texts]
+
+            def embed_query(self, text):
+                return [0.0, 0.0]
+
+            @property
+            def dimension(self):
+                return 2
+
+        provider = Provider()
+        nodes = [self._make_node(i) for i in range(5)]
+
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider):
+            store = EmbeddingStore(db)
+            embedded = store.embed_nodes(nodes, batch_size=2)
+            assert embedded == 5
+            assert [len(call) for call in provider.calls] == [2, 2, 1]
+            assert store.count() == 5
+            store.close()
+
+    def test_embed_nodes_preserves_completed_batches_on_later_failure(self, tmp_path):
+        db = tmp_path / "embeddings.db"
+
+        class Provider:
+            name = "test:provider"
+
+            def __init__(self):
+                self.calls = 0
+
+            def embed(self, texts):
+                self.calls += 1
+                if self.calls == 2:
+                    raise RuntimeError("rate limited")
+                return [[1.0, 0.0] for _ in texts]
+
+            def embed_query(self, text):
+                return [0.0, 0.0]
+
+            @property
+            def dimension(self):
+                return 2
+
+        provider = Provider()
+        nodes = [self._make_node(i) for i in range(5)]
+
+        with patch("code_review_graph.embeddings.get_provider", return_value=provider):
+            store = EmbeddingStore(db)
+            with pytest.raises(RuntimeError, match="rate limited"):
+                store.embed_nodes(nodes, batch_size=2)
+            assert store.count() == 2
             store.close()
 
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -738,6 +738,31 @@ class TestVoyageEmbeddingProvider:
             with pytest.raises(RuntimeError, match="refusing to misalign"):
                 provider.embed(["a", "b"])
 
+    def test_min_interval_paces_batched_requests(self):
+        provider = VoyageEmbeddingProvider(
+            api_key="k",
+            batch_size=1,
+            min_interval_sec=2.0,
+        )
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=[
+                    _make_voyage_response([[0.1] * 1024]),
+                    _make_voyage_response([[0.2] * 1024]),
+                ],
+            ),
+            patch(
+                "code_review_graph.embeddings.time.monotonic",
+                side_effect=[100.0, 101.0, 103.0],
+            ),
+            patch("code_review_graph.embeddings.time.sleep") as sleep,
+        ):
+            result = provider.embed(["hello", "world"])
+
+        assert len(result) == 2
+        sleep.assert_called_once_with(1.0)
+
 
 class TestGetProviderVoyage:
     """Tests for get_provider() with Voyage."""
@@ -767,12 +792,14 @@ class TestGetProviderVoyage:
             "CRG_VOYAGE_BASE_URL": "https://voyage.example.test/v1",
             "CRG_VOYAGE_OUTPUT_DIMENSION": "512",
             "CRG_VOYAGE_OUTPUT_DTYPE": "float",
+            "CRG_VOYAGE_MIN_INTERVAL_SEC": "21",
             "CRG_ACCEPT_CLOUD_EMBEDDINGS": "1",
         }
         with patch.dict(os.environ, env, clear=False):
             provider = get_provider("voyage")
 
         assert isinstance(provider, VoyageEmbeddingProvider)
+        assert provider._min_interval_sec == 21.0
         assert provider.name == (
             "voyage:voyage-code-3:dim512:float@https://voyage.example.test/v1"
         )

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -16,6 +16,7 @@ from code_review_graph.embeddings import (
     LocalEmbeddingProvider,
     MiniMaxEmbeddingProvider,
     OpenAIEmbeddingProvider,
+    VoyageEmbeddingProvider,
     _cosine_similarity,
     _decode_vector,
     _encode_vector,
@@ -237,17 +238,17 @@ class TestGoogleEmbeddingProviderRetryLogging:
 class TestGetProviderValidation:
     """Unknown provider names must raise instead of silently using local."""
 
-    @pytest.mark.parametrize("name", ["voyage", "opnai", "cohere", "VoYage"])
+    @pytest.mark.parametrize("name", ["opnai", "cohere", "moonbase", "MoOnBase"])
     def test_unknown_provider_raises(self, name):
         with pytest.raises(ValueError, match="Unknown embedding provider"):
             get_provider(name)
 
     def test_unknown_provider_message_lists_valid_names(self):
         with pytest.raises(ValueError) as exc_info:
-            get_provider("voyage")
+            get_provider("moonbase")
         msg = str(exc_info.value)
-        assert "voyage" in msg
-        assert "Valid: local, openai, google, minimax" in msg
+        assert "moonbase" in msg
+        assert "Valid: local, openai, google, minimax, voyage" in msg
 
     def test_case_and_whitespace_normalized_for_openai(self):
         """'  OPENAI ' must route to the openai branch (and fail on its
@@ -544,6 +545,156 @@ class TestGetProviderMiniMax:
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
                 get_provider("minimax")
+
+
+def _make_voyage_response(vectors: list[list[float]]) -> MagicMock:
+    body = json.dumps({
+        "data": [{"embedding": v, "index": i} for i, v in enumerate(vectors)],
+        "model": "voyage-code-3",
+        "object": "list",
+        "usage": {"total_tokens": 5},
+    }).encode("utf-8")
+    mock = MagicMock()
+    mock.read.return_value = body
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+class TestVoyageEmbeddingProvider:
+    """Unit tests for VoyageEmbeddingProvider."""
+
+    def test_name_includes_model_dimension_dtype_and_endpoint(self):
+        provider = VoyageEmbeddingProvider(
+            api_key="k",
+            base_url="https://api.voyageai.com/v1/",
+            model="voyage-code-3",
+            output_dimension=1024,
+            output_dtype="float",
+        )
+
+        assert (
+            provider.name
+            == "voyage:voyage-code-3:dim1024:float@https://api.voyageai.com/v1"
+        )
+
+    def test_default_dimension_before_call(self):
+        provider = VoyageEmbeddingProvider(api_key="k")
+        assert provider.dimension == 1024
+
+    def test_embed_calls_api_with_document_input_type(self):
+        provider = VoyageEmbeddingProvider(api_key="secret-key")
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_voyage_response([[0.1] * 1024, [0.2] * 1024]),
+        ) as mock_urlopen:
+            result = provider.embed(["hello", "world"])
+
+        assert len(result) == 2
+        assert len(result[0]) == 1024
+
+        req = mock_urlopen.call_args[0][0]
+        payload = json.loads(req.data.decode("utf-8"))
+        assert payload["model"] == "voyage-code-3"
+        assert payload["input"] == ["hello", "world"]
+        assert payload["input_type"] == "document"
+        assert payload["output_dimension"] == 1024
+        assert payload["output_dtype"] == "float"
+        assert req.headers["Authorization"] == "Bearer secret-key"
+        assert req.full_url == "https://api.voyageai.com/v1/embeddings"
+
+    def test_embed_query_calls_api_with_query_input_type(self):
+        provider = VoyageEmbeddingProvider(api_key="k")
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_voyage_response([[0.5] * 1024]),
+        ) as mock_urlopen:
+            result = provider.embed_query("search term")
+
+        assert len(result) == 1024
+        payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert payload["input_type"] == "query"
+
+    def test_custom_output_dimension_and_dtype_forwarded(self):
+        provider = VoyageEmbeddingProvider(
+            api_key="k",
+            model="voyage-code-3",
+            output_dimension=512,
+            output_dtype="float",
+        )
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_voyage_response([[0.1] * 512]),
+        ) as mock_urlopen:
+            provider.embed_query("x")
+
+        payload = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert payload["output_dimension"] == 512
+        assert provider.dimension == 512
+
+    def test_response_without_index_field_falls_back_to_server_order(self):
+        provider = VoyageEmbeddingProvider(api_key="k")
+        body = json.dumps({
+            "data": [
+                {"embedding": [1.0]},
+                {"embedding": [2.0]},
+            ],
+        }).encode("utf-8")
+        mock = MagicMock()
+        mock.read.return_value = body
+        mock.__enter__ = MagicMock(return_value=mock)
+        mock.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock):
+            assert provider.embed(["a", "b"]) == [[1.0], [2.0]]
+
+    def test_response_length_mismatch_raises(self):
+        provider = VoyageEmbeddingProvider(api_key="k")
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_voyage_response([[0.1]]),
+        ):
+            with pytest.raises(RuntimeError, match="refusing to misalign"):
+                provider.embed(["a", "b"])
+
+
+class TestGetProviderVoyage:
+    """Tests for get_provider() with Voyage."""
+
+    def test_get_provider_voyage_with_key(self):
+        env = {
+            "VOYAGE_API_KEY": "test-key",
+            "CRG_ACCEPT_CLOUD_EMBEDDINGS": "1",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            provider = get_provider("voyage")
+
+        assert isinstance(provider, VoyageEmbeddingProvider)
+        assert provider.name == (
+            "voyage:voyage-code-3:dim1024:float@https://api.voyageai.com/v1"
+        )
+
+    def test_get_provider_voyage_without_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="VOYAGE_API_KEY"):
+                get_provider("voyage")
+
+    def test_get_provider_voyage_respects_env_configuration(self):
+        env = {
+            "VOYAGE_API_KEY": "test-key",
+            "CRG_VOYAGE_MODEL": "voyage-code-3",
+            "CRG_VOYAGE_BASE_URL": "https://voyage.example.test/v1",
+            "CRG_VOYAGE_OUTPUT_DIMENSION": "512",
+            "CRG_VOYAGE_OUTPUT_DTYPE": "float",
+            "CRG_ACCEPT_CLOUD_EMBEDDINGS": "1",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            provider = get_provider("voyage")
+
+        assert isinstance(provider, VoyageEmbeddingProvider)
+        assert provider.name == (
+            "voyage:voyage-code-3:dim512:float@https://voyage.example.test/v1"
+        )
 
 
 class TestEmbeddingStoreContextManager:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -804,6 +804,20 @@ class TestGetProviderVoyage:
             "voyage:voyage-code-3:dim512:float@https://voyage.example.test/v1"
         )
 
+    def test_get_provider_voyage_ignores_local_embedding_model_env(self):
+        env = {
+            "VOYAGE_API_KEY": "test-key",
+            "CRG_EMBEDDING_MODEL": "local-only-model",
+            "CRG_ACCEPT_CLOUD_EMBEDDINGS": "1",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            provider = get_provider("voyage")
+
+        assert isinstance(provider, VoyageEmbeddingProvider)
+        assert provider.name == (
+            "voyage:voyage-code-3:dim1024:float@https://api.voyageai.com/v1"
+        )
+
 
 class TestEmbeddingStoreContextManager:
     """Regression tests for #260: EmbeddingStore must support the context

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -848,12 +848,12 @@ class TestEmbedGraphProviderErrors:
     def test_unknown_provider_returns_structured_error(self, tmp_path):
         (tmp_path / ".code-review-graph").mkdir()
         result = docs_module.embed_graph(
-            repo_root=str(tmp_path), provider="voyage",
+            repo_root=str(tmp_path), provider="moonbase",
         )
         assert result["status"] == "error"
         assert "Unknown embedding provider" in result["error"]
-        assert "voyage" in result["error"]
-        assert "Valid: local, openai, google, minimax" in result["error"]
+        assert "moonbase" in result["error"]
+        assert "Valid: local, openai, google, minimax, voyage" in result["error"]
 
     def test_missing_env_vars_return_structured_error(self, tmp_path, monkeypatch):
         (tmp_path / ".code-review-graph").mkdir()
@@ -872,7 +872,7 @@ class TestEmbedGraphProviderErrors:
             docs_module, "_get_store", lambda repo_root=None: (store, tmp_path),
         )
         result = docs_module.embed_graph(
-            repo_root=str(tmp_path), provider="voyage",
+            repo_root=str(tmp_path), provider="moonbase",
         )
         assert result["status"] == "error"
         store.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add Voyage AI as an embedding provider
- expose `voyage` in CLI embedding-provider choices
- persist embedding batches incrementally so large repository embeds can resume after provider rate limits
- add optional Voyage request throttling via `CRG_VOYAGE_MIN_INTERVAL_SEC`
- add provider tests for request payloads, response parsing, API key handling, provider identity, batch persistence, and throttling

## Defaults
- model: `voyage-code-3`
- output dimension: `1024`
- output dtype: `float`
- document embeddings use `input_type=document`
- query embeddings use `input_type=query`
- request throttling defaults to disabled unless `CRG_VOYAGE_MIN_INTERVAL_SEC` is set

## Tests
- `python -m pytest tests/test_embeddings.py -q`
- `python -m ruff check code_review_graph/cli.py code_review_graph/embeddings.py tests/test_embeddings.py`
- `python -m compileall -q code_review_graph tests/test_embeddings.py`
- `git diff --check`

## Operational note
This was tested in an internal CRG deployment with a reduced-rate Voyage account. A 21s request interval allowed a full monorepo embedding run to complete without 429s.