### PR TITLE
[Bug]: C# method names extracted as the return type: async Task Foo() indexes as Task, merging disti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 - GitHub Copilot auto-detection now requires the Copilot extension and also
   recognizes the extension bundled with released VS Code installations.
+- C# methods with a non-generic return type are no longer named after that
+  type: `public async Task Foo()` indexed as `Task`, collapsing every such
+  method in a class onto one qualified name (#791).
 - Added a post-index Python import resolver using unique module suffixes, so
   `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while duplicate
   package candidates remain explicitly unresolved (#720).

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14051,6 +14051,16 @@ class CodeParser:
                 if child.type == "identifier":
                     return child.text.decode("utf-8", errors="replace")
             return None
+        # C#: unlike Java there is no type_identifier — a non-generic return
+        # type such as ``Task`` is itself an ``identifier``, so the generic
+        # loop below would return it instead of the method name. Read the
+        # ``name`` field; unusual shapes still fall through.
+        if language == "csharp" and kind == "function" and node.type in (
+            "method_declaration", "constructor_declaration",
+        ):
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                return name_node.text.decode("utf-8", errors="replace")
 
         if language == "cpp" and kind == "function":
             declarator = node.child_by_field_name("declarator")

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -460,6 +460,42 @@ class TestCSharpParsing:
 @pytest.mark.skipif(
     not _has_csharp_parser(), reason="csharp tree-sitter grammar not installed",
 )
+class TestCSharpMethodNames:
+    """Regression tests for #791: a non-generic C# return type is itself an
+    ``identifier``, so ``async Task Foo()`` was named ``Task`` and every such
+    method in a class merged onto one ``qualified_name``.
+    """
+
+    def _parse(self, source: str, tmp_path):
+        p = tmp_path / "x.cs"
+        p.write_text(source, encoding="utf-8")
+        return CodeParser().parse_file(p)
+
+    def test_non_generic_return_type_is_not_the_name(self, tmp_path):
+        nodes, _ = self._parse(
+            "public class Suite {\n"
+            "    public async Task Should_do_thing() { }\n"
+            "    public async Task Should_do_other_thing() { }\n"
+            "    public async Task<int> Returns_generic() { return 1; }\n"
+            "    public void PlainVoid() { }\n"
+            "    public Suite() { }\n"
+            "}\n",
+            tmp_path,
+        )
+        funcs = [n for n in nodes if n.kind == "Function"]
+        assert {f.name for f in funcs} == {
+            "Should_do_thing",
+            "Should_do_other_thing",
+            "Returns_generic",
+            "PlainVoid",
+            "Suite",
+        }
+        assert len(funcs) == 5
+
+
+@pytest.mark.skipif(
+    not _has_csharp_parser(), reason="csharp tree-sitter grammar not installed",
+)
 class TestCSharpAttributes:
     """Regression tests for #295 (C# half): C# attributes use
     ``attribute_list`` nodes, not ``modifiers > annotation``, so they need


### PR DESCRIPTION
`_get_name()` had a Java special case for the return-type-before-name shape but none for C#, where a non-generic return type like `Task` is itself an `identifier` and so was matched first by the generic loop. Added a C# branch that reads the `name` field of `method_declaration`/`constructor_declaration`, which is grammar-accurate and unaffected by generic vs. non-generic return types; it deliberately falls through to the generic loop when no `name` field is present.

Fixes #791

### Testing
[targeted; 3 commit(s) checked individually] $ /Users/m2/Documents/PW/github-bot/work/tirth8205__code-review-graph/791/.venv/bin/python -m pytest -q --no-header tests/test_multilang.py tests/test_parser.py

### Notes for reviewers
Scrutinise the `kind == "function"` guard: the issue reports these methods surfacing as `Test` nodes on a TUnit repo, and the new test only exercises a non-test file (`x.cs`), so all its nodes are `Function`. If `_get_name()` is ever called with a `test`-ish kind for methods in test files, the branch would not fire and the exact case the issue is about would stay broken — I could not verify from the diff whether `kind` here is always "function" for method_declaration regardless of Function/Test classification downstream. That is the first thing I would check, ideally by adding a case under a `Tests/` path or an `[Test]`-attributed method. Secondary, smaller items: (a) whether C# node types beyond `method_declaration`/`constructor_declaration` have the same shape — `local_function_statement`, `operator_declaration`, `destructor_declaration`, `delegate_declaration` — the contributor scoped narrowly, which is defensible but is a scope call that is yours; (b) the reported node-count jump (10,883 → 14,473) means previously-merged nodes now split, so downstream consumers keyed on `qualified_name` (caches, stored graphs, edge dedup) see churn on rebuild — the contributor says `callers_of`/`children_of` showed no regressions, but that was verified on their repo, not in CI.

