### PR TITLE
fix(resolver): read path aliases from jsconfig.json (#776)

### DIFF
--- a/code_review_graph/tsconfig_resolver.py
+++ b/code_review_graph/tsconfig_resolver.py
@@ -1,8 +1,10 @@
-"""TypeScript tsconfig.json path alias resolver.
+"""TypeScript tsconfig.json / jsconfig.json path alias resolver.
 
 Resolves TypeScript path aliases (e.g., ``@/ -> src/``) declared in
 ``compilerOptions.paths`` so that ``IMPORTS_FROM`` edges can point to
-real file paths instead of raw alias strings.
+real file paths instead of raw alias strings. Plain-JS projects (Vue,
+Nuxt, Vite) declare the same aliases in ``jsconfig.json``, which shares
+the ``compilerOptions`` schema, so it is handled by the same parser.
 """
 
 from __future__ import annotations
@@ -18,8 +20,15 @@ logger = logging.getLogger(__name__)
 # Extensions probed when resolving an alias target
 _PROBE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".vue"]
 
-# Tsconfig filenames to look for when walking up the directory tree
-_TSCONFIG_NAMES = ["tsconfig.json", "tsconfig.app.json"]
+# Config filenames to look for when walking up the directory tree.
+# Order defines precedence within a directory: tsconfig.json wins over
+# tsconfig.app.json, and both win over jsconfig.json (issue #776).
+# jsconfig.json is a tsconfig.json with JS-oriented compiler defaults;
+# none of those implicit defaults affect baseUrl/paths resolution, so
+# the same parser (JSONC + relative "extends" chains) covers it.
+# The nearest directory containing any of these names still wins over
+# configs higher up the tree, matching editor/bundler behavior.
+_TSCONFIG_NAMES = ["tsconfig.json", "tsconfig.app.json", "jsconfig.json"]
 
 
 class TsconfigResolver:

--- a/tests/test_tsconfig_resolver.py
+++ b/tests/test_tsconfig_resolver.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 
 from code_review_graph.tsconfig_resolver import TsconfigResolver
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _write_config(root: Path, name: str, paths: dict, base_url: str = ".") -> None:
+    (root / name).write_text(
+        json.dumps({"compilerOptions": {"baseUrl": base_url, "paths": paths}}),
+        encoding="utf-8",
+    )
 
 
 class TestTsconfigResolver:
@@ -54,3 +62,72 @@ class TestTsconfigResolver:
         assert cache_size_after_first >= 1
         self.resolver.resolve_alias("@/lib/utils", importer)
         assert len(self.resolver._cache) == cache_size_after_first
+
+
+class TestJsconfigResolution:
+    """Regression tests for issue #776: jsconfig.json path aliases."""
+
+    def setup_method(self):
+        self.resolver = TsconfigResolver()
+
+    def test_jsconfig_only_project_resolves_alias(self):
+        """A plain-JS project declaring aliases only in jsconfig.json resolves them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_config(root, "jsconfig.json", {"@/*": ["src/*"]})
+            target = root / "src" / "composables" / "useThing.js"
+            target.parent.mkdir(parents=True)
+            target.write_text("export function useThing() {}\n", encoding="utf-8")
+            importer = root / "src" / "App.vue"
+            importer.write_text("import '@/composables/useThing'\n", encoding="utf-8")
+
+            result = self.resolver.resolve_alias("@/composables/useThing", str(importer))
+            assert result is not None
+            assert Path(result) == target.resolve()
+
+    def test_tsconfig_wins_over_jsconfig_in_same_dir(self):
+        """When both configs exist in a directory, tsconfig.json takes precedence."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_config(root, "tsconfig.json", {"@/*": ["ts_src/*"]})
+            _write_config(root, "jsconfig.json", {"@/*": ["js_src/*"]})
+            ts_target = root / "ts_src" / "mod.ts"
+            ts_target.parent.mkdir(parents=True)
+            ts_target.write_text("export const x = 1\n", encoding="utf-8")
+            js_target = root / "js_src" / "mod.js"
+            js_target.parent.mkdir(parents=True)
+            js_target.write_text("export const x = 1\n", encoding="utf-8")
+            importer = root / "main.ts"
+            importer.write_text("import { x } from '@/mod'\n", encoding="utf-8")
+
+            result = self.resolver.resolve_alias("@/mod", str(importer))
+            assert result is not None
+            assert Path(result) == ts_target.resolve()
+
+    def test_jsconfig_with_jsonc_comments_and_extends(self):
+        """jsconfig files support JSONC comments and relative extends chains."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "jsconfig.base.json").write_text(
+                '{\n'
+                '  // shared aliases\n'
+                '  "compilerOptions": {\n'
+                '    "baseUrl": ".",\n'
+                '    "paths": {"@/*": ["src/*"],}\n'
+                '  }\n'
+                '}\n',
+                encoding="utf-8",
+            )
+            (root / "jsconfig.json").write_text(
+                '{"extends": "./jsconfig.base.json", "compilerOptions": {}}\n',
+                encoding="utf-8",
+            )
+            target = root / "src" / "util.js"
+            target.parent.mkdir(parents=True)
+            target.write_text("export const u = 1\n", encoding="utf-8")
+            importer = root / "src" / "app.js"
+            importer.write_text("import { u } from '@/util'\n", encoding="utf-8")
+
+            result = self.resolver.resolve_alias("@/util", str(importer))
+            assert result is not None
+            assert Path(result) == target.resolve()


### PR DESCRIPTION
Fixes #776.

## Problem (reproduced on main)
On current main, built a temp project with jsconfig.json declaring {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}, a real target file src/composables/useThing.js, and an importer src/App.vue. TsconfigResolver().resolve_alias("@/composables/useThing", importer) returned None , the alias stayed unresolved because _TSCONFIG_NAMES in code_review_graph/tsconfig_resolver.py only contained tsconfig.json and tsconfig.app.json, matching the issue report (silent unresolved imports on jsconfig-only projects). After the fix the same call returns the resolved absolute path to useThing.js.

## Fix
Minimal fix exactly as the issue suggests: append "jsconfig.json" to _TSCONFIG_NAMES so the upward directory walk in _load_tsconfig_for_file also finds jsconfig.json. List order defines within-directory precedence, so tsconfig.json > tsconfig.app.json > jsconfig.json when multiple exist in one directory; the nearest directory containing any config still wins over configs higher up, matching editor/bundler behavior. Documented both precedence rules in a comment at the definition and updated the module docstring. Verified that no jsconfig-specific handling is needed elsewhere: jsconfig.json shares the tsconfig compilerOptions schema, the existing _resolve_extends handles relative "extends" chains (with .json suffix inference) identically for jsconfig files, the JSONC comment/trailing-comma stripping applies unchanged, and jsconfig's implicit compiler defaults (allowJs, checkJs, noEmit, etc.) do not affect the baseUrl/paths subset used for alias resolution , when baseUrl is absent, paths already resolve relative to the config file's directory, which is the correct behavior for both file types.

## Tests
Added TestJsconfigResolution in tests/test_tsconfig_resolver.py: test_jsconfig_only_project_resolves_alias (jsconfig-only Vue-style project resolves @/composables/useThing to the real file), test_tsconfig_wins_over_jsconfig_in_same_dir (both configs map @/* to different roots; tsconfig's target wins), test_jsconfig_with_jsonc_comments_and_extends (jsconfig with a relative extends chain, // comments, and a trailing comma resolves correctly). Written before the fix: test_jsconfig_only_project_resolves_alias and test_jsconfig_with_jsonc_comments_and_extends failed with 'assert None is not None' (resolver ignores jsconfig.json , the exact bug); the precedence test passes on main by construction (tsconfig already found first) and acts as a regression guard that the new list order never lets jsconfig shadow tsconfig. All 10 resolver tests pass after the fix. Note: test path assertions use .resolve() on expected paths because the resolver returns fully resolved paths (macOS /var -> /private/var symlink).

## Verification
Full suite: 2336 passed, 5 skipped, 2 xpassed in 43.49s. ruff: "All checks passed!" (code_review_graph/ plus the modified test file). mypy (uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional): "Success: no issues found in 70 source files"..
Independently re-verified by an adversarial review pass (revert-check of the new tests, call-site sweep of changed functions, edge-case probes) before this PR was opened.
