### PR TITLE
fix(visualize): consider edge count in auto-mode rendering switch (#609)

### DIFF
--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -8,7 +8,9 @@ Supports multiple rendering modes for large graphs:
 - ``full``  — render every node (default, current behavior)
 - ``community`` — aggregate by community; double-click to drill down
 - ``file``  — aggregate by file; each file is a node
-- ``auto``  — choose community mode when node count exceeds threshold
+- ``auto``  — choose an aggregated mode when the rendered node count or
+  edge count exceeds its threshold (community when community data exists,
+  file otherwise)
 """
 
 from __future__ import annotations
@@ -23,6 +25,17 @@ from pathlib import Path
 from .graph import GraphStore, edge_to_dict, node_to_dict
 
 logger = logging.getLogger(__name__)
+
+# Auto-mode thresholds for the full D3 force layout. Rendering cost scales
+# with both counts: every simulation tick runs an O(E) link force on top of
+# the O(N log N) many-body force, and the SVG DOM holds one element per node
+# *and* one per edge. The long-standing 3000-node cap implicitly tolerated
+# the ~3 edges per node typical of graphs at that size (~9000 rendered SVG
+# edge elements), so the edge cap is derived from the same rendering budget:
+# 3x the node cap. Issue #609 (2792 nodes / 17488 edges) stalled because
+# only nodes were checked.
+DEFAULT_MAX_FULL_NODES = 3000
+DEFAULT_MAX_FULL_EDGES = 3 * DEFAULT_MAX_FULL_NODES
 
 
 def _build_name_index(
@@ -357,11 +370,40 @@ def _aggregate_file(data: dict) -> dict:
     }
 
 
+def _has_community_data(data: dict) -> bool:
+    """Return True if the exported graph carries any community assignment."""
+    if data.get("communities"):
+        return True
+    return any(n.get("community_id") is not None for n in data["nodes"])
+
+
+def _resolve_auto_mode(
+    node_count: int,
+    edge_count: int,
+    max_full_nodes: int,
+    max_full_edges: int,
+    has_communities: bool,
+) -> str:
+    """Pick the effective rendering mode for ``mode="auto"``.
+
+    The full force layout is only viable while *both* rendered counts stay
+    within budget (see DEFAULT_MAX_FULL_NODES / DEFAULT_MAX_FULL_EDGES).
+    When aggregation is needed, prefer community mode; fall back to file
+    aggregation when no community data is available (otherwise every node
+    would collapse into a single "Uncategorized" super-node whose drill-down
+    re-renders the entire graph).
+    """
+    if node_count <= max_full_nodes and edge_count <= max_full_edges:
+        return "full"
+    return "community" if has_communities else "file"
+
+
 def generate_html(
     store: GraphStore,
     output_path: str | Path,
     mode: str = "auto",
-    max_full_nodes: int = 3000,
+    max_full_nodes: int = DEFAULT_MAX_FULL_NODES,
+    max_full_edges: int = DEFAULT_MAX_FULL_EDGES,
 ) -> Path:
     """Generate a self-contained interactive HTML visualization.
 
@@ -369,9 +411,12 @@ def generate_html(
         store: The GraphStore to read graph data from.
         output_path: Path for the output HTML file.
         mode: Rendering mode — ``"auto"``, ``"full"``, ``"community"``,
-              or ``"file"``.  ``"auto"`` switches to ``"community"`` when
-              the node count exceeds *max_full_nodes*.
-        max_full_nodes: Threshold for auto-switching to community mode.
+              or ``"file"``.  ``"auto"`` switches to an aggregated mode
+              (community, or file when no community data exists) when the
+              rendered node count exceeds *max_full_nodes* or the rendered
+              edge count exceeds *max_full_edges*.
+        max_full_nodes: Rendered-node threshold for auto-switching.
+        max_full_edges: Rendered-edge threshold for auto-switching.
 
     Writes the HTML file to *output_path* and returns the resolved Path.
     """
@@ -387,9 +432,20 @@ def generate_html(
     # Determine effective mode
     effective_mode = mode
     if effective_mode == "auto":
-        effective_mode = (
-            "community" if stats.total_nodes > max_full_nodes else "full"
+        effective_mode = _resolve_auto_mode(
+            node_count=len(data["nodes"]),
+            edge_count=len(data["edges"]),
+            max_full_nodes=max_full_nodes,
+            max_full_edges=max_full_edges,
+            has_communities=_has_community_data(data),
         )
+        if effective_mode != "full":
+            logger.info(
+                "auto mode: %d nodes / %d edges exceeds full-render budget "
+                "(%d nodes / %d edges) — using %s aggregation",
+                len(data["nodes"]), len(data["edges"]),
+                max_full_nodes, max_full_edges, effective_mode,
+            )
 
     if effective_mode == "community":
         # Keep full data available for drill-down; aggregate for top-level

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -681,6 +681,118 @@ def test_auto_mode_switches_at_threshold(large_store, tmp_path):
     assert "community_details" in content2
 
 
+def test_auto_mode_switches_on_edge_count(large_store, tmp_path):
+    """Auto mode must switch to an aggregated view when edges exceed the cap.
+
+    Regression for issue #609: node count under the limit but edge count
+    over it must not fall through to the full force-layout template.
+    """
+    from code_review_graph.visualization import generate_html
+
+    # Under both limits -> full template
+    output_full = tmp_path / "auto_under_both.html"
+    generate_html(
+        large_store, output_full, mode="auto",
+        max_full_nodes=100000, max_full_edges=100000,
+    )
+    content_full = output_full.read_text()
+    assert "btn-community" in content_full
+    assert "flow-select" in content_full
+
+    # Under the node limit but over the edge limit -> aggregated template
+    output_agg = tmp_path / "auto_over_edges.html"
+    generate_html(
+        large_store, output_agg, mode="auto",
+        max_full_nodes=100000, max_full_edges=1,
+    )
+    content_agg = output_agg.read_text()
+    assert "btn-back" in content_agg
+    assert "community_details" in content_agg
+
+
+def test_auto_mode_decision_at_issue_609_boundary():
+    """The reported 2792-node/17488-edge graph must pick an aggregated view.
+
+    Regression for issue #609 using the exact reported boundary against the
+    shipped defaults, without building a 17k-edge store.
+    """
+    from code_review_graph.visualization import (
+        DEFAULT_MAX_FULL_EDGES,
+        DEFAULT_MAX_FULL_NODES,
+        _resolve_auto_mode,
+    )
+
+    # Shipped defaults: node cap unchanged, edge cap derived from it
+    assert DEFAULT_MAX_FULL_NODES == 3000
+    assert DEFAULT_MAX_FULL_EDGES == 3 * DEFAULT_MAX_FULL_NODES
+
+    # A graph under both caps stays in full mode
+    assert _resolve_auto_mode(
+        node_count=2792, edge_count=8000,
+        max_full_nodes=DEFAULT_MAX_FULL_NODES,
+        max_full_edges=DEFAULT_MAX_FULL_EDGES,
+        has_communities=True,
+    ) == "full"
+
+    # The exact graph from issue #609: 2792 nodes (under), 17488 edges (over)
+    assert _resolve_auto_mode(
+        node_count=2792, edge_count=17488,
+        max_full_nodes=DEFAULT_MAX_FULL_NODES,
+        max_full_edges=DEFAULT_MAX_FULL_EDGES,
+        has_communities=True,
+    ) == "community"
+
+    # Node count over the cap still switches (pre-existing behavior)
+    assert _resolve_auto_mode(
+        node_count=3001, edge_count=100,
+        max_full_nodes=DEFAULT_MAX_FULL_NODES,
+        max_full_edges=DEFAULT_MAX_FULL_EDGES,
+        has_communities=True,
+    ) == "community"
+
+    # Without community data the aggregated view falls back to file mode
+    assert _resolve_auto_mode(
+        node_count=2792, edge_count=17488,
+        max_full_nodes=DEFAULT_MAX_FULL_NODES,
+        max_full_edges=DEFAULT_MAX_FULL_EDGES,
+        has_communities=False,
+    ) == "file"
+
+
+def test_generate_html_defaults_match_constants():
+    """generate_html defaults must stay wired to the documented constants."""
+    import inspect
+
+    from code_review_graph.visualization import (
+        DEFAULT_MAX_FULL_EDGES,
+        DEFAULT_MAX_FULL_NODES,
+        generate_html,
+    )
+
+    sig = inspect.signature(generate_html)
+    assert sig.parameters["max_full_nodes"].default == DEFAULT_MAX_FULL_NODES
+    assert sig.parameters["max_full_edges"].default == DEFAULT_MAX_FULL_EDGES
+
+
+def test_auto_mode_falls_back_to_file_without_communities(
+    store_with_data, tmp_path
+):
+    """Auto-switch without community data must aggregate by file, not lump
+    everything into a single 'Uncategorized' community super-node."""
+    from code_review_graph.visualization import generate_html
+
+    output_path = tmp_path / "auto_no_communities.html"
+    generate_html(
+        store_with_data, output_path, mode="auto",
+        max_full_nodes=1, max_full_edges=100000,
+    )
+    content = output_path.read_text()
+    # Aggregated template, file mode data
+    assert "btn-back" in content
+    assert '"mode": "file"' in content
+    assert '"mode": "community"' not in content
+
+
 def test_community_mode_html_generation(large_store, tmp_path):
     """Community mode generates valid HTML with aggregated data."""
     from code_review_graph.visualization import generate_html


### PR DESCRIPTION
Fixes #609.

## Problem (reproduced on main)
Built a synthetic GraphStore matching the exact reported boundary (349 files x 8 nodes = 2792 nodes; 2443 CONTAINS + 15045 random CALLS = 17488 edges) and called generate_html(store, out, mode="auto") on current main. Observed: export reported 2792 rendered nodes / 17488 rendered edges, and auto mode emitted the FULL force-layout template (markers btn-community/flow-select present), a 4.34 MB HTML embedding all 17488 edges , one SVG line element per edge plus an O(E) link force per simulation tick, the stall the maintainer validated. The decision at visualization.py:389-392 was `"community" if stats.total_nodes > max_full_nodes else "full"` , edges never consulted, and 2792 <= 3000 kept full mode. After the fix the same repro emits the aggregated template with "mode": "file" (the repro store has no community data), 1.38 MB, 349 top-level nodes.

## Fix
Minimal change confined to visualization.py. Added module constants DEFAULT_MAX_FULL_NODES = 3000 (unchanged) and DEFAULT_MAX_FULL_EDGES = 3 * DEFAULT_MAX_FULL_NODES = 9000, with an in-code comment deriving the edge cap from the same rendering-cost budget as the node cap: each force tick costs O(E) link force on top of O(N log N) many-body, and the SVG DOM holds one element per node and per edge; the long-standing 3000-node cap implicitly tolerated the ~3 edges/node typical at that size (~9000 rendered edges), so 3x the node cap keeps the same budget while staying conservative (17488 > 9000 switches; typical mid-size graphs do not). New helper _resolve_auto_mode(node_count, edge_count, max_full_nodes, max_full_edges, has_communities) returns "full" only when BOTH rendered counts are within budget; otherwise "community", falling back to "file" when no community data exists (_has_community_data checks the communities list and node-level community_id) , per the owner comment, since community aggregation without data collapses everything into one Uncategorized super-node whose drill-down re-renders the whole graph. generate_html gained max_full_edges (keyword with default, fully backward compatible; CLI passes only mode so defaults apply), uses rendered counts (len(data["nodes"])/len(data["edges"]) , the owner comment specifies "rendered edge count", and stats.total_edges includes unresolvable edges that are dropped before rendering), and logs an info line stating why auto switched. Explicit --mode full/community/file still bypasses the heuristic entirely.

## Tests
Four tests in tests/test_visualization.py, written before the fix and confirmed failing on unfixed code: test_auto_mode_switches_on_edge_count (end-to-end: under both limits -> full template; under node limit but over edge limit -> aggregated template; failed with TypeError: unexpected keyword argument 'max_full_edges'), test_auto_mode_decision_at_issue_609_boundary (asserts defaults 3000/9000 and the exact reported 2792-node/17488-edge graph resolves to an aggregated view, 2792/8000 stays full, 3001 nodes still switches, no-community case resolves to file; failed with ImportError: cannot import name 'DEFAULT_MAX_FULL_EDGES'), test_generate_html_defaults_match_constants (signature defaults wired to the constants; failed with ImportError), test_auto_mode_falls_back_to_file_without_communities (auto-switch on a store with no community data emits '"mode": "file"', not community; failed with TypeError). All 31 tests in the file pass after the fix.

## Verification
Full suite: 2337 passed, 5 skipped, 2 xpassed in 38.78s. ruff: "All checks passed!" (code_review_graph/ + tests/test_visualization.py); mypy: "Success: no issues found in 70 source files" (uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional).
Independently re-verified by an adversarial review pass (revert-check of the new tests, call-site sweep of changed functions, edge-case probes) before this PR was opened.
