### PR TITLE
fix(parser): store the hash of the bytes actually parsed (#746)

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2450,7 +2450,7 @@ class CodeParser:
             self._parsers[language] = parser
         return self._parsers[language]
 
-    def detect_language(self, path: Path) -> Optional[str]:
+    def detect_language(self, path: Path, source: Optional[bytes] = None) -> Optional[str]:
         """Map a file path to its language name.
 
         Extension-based lookup is tried first.  For extension-less files
@@ -2459,6 +2459,12 @@ class CodeParser:
         already have a known extension are never re-read — shebang probing
         only runs when the extension lookup returns ``None`` **and** the path
         has no suffix at all.  See issue #237.
+
+        When *source* is provided, the shebang is sniffed from those bytes
+        instead of re-reading the file.  Callers that hash-and-parse one byte
+        snapshot MUST pass it: a separate disk read can race a concurrent
+        save, mis-detect the language, and store a wrong parse under the
+        snapshot's hash (issue #746).
         """
         if path.name.lower().endswith(".blade.php"):
             return "blade"
@@ -2476,12 +2482,20 @@ class CodeParser:
         # and other extension-less text files also fall here, but the probe is a
         # cheap 256-byte read that returns None when no shebang is found.
         if suffix == "":
-            return self._detect_language_from_shebang(path)
+            head = source[:_SHEBANG_PROBE_BYTES] if source is not None else None
+            return self._detect_language_from_shebang(path, head)
         return None
 
     @staticmethod
-    def _detect_language_from_shebang(path: Path) -> Optional[str]:
+    def _detect_language_from_shebang(
+        path: Path,
+        head: Optional[bytes] = None,
+    ) -> Optional[str]:
         """Inspect the first line of ``path`` for a shebang interpreter.
+
+        When *head* is given it is used as the first bytes of the file and
+        the file is not read from disk (TOCTOU-safe for callers that already
+        hold the byte snapshot being parsed, see issue #746).
 
         Returns the mapped language name or ``None`` if the file has no
         shebang, is unreadable, or names an interpreter we don't map.
@@ -2498,11 +2512,12 @@ class CodeParser:
         endings are handled.  Binary files read as garbage bytes simply
         fail the ``#!`` prefix check and return ``None``.
         """
-        try:
-            with path.open("rb") as fh:
-                head = fh.read(_SHEBANG_PROBE_BYTES)
-        except (OSError, PermissionError):
-            return None
+        if head is None:
+            try:
+                with path.open("rb") as fh:
+                    head = fh.read(_SHEBANG_PROBE_BYTES)
+            except (OSError, PermissionError):
+                return None
         if not head.startswith(b"#!"):
             return None
 
@@ -2554,9 +2569,12 @@ class CodeParser:
         """Parse pre-read bytes and return extracted nodes and edges.
 
         This avoids re-reading the file from disk, eliminating TOCTOU gaps
-        when the caller has already read the bytes (e.g. for hashing).
+        when the caller has already read the bytes (e.g. for hashing): every
+        parse decision, including shebang language detection, derives from
+        *source* so the stored file hash always describes the bytes that were
+        actually parsed (issue #746).
         """
-        language = self.detect_language(path)
+        language = self.detect_language(path, source)
         if not language:
             return [], []
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,6 +1,9 @@
 """Tests for the incremental graph update module."""
 
+import hashlib
+import io
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch  # noqa: F401 – used in tests
 
 import pytest
@@ -845,6 +848,130 @@ class TestIncrementalUpdate:
             # File should have been removed from graph
             nodes = store.get_nodes_by_file(str(tmp_path / "old.py"))
             assert len(nodes) == 0
+        finally:
+            store.close()
+
+
+class TestRacingSaveSnapshotCoherence:
+    """Regression tests for #746: a file saved while it is being indexed.
+
+    Every parse-and-store path must be a pure function of one byte snapshot:
+    the stored ``file_hash`` is the hash of the bytes that were actually
+    parsed, and no parse decision may come from a second read of the file.
+    Otherwise a save racing the indexer can persist a partial (or empty)
+    parse under the final file hash, and the file is silently under-indexed
+    until it changes again.
+    """
+
+    def test_save_racing_parse_probe_does_not_wipe_extensionless_script(
+        self, tmp_path, monkeypatch,
+    ):
+        """A save racing the parse-stage shebang probe must not wipe an
+        extension-less script from the graph.
+
+        Timeline being simulated: the user edits ``tool`` (v1 -> v2); the
+        watcher hands the file to ``incremental_update``; the change filter
+        still sees the intact file, but by the time ``parse_bytes`` runs its
+        shebang probe an editor save (truncate+rewrite) has momentarily
+        emptied the file on disk; the save then completes with the same v2
+        bytes. Before the fix, the parse-stage probe re-read the empty disk
+        file, detected no language, and a complete v2 snapshot parsed to zero
+        nodes — leaving the graph silently missing the file while ``status``
+        reports it up to date.
+        """
+        script = tmp_path / "tool"
+        v1 = b"#!/usr/bin/env python3\n\ndef damaged():\n    return 0\n"
+        v2 = b"#!/usr/bin/env python3\n\ndef damaged_v2():\n    return 1\n"
+        script.write_bytes(v1)
+
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            incremental_update(
+                tmp_path, store, changed_files=["tool"], reconcile_stale=False,
+            )
+            names = {
+                n.name
+                for n in store.get_nodes_by_file(str(script))
+                if n.kind == "Function"
+            }
+            assert "damaged" in names
+
+            script.write_bytes(v2)  # the user's edit
+
+            # First probe (the change filter) sees the intact file; every
+            # later on-disk probe hits the mid-save empty window.
+            real_open = Path.open
+            probes = {"count": 0}
+
+            def racing_open(path_self, *args, **kwargs):
+                if path_self == script and args[:1] == ("rb",):
+                    probes["count"] += 1
+                    if probes["count"] >= 2:
+                        return io.BytesIO(b"")
+                return real_open(path_self, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "open", racing_open)
+            incremental_update(
+                tmp_path, store, changed_files=["tool"], reconcile_stale=False,
+            )
+            monkeypatch.undo()
+
+            nodes = store.get_nodes_by_file(str(script))
+            names = {n.name for n in nodes if n.kind == "Function"}
+            assert "damaged_v2" in names, (
+                "a save racing the parse-stage shebang probe wiped the "
+                "script from the graph"
+            )
+            # The stored hash is the hash of the bytes actually parsed,
+            # which here equal the final on-disk content.
+            assert nodes[0].file_hash == hashlib.sha256(v2).hexdigest()
+        finally:
+            store.close()
+
+    def test_mid_save_read_stores_hash_of_parsed_snapshot(
+        self, tmp_path, monkeypatch,
+    ):
+        """The serial incremental path must store the hash of the bytes it
+        actually parsed. When the parse-stage read races a save and captures a
+        partial file, the stored hash is the partial content's hash, so the
+        file still looks stale against the final on-disk bytes and the next
+        update repairs it.
+        """
+        py = tmp_path / "mod.py"
+        prefix = b"def full_one():\n    return 1\n"
+        final = prefix + b"\n\ndef full_two():\n    return 2\n"
+        py.write_bytes(final)
+
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            reads = {"count": 0}
+            real_read_bytes = Path.read_bytes
+
+            def mid_save_read(path_self):
+                if path_self == py:
+                    reads["count"] += 1
+                    if reads["count"] == 2:  # the parse-stage read
+                        return prefix
+                return real_read_bytes(path_self)
+
+            monkeypatch.setattr(Path, "read_bytes", mid_save_read)
+            incremental_update(tmp_path, store, changed_files=["mod.py"])
+            monkeypatch.undo()
+
+            nodes = store.get_nodes_by_file(str(py))
+            assert nodes, "racing read must not wipe the file from the graph"
+            names = {n.name for n in nodes if n.kind == "Function"}
+            assert names == {"full_one"}
+            stored_hash = nodes[0].file_hash
+            assert stored_hash == hashlib.sha256(prefix).hexdigest()
+            assert stored_hash != hashlib.sha256(final).hexdigest()
+
+            # The stale hash makes the next update re-index the file.
+            incremental_update(tmp_path, store, changed_files=["mod.py"])
+            nodes = store.get_nodes_by_file(str(py))
+            names = {n.name for n in nodes if n.kind == "Function"}
+            assert names == {"full_one", "full_two"}
+            assert nodes[0].file_hash == hashlib.sha256(final).hexdigest()
         finally:
             store.close()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -160,6 +160,44 @@ class TestCodeParser:
         for n in nodes:
             assert n.language == "bash"
 
+    def test_parse_bytes_shebang_language_from_snapshot_not_disk(self, tmp_path):
+        """Regression for #746: ``parse_bytes`` must derive the language from
+        the byte snapshot it was given, not from a re-read of the file.
+
+        Simulates a save racing the indexer: an editor's truncate+rewrite save
+        has just emptied the extension-less script on disk while the indexer
+        parses its complete snapshot. If the shebang probe re-reads the disk it
+        sees an empty file, detects no language, and a complete snapshot parses
+        to zero nodes — stored under the snapshot's (final) file hash.
+        """
+        p = self._write_shebang_file(
+            tmp_path, "tool",
+            "#!/usr/bin/env python3\n\ndef damaged():\n    return 1\n",
+        )
+        snapshot = p.read_bytes()
+        p.write_bytes(b"")  # the racing save has truncated the file
+
+        nodes, _ = self.parser.parse_bytes(p, snapshot)
+
+        func_names = {n.name for n in nodes if n.kind == "Function"}
+        assert "damaged" in func_names
+        for n in nodes:
+            assert n.language == "python"
+
+    def test_detect_language_uses_provided_source_over_disk(self, tmp_path):
+        """With pre-read source bytes, shebang detection must not touch disk."""
+        p = tmp_path / "tool"
+        p.write_bytes(b"")  # on-disk content is mid-save (empty)
+        source = b"#!/usr/bin/env python3\nprint(1)\n"
+        assert self.parser.detect_language(p, source) == "python"
+
+    def test_detect_language_without_source_still_probes_disk(self, tmp_path):
+        """Path-only callers (file filters) keep the on-disk shebang probe."""
+        p = self._write_shebang_file(
+            tmp_path, "runner", "#!/usr/bin/env bash\necho hi\n",
+        )
+        assert self.parser.detect_language(p) == "bash"
+
     def test_parse_python_file(self):
         nodes, edges = self.parser.parse_file(FIXTURES / "sample_python.py")
 


### PR DESCRIPTION
Fixes #746.

## Problem (reproduced on main)
First absorbed the issue thread: the owner validated at 9fed471 that both serial and pooled incremental paths read one byte snapshot, hash it, and parse the same bytes; the reporter then retracted (their surviving DB showed 0 files with matching-hash-but-short-node-count and recommended closing). I audited every parse-and-store path on current main (90d760a): full_build serial (incremental.py:1081-1084), full_build pooled via _parse_single_file (incremental.py:1037-1046), incremental_update serial (1262-1265), incremental_update pooled (1278-1292), watcher (delegates to incremental_update), daemon (spawns watch children), MCP build_or_update_graph (delegates to full_build/incremental_update), and the new forget.py referrer re-parse (142-145). All five store sites are coherent: sha256 is computed from the exact bytes passed to parse_bytes. However, the audit found one real instance of the reported bug class: parse_bytes(path, source) called detect_language(path), which for extension-less files re-reads the file from disk for shebang sniffing (parser.py:2502). Deterministic reproduction on main (scratch script, since removed): write an extension-less script '#!/usr/bin/env python3\\ndef damaged(): ...', capture its bytes, truncate the file on disk (simulating an editor's truncate+rewrite save in flight), then parse_bytes(script, snapshot). Observed: control parse yields [('File',...),('Function','damaged')]; racing parse of the SAME complete snapshot yields [] because the shebang probe read the empty disk file, while sha256(snapshot) equals the final on-disk hash (the save rewrites identical bytes). End-to-end via incremental_update this wipes the file's nodes from the graph while status reports it up to date. The reporter's TypeScript case (.ts files use pure extension-based detection) remains unreproduced, consistent with the thread's conclusion.

## Fix
Make every parse decision derive from the byte snapshot that gets hashed, so the stored file_hash always describes the bytes actually parsed. CodeParser.detect_language gains an optional source: bytes parameter; when provided and the path has no extension, the shebang is sniffed from source[:_SHEBANG_PROBE_BYTES] instead of re-reading disk (_detect_language_from_shebang now accepts a pre-read head). parse_bytes passes its snapshot through: language = self.detect_language(path, source). Path-only callers (the incremental change filter, watcher _parseable_file, stale reconciliation) keep the on-disk probe, which is safe because they store nothing; a racing save can only defer a file one round and the save-completion event or next git diff re-queues it. This is the minimal fix: no store-path signatures change, and it covers serial, pooled, watcher, daemon, and MCP paths at once since they all funnel through parse_bytes.

## Tests
tests/test_parser.py::TestCodeParser::test_parse_bytes_shebang_language_from_snapshot_not_disk (pre-fix failure: AssertionError: assert 'damaged' in set()); tests/test_parser.py::TestCodeParser::test_detect_language_uses_provided_source_over_disk (pre-fix failure: TypeError: CodeParser.detect_language() takes 2 positional arguments but 3 were given); tests/test_parser.py::TestCodeParser::test_detect_language_without_source_still_probes_disk (guards the path-only fallback; passed before and after); tests/test_incremental.py::TestRacingSaveSnapshotCoherence::test_save_racing_parse_probe_does_not_wipe_extensionless_script (end-to-end race simulation patching Path.open so the second on-disk probe sees an empty mid-save file; pre-fix failure: AssertionError: a save racing the parse-stage shebang probe wiped the script from the graph, assert 'damaged_v2' in set()); tests/test_incremental.py::TestRacingSaveSnapshotCoherence::test_mid_save_read_stores_hash_of_parsed_snapshot (the acceptance-criteria invariant test: patches Path.read_bytes to return partial content on the parse-stage read, asserts stored hash == sha256(partial parsed bytes) != on-disk hash, and that the next update re-indexes; passes before and after, pinning the already-coherent serial incremental path against regression). Failing-first output captured before implementing: 3 failed, 2 passed.

## Verification
Full suite: 2338 passed, 5 skipped, 2 xpassed in 36.49s. ruff (uv run ruff check code_review_graph/): All checks passed! mypy (uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional): Success: no issues found in 70 source files. Note: ruff on tests/test_parser.py reports 3 pre-existing findings (2x E501, 1x F841) that exist identically on main at shifted line numbers; the CI lint gate covers code_review_graph/ only and my test additions introduce no new findings..
Independently re-verified by an adversarial review pass (revert-check of the new tests, call-site sweep of changed functions, edge-case probes) before this PR was opened.
