### PR TITLE
fix(cli): report accurate languages and file count in status (#474)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1611,9 +1611,14 @@ class GraphStore:
         for row in self._conn.execute("SELECT kind, COUNT(*) as cnt FROM edges GROUP BY kind"):
             edges_by_kind[row["kind"]] = row["cnt"]
 
+        # Derive languages from the live File inventory, not from every node
+        # row: virtual or leftover rows without a backing File node (e.g. the
+        # synthetic Spring Event nodes) must not keep a language alive in
+        # `status` after its last real file left the graph (issue #474).
         languages = [
             r["language"] for r in self._conn.execute(
-                "SELECT DISTINCT language FROM nodes WHERE language IS NOT NULL AND language != ''"
+                "SELECT DISTINCT language FROM nodes WHERE kind = 'File' "
+                "AND language IS NOT NULL AND language != '' ORDER BY language"
             )
         ]
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1317,7 +1317,13 @@ def incremental_update(
         _run_rescript_resolver(store) if rescript_changed else None
     )
 
-    spring_changed = any(rp.endswith(".java") for rp in all_files)
+    # Like python_changed above, include stale/missing paths so a deletion
+    # that only surfaces through reconciliation still clears derived state
+    # (e.g. virtual Spring Event nodes — issue #474).
+    spring_changed = any(
+        path.endswith(".java")
+        for path in set(all_files) | set(stale_files) | missing_paths
+    )
     spring_stats = _run_spring_resolver(store) if spring_changed else None
     spring_event_stats = (
         _run_spring_event_resolver(store) if spring_changed else None

--- a/tests/test_status_stats.py
+++ b/tests/test_status_stats.py
@@ -1,0 +1,166 @@
+"""Regression tests for issue #474 — ``status`` must report the live graph.
+
+``get_stats()`` used to derive ``languages`` from every node row in the
+database.  Virtual rows that are not tied to a real indexed file (for
+example the Spring ``Event`` nodes emitted by the event resolver with the
+synthetic file path ``"event"``) could therefore keep a language alive in
+``code-review-graph status`` long after the last real file of that
+language left the graph.  These tests pin the contract: the file count and
+language list printed by ``status`` always match the files actually
+indexed in the graph — after a full build and after an incremental update
+that removes every file of one language.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from code_review_graph import cli
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build, incremental_update
+
+
+def _write_spring_event_trio(root: Path) -> Path:
+    """Create Java files that make the event resolver emit a virtual node."""
+    pkg = root / "alpha"
+    pkg.mkdir(parents=True)
+    (pkg / "SharedEvent.java").write_text(
+        "package alpha;\nclass SharedEvent {}\n", encoding="utf-8",
+    )
+    (pkg / "Publisher.java").write_text(
+        "package alpha;\n"
+        "class Publisher {\n"
+        "  void publish() { events.publishEvent(new SharedEvent()); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (pkg / "Listener.java").write_text(
+        "package alpha;\n"
+        "import org.springframework.context.event.EventListener;\n"
+        "class Listener {\n"
+        "  @EventListener\n"
+        "  void on(SharedEvent e) {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def _build_mixed_repo(tmp_path: Path) -> GraphStore:
+    _write_spring_event_trio(tmp_path)
+    (tmp_path / "main.py").write_text(
+        "def greet():\n    return 'hi'\n", encoding="utf-8",
+    )
+    db_dir = tmp_path / ".code-review-graph"
+    db_dir.mkdir()
+    store = GraphStore(db_dir / "graph.db")
+    full_build(tmp_path, store)
+    return store
+
+
+def _live_file_inventory(store: GraphStore) -> tuple[int, list[str]]:
+    """File count and language list straight from the File rows in SQLite."""
+    files = store._conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE kind = 'File'"
+    ).fetchone()[0]
+    languages = [
+        row[0]
+        for row in store._conn.execute(
+            "SELECT DISTINCT language FROM nodes WHERE kind = 'File' "
+            "AND language IS NOT NULL AND language != '' ORDER BY language"
+        )
+    ]
+    return files, languages
+
+
+class TestStatusMatchesLiveGraph:
+    def test_stats_match_db_contents_after_build(self, tmp_path: Path) -> None:
+        store = _build_mixed_repo(tmp_path)
+        try:
+            stats = store.get_stats()
+            db_files, db_languages = _live_file_inventory(store)
+
+            assert stats.files_count == db_files == 4
+            assert sorted(stats.languages) == db_languages == ["java", "python"]
+        finally:
+            store.close()
+
+    def test_update_removing_language_drops_it_from_stats(
+        self, tmp_path: Path,
+    ) -> None:
+        """An update that removes every Java file must drop 'java'.
+
+        The deletion is surfaced through stale-file reconciliation (empty
+        ``changed_files``), the path a plain git diff does not cover — for
+        example when files become ignored or the diff base is unavailable.
+        On the buggy code the virtual Event node (file_path='event',
+        language='java') survived and kept 'java' in the status output.
+        """
+        store = _build_mixed_repo(tmp_path)
+        try:
+            assert "java" in store.get_stats().languages
+
+            pkg = tmp_path / "alpha"
+            for java_file in pkg.glob("*.java"):
+                java_file.unlink()
+            pkg.rmdir()
+
+            result = incremental_update(tmp_path, store, changed_files=[])
+            assert result["stale_files_removed"] == 3
+
+            stats = store.get_stats()
+            db_files, db_languages = _live_file_inventory(store)
+
+            assert stats.files_count == db_files == 1
+            assert sorted(stats.languages) == db_languages == ["python"]
+            assert "java" not in stats.languages
+
+            # The stale virtual Event row must be gone from the graph too.
+            stale = store._conn.execute(
+                "SELECT COUNT(*) FROM nodes WHERE kind = 'Event'"
+            ).fetchone()[0]
+            assert stale == 0
+        finally:
+            store.close()
+
+    def test_stats_ignore_rows_not_backed_by_file_nodes(
+        self, tmp_path: Path,
+    ) -> None:
+        """Historical/virtual rows without a File node must not leak."""
+        store = _build_mixed_repo(tmp_path)
+        try:
+            # Simulate a leftover row from an old build: a node whose file
+            # was removed from the graph without its row being cleaned up.
+            store._conn.execute(
+                "INSERT INTO nodes (kind, name, qualified_name, file_path,"
+                " language, updated_at) VALUES ('Function', 'old_sub',"
+                " 'legacy.pl::old_sub', '/gone/legacy.pl', 'perl', 0)"
+            )
+            store.commit()
+
+            stats = store.get_stats()
+            assert sorted(stats.languages) == ["java", "python"]
+            assert "perl" not in stats.languages
+        finally:
+            store.close()
+
+
+class TestStatusCli:
+    def test_status_json_reports_live_files_and_sorted_languages(
+        self, tmp_path: Path, capsys,
+    ) -> None:
+        store = _build_mixed_repo(tmp_path)
+        store.close()
+
+        argv = [
+            "code-review-graph", "status", "--repo", str(tmp_path), "--json",
+        ]
+        with patch.object(sys, "argv", argv):
+            cli.main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["files"] == 4
+        assert payload["languages"] == ["java", "python"]


### PR DESCRIPTION
Fixes #474.

## Problem (reproduced on main)
gh issue view 474 --comments: user reports status showing Files: 8 and Languages: perl, cpp on a mostly Python/shell project; owner could not reproduce the trivial case and asked for environment details. Locally on current main: (a) built a small git fixture (main.py, util.sh, legacy.pl) , build/status/update via CLI were all correct through the git-diff path, confirming the owner's finding. (b) Built the full repo graph and compared status against the DB with sqlite3 , consistent, but build reported 258 files vs 239 File nodes (files parsing to zero nodes). (c) Found the reproducible defect: a repo with Java Spring event publisher/listener plus main.py; full_build → status languages ['java','python'] (correct); deleted all .java files and ran incremental_update(changed_files=[]) so the deletion surfaces via stale-file reconciliation (the path git diff does not cover, e.g. newly-ignored files or unavailable diff base) → update removed 3 stale files, files_count=1, but status still reported languages ['java','python'], with sqlite3 showing the surviving row: kind=Event, name=alpha.SharedEvent, file_path='event', language='java'. Also confirmed: an orphan node row without a backing File node (INSERT of a perl Function at a nonexistent path) leaked 'perl' into status, and the language list order was nondeterministic (insertion order, no ORDER BY).

## Fix
Two-part minimal fix. (1) graph.py get_stats(): derive the languages list from live File rows only , SELECT DISTINCT language FROM nodes WHERE kind = 'File' AND language IS NOT NULL AND language != '' ORDER BY language , instead of scanning every node row. This guarantees the status language list and file count describe the same live indexed-file inventory, immune to virtual rows (Spring Event nodes with file_path='event'), resolver leftovers, or historical orphan rows, and makes output order deterministic. files_count (COUNT of kind='File') was already live and is unchanged. (2) incremental.py incremental_update(): the spring_changed check (which gates the Spring DI, Spring event, and Temporal resolver reruns) now includes stale_files and missing_paths, exactly mirroring the existing python_changed check two lines above, so when .java files leave the graph via stale reconciliation the event resolver reruns and clears its virtual Event nodes at the source instead of leaving them in the DB. Chose File-row derivation over only fixing the resolver gap because it makes status structurally unable to report a language with zero indexed files, which is the contract the issue expects.

## Tests
tests/test_status_stats.py , TestStatusMatchesLiveGraph::test_stats_match_db_contents_after_build, TestStatusMatchesLiveGraph::test_update_removing_language_drops_it_from_stats, TestStatusMatchesLiveGraph::test_stats_ignore_rows_not_backed_by_file_nodes, TestStatusCli::test_status_json_reports_live_files_and_sorted_languages. Proof they fail without the fix (run on main before implementing): 3 failed, 1 passed , test_update_removing_language_drops_it_from_stats failed with assert ['java', 'python'] == ['python'] (stale java from the virtual Event row), test_stats_ignore_rows_not_backed_by_file_nodes failed with assert ['java', 'perl', 'python'] == ['java', 'python'] (orphan row leaked), test_status_json_reports_live_files_and_sorted_languages failed with assert ['python', 'java'] == ['java', 'python'] (nondeterministic order). The build-only consistency test passed on main by design (that flow was already correct). All 4 pass with the fix.

## Verification
Full suite: 2337 passed, 5 skipped, 2 xpassed in 31.30s. ruff: All checks passed! | mypy: Success: no issues found in 70 source files.
Independently re-verified by an adversarial review pass (revert-check of the new tests, call-site sweep of changed functions, edge-case probes) before this PR was opened.
