### PR TITLE
fix(graph): expand C# namespace imports in impact and test resolution (#310, #792)

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1010,6 +1010,37 @@ class GraphStore:
                     if isinstance(candidate, str)
                 )
 
+        # C# `using X.Y;` directives store IMPORTS_FROM targets as raw
+        # namespace strings rather than file paths, so the path-keyed
+        # evidence above never matches a candidate's defining file. Map
+        # declared namespaces back to the files declaring them and add
+        # those files as import evidence. See: #310, #792
+        namespace_files: dict[str, set[str]] = {}
+        for row in conn.execute(
+            "SELECT file_path, extra FROM nodes "
+            "WHERE kind = 'File' AND extra LIKE '%\"csharp_namespaces\"%'"
+        ).fetchall():
+            try:
+                node_extra = json.loads(row["extra"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(node_extra, dict):
+                continue
+            declared = node_extra.get("csharp_namespaces")
+            if not isinstance(declared, list):
+                continue
+            for ns in declared:
+                if isinstance(ns, str) and ns:
+                    namespace_files.setdefault(ns, set()).add(
+                        row["file_path"],
+                    )
+        if namespace_files:
+            for imported in import_targets.values():
+                expanded: set[str] = set()
+                for target in imported:
+                    expanded |= namespace_files.get(target, set())
+                imported |= expanded
+
         resolved = 0
         changed = False
         for edge in bare_edges:
@@ -1239,6 +1270,27 @@ class GraphStore:
 
     # --- Impact / Graph traversal ---
 
+    def _impact_seed_qns(self, changed_files: list[str]) -> set[str]:
+        """Seed qualified names for the impact traversal.
+
+        Includes every node in the changed files plus, for changed C#
+        files, the namespaces they declare. C# ``using X.Y;`` directives
+        store IMPORTS_FROM targets as raw namespace strings rather than
+        file paths, so without these bridge seeds the traversal can never
+        reach importers of a changed .cs file. The namespace strings have
+        no node rows, so they act purely as bridges and never surface in
+        results. See: #310
+        """
+        seeds: set[str] = set()
+        for f in changed_files:
+            for n in self.get_nodes_by_file(f):
+                seeds.add(n.qualified_name)
+                if n.kind == "File" and n.language == "csharp":
+                    for ns in n.extra.get("csharp_namespaces") or []:
+                        if isinstance(ns, str) and ns:
+                            seeds.add(ns)
+        return seeds
+
     def get_impact_radius(
         self,
         changed_files: list[str],
@@ -1298,11 +1350,7 @@ class GraphStore:
             }
 
         # Seed qualified names
-        seeds: set[str] = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
-            for n in nodes:
-                seeds.add(n.qualified_name)
+        seeds = self._impact_seed_qns(changed_files)
 
         if not seeds:
             return {
@@ -1501,11 +1549,7 @@ class GraphStore:
         max_nodes = max(0, int(max_nodes))
         nxg = self._build_networkx_graph()
 
-        seeds: set[str] = set()
-        for f in changed_files:
-            nodes = self.get_nodes_by_file(f)
-            for n in nodes:
-                seeds.add(n.qualified_name)
+        seeds = self._impact_seed_qns(changed_files)
 
         best: dict[str, float] = dict.fromkeys(seeds, 1.0)
         frontier = dict(best)

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -673,6 +673,177 @@ class TestCSharpNamespaceResolution:
         ]
 
 
+@pytest.mark.skipif(
+    not _has_csharp_parser(), reason="csharp tree-sitter grammar not installed",
+)
+class TestCSharpNamespaceImpactAndCoverage:
+    """End-to-end regression tests for #310 / #792.
+
+    C# ``using X.Y;`` directives produce IMPORTS_FROM edges targeting the
+    raw namespace string, never a file path. PR #353 added a namespace
+    fallback for ``importers_of`` only, leaving:
+
+    - ``get_impact_radius`` returning 0 impacted files/nodes for changed
+      .cs files (the impact traversal had no namespace expansion), and
+    - ``tests_for`` / the ``detect_changes`` test-gap detector reporting
+      covered C# code as untested (``_resolve_bare_endpoints`` only accepts
+      file-path import evidence C# never emits).
+    """
+
+    def _build(self, tmp_path):
+        from code_review_graph.graph import GraphStore
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".code-review-graph").mkdir()
+        core = tmp_path / "Core.cs"
+        core.write_text(
+            "namespace ACME.Core;\n"
+            "public class TaskBoard {\n"
+            "    public int CountTasks() { return 0; }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        app = tmp_path / "App.cs"
+        app.write_text(
+            "using ACME.Core;\n"
+            "namespace ACME.App;\n"
+            "public class App {\n"
+            "    public void Run() {\n"
+            "        var b = new TaskBoard();\n"
+            "        b.CountTasks();\n"
+            "    }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        # NUnit-style test whose name does NOT match any naming convention
+        # (no Test prefix on the method), so coverage must come from the
+        # resolved TESTED_BY edge rather than the name-based fallback.
+        tests = tmp_path / "TaskBoardTests.cs"
+        tests.write_text(
+            "using NUnit.Framework;\n"
+            "using ACME.Core;\n"
+            "namespace ACME.Core.Tests;\n"
+            "[TestFixture]\n"
+            "public class TaskBoardTests {\n"
+            "    [Test]\n"
+            "    public void CountTasks_ReturnsZero() {\n"
+            "        var board = new TaskBoard();\n"
+            "        var n = board.CountTasks();\n"
+            "    }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        unrelated = tmp_path / "Unrelated.cs"
+        unrelated.write_text(
+            "using System.Linq;\n"
+            "namespace ACME.Other;\n"
+            "public class Other {}\n",
+            encoding="utf-8",
+        )
+
+        store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+        parser = CodeParser()
+        for path in (core, app, tests, unrelated):
+            nodes, edges = parser.parse_file(path)
+            for n in nodes:
+                store.upsert_node(n)
+            for e in edges:
+                store.upsert_edge(e)
+        store.commit()
+        # Same bare-endpoint resolution the build/postprocess pipeline runs.
+        store.resolve_bare_call_targets()
+        store.resolve_bare_tested_by_sources()
+        return store, core, app, tests, unrelated
+
+    def test_impact_radius_sql_reaches_csharp_importers(self, tmp_path):
+        store, core, app, tests, unrelated = self._build(tmp_path)
+        try:
+            impact = store.get_impact_radius_sql([str(core)])
+            assert str(app) in impact["impacted_files"]
+            assert str(tests) in impact["impacted_files"]
+            assert str(unrelated) not in impact["impacted_files"]
+            assert impact["total_impacted"] > 0
+            # The namespace string itself must never surface as a node.
+            impacted_qns = {n.qualified_name for n in impact["impacted_nodes"]}
+            assert "ACME.Core" not in impacted_qns
+        finally:
+            store.close()
+
+    def test_impact_radius_networkx_reaches_csharp_importers(self, tmp_path):
+        store, core, app, tests, unrelated = self._build(tmp_path)
+        try:
+            impact = store._get_impact_radius_networkx([str(core)])
+            assert str(app) in impact["impacted_files"]
+            assert str(tests) in impact["impacted_files"]
+            assert str(unrelated) not in impact["impacted_files"]
+            impacted_qns = {n.qualified_name for n in impact["impacted_nodes"]}
+            assert "ACME.Core" not in impacted_qns
+        finally:
+            store.close()
+
+    def test_importer_appears_in_both_importers_of_and_impact(self, tmp_path):
+        """Owner acceptance for #310: the same importer must appear in both
+        ``importers_of`` and the public ``get_impact_radius`` results."""
+        from code_review_graph.tools.query import query_graph
+
+        store, core, app, _tests, _unrelated = self._build(tmp_path)
+        try:
+            result = query_graph(
+                "importers_of", str(core), repo_root=str(tmp_path),
+            )
+            assert result.get("status") == "ok"
+            importers = {r["file"] for r in result.get("results", [])}
+            assert str(app) in importers
+
+            impact = store.get_impact_radius([str(core)])
+            assert str(app) in impact["impacted_files"]
+        finally:
+            store.close()
+
+    def test_bare_tested_by_source_resolves_via_namespace_evidence(self, tmp_path):
+        store, core, _app, tests, _unrelated = self._build(tmp_path)
+        try:
+            method_qn = f"{core}::TaskBoard.CountTasks"
+            test_qn = f"{tests}::TaskBoardTests.CountTasks_ReturnsZero"
+            tested_by = [
+                e for e in store.get_edges_by_source(method_qn)
+                if e.kind == "TESTED_BY"
+            ]
+            assert [e.target_qualified for e in tested_by] == [test_qn]
+        finally:
+            store.close()
+
+    def test_tests_for_finds_csharp_test_via_edge(self, tmp_path):
+        from code_review_graph.tools.query import query_graph
+
+        store, core, _app, tests, _unrelated = self._build(tmp_path)
+        store.close()
+        result = query_graph(
+            "tests_for",
+            f"{core}::TaskBoard.CountTasks",
+            repo_root=str(tmp_path),
+        )
+        assert result.get("status") == "ok"
+        found = {
+            r["qualified_name"]: r for r in result.get("results", [])
+        }
+        test_qn = f"{tests}::TaskBoardTests.CountTasks_ReturnsZero"
+        assert test_qn in found
+        # Must come from the resolved TESTED_BY edge, not name matching.
+        assert found[test_qn].get("inferred_by") != "naming_convention"
+
+    def test_detect_changes_does_not_report_covered_method_untested(self, tmp_path):
+        from code_review_graph.changes import analyze_changes
+
+        store, core, _app, _tests, _unrelated = self._build(tmp_path)
+        try:
+            result = analyze_changes(store, [str(core)])
+            gap_names = {g["name"] for g in result["test_gaps"]}
+            assert "CountTasks" not in gap_names
+        finally:
+            store.close()
+
+
 class TestRubyParsing:
     def setup_method(self):
         self.parser = CodeParser()


### PR DESCRIPTION
Fixes #310. Fixes #792.

## Problem (reproduced on main)
Built a 3-file C# graph on current main (Core.cs declaring namespace ACME.Core with TaskBoard.CountTasks; App.cs with `using ACME.Core` calling CountTasks; TaskBoardTests.cs NUnit-style test calling CountTasks), upserted via CodeParser + GraphStore, then ran the postprocess bare-endpoint resolution. Observed: (1) importers_of Core.cs correctly returned App.cs and TaskBoardTests.cs (PR #353's fallback works); (2) get_impact_radius([Core.cs]) returned impacted_files=[] and impacted_nodes=[] , the stored IMPORTS_FROM edges target the raw string "ACME.Core" and neither impact engine can traverse them; (3) resolve_bare_call_targets/resolve_bare_tested_by_sources resolved 0 edges , _resolve_bare_endpoints builds import evidence by treating IMPORTS_FROM targets as file paths, which C# never emits, so the TESTED_BY edge source stayed the bare string "CountTasks"; (4) tests_for via get_transitive_tests found nothing edge-based, and analyze_changes reported "Untested: TaskBoard, CountTasks" (2 test gaps) despite direct test coverage. This matches the owner's revalidation comment on #310 and the mechanism in #792 exactly.

## Fix
Two minimal changes in code_review_graph/graph.py, both keyed off the csharp_namespaces metadata that File nodes already carry (added by PR #353). (a) Impact traversal: extracted the duplicated seed loop from get_impact_radius_sql and _get_impact_radius_networkx into a shared _impact_seed_qns() helper that, for changed C# File nodes, also seeds the file's declared namespace strings. IMPORTS_FROM has incoming direction, so a namespace seed bridges straight to every file with a `using` edge targeting it. Namespace strings have no node rows, so both engines' result selection (SQL joins the nodes table; networkx batch-fetches nodes) filters them out automatically , they act purely as ghost bridges, mirroring the engine's existing documented ghost-endpoint behavior. (b) Bare-endpoint evidence: in _resolve_bare_endpoints, after building the path-keyed import_targets map, build a namespace->declaring-files map from File nodes whose extra contains csharp_namespaces (parameterized query + json.loads, cheap LIKE pre-filter) and expand any import target that names a declared namespace into the files declaring it. This gives bare CALLS targets and TESTED_BY sources the same import evidence other languages get, so the existing single-candidate resolution logic (including its conservative ambiguous-candidate handling when multiple files declare the same namespace) works unchanged for C#. tests_for and the detect_changes test-gap detector both read resolved TESTED_BY edges, so they need no changes of their own. This is the query/postprocess-side design the owner asked for: canonical namespace/file relationships usable by both query and traversal, without a parser or schema change.

## Tests
tests/test_multilang.py::TestCSharpNamespaceImpactAndCoverage , 6 tests on a 4-file C# fixture (namespace declarer, using-consumer, NUnit-style test file whose method name defeats the naming-convention fallback, and an unrelated file): test_impact_radius_sql_reaches_csharp_importers, test_impact_radius_networkx_reaches_csharp_importers, test_importer_appears_in_both_importers_of_and_impact (owner's #310 acceptance: same importer in importers_of AND public get_impact_radius), test_bare_tested_by_source_resolves_via_namespace_evidence, test_tests_for_finds_csharp_test_via_edge (asserts inferred_by != naming_convention), test_detect_changes_does_not_report_covered_method_untested. Proof of failure without the fix: run before implementing, all 6 failed , impact engines returned empty impacted_files, TESTED_BY lookup by qualified source returned [], tests_for returned {}, and detect_changes gaps contained CountTasks ("6 failed in 1.04s", failures at the exact asserts listed). All 6 pass after the fix.

## Verification
Full suite: 2339 passed, 5 skipped, 2 xpassed in 44.26s. ruff: "All checks passed!" (code_review_graph/ + tests/test_multilang.py). mypy (uv run --with mypy mypy code_review_graph/ --ignore-missing-imports --no-strict-optional): "Success: no issues found in 70 source files".
Independently re-verified by an adversarial review pass (revert-check of the new tests, call-site sweep of changed functions, edge-case probes) before this PR was opened.
