### PR TITLE
fix(windows): POSIX-stable qualified names and file paths (#774)

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -16,6 +16,7 @@ from typing import Any
 from .constants import SECURITY_KEYWORDS as _SECURITY_KEYWORDS
 from .flows import get_affected_flows
 from .graph import GraphNode, GraphStore, _sanitize_name, node_to_dict
+from .parser import normalize_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -415,7 +416,7 @@ def analyze_changes(
         # remaps before calling, and remapping twice would corrupt keys.
         root_path = Path(repo_root)
         changed_ranges = {
-            str(root_path / key): ranges
+            normalize_file_path(root_path / key): ranges
             for key, ranges in parse_diff_ranges(repo_root, base).items()
         }
 
@@ -448,7 +449,7 @@ def analyze_changes(
         root_path = Path(repo_root)
         for key, count in compute_file_churn(repo_root).items():
             churn_counts[key] = count
-            churn_counts[str(root_path / key)] = count
+            churn_counts[normalize_file_path(root_path / key)] = count
 
     # Compute per-node risk scores.
     node_risks: list[dict[str, Any]] = []

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 from .constants import SECURITY_KEYWORDS as _SECURITY_KEYWORDS
 from .graph import FlowAdjacency, GraphNode, GraphStore, _sanitize_name
+from .parser import normalize_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -475,6 +476,9 @@ def incremental_trace_flows(
     if not changed_files:
         return 0
 
+    # Graph identity uses POSIX separators (#774); bridge native-separator
+    # caller paths before matching against stored file_path values.
+    changed_files = [normalize_file_path(p) for p in changed_files]
     conn = store._conn
     changed_file_set = set(changed_files)
 

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -35,7 +35,7 @@ from .constants import (
     MAX_IMPACT_NODES,
 )
 from .migrations import get_schema_version, run_migrations
-from .parser import EdgeInfo, NodeInfo
+from .parser import EdgeInfo, NodeInfo, normalize_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -285,6 +285,7 @@ class GraphStore:
 
     def remove_file_data(self, file_path: str) -> None:
         """Remove all nodes and edges associated with a file."""
+        file_path = normalize_file_path(file_path)
         self._conn.execute("DELETE FROM nodes WHERE file_path = ?", (file_path,))
         self._conn.execute("DELETE FROM edges WHERE file_path = ?", (file_path,))
         self._invalidate_cache()
@@ -295,6 +296,7 @@ class GraphStore:
 
     def remove_files_permanently(self, file_paths: list[str]) -> int:
         """Atomically remove deleted files and graph references to their nodes."""
+        file_paths = [normalize_file_path(p) for p in file_paths]
         changed = 0
         has_embeddings = self._conn.execute(
             "SELECT 1 FROM sqlite_master "
@@ -418,7 +420,7 @@ class GraphStore:
     def iter_nodes_by_file(self, file_path: str) -> Iterator[GraphNode]:
         """Yield file nodes without first materializing the complete row set."""
         rows = self._conn.execute(
-            "SELECT * FROM nodes WHERE file_path = ?", (file_path,)
+            "SELECT * FROM nodes WHERE file_path = ?", (normalize_file_path(file_path),)
         )
         for row in rows:
             yield self._row_to_node(row)
@@ -1772,7 +1774,7 @@ class GraphStore:
         rows = self._conn.execute(
             "SELECT DISTINCT file_path FROM nodes "
             "WHERE file_path LIKE ?",
-            (f"%{pattern}",),
+            (f"%{normalize_file_path(pattern)}",),
         ).fetchall()
         return [r["file_path"] for r in rows]
 
@@ -1816,6 +1818,7 @@ class GraphStore:
         """Return node IDs belonging to the given file paths."""
         if not file_paths:
             return set()
+        file_paths = [normalize_file_path(p) for p in file_paths]
         result: set[int] = set()
         batch_size = 450
         for i in range(0, len(file_paths), batch_size):

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -54,6 +54,19 @@ def _compatible_edge_languages(language: str) -> tuple[str, ...]:
     return (language,)
 
 
+def _bridge_qualified_name(qualified_name: str) -> str:
+    """Return *qualified_name* with its file-path component POSIX-normalized.
+
+    Qualified names embed the file path before the first ``::`` (File nodes
+    are just the path). Stored identities always use forward slashes (#774),
+    so a Windows-native spelling must be bridged to find the POSIX-keyed row.
+    Only the path component is rewritten — the symbol part may legitimately
+    contain backslashes (PHP fully-qualified names).
+    """
+    path_part, sep, symbol_part = qualified_name.partition("::")
+    return normalize_file_path(path_part) + sep + symbol_part
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -412,6 +425,14 @@ class GraphStore:
         row = self._conn.execute(
             "SELECT * FROM nodes WHERE qualified_name = ?", (qualified_name,)
         ).fetchone()
+        if row is None:
+            # Bridge Windows-native path spellings to the stored POSIX
+            # identity (#774), mirroring the file-keyed lookups above.
+            bridged = _bridge_qualified_name(qualified_name)
+            if bridged != qualified_name:
+                row = self._conn.execute(
+                    "SELECT * FROM nodes WHERE qualified_name = ?", (bridged,)
+                ).fetchone()
         return self._row_to_node(row) if row else None
 
     def get_nodes_by_file(self, file_path: str) -> list[GraphNode]:

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -20,7 +20,7 @@ from pathlib import Path, PurePosixPath
 from typing import Callable, Optional
 
 from .graph import GraphStore
-from .parser import CodeParser
+from .parser import CodeParser, normalize_file_path
 
 _MAX_PARSE_WORKERS = int(os.environ.get("CRG_PARSE_WORKERS", str(min(os.cpu_count() or 4, 8))))
 
@@ -914,7 +914,9 @@ def _reconcile_stale_files(
     stored_files = set(store.get_all_files())
     current_paths: set[str]
     if current_files is not None:
-        current_paths = {str(repo_root / file_path) for file_path in current_files}
+        current_paths = {
+            normalize_file_path(repo_root / file_path) for file_path in current_files
+        }
     else:
         ignore_patterns = _load_ignore_patterns(repo_root)
         parser = CodeParser(repo_root)
@@ -1210,7 +1212,7 @@ def incremental_update(
     # Find dependent files (files that import from changed files)
     dependent_files: set[str] = set()
     for rel_path in changed_files:
-        full_path = str(repo_root / rel_path)
+        full_path = normalize_file_path(repo_root / rel_path)
         deps = find_dependents(store, full_path)
         for d in deps:
             # Convert back to relative path if needed
@@ -1234,8 +1236,8 @@ def incremental_update(
             continue
         abs_path = repo_root / rel_path
         if not abs_path.is_file():
-            if str(abs_path) not in stale_files:
-                missing_paths.add(str(abs_path))
+            if normalize_file_path(abs_path) not in stale_files:
+                missing_paths.add(normalize_file_path(abs_path))
             continue
         if parser.detect_language(abs_path) is None:
             continue
@@ -1420,7 +1422,8 @@ def _create_watch_handler(
             return str(relative)
 
         def _stored_descendants(self, relative_directory: str) -> set[str]:
-            directory = str(repo_root / relative_directory) + os.sep
+            # Stored file paths use POSIX separators (#774).
+            directory = normalize_file_path(repo_root / relative_directory) + "/"
             return {
                 str(Path(file_path).relative_to(repo_root))
                 for file_path in store.get_all_files()

--- a/code_review_graph/jedi_resolver.py
+++ b/code_review_graph/jedi_resolver.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from .parser import CodeParser, EdgeInfo
+from .parser import CodeParser, EdgeInfo, normalize_file_path
 from .parser import _is_test_file as _parser_is_test_file
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,7 @@ def enrich_jedi_calls(store, repo_root: Path) -> dict:
                 continue
 
             # Build qualified target: file_path::Class.method or file_path::func
-            target_file = str(module_path)
+            target_file = normalize_file_path(module_path)
             parent = name.parent()
             if parent and parent.type == "class":
                 target = f"{target_file}::{parent.name}.{name.name}"

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -20,7 +20,7 @@ import sys
 import threading
 from dataclasses import dataclass, field
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, NamedTuple, Optional
 
 try:
@@ -647,6 +647,23 @@ def _read_php_composer_psr4(
 # ---------------------------------------------------------------------------
 
 
+def normalize_file_path(path: "str | PurePath") -> str:
+    """Return *path* as a forward-slash (POSIX) string for graph identity.
+
+    ``file_path`` values and the path component of qualified names are graph
+    identity: they must be separator-stable across operating systems so a
+    graph built on Windows produces the same identifiers as one built on
+    Linux/macOS, and so consumers that reconstruct identifiers from ``Path``
+    objects always agree with the parser. See issue #774.
+
+    Only apply this to file *paths* — never to symbol names: PHP namespace
+    identifiers (``App\\Domain\\Job``) legitimately contain backslashes.
+    """
+    if isinstance(path, PurePath):
+        return path.as_posix()
+    return str(path).replace("\\", "/")
+
+
 @dataclass
 class NodeInfo:
     kind: str  # File, Class, Function, Type, Test
@@ -663,6 +680,13 @@ class NodeInfo:
     extra: dict = field(default_factory=dict)
     identity_name: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        # Identity invariant (#774): file paths always use POSIX separators.
+        # File nodes carry their path in ``name`` as well.
+        self.file_path = normalize_file_path(self.file_path)
+        if self.kind == "File":
+            self.name = normalize_file_path(self.name)
+
 
 @dataclass
 class EdgeInfo:
@@ -674,6 +698,12 @@ class EdgeInfo:
     file_path: str
     line: int = 0
     extra: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Identity invariant (#774): file paths always use POSIX separators.
+        # ``source``/``target`` are left alone — they may contain qualified
+        # names whose symbol part legitimately embeds backslashes (PHP FQNs).
+        self.file_path = normalize_file_path(self.file_path)
 
 
 # ---------------------------------------------------------------------------
@@ -2655,7 +2685,7 @@ class CodeParser:
             tree = parser.parse(parse_source)
         nodes: list[NodeInfo] = []
         edges: list[EdgeInfo] = []
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
 
         # File node
         test_file = _is_test_file(file_path_str)
@@ -2893,7 +2923,7 @@ class CodeParser:
         """Parse static Blade template references without a Tree-sitter grammar."""
         text = source.decode("utf-8", errors="replace")
         masked = self._mask_blade_comments(text)
-        file_path = str(path)
+        file_path = normalize_file_path(path)
         nodes = [
             NodeInfo(
                 kind="File",
@@ -2928,7 +2958,7 @@ class CodeParser:
             return [], []
 
         tree = vue_parser.parse(source)
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         test_file = _is_test_file(file_path_str)
 
         all_nodes: list[NodeInfo] = [NodeInfo(
@@ -3050,7 +3080,7 @@ class CodeParser:
             return [], []
 
         tree = svelte_parser.parse(source)
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         test_file = _is_test_file(file_path_str)
 
         all_nodes: list[NodeInfo] = [NodeInfo(
@@ -3231,7 +3261,7 @@ class CodeParser:
             cells.append(CellInfo(cell_index=cell_idx, language=cell_lang, source=cell_source))
 
         if not cells:
-            file_path_str = str(path)
+            file_path_str = normalize_file_path(path)
             return [NodeInfo(
                 kind="File",
                 name=file_path_str,
@@ -3257,7 +3287,7 @@ class CodeParser:
             cells: List of CellInfo with index, language, and source.
             default_language: Default language for the File node.
         """
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         test_file = _is_test_file(file_path_str)
 
         # Group cells by language
@@ -3454,7 +3484,7 @@ class CodeParser:
             ))
 
         if not cells:
-            file_path_str = str(path)
+            file_path_str = normalize_file_path(path)
             file_node = NodeInfo(
                 kind="File",
                 name=file_path_str,
@@ -3493,7 +3523,7 @@ class CodeParser:
         text = source.decode("utf-8", errors="replace")
         cleaned = _strip_vbnet_noise(text)
         statements = _vbnet_logical_lines(cleaned)
-        file_path = str(path)
+        file_path = normalize_file_path(path)
         line_count = text.count("\n") + 1
         test_file = _is_test_file(file_path)
 
@@ -3915,7 +3945,7 @@ class CodeParser:
         extraction since signatures have no call sites.
         """
         text = source.decode("utf-8", errors="replace")
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         test_file = _is_test_file(file_path_str)
         is_interface = path.suffix.lower() == ".resi"
 
@@ -4322,7 +4352,7 @@ class CodeParser:
         a ``ref()`` / ``source()`` call remains a best-effort content signal.
         """
         text = source.decode("utf-8", errors="replace")
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         test_file = _is_test_file(file_path_str)
 
         nodes: list[NodeInfo] = []
@@ -5439,7 +5469,7 @@ class CodeParser:
 
     @staticmethod
     def _spring_config_file_node(path: Path, source: bytes, language: str) -> NodeInfo:
-        file_path = str(path)
+        file_path = normalize_file_path(path)
         return NodeInfo(
             kind="File",
             name=file_path,
@@ -5475,7 +5505,7 @@ class CodeParser:
         if self._is_non_spring_yaml(documents):
             return [], []
 
-        file_path = str(path)
+        file_path = normalize_file_path(path)
         nodes = [self._spring_config_file_node(path, source, "yaml")]
         emitted: set[str] = set()
 
@@ -5609,7 +5639,7 @@ class CodeParser:
     ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
         """Index Spring .properties keys without retaining their values."""
         text = source.decode("utf-8", errors="replace")
-        file_path = str(path)
+        file_path = normalize_file_path(path)
         nodes = [self._spring_config_file_node(path, source, "properties")]
         emitted: set[str] = set()
         for line_number, line in self._spring_property_logical_lines(text):
@@ -5655,7 +5685,7 @@ class CodeParser:
         if root is None:
             return [], []
 
-        file_path_str = str(path)
+        file_path_str = normalize_file_path(path)
         line_count = source.count(b"\n") + 1
         nodes: list[NodeInfo] = [NodeInfo(
             kind="File",
@@ -12859,7 +12889,7 @@ class CodeParser:
             file_stat = module_path.stat()
         except (OSError, ValueError):
             return {}
-        resolved_module = str(module_path)
+        resolved_module = normalize_file_path(module_path)
         if resolved_module in resolving:
             return {}
 
@@ -12891,7 +12921,7 @@ class CodeParser:
         resolving: frozenset[str],
     ) -> dict[str, str]:
         """Read and parse one Python module for star-export discovery."""
-        resolved_module = str(module_path)
+        resolved_module = normalize_file_path(module_path)
         try:
             source = module_path.read_bytes()
         except (OSError, PermissionError):
@@ -13016,7 +13046,7 @@ class CodeParser:
                 if not self._path_is_within(resolved, boundary):
                     continue
                 if resolved.is_file():
-                    return str(resolved)
+                    return normalize_file_path(resolved)
         return None
 
     def _collect_js_exported_local_names(
@@ -13300,7 +13330,7 @@ class CodeParser:
         point at a forgotten file falls back to a bare module, and the calls
         it feeds stay bare too.
         """
-        self._excluded_files = {str(Path(p).resolve()) for p in paths}
+        self._excluded_files = {normalize_file_path(Path(p).resolve()) for p in paths}
         # Drop resolutions cached before the exclusions were applied.
         self._module_file_cache.clear()
 
@@ -13319,6 +13349,10 @@ class CodeParser:
             resolved = self._module_file_cache[cache_key]
         else:
             resolved = self._do_resolve_module(module, file_path, language)
+            if resolved is not None:
+                # Resolution walks the real filesystem, so on Windows the
+                # raw result uses backslashes; identity must not (#774).
+                resolved = normalize_file_path(resolved)
             if len(self._module_file_cache) >= self._MODULE_CACHE_MAX:
                 self._module_file_cache.clear()
             self._module_file_cache[cache_key] = resolved
@@ -13768,7 +13802,7 @@ class CodeParser:
             return None
         if not _path_is_within(resolved, boundary):
             return None
-        return str(resolved)
+        return normalize_file_path(resolved)
 
     def _resolve_php_composer_module(
         self,
@@ -13973,7 +14007,7 @@ class CodeParser:
             boundary = self._python_repo_boundary(file_path)
             if not self._path_is_within(candidate, boundary) or not candidate.is_file():
                 return None
-            resolved = str(candidate)
+            resolved = normalize_file_path(candidate)
         else:
             resolved = self._resolve_module_to_file(module, file_path, language)
         if not resolved:
@@ -14090,7 +14124,14 @@ class CodeParser:
         return None
 
     def _qualify(self, name: str, file_path: str, enclosing_class: Optional[str]) -> str:
-        """Create a qualified name: file_path::ClassName.name or file_path::name."""
+        """Create a qualified name: file_path::ClassName.name or file_path::name.
+
+        The path component is normalized to POSIX separators so identities
+        are stable across operating systems (#774). ``name`` and
+        ``enclosing_class`` are never touched — PHP namespace identifiers
+        legitimately contain backslashes.
+        """
+        file_path = normalize_file_path(file_path)
         if enclosing_class:
             return f"{file_path}::{enclosing_class}.{name}"
         return f"{file_path}::{name}"

--- a/code_review_graph/search.py
+++ b/code_review_graph/search.py
@@ -13,6 +13,7 @@ import sqlite3
 from typing import Any, Optional
 
 from .graph import GraphStore, _sanitize_name
+from .parser import normalize_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -390,7 +391,10 @@ def hybrid_search(
 
     # ------ Phase 3+4: Batch-fetch nodes, apply boosting and kind filter ------
     kind_boosts = detect_query_kind_boost(query)
-    context_set = set(context_files) if context_files else set()
+    # Stored file paths use POSIX separators (#774); bridge native spellings.
+    context_set = (
+        {normalize_file_path(p) for p in context_files} if context_files else set()
+    )
 
     # Batch-fetch all candidate nodes in one query
     candidate_ids = [node_id for node_id, _ in merged]

--- a/code_review_graph/tools/_common.py
+++ b/code_review_graph/tools/_common.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ..graph import GraphStore
 from ..incremental import find_project_root, get_db_path
+from ..parser import normalize_file_path
 
 _PROVENANCE_READ_TIMEOUT_SECONDS = 0.05
 _PROVENANCE_GIT_TIMEOUT_SECONDS = 1.0
@@ -242,7 +243,7 @@ def _resolve_graph_file_paths(
             except ValueError:
                 pass
         else:
-            candidates.append(str(root / path))
+            candidates.append(normalize_file_path(root / path))
 
         for candidate in candidates:
             if store.get_nodes_by_file(candidate):

--- a/code_review_graph/tools/context.py
+++ b/code_review_graph/tools/context.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ..incremental import get_db_path
+from ..parser import normalize_file_path
 from ._common import _get_store, _resolve_root, compact_response, graph_provenance
 
 logger = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ def get_minimal_context(
                 if not files:
                     files = _get_changed(root, base)
                 if files:
-                    abs_files = [str(root / f) for f in files]
+                    abs_files = [normalize_file_path(root / f) for f in files]
                     analysis = analyze_changes(
                         store, abs_files, repo_root=str(root), base=base,
                     )

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -13,6 +13,7 @@ from ..embeddings import EmbeddingStore
 from ..graph import GraphNode, GraphStore, _sanitize_name, edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_db_path, get_staged_and_unstaged
+from ..parser import normalize_file_path
 from ..search import hybrid_search
 from ._common import _BUILTIN_CALL_NAMES, _get_store, _resolve_graph_file_paths
 
@@ -304,7 +305,7 @@ def query_graph(
         if pattern != "file_summary" and not raw_config_target:
             node = store.get_node(target)
             if not node:
-                abs_target = str(root / target)
+                abs_target = normalize_file_path(root / target)
                 node = store.get_node(abs_target)
             if not node:
                 java_candidates = _java_fqn_candidates(store, target)

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -12,6 +12,7 @@ from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_staged_and_unstaged
+from ..parser import normalize_file_path
 from ._common import _get_store, _resolve_graph_file_paths
 
 logger = logging.getLogger(__name__)
@@ -323,8 +324,9 @@ def get_affected_flows_func(
                 "total": 0,
             }
 
-        # Convert to absolute paths for graph lookup
-        abs_files = [str(root / f) for f in changed_files]
+        # Convert to absolute paths for graph lookup. Graph identity uses
+        # POSIX separators (#774), so normalize the joined paths.
+        abs_files = [normalize_file_path(root / f) for f in changed_files]
         result = _get_affected_flows(store, abs_files)
 
         total = result["total"]
@@ -405,15 +407,16 @@ def detect_changes_func(
 
         original_tokens = estimate_file_tokens(root, changed_files)
 
-        # Convert to absolute paths for graph lookup.
-        abs_files = [str(root / f) for f in changed_files]
+        # Convert to absolute paths for graph lookup. Graph identity uses
+        # POSIX separators (#774), so normalize the joined paths.
+        abs_files = [normalize_file_path(root / f) for f in changed_files]
 
         # Parse diff ranges for line-level mapping.
         diff_ranges = parse_diff_ranges(str(root), base)
         # Remap to absolute paths so they match graph file_paths.
         abs_ranges: dict[str, list[tuple[int, int]]] = {}
         for rel_path, ranges in diff_ranges.items():
-            abs_path = str(root / rel_path)
+            abs_path = normalize_file_path(root / rel_path)
             abs_ranges[abs_path] = ranges
 
         analysis = analyze_changes(

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -564,8 +564,8 @@ class TestAnalyzeChangesInternalParseRemap:
         return _spy
 
     def test_internal_parse_remaps_relative_keys_to_absolute(self, tmp_path):
-        """Forward-slash relative diff keys become absolute native paths."""
-        abs_path = str(tmp_path / "src" / "app.py")
+        """Forward-slash relative diff keys become absolute POSIX paths."""
+        abs_path = (tmp_path / "src" / "app.py").as_posix()
         self._add_func_at(abs_path)
 
         captured: dict = {}
@@ -593,7 +593,7 @@ class TestAnalyzeChangesInternalParseRemap:
 
     def test_internal_parse_preserves_already_absolute_keys(self, tmp_path):
         """Keys that are already absolute are not double-joined."""
-        abs_path = str(tmp_path / "src" / "app.py")
+        abs_path = (tmp_path / "src" / "app.py").as_posix()
         self._add_func_at(abs_path)
 
         captured: dict = {}

--- a/tests/test_commonjs_imports.py
+++ b/tests/test_commonjs_imports.py
@@ -26,8 +26,8 @@ def test_static_require_resolves_relative_file_and_deduplicates(tmp_path):
 
     imports = _imports(edges)
     assert len(imports) == 1
-    assert imports[0].source == str(path)
-    assert imports[0].target == str(dependency.resolve())
+    assert imports[0].source == path.as_posix()
+    assert imports[0].target == dependency.resolve().as_posix()
 
 
 def test_destructured_require_populates_import_map_for_call_resolution(tmp_path):
@@ -40,7 +40,7 @@ def test_destructured_require_populates_import_map_for_call_resolution(tmp_path)
     )
 
     calls = [edge for edge in edges if edge.kind == "CALLS"]
-    assert any(edge.target == f"{dependency.resolve()}::run" for edge in calls)
+    assert any(edge.target == f"{dependency.resolve().as_posix()}::run" for edge in calls)
 
 
 def test_static_dynamic_import_is_recorded(tmp_path):
@@ -51,7 +51,7 @@ def test_static_dynamic_import_is_recorded(tmp_path):
         "async function load() { return import('./dependency'); }\n",
     )
 
-    assert [edge.target for edge in _imports(edges)] == [str(dependency.resolve())]
+    assert [edge.target for edge in _imports(edges)] == [dependency.resolve().as_posix()]
 
 
 def test_package_require_remains_an_unresolved_package_edge(tmp_path):

--- a/tests/test_cpp_overload_identity.py
+++ b/tests/test_cpp_overload_identity.py
@@ -35,7 +35,7 @@ void IWorkspace::deleteDataFile(
 void IWorkspace::deleteDataFile(DataFile* file, bool refresh) {}
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     three_arg = f"{prefix}::IWorkspace.deleteDataFile(DataFile*,bool,bool)"
     two_arg = f"{prefix}::IWorkspace.deleteDataFile(DataFile*,bool)"
     changed = f"{prefix}::markChanged()"
@@ -80,10 +80,10 @@ void attributed([[maybe_unused]] int value) {}
             if node.kind == "Function"
         ]
         assert {node.qualified_name for node in functions} == {
-            f"{source_path}::Widget.update(const std::vector<int>&,DataFile*,bool)",
-            f"{source_path}::commented(int)",
-            f"{source_path}::unnamed(int)",
-            f"{source_path}::attributed(int)",
+            f"{source_path.as_posix()}::Widget.update(const std::vector<int>&,DataFile*,bool)",
+            f"{source_path.as_posix()}::commented(int)",
+            f"{source_path.as_posix()}::unnamed(int)",
+            f"{source_path.as_posix()}::attributed(int)",
         }
     finally:
         store.close()
@@ -99,7 +99,7 @@ void process(double value) {}
 void caller() { process(1); }
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     int_overload = f"{prefix}::process(int)"
     double_overload = f"{prefix}::process(double)"
     caller = f"{prefix}::caller()"
@@ -158,7 +158,7 @@ def test_cpp_call_resolution_prefers_the_lexical_class_scope(tmp_path: Path):
 struct B { void process() {} };
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     caller = f"{prefix}::A.caller()"
     target = f"{prefix}::A.process()"
 
@@ -185,7 +185,7 @@ struct A {
 };
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     caller = f"{prefix}::A.caller(B&)"
 
     try:
@@ -216,8 +216,8 @@ def test_cpp_this_call_resolves_to_signature_identity(tmp_path: Path):
 };
 """,
     )
-    caller = f"{source_path}::A.caller()"
-    target = f"{source_path}::A.process()"
+    caller = f"{source_path.as_posix()}::A.caller()"
+    target = f"{source_path.as_posix()}::A.process()"
 
     try:
         call_edges = [
@@ -246,7 +246,7 @@ struct A {
 };
 """,
     )
-    caller = f"{source_path}::A.caller()"
+    caller = f"{source_path.as_posix()}::A.caller()"
 
     try:
         call_edges = [
@@ -257,8 +257,8 @@ struct A {
         assert len(call_edges) == 1
         assert call_edges[0].target_qualified == "process"
         assert set(call_edges[0].extra["ambiguous_targets"]) == {
-            f"{source_path}::A.process(int)",
-            f"{source_path}::A.process(double)",
+            f"{source_path.as_posix()}::A.process(int)",
+            f"{source_path.as_posix()}::A.process(double)",
         }
         assert call_edges[0].extra["ambiguous_target_count"] == 2
         assert call_edges[0].extra["ambiguous_targets_truncated"] is False
@@ -277,7 +277,7 @@ struct A { void caller() { helper(); } };
 }
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     target = f"{prefix}::N.helper()"
 
     try:
@@ -304,8 +304,8 @@ void caller() { A::run(); }
 }
 """,
     )
-    caller = f"{source_path}::N.caller()"
-    target = f"{source_path}::N.A.run()"
+    caller = f"{source_path.as_posix()}::N.caller()"
+    target = f"{source_path.as_posix()}::N.A.run()"
 
     try:
         call_edges = [
@@ -328,8 +328,8 @@ void process(int value) {}
 void caller() { process(1); }
 """,
     )
-    caller = f"{source_path}::caller()"
-    target = f"{source_path}::process(int)"
+    caller = f"{source_path.as_posix()}::caller()"
+    target = f"{source_path.as_posix()}::process(int)"
 
     try:
         call_edges = [
@@ -352,7 +352,7 @@ def test_cpp_candidate_metadata_is_bounded_and_reports_truncation(tmp_path: Path
         tmp_path,
         f"{overloads}\nvoid caller() {{ process(1); }}\n",
     )
-    caller = f"{source_path}::caller()"
+    caller = f"{source_path.as_posix()}::caller()"
 
     try:
         call_edges = [
@@ -394,7 +394,7 @@ namespace N { void helper() {} }
 void caller() { A::unique(); A::overloaded(1); N::helper(); }
 """,
     )
-    caller = f"{source_path}::caller()"
+    caller = f"{source_path.as_posix()}::caller()"
 
     try:
         call_edges = [
@@ -407,8 +407,8 @@ void caller() { A::unique(); A::overloaded(1); N::helper(); }
             for edge in call_edges
             if not edge.extra.get("ambiguous_targets")
         } == {
-            f"{source_path}::A.unique()",
-            f"{source_path}::N.helper()",
+            f"{source_path.as_posix()}::A.unique()",
+            f"{source_path.as_posix()}::N.helper()",
         }
         ambiguous_edges = [
             edge for edge in call_edges if edge.extra.get("ambiguous_targets")
@@ -416,8 +416,8 @@ void caller() { A::unique(); A::overloaded(1); N::helper(); }
         assert len(ambiguous_edges) == 1
         assert ambiguous_edges[0].target_qualified == "A::overloaded"
         assert set(ambiguous_edges[0].extra["ambiguous_targets"]) == {
-            f"{source_path}::A.overloaded(int)",
-            f"{source_path}::A.overloaded(double)",
+            f"{source_path.as_posix()}::A.overloaded(int)",
+            f"{source_path.as_posix()}::A.overloaded(double)",
         }
     finally:
         store.close()
@@ -455,11 +455,11 @@ void logValues(int value, ...) {}
             if node.kind == "Function"
         }
         assert identities == {
-            f"{source_path}::Widget.update()",
-            f"{source_path}::Widget.update() const",
-            f"{source_path}::Widget.visit() &",
-            f"{source_path}::Widget.visit() &&",
-            f"{source_path}::logValues(int,...)",
+            f"{source_path.as_posix()}::Widget.update()",
+            f"{source_path.as_posix()}::Widget.update() const",
+            f"{source_path.as_posix()}::Widget.visit() &",
+            f"{source_path.as_posix()}::Widget.visit() &&",
+            f"{source_path.as_posix()}::logValues(int,...)",
         }
     finally:
         store.close()
@@ -483,17 +483,17 @@ namespace Beta { void process(int value) {} }
             if node.kind == "Function"
         }
         assert identities == {
-            f"{source_path}::Alpha.process(int)",
-            f"{source_path}::Alpha.Widget.read() const",
-            f"{source_path}::Beta.process(int)",
+            f"{source_path.as_posix()}::Alpha.process(int)",
+            f"{source_path.as_posix()}::Alpha.Widget.read() const",
+            f"{source_path.as_posix()}::Beta.process(int)",
         }
-        class_qn = f"{source_path}::Widget"
+        class_qn = f"{source_path.as_posix()}::Widget"
         widget = store.get_node(class_qn)
         assert widget is not None
         assert widget.parent_name is None
         assert any(
             edge.kind == "CONTAINS" and edge.target_qualified == class_qn
-            for edge in store.get_edges_by_source(str(source_path))
+            for edge in store.get_edges_by_source(source_path.as_posix())
         )
         assert any(
             edge.kind == "INHERITS" and edge.target_qualified == "Base"
@@ -501,7 +501,7 @@ namespace Beta { void process(int value) {} }
         )
         assert any(
             edge.kind == "CONTAINS"
-            and edge.target_qualified == f"{source_path}::Alpha.Widget.read() const"
+            and edge.target_qualified == f"{source_path.as_posix()}::Alpha.Widget.read() const"
             for edge in store.get_edges_by_source(class_qn)
         )
     finally:
@@ -520,7 +520,7 @@ def test_cpp_nested_class_keys_stay_legacy_while_function_scope_is_complete(
 };
 """,
     )
-    prefix = str(source_path)
+    prefix = source_path.as_posix()
     outer = f"{prefix}::Outer"
     inner = f"{prefix}::Outer.Inner"
     deep = f"{prefix}::Inner.Deep"
@@ -555,7 +555,7 @@ def test_reindex_replaces_legacy_unsuffixed_cpp_identity(tmp_path: Path):
     graph_dir = tmp_path / ".code-review-graph"
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
-    legacy_qn = f"{source_path}::IWorkspace.deleteDataFile"
+    legacy_qn = f"{source_path.as_posix()}::IWorkspace.deleteDataFile"
 
     try:
         store.upsert_node(
@@ -577,7 +577,7 @@ def test_reindex_replaces_legacy_unsuffixed_cpp_identity(tmp_path: Path):
 
         assert store.get_node(legacy_qn) is None
         assert store.get_node(
-            f"{source_path}::IWorkspace.deleteDataFile(DataFile*,bool)"
+            f"{source_path.as_posix()}::IWorkspace.deleteDataFile(DataFile*,bool)"
         ) is not None
     finally:
         store.close()
@@ -591,8 +591,8 @@ def test_incremental_upgrade_rebuilds_cpp_identities_and_removes_stale_edges(
     callee_path.write_text("void run(int value) {}\n", encoding="utf-8")
     caller_path.write_text("void caller() { run(1); }\n", encoding="utf-8")
     store = GraphStore(tmp_path / "graph.db")
-    legacy_callee = f"{callee_path}::run"
-    legacy_caller = f"{caller_path}::caller"
+    legacy_callee = f"{callee_path.as_posix()}::run"
+    legacy_caller = f"{caller_path.as_posix()}::caller"
 
     try:
         for path, name in ((callee_path, "run"), (caller_path, "caller")):
@@ -622,10 +622,10 @@ def test_incremental_upgrade_rebuilds_cpp_identities_and_removes_stale_edges(
         assert result["identity_rebuild"] is True
         assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
         assert store.get_node(legacy_callee) is None
-        assert store.get_node(f"{callee_path}::run(int)") is not None
+        assert store.get_node(f"{callee_path.as_posix()}::run(int)") is not None
         assert all(
             edge.target_qualified != legacy_callee
-            for edge in store.get_edges_by_source(f"{caller_path}::caller()")
+            for edge in store.get_edges_by_source(f"{caller_path.as_posix()}::caller()")
         )
     finally:
         store.close()
@@ -655,7 +655,7 @@ def test_cross_file_bare_call_is_not_claimed_by_each_exact_overload(
             store.store_file_nodes_edges(str(path), nodes, edges)
         bare_edges = [
             edge
-            for edge in store.get_edges_by_source(f"{caller_path}::caller()")
+            for edge in store.get_edges_by_source(f"{caller_path.as_posix()}::caller()")
             if edge.kind == "CALLS"
         ]
         assert [(edge.target_qualified, edge.extra) for edge in bare_edges] == [
@@ -667,7 +667,7 @@ def test_cross_file_bare_call_is_not_claimed_by_each_exact_overload(
     for overload in ("process(int)", "process(double)"):
         callers = query_graph(
             "callers_of",
-            f"{callee_path}::{overload}",
+            f"{callee_path.as_posix()}::{overload}",
             repo_root=str(tmp_path),
         )
         assert callers["status"] == "ok"
@@ -677,7 +677,7 @@ def test_cross_file_bare_call_is_not_claimed_by_each_exact_overload(
 def test_failed_cpp_identity_upgrade_remains_pending_and_retries(tmp_path: Path):
     source_path = tmp_path / "run.cpp"
     source_path.write_text("void run(int value) {}\n", encoding="utf-8")
-    legacy_qn = f"{source_path}::run"
+    legacy_qn = f"{source_path.as_posix()}::run"
     store = GraphStore(tmp_path / "graph.db")
 
     try:
@@ -718,7 +718,7 @@ def test_failed_cpp_identity_upgrade_remains_pending_and_retries(tmp_path: Path)
         assert retried["errors"] == []
         assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
         assert store.get_node(legacy_qn) is None
-        assert store.get_node(f"{source_path}::run(int)") is not None
+        assert store.get_node(f"{source_path.as_posix()}::run(int)") is not None
     finally:
         store.close()
 
@@ -744,10 +744,10 @@ A& clone(double value) { static A result; return result; }
             if node.kind == "Function"
         }
         assert functions == {
-            f"{source_path}::A.operator=(const A&)",
-            f"{source_path}::A.operator bool() const",
-            f"{source_path}::clone(int)",
-            f"{source_path}::clone(double)",
+            f"{source_path.as_posix()}::A.operator=(const A&)",
+            f"{source_path.as_posix()}::A.operator bool() const",
+            f"{source_path.as_posix()}::clone(int)",
+            f"{source_path.as_posix()}::clone(double)",
         }
     finally:
         store.close()
@@ -762,10 +762,10 @@ void ::N::A::run() {}
     )
 
     try:
-        run = store.get_node(f"{source_path}::N.A.run()")
+        run = store.get_node(f"{source_path.as_posix()}::N.A.run()")
         assert run is not None
         assert run.parent_name == "N.A"
-        assert store.get_node(f"{source_path}::.N.A.run()") is None
+        assert store.get_node(f"{source_path.as_posix()}::.N.A.run()") is None
     finally:
         store.close()
 
@@ -787,8 +787,8 @@ def test_cross_file_receiver_call_without_type_evidence_stays_unresolved(
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
 
-    target = f"{callee_path}::A.process()"
-    caller = f"{caller_path}::test_receiver(B&)"
+    target = f"{callee_path.as_posix()}::A.process()"
+    caller = f"{caller_path.as_posix()}::test_receiver(B&)"
     try:
         parser = CodeParser()
         for path in (callee_path, caller_path):
@@ -796,8 +796,8 @@ def test_cross_file_receiver_call_without_type_evidence_stays_unresolved(
             store.store_file_nodes_edges(str(path), nodes, edges)
         store.upsert_edge(EdgeInfo(
             kind="IMPORTS_FROM",
-            source=str(caller_path),
-            target=str(callee_path),
+            source=caller_path.as_posix(),
+            target=callee_path.as_posix(),
             file_path=str(caller_path),
             line=1,
         ))
@@ -856,7 +856,7 @@ void A::run(double value) {}
     graph_dir = tmp_path / ".code-review-graph"
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
-    caller = f"{caller_path}::test_run()"
+    caller = f"{caller_path.as_posix()}::test_run()"
 
     try:
         parser = CodeParser()
@@ -872,12 +872,12 @@ void A::run(double value) {}
             if edge.kind == "CALLS"
         ]
         unique = next(edge for edge in calls if edge.target_qualified.endswith("unique()"))
-        assert unique.target_qualified == f"{callee_path}::A.unique()"
+        assert unique.target_qualified == f"{callee_path.as_posix()}::A.unique()"
 
         overloaded = next(edge for edge in calls if edge.target_qualified == "A::run")
         assert set(overloaded.extra["ambiguous_targets"]) == {
-            f"{callee_path}::A.run(int)",
-            f"{callee_path}::A.run(double)",
+            f"{callee_path.as_posix()}::A.run(int)",
+            f"{callee_path.as_posix()}::A.run(double)",
         }
         assert overloaded.extra["ambiguous_target_count"] == 2
         assert overloaded.extra["ambiguous_targets_truncated"] is False
@@ -887,7 +887,7 @@ void A::run(double value) {}
             for edge in store.get_edges_by_target(caller)
             if edge.kind == "TESTED_BY"
         }
-        unique_target = f"{callee_path}::A.unique()"
+        unique_target = f"{callee_path.as_posix()}::A.unique()"
         assert tested_by[unique_target].extra["cpp_scoped_target"] == "A::unique"
         assert tested_by["A::run"].extra == overloaded.extra
         assert [
@@ -895,7 +895,7 @@ void A::run(double value) {}
             for match in store.get_transitive_tests(unique_target, max_depth=0)
         ] == [caller]
         assert store.get_transitive_tests(
-            f"{callee_path}::A.run(int)", max_depth=0,
+            f"{callee_path.as_posix()}::A.run(int)", max_depth=0,
         ) == []
     finally:
         store.close()
@@ -907,7 +907,7 @@ void A::run(double value) {}
         result["qualified_name"] for result in tests_for_unique["results"]
     ] == [caller]
     tests_for_overload = query_graph(
-        "tests_for", f"{callee_path}::A.run(int)", repo_root=str(tmp_path),
+        "tests_for", f"{callee_path.as_posix()}::A.run(int)", repo_root=str(tmp_path),
     )
     assert tests_for_overload["results"] == []
 
@@ -933,7 +933,7 @@ def test_ambiguous_scoped_calls_do_not_create_indirect_test_coverage(
     graph_dir = tmp_path / ".code-review-graph"
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
-    production = f"{production_path}::production()"
+    production = f"{production_path.as_posix()}::production()"
 
     try:
         parser = CodeParser()
@@ -969,8 +969,8 @@ def test_deleted_scoped_candidate_becomes_explicitly_unresolved(tmp_path: Path):
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
     parser = CodeParser()
-    production = f"{production_path}::production()"
-    test = f"{test_path}::test_scenario()"
+    production = f"{production_path.as_posix()}::production()"
+    test = f"{test_path.as_posix()}::test_scenario()"
 
     try:
         for path in (callee_path, production_path, test_path):
@@ -1022,7 +1022,7 @@ def test_missing_scoped_candidate_rechecks_when_definition_appears(tmp_path: Pat
     )
     store = GraphStore(tmp_path / "graph.db")
     parser = CodeParser()
-    caller = f"{caller_path}::caller()"
+    caller = f"{caller_path.as_posix()}::caller()"
 
     try:
         nodes, edges = parser.parse_file(caller_path)
@@ -1049,7 +1049,7 @@ def test_missing_scoped_candidate_rechecks_when_definition_appears(tmp_path: Pat
             for edge in store.get_edges_by_source(caller)
             if edge.kind == "CALLS"
         )
-        assert call.target_qualified == f"{callee_path}::A.run(int)"
+        assert call.target_qualified == f"{callee_path.as_posix()}::A.run(int)"
         assert "unresolved_targets" not in call.extra
     finally:
         store.close()
@@ -1065,7 +1065,7 @@ def test_cross_file_scoped_resolution_rechecks_candidate_changes(tmp_path: Path)
     )
     store = GraphStore(tmp_path / "graph.db")
     parser = CodeParser()
-    caller = f"{caller_path}::test_caller()"
+    caller = f"{caller_path.as_posix()}::test_caller()"
 
     try:
         for path in (callee_path, caller_path):
@@ -1078,14 +1078,14 @@ def test_cross_file_scoped_resolution_rechecks_candidate_changes(tmp_path: Path)
             for edge in store.get_edges_by_source(caller)
             if edge.kind == "CALLS"
         )
-        assert call.target_qualified == f"{callee_path}::A.run(int)"
+        assert call.target_qualified == f"{callee_path.as_posix()}::A.run(int)"
         assert call.extra["cpp_scoped_target"] == "A::run"
         tested_by = next(
             edge
             for edge in store.get_edges_by_target(caller)
             if edge.kind == "TESTED_BY"
         )
-        assert tested_by.source_qualified == f"{callee_path}::A.run(int)"
+        assert tested_by.source_qualified == f"{callee_path.as_posix()}::A.run(int)"
         assert tested_by.extra == call.extra
 
         callee_path.write_text(
@@ -1124,7 +1124,7 @@ def test_cross_file_scoped_resolution_rechecks_candidate_changes(tmp_path: Path)
             for edge in store.get_edges_by_source(caller)
             if edge.kind == "CALLS"
         )
-        assert call.target_qualified == f"{callee_path}::A.run(double)"
+        assert call.target_qualified == f"{callee_path.as_posix()}::A.run(double)"
         assert call.extra["cpp_scoped_target"] == "A::run"
         assert "ambiguous_targets" not in call.extra
         assert "ambiguous_target_count" not in call.extra
@@ -1134,7 +1134,7 @@ def test_cross_file_scoped_resolution_rechecks_candidate_changes(tmp_path: Path)
             for edge in store.get_edges_by_target(caller)
             if edge.kind == "TESTED_BY"
         )
-        assert tested_by.source_qualified == f"{callee_path}::A.run(double)"
+        assert tested_by.source_qualified == f"{callee_path.as_posix()}::A.run(double)"
         assert tested_by.extra == call.extra
     finally:
         store.close()
@@ -1178,7 +1178,7 @@ def test_non_cpp_failure_does_not_repeat_cpp_identity_migration(tmp_path: Path):
             {"file": "broken.py", "error": "simulated non-C++ parse failure"},
         ]
         assert store.get_metadata("cpp_identity_version") == CPP_IDENTITY_VERSION
-        assert store.get_node(f"{cpp_path}::run(int)") is not None
+        assert store.get_node(f"{cpp_path.as_posix()}::run(int)") is not None
 
         no_retry = incremental_update(tmp_path, store, changed_files=[])
         assert no_retry.get("identity_rebuild") is None
@@ -1193,7 +1193,7 @@ def test_non_cpp_scoped_unresolved_callee_query_behavior_stays_unchanged(
     graph_dir = tmp_path / ".code-review-graph"
     graph_dir.mkdir()
     store = GraphStore(graph_dir / "graph.db")
-    caller = f"{source_path}::caller"
+    caller = f"{source_path.as_posix()}::caller"
 
     try:
         store.upsert_node(NodeInfo(

--- a/tests/test_custom_languages.py
+++ b/tests/test_custom_languages.py
@@ -292,7 +292,7 @@ class TestParserIntegration:
         assert "point" in classes
         assert classes["point"].language == "erlang"
 
-        file_path = str(src)
+        file_path = src.as_posix()
         calls = {(e.source, e.target) for e in edges if e.kind == "CALLS"}
         # helper(A) inside add/2 resolves to the same-file definition.
         assert (f"{file_path}::add", f"{file_path}::helper") in calls

--- a/tests/test_embedding_refresh.py
+++ b/tests/test_embedding_refresh.py
@@ -76,7 +76,7 @@ class TestOrphanCleanup:
                 "SELECT qualified_name FROM embeddings ORDER BY qualified_name",
             ).fetchall()
             assert [row["qualified_name"] for row in remaining] == [
-                f"{tmp_path / 'module.py'}::keep",
+                f"{(tmp_path / 'module.py').as_posix()}::keep",
             ]
         finally:
             embeddings.close()
@@ -205,7 +205,7 @@ class TestExplicitRefresh:
         graph._conn.execute(
             "INSERT INTO embeddings (qualified_name, vector, text_hash) "
             "VALUES (?, ?, ?)",
-            (f"{tmp_path / 'module.py'}::keep", b"\x00" * 8, "old"),
+            (f"{(tmp_path / 'module.py').as_posix()}::keep", b"\x00" * 8, "old"),
         )
         graph.commit()
 
@@ -323,7 +323,7 @@ class TestRefreshWiring:
             "INSERT INTO embeddings (qualified_name, vector, text_hash, provider) "
             "VALUES (?, ?, ?, ?)",
             (
-                f"{tmp_path / 'module.py'}::keep",
+                f"{(tmp_path / 'module.py').as_posix()}::keep",
                 b"\x00" * 8,
                 "old",
                 "openai:test-model@https://api.example.test/v1",

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -72,19 +72,21 @@ class TestEnrichSearch:
         self.store.close()
 
     def _seed_data(self):
+        # POSIX spelling matches graph identity on every platform (#774).
+        posix_dir = Path(self.tmpdir).as_posix()
         nodes = [
             NodeInfo(
-                kind="Function", name="parse_file", file_path=f"{self.tmpdir}/parser.py",
+                kind="Function", name="parse_file", file_path=f"{posix_dir}/parser.py",
                 line_start=10, line_end=50, language="python",
                 params="(path: str)", return_type="list[Node]",
             ),
             NodeInfo(
-                kind="Function", name="full_build", file_path=f"{self.tmpdir}/build.py",
+                kind="Function", name="full_build", file_path=f"{posix_dir}/build.py",
                 line_start=1, line_end=30, language="python",
             ),
             NodeInfo(
                 kind="Test", name="test_parse_file",
-                file_path=f"{self.tmpdir}/test_parser.py",
+                file_path=f"{posix_dir}/test_parser.py",
                 line_start=1, line_end=20, language="python",
                 is_test=True,
             ),
@@ -94,17 +96,17 @@ class TestEnrichSearch:
         edges = [
             EdgeInfo(
                 kind="CALLS",
-                source=f"{self.tmpdir}/build.py::full_build",
-                target=f"{self.tmpdir}/parser.py::parse_file",
-                file_path=f"{self.tmpdir}/build.py", line=15,
+                source=f"{posix_dir}/build.py::full_build",
+                target=f"{posix_dir}/parser.py::parse_file",
+                file_path=f"{posix_dir}/build.py", line=15,
             ),
             EdgeInfo(
                 # TESTED_BY edges are stored as source=production, target=test
                 # by the parser. See: #515
                 kind="TESTED_BY",
-                source=f"{self.tmpdir}/parser.py::parse_file",
-                target=f"{self.tmpdir}/test_parser.py::test_parse_file",
-                file_path=f"{self.tmpdir}/test_parser.py", line=1,
+                source=f"{posix_dir}/parser.py::parse_file",
+                target=f"{posix_dir}/test_parser.py::test_parse_file",
+                file_path=f"{posix_dir}/test_parser.py", line=1,
             ),
         ]
         for e in edges:
@@ -153,7 +155,8 @@ class TestEnrichFileRead:
         self.store.close()
 
     def _seed_data(self):
-        self.file_path = f"{self.tmpdir}/parser.py"
+        # POSIX spelling matches graph identity on every platform (#774).
+        self.file_path = (Path(self.tmpdir) / "parser.py").as_posix()
         nodes = [
             NodeInfo(
                 kind="File", name="parser.py", file_path=self.file_path,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,7 +4,7 @@ import logging
 import sqlite3
 import tempfile
 import time
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -72,6 +72,42 @@ class TestGraphStore:
         result = self.store.get_node("/test/file.py::MyClass.do_thing")
         assert result is not None
         assert result.parent_name == "MyClass"
+
+    def test_get_node_bridges_windows_native_qualified_names(self):
+        """A Windows-native path prefix still finds the POSIX-keyed node (#774)."""
+        path = "repo/pkg/mod.py"
+        self.store.upsert_node(self._make_file_node(path))
+        self.store.upsert_node(self._make_func_node("my_func", path))
+        self.store.commit()
+
+        native_prefix = str(PureWindowsPath(path))
+        assert native_prefix == "repo\\pkg\\mod.py"
+        native_qn = f"{native_prefix}::my_func"
+        result = self.store.get_node(native_qn)
+        assert result is not None
+        assert result.qualified_name == "repo/pkg/mod.py::my_func"
+
+        file_node = self.store.get_node(native_prefix)
+        assert file_node is not None
+        assert file_node.qualified_name == "repo/pkg/mod.py"
+
+        assert self.store.get_node(f"{native_prefix}::missing") is None
+
+    def test_get_node_bridge_keeps_php_backslashes_in_symbol_part(self):
+        """Only the path component is normalized; PHP FQN symbols keep ``\\``."""
+        node = NodeInfo(
+            kind="Class", name="App\\Domain\\Job", file_path="src/App.php",
+            line_start=1, line_end=10, language="php",
+        )
+        self.store.upsert_node(node)
+        self.store.commit()
+
+        posix_qn = "src/App.php::App\\Domain\\Job"
+        assert self.store.get_node(posix_qn) is not None
+        native_qn = "src\\App.php::App\\Domain\\Job"
+        bridged = self.store.get_node(native_qn)
+        assert bridged is not None
+        assert bridged.qualified_name == posix_qn
 
     def test_upsert_edge(self):
         edge = EdgeInfo(
@@ -714,10 +750,10 @@ def test_impact_radius_real_build_includes_importer_not_imported_dependency(
             max_depth=1,
         )
 
-    expected = {str(importer)}
+    expected = {importer.as_posix()}
     assert set(sql["impacted_files"]) == expected
     assert set(networkx["impacted_files"]) == expected
-    assert str(dependency) not in sql["impacted_files"]
+    assert dependency.as_posix() not in sql["impacted_files"]
     assert sql["impact_scores"] == networkx["impact_scores"]
 
 

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -73,23 +73,23 @@ module "network" {
     try:
         result = full_build(tmp_path, store)
 
-        resource_qn = f"{tmp_path / 'main.tf'}::resource.example_server.web"
+        resource_qn = f"{(tmp_path / 'main.tf').as_posix()}::resource.example_server.web"
         reference_targets = {
             edge.target_qualified
             for edge in store.get_edges_by_source(resource_qn)
             if edge.kind == "REFERENCES"
         }
         assert reference_targets == {
-            f"{tmp_path / 'variables.tf'}::var.names",
-            f"{tmp_path / 'variables.tf'}::local.tags",
+            f"{(tmp_path / 'variables.tf').as_posix()}::var.names",
+            f"{(tmp_path / 'variables.tf').as_posix()}::local.tags",
         }
 
-        local_qn = f"{tmp_path / 'variables.tf'}::local.tags"
+        local_qn = f"{(tmp_path / 'variables.tf').as_posix()}::local.tags"
         assert {
             edge.target_qualified
             for edge in store.get_edges_by_source(local_qn)
             if edge.kind == "REFERENCES"
-        } == {f"{tmp_path / 'variables.tf'}::var.region"}
+        } == {f"{(tmp_path / 'variables.tf').as_posix()}::var.region"}
 
         module_imports = [
             edge
@@ -97,7 +97,7 @@ module "network" {
             if edge.kind == "IMPORTS_FROM"
         ]
         assert len(module_imports) == 1
-        assert module_imports[0].target_qualified == str(module_dir / "main.tf")
+        assert module_imports[0].target_qualified == (module_dir / "main.tf").as_posix()
         assert result["hcl_resolution"]["references_resolved"] == 2
         assert result["hcl_resolution"]["imports_resolved"] == 1
     finally:

--- a/tests/test_java_call_references.py
+++ b/tests/test_java_call_references.py
@@ -29,12 +29,12 @@ def test_java_method_references_chained_calls_and_constructors_are_calls() -> No
 
     method_reference = next(
         edge for edge in route_calls
-        if edge.target == f"{path}::Handler.handle"
+        if edge.target == f"{path.as_posix()}::Handler.handle"
     )
     assert method_reference.extra["receiver"] == "handler"
     assert method_reference.extra["call_syntax"] == "method_reference"
     assert any(edge.target == "GET" for edge in route_calls)
-    assert any(edge.target == f"{path}::Handler" for edge in route_calls)
+    assert any(edge.target == f"{path.as_posix()}::Handler" for edge in route_calls)
 
 
 @pytest.mark.parametrize(
@@ -49,8 +49,8 @@ def test_java_framework_callbacks_remain_flow_entry_points(
     tmp_path: Path,
     decorator: str,
 ) -> None:
-    callback_path = str(tmp_path / "Callback.java")
-    caller_path = str(tmp_path / "Caller.java")
+    callback_path = (tmp_path / "Callback.java").as_posix()
+    caller_path = (tmp_path / "Caller.java").as_posix()
     callback_qn = f"{callback_path}::Callback.execute"
     with GraphStore(tmp_path / "graph.db") as store:
         store.upsert_node(NodeInfo(

--- a/tests/test_julia_reconciliation.py
+++ b/tests/test_julia_reconciliation.py
@@ -468,9 +468,9 @@ def test_full_build_persists_distinct_qualified_nodes_and_callers(tmp_path):
     store = GraphStore(tmp_path / "graph.db")
     try:
         result = full_build(tmp_path, store)
-        local_qn = f"{source_path}::Demo.show"
-        base_qn = f"{source_path}::Demo.Base.show"
-        alias_qn = f"{source_path}::Demo.FloatVec"
+        local_qn = f"{source_path.as_posix()}::Demo.show"
+        base_qn = f"{source_path.as_posix()}::Demo.Base.show"
+        alias_qn = f"{source_path.as_posix()}::Demo.FloatVec"
 
         local_node = store.get_node(local_qn)
         base_node = store.get_node(base_qn)
@@ -481,8 +481,9 @@ def test_full_build_persists_distinct_qualified_nodes_and_callers(tmp_path):
         assert store.get_node(alias_qn) is not None
 
         callers = store.get_edges_by_target(base_qn)
+        invoke_qn = f"{source_path.as_posix()}::Demo.invoke"
         assert any(
-            edge.kind == "CALLS" and edge.source_qualified == f"{source_path}::Demo.invoke"
+            edge.kind == "CALLS" and edge.source_qualified == invoke_qn
             for edge in callers
         )
         assert result["errors"] == []

--- a/tests/test_language_reconciliation.py
+++ b/tests/test_language_reconciliation.py
@@ -94,12 +94,12 @@ End Namespace
         store = GraphStore(":memory:")
         store.store_file_nodes_edges(str(path), nodes, edges)
 
-        repository_qn = f"{path}::Acme.Repository"
-        base_qn = f"{path}::Acme.BaseRepository"
-        interface_qn = f"{path}::Acme.IRepository"
-        helper_qn = f"{path}::Acme.Repository.Helper"
-        property_qn = f"{path}::Acme.Repository.Current"
-        save_qn = f"{path}::Acme.Repository.Save"
+        repository_qn = f"{path.as_posix()}::Acme.Repository"
+        base_qn = f"{path.as_posix()}::Acme.BaseRepository"
+        interface_qn = f"{path.as_posix()}::Acme.IRepository"
+        helper_qn = f"{path.as_posix()}::Acme.Repository.Helper"
+        property_qn = f"{path.as_posix()}::Acme.Repository.Current"
+        save_qn = f"{path.as_posix()}::Acme.Repository.Save"
 
         assert store.get_node(repository_qn) is not None
         assert store.get_node(base_qn) is not None
@@ -146,7 +146,7 @@ End Class
 
         store = GraphStore(":memory:")
         store.store_file_nodes_edges(str(path), nodes, edges)
-        assert store.get_node(f"{path}::Writer.Save") is not None
+        assert store.get_node(f"{path.as_posix()}::Writer.Save") is not None
         store.close()
 
 
@@ -255,8 +255,8 @@ endmodule
             if edge.kind == "REFERENCES" and edge.source.endswith("::Top")
         }
         assert targets == {
-            f"{path}::Top.local_signal",
-            f"{path}::Top.bus",
+            f"{path.as_posix()}::Top.local_signal",
+            f"{path.as_posix()}::Top.bus",
         }
         assert all(not target.endswith(".member") for target in targets)
 
@@ -336,8 +336,8 @@ impl MemoryRepository {
         assert ("save", "MemoryRepository") in methods
         assert ("clear", "MemoryRepository") in methods
 
-        duplicate_qn = f"{path}::MemoryRepository.duplicate"
-        new_qn = f"{path}::MemoryRepository.new"
+        duplicate_qn = f"{path.as_posix()}::MemoryRepository.duplicate"
+        new_qn = f"{path.as_posix()}::MemoryRepository.new"
         assert any(
             edge.kind == "CALLS"
             and edge.source == duplicate_qn
@@ -347,8 +347,8 @@ impl MemoryRepository {
 
         store = GraphStore(":memory:")
         store.store_file_nodes_edges(str(path), nodes, edges)
-        concrete_qn = f"{path}::MemoryRepository"
-        trait_qn = f"{path}::Repository"
+        concrete_qn = f"{path.as_posix()}::MemoryRepository"
+        trait_qn = f"{path.as_posix()}::Repository"
         assert store.get_node(concrete_qn).line_start == 5
         assert any(
             edge.kind == "IMPLEMENTS" and edge.target_qualified == trait_qn
@@ -383,7 +383,7 @@ impl MemoryRepository {
         parser = CodeParser(repo_root=tmp_path)
         db_nodes, db_edges = parser.parse_file(db)
         lib_nodes, lib_edges = parser.parse_file(lib)
-        target = f"{db.resolve()}::Repository.new"
+        target = f"{db.resolve().as_posix()}::Repository.new"
         calls = [edge for edge in lib_edges if edge.kind == "CALLS"]
         assert [edge.target for edge in calls].count(target) == 2
         assert all("::Repo.new" not in edge.target for edge in calls)
@@ -423,9 +423,9 @@ impl MemoryRepository {
             edge.target for edge in edges if edge.kind == "IMPORTS_FROM"
         }
         assert targets == {
-            str(nested.resolve()),
-            str(parent.resolve()),
-            str(root.resolve()),
+            nested.resolve().as_posix(),
+            parent.resolve().as_posix(),
+            root.resolve().as_posix(),
         }
 
     def test_workspace_dependency_alias_resolves_from_workspace_manifest(self, tmp_path):
@@ -459,7 +459,7 @@ impl MemoryRepository {
         _, edges = CodeParser(repo_root=tmp_path).parse_file(app_main)
         imports = [edge for edge in edges if edge.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
-        assert imports[0].target == str(dep_lib.resolve())
+        assert imports[0].target == dep_lib.resolve().as_posix()
 
     def test_path_dependency_without_cargo_manifest_stays_unresolved(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text(
@@ -508,8 +508,8 @@ impl MemoryRepository {
             "pub fn build() { Repository::new(); }\n",
             encoding="utf-8",
         )
-        target = f"{db.resolve()}::Repository.new"
-        caller = f"{lib.resolve()}::build"
+        target = f"{db.resolve().as_posix()}::Repository.new"
+        caller = f"{lib.resolve().as_posix()}::build"
 
         store = GraphStore(":memory:")
         try:
@@ -534,7 +534,7 @@ impl MemoryRepository {
             assert any(
                 edge.kind == "CALLS" and edge.target_qualified == target
                 for edge in store.get_edges_by_source(
-                    f"{lib.resolve()}::build_again",
+                    f"{lib.resolve().as_posix()}::build_again",
                 )
             )
         finally:
@@ -568,11 +568,11 @@ class SecondService {
             edge.target
             for edge in edges
             if edge.kind == "CALLS"
-            and edge.source == f"{path}::SecondService.dispatch"
+            and edge.source == f"{path.as_posix()}::SecondService.dispatch"
         }
         assert targets == {
-            f"{path}::SecondService.run",
-            f"{path}::FirstService.run",
+            f"{path.as_posix()}::SecondService.run",
+            f"{path.as_posix()}::FirstService.run",
         }
 
     def test_import_alias_and_fully_qualified_calls_use_composer_evidence(
@@ -604,7 +604,7 @@ class SecondService {
         )
 
         _, edges = CodeParser(repo_root=tmp_path).parse_file(caller)
-        target = f"{mailer.resolve()}::Mailer.send"
+        target = f"{mailer.resolve().as_posix()}::Mailer.send"
         calls = [
             edge for edge in edges
             if edge.kind == "CALLS" and edge.source.endswith("::SignupController.register")
@@ -654,7 +654,7 @@ class SecondService {
             "function register(): void { Mailer::send(); }\n"
         )
         caller.write_text(source, encoding="utf-8")
-        target = f"{mailer.resolve()}::Mailer.send"
+        target = f"{mailer.resolve().as_posix()}::Mailer.send"
 
         store = GraphStore(":memory:")
         try:
@@ -666,7 +666,7 @@ class SecondService {
             assert result["errors"] == []
             assert any(
                 edge.kind == "CALLS" and edge.target_qualified == target
-                for edge in store.get_edges_by_source(f"{caller.resolve()}::register")
+                for edge in store.get_edges_by_source(f"{caller.resolve().as_posix()}::register")
             )
         finally:
             store.close()

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -234,7 +234,7 @@ class TestJavaImportResolution:
         _, edges = parser.parse_file(svc / "App.java")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
-        assert imports[0].target == str((auth / "User.java").resolve())
+        assert imports[0].target == (auth / "User.java").resolve().as_posix()
 
     def test_jdk_import_stays_unresolved(self):
         """JDK imports have no local file and remain as raw strings."""
@@ -267,7 +267,7 @@ class TestJavaImportResolution:
         _, edges = parser.parse_file(app_dir / "App.java")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
-        assert imports[0].target == str((pkg / "Helper.java").resolve())
+        assert imports[0].target == (pkg / "Helper.java").resolve().as_posix()
 
     def test_wildcard_import_stays_unresolved(self, tmp_path):
         """Wildcard imports cannot resolve to a single file."""
@@ -602,8 +602,8 @@ class TestCSharpNamespaceResolution:
         result = query_graph("importers_of", str(core), repo_root=str(tmp_path))
         assert result.get("status") == "ok"
         importers = {r["file"] for r in result.get("results", [])}
-        assert str(app) in importers
-        assert str(unrelated) not in importers
+        assert app.as_posix() in importers
+        assert unrelated.as_posix() not in importers
 
     def test_importers_of_resolves_nested_block_namespace(self, tmp_path):
         from code_review_graph.graph import GraphStore
@@ -642,7 +642,7 @@ class TestCSharpNamespaceResolution:
         result = query_graph("importers_of", str(core), repo_root=str(tmp_path))
         assert result.get("status") == "ok"
         importers = {r["file"] for r in result.get("results", [])}
-        assert str(app) in importers
+        assert app.as_posix() in importers
 
     def test_deep_ast_preserves_nested_namespace_metadata(self, tmp_path):
         """Namespace discovery must not recurse through the whole C# AST."""
@@ -982,7 +982,7 @@ class TestPHPImportResolution:
         _, edges = parser.parse_file(svc / "MatchService.php")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
-        assert imports[0].target == str((entity / "Job.php").resolve())
+        assert imports[0].target == (entity / "Job.php").resolve().as_posix()
 
     def test_vendor_import_stays_unresolved(self, tmp_path):
         """A class with no local file stays as the bare FQN, not a raw
@@ -1019,7 +1019,7 @@ class TestPHPImportResolution:
         _, edges = parser.parse_file(job / "Job.php")
         imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
         assert len(imports) == 1
-        assert imports[0].target == str((contact / "Contact.php").resolve())
+        assert imports[0].target == (contact / "Contact.php").resolve().as_posix()
 
     def test_grouped_use_expands_to_multiple_imports(self, tmp_path):
         """``use App\\Domain\\{Entity\\Job, Model\\Status}`` -> two imports,
@@ -1043,8 +1043,8 @@ class TestPHPImportResolution:
         parser = CodeParser(tmp_path)
         _, edges = parser.parse_file(consumer / "C.php")
         targets = {e.target for e in edges if e.kind == "IMPORTS_FROM"}
-        assert str((base / "Entity/Job.php").resolve()) in targets
-        assert str((base / "Model/Status.php").resolve()) in targets
+        assert (base / "Entity/Job.php").resolve().as_posix() in targets
+        assert (base / "Model/Status.php").resolve().as_posix() in targets
         assert len(targets) == 2
 
 
@@ -2704,7 +2704,7 @@ class TestNixParsing:
         assert any("foo.nix" in t for t in targets)
 
     def test_contains_edges_wire_file_to_top_level_bindings(self):
-        file_path = str(self.flake_path)
+        file_path = self.flake_path.as_posix()
         contains_targets = {
             e.target for e in self.flake_edges
             if e.kind == "CONTAINS" and e.source == file_path

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -259,7 +259,7 @@ class Plain:
         """Call targets defined in the same file should be qualified."""
         nodes, edges = self.parser.parse_file(FIXTURES / "sample_python.py")
         calls = [e for e in edges if e.kind == "CALLS"]
-        file_path = str(FIXTURES / "sample_python.py")
+        file_path = (FIXTURES / "sample_python.py").as_posix()
 
         # create_auth_service() calls AuthService() — a class defined in the same file
         auth_service_calls = [
@@ -272,7 +272,7 @@ class Plain:
         _, edges = self.parser.parse_file(FIXTURES / "caller_example.py")
         calls = [e for e in edges if e.kind == "CALLS"]
 
-        sample_path = str((FIXTURES / "sample_python.py").resolve())
+        sample_path = (FIXTURES / "sample_python.py").resolve().as_posix()
         # setup_and_run() calls create_auth_service(), imported from sample_python
         resolved_calls = [
             e for e in calls if e.target == f"{sample_path}::create_auth_service"
@@ -291,7 +291,7 @@ class Plain:
         """Decorated functions should be in defined_names and resolvable as call targets."""
         _, edges = self.parser.parse_file(FIXTURES / "sample_python.py")
         calls = [e for e in edges if e.kind == "CALLS"]
-        file_path = str(FIXTURES / "sample_python.py")
+        file_path = (FIXTURES / "sample_python.py").as_posix()
 
         # guarded_process() calls process_request() — both in the same file,
         # but guarded_process is wrapped in a decorated_definition node
@@ -329,7 +329,7 @@ class Plain:
         try:
             _, edges = self.parser.parse_file(tmp)
             calls = [e for e in edges if e.kind == "CALLS"]
-            module_scope_calls = [e for e in calls if e.source == str(tmp)]
+            module_scope_calls = [e for e in calls if e.source == tmp.as_posix()]
             assert any(
                 "helper" in e.target for e in module_scope_calls
             ), f"Expected module-scope CALLS edge to helper(); got: {[(e.source, e.target) for e in calls]}"
@@ -363,7 +363,7 @@ class Plain:
             _, edges = self.parser.parse_file(tmp)
             calls = [e for e in edges if e.kind == "CALLS"]
             assert any(
-                "do_work" in e.target and e.source == str(tmp) for e in calls
+                "do_work" in e.target and e.source == tmp.as_posix() for e in calls
             ), f"Expected notebook CALLS edge to do_work(); got: {[(e.source, e.target) for e in calls]}"
         finally:
             tmp.unlink()
@@ -399,7 +399,7 @@ class Plain:
         tested_by = [e for e in edges if e.kind == "TESTED_BY"]
         assert len(tested_by) >= 1, "fixture should yield at least one TESTED_BY edge"
 
-        test_file = str(FIXTURES / "test_sample.py")
+        test_file = (FIXTURES / "test_sample.py").as_posix()
         test_qualified = {
             f"{test_file}::{n.name}" for n in nodes if n.kind == "Test"
         }
@@ -578,7 +578,7 @@ class Plain:
         nodes, edges = self.parser.parse_file(FIXTURES / "sample.dart")
         contains = [e for e in edges if e.kind == "CONTAINS"]
         # File should contain top-level classes and functions
-        file_path = str(FIXTURES / "sample.dart")
+        file_path = (FIXTURES / "sample.dart").as_posix()
         file_contains = [e for e in contains if e.source == file_path]
         assert len(file_contains) >= 1
         # Dog class should contain its methods
@@ -683,7 +683,7 @@ class Plain:
         ]
         assert len(it_tests) >= 2
 
-        file_path = str(FIXTURES / "sample_vitest.test.ts")
+        file_path = (FIXTURES / "sample_vitest.test.ts").as_posix()
         describe_qualified = {f"{file_path}::{n.name}" for n in describe_nodes}
         contains_sources = {e.source for e in edges if e.kind == "CONTAINS"}
         assert describe_qualified & contains_sources
@@ -694,7 +694,7 @@ class Plain:
         calls = [e for e in edges if e.kind == "CALLS"]
         assert len(calls) >= 1
         test_names = {n.name for n in nodes if n.kind == "Test"}
-        file_path = str(FIXTURES / "sample_vitest.test.ts")
+        file_path = (FIXTURES / "sample_vitest.test.ts").as_posix()
         test_qualified = {f"{file_path}::{name}" for name in test_names}
         call_sources = {e.source for e in calls}
         assert call_sources & test_qualified
@@ -869,10 +869,10 @@ class Plain:
         _, edges = self.parser.parse_bytes(path, source)
 
         calls = [e for e in edges if e.kind == "CALLS"]
-        expected_target = f"{str((FIXTURES / 'MarkdownMsg.tsx').resolve())}::MarkdownMsg"
+        expected_target = f"{(FIXTURES / 'MarkdownMsg.tsx').resolve().as_posix()}::MarkdownMsg"
         jsx_calls = [
             e for e in calls
-            if e.source == f"{path}::BookWorkspace" and e.target == expected_target
+            if e.source == f"{path.as_posix()}::BookWorkspace" and e.target == expected_target
         ]
         assert len(jsx_calls) == 1
 
@@ -902,7 +902,7 @@ class Plain:
         calls = [e for e in edges if e.kind == "CALLS"]
         jsx_calls = [
             e for e in calls
-            if e.source == f"{path}::BookWorkspace" and e.target == "MarkdownMsg"
+            if e.source == f"{path.as_posix()}::BookWorkspace" and e.target == "MarkdownMsg"
         ]
         assert len(jsx_calls) == 1
 
@@ -918,10 +918,10 @@ class Plain:
         _, edges = self.parser.parse_bytes(path, source)
 
         calls = [e for e in edges if e.kind == "CALLS"]
-        expected_target = f"{str((FIXTURES / 'MarkdownMsg.tsx').resolve())}::MarkdownMsg"
+        expected_target = f"{(FIXTURES / 'MarkdownMsg.tsx').resolve().as_posix()}::MarkdownMsg"
         jsx_calls = [
             e for e in calls
-            if e.source == f"{path}::BookWorkspace" and e.target == expected_target
+            if e.source == f"{path.as_posix()}::BookWorkspace" and e.target == expected_target
         ]
         assert len(jsx_calls) == 1
 
@@ -937,10 +937,10 @@ class Plain:
         _, edges = self.parser.parse_bytes(path, source)
 
         calls = [e for e in edges if e.kind == "CALLS"]
-        expected_target = f"{str((FIXTURES / 'MarkdownMsg.tsx').resolve())}::MarkdownMsg"
+        expected_target = f"{(FIXTURES / 'MarkdownMsg.tsx').resolve().as_posix()}::MarkdownMsg"
         jsx_calls = [
             e for e in calls
-            if e.source == f"{path}::BookWorkspace" and e.target == expected_target
+            if e.source == f"{path.as_posix()}::BookWorkspace" and e.target == expected_target
         ]
         assert len(jsx_calls) == 1
 
@@ -968,12 +968,13 @@ class Plain:
 
             calls = [e for e in edges if e.kind == "CALLS"]
             expected_target = (
-                f"{str((root / 'components' / 'MarkdownMsg.tsx').resolve())}"
+                f"{(root / 'components' / 'MarkdownMsg.tsx').resolve().as_posix()}"
                 "::MarkdownMsg"
             )
             jsx_calls = [
                 e for e in calls
-                if e.source == f"{consumer}::BookWorkspace" and e.target == expected_target
+                if e.source == f"{consumer.as_posix()}::BookWorkspace"
+                and e.target == expected_target
             ]
             assert len(jsx_calls) == 1
 
@@ -1001,12 +1002,13 @@ class Plain:
 
             calls = [e for e in edges if e.kind == "CALLS"]
             expected_target = (
-                f"{str((root / 'components' / 'MarkdownMsg.tsx').resolve())}"
+                f"{(root / 'components' / 'MarkdownMsg.tsx').resolve().as_posix()}"
                 "::MarkdownMsg"
             )
             jsx_calls = [
                 e for e in calls
-                if e.source == f"{consumer}::BookWorkspace" and e.target == expected_target
+                if e.source == f"{consumer.as_posix()}::BookWorkspace"
+                and e.target == expected_target
             ]
             assert len(jsx_calls) == 1
 
@@ -1034,12 +1036,13 @@ class Plain:
 
             calls = [e for e in edges if e.kind == "CALLS"]
             expected_target = (
-                f"{str((root / 'components' / 'MarkdownMsg.tsx').resolve())}"
+                f"{(root / 'components' / 'MarkdownMsg.tsx').resolve().as_posix()}"
                 "::MarkdownMsg"
             )
             jsx_calls = [
                 e for e in calls
-                if e.source == f"{consumer}::BookWorkspace" and e.target == expected_target
+                if e.source == f"{consumer.as_posix()}::BookWorkspace"
+                and e.target == expected_target
             ]
             assert len(jsx_calls) == 1
 
@@ -1082,7 +1085,7 @@ class Plain:
             _, edges = self.parser.parse_file(consumer)
 
             expected_target = (
-                f"{str((components / 'MarkdownMsg.jsx').resolve())}::MarkdownMsg"
+                f"{(components / 'MarkdownMsg.jsx').resolve().as_posix()}::MarkdownMsg"
             )
             jsx_calls = [
                 e for e in edges
@@ -1092,8 +1095,8 @@ class Plain:
             for edge in jsx_calls:
                 by_source[edge.source] = by_source.get(edge.source, 0) + 1
             assert by_source == {
-                f"{consumer}::BookDashboard": 3,
-                f"{consumer}::AIPanel": 2,
+                f"{consumer.as_posix()}::BookDashboard": 3,
+                f"{consumer.as_posix()}::AIPanel": 2,
             }
 
     def test_nested_barrel_chain_resolves_component_to_origin_file(self):
@@ -1125,12 +1128,12 @@ class Plain:
             _, edges = self.parser.parse_file(consumer)
 
             expected_target = (
-                f"{str((messages / 'MarkdownMsg.jsx').resolve())}::MarkdownMsg"
+                f"{(messages / 'MarkdownMsg.jsx').resolve().as_posix()}::MarkdownMsg"
             )
             jsx_calls = [
                 e for e in edges
                 if e.kind == "CALLS"
-                and e.source == f"{consumer}::BookDashboard"
+                and e.source == f"{consumer.as_posix()}::BookDashboard"
                 and e.target == expected_target
             ]
             assert len(jsx_calls) == 1
@@ -1724,7 +1727,7 @@ class TestValueReferences:
         """REFERENCES edges should have resolved (qualified) targets for local funcs."""
         nodes, edges = self.parser.parse_file(FIXTURES / "sample_map_dispatch.ts")
         refs = [e for e in edges if e.kind == "REFERENCES"]
-        file_path = str(FIXTURES / "sample_map_dispatch.ts")
+        file_path = (FIXTURES / "sample_map_dispatch.ts").as_posix()
         # At least some targets should be fully qualified
         qualified_refs = [e for e in refs if "::" in e.target]
         assert len(qualified_refs) > 0
@@ -1755,7 +1758,7 @@ class TestModuleScopeCalls:
         calls = [e for e in edges if e.kind == "CALLS"]
         top_level = [
             e for e in calls
-            if e.source == str(path) and e.target.endswith("worker")
+            if e.source == path.as_posix() and e.target.endswith("worker")
         ]
         assert len(top_level) == 1
         # Edge originates at the call site (line 4), not the def (line 1).
@@ -1775,7 +1778,7 @@ class TestModuleScopeCalls:
         calls = [e for e in edges if e.kind == "CALLS"]
         top_level = [
             e for e in calls
-            if e.source == str(path) and e.target.endswith("run_job")
+            if e.source == path.as_posix() and e.target.endswith("run_job")
         ]
         assert len(top_level) == 1
         # Edge originates inside the `if __name__` block (line 5).
@@ -1796,7 +1799,7 @@ class TestModuleScopeCalls:
         calls = [e for e in edges if e.kind == "CALLS"]
         top_level = [
             e for e in calls
-            if e.source == str(path) and e.target.endswith("App")
+            if e.source == path.as_posix() and e.target.endswith("App")
         ]
         assert len(top_level) == 1
         # Edge originates at the JSX site (line 3), not the import (line 1).
@@ -1818,7 +1821,7 @@ class TestModuleScopeCalls:
         top_level = [
             e for e in edges
             if e.kind == "CALLS"
-            and e.source == str(path)
+            and e.source == path.as_posix()
             and e.target.endswith("worker")
         ]
         assert len(top_level) == 1
@@ -1833,7 +1836,7 @@ class TestModuleScopeCalls:
         top_level = [
             e for e in edges
             if e.kind == "CALLS"
-            and e.source == str(path)
+            and e.source == path.as_posix()
             and e.target.endswith("puts")
         ]
         assert len(top_level) == 1
@@ -2012,10 +2015,10 @@ class TestJsMemberAssignedFunctions:
         )
         contains = [
             e for e in edges
-            if e.kind == "CONTAINS" and e.target == f"{path}::app.handle"
+            if e.kind == "CONTAINS" and e.target == f"{path.as_posix()}::app.handle"
         ]
         assert len(contains) == 1
-        assert contains[0].source == str(path)
+        assert contains[0].source == path.as_posix()
 
     def test_non_function_member_assignment_not_captured(self):
         """``obj.prop = <non-function>`` must not create a Function node."""
@@ -2040,7 +2043,7 @@ class TestJsMemberAssignedFunctions:
         assert {n.name for n in functions} == {"a", "b"}
         assert all(n.name != "x.run" for n in functions)
         assert all(
-            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            not (e.kind == "CONTAINS" and e.target == f"{path.as_posix()}::x.run")
             for e in edges
         )
 
@@ -2055,7 +2058,7 @@ class TestJsMemberAssignedFunctions:
         functions = [n for n in nodes if n.kind == "Function"]
         assert all(n.name != "x.run" for n in functions)
         assert all(
-            not (e.kind == "CONTAINS" and e.target == f"{path}::x.run")
+            not (e.kind == "CONTAINS" and e.target == f"{path.as_posix()}::x.run")
             for e in edges
         )
 
@@ -2071,7 +2074,7 @@ class TestJsMemberAssignedFunctions:
         assert all(
             not (
                 e.kind == "CONTAINS"
-                and e.target == f"{path}::factory().handle"
+                and e.target == f"{path.as_posix()}::factory().handle"
             )
             for e in edges
         )
@@ -2086,7 +2089,7 @@ class TestJsMemberAssignedFunctions:
         )
         calls = [
             e for e in edges
-            if e.kind == "CALLS" and e.source == f"{path}::start"
+            if e.kind == "CALLS" and e.source == f"{path.as_posix()}::start"
         ]
         assert len(calls) == 2
         handle_call = next(e for e in calls if e.target == "handle")
@@ -2105,7 +2108,7 @@ class TestJsMemberAssignedFunctions:
         calls = [
             e for e in edges
             if e.kind == "CALLS"
-            and e.source == f"{path}::app.handle"
+            and e.source == f"{path.as_posix()}::app.handle"
             and e.target.endswith("helper")
         ]
         assert len(calls) == 1
@@ -2120,10 +2123,10 @@ class TestJsMemberAssignedFunctions:
         )
         calls = [
             e for e in edges
-            if e.kind == "CALLS" and e.source == f"{path}::start"
+            if e.kind == "CALLS" and e.source == f"{path.as_posix()}::start"
         ]
         assert len(calls) == 1
-        assert calls[0].target == f"{path}::app.handle"
+        assert calls[0].target == f"{path.as_posix()}::app.handle"
 
     def test_optional_member_call_resolves_to_member_assigned_function(self):
         """Optional chaining retains the same static member-call target."""
@@ -2135,10 +2138,10 @@ class TestJsMemberAssignedFunctions:
         )
         calls = [
             e for e in edges
-            if e.kind == "CALLS" and e.source == f"{path}::start"
+            if e.kind == "CALLS" and e.source == f"{path.as_posix()}::start"
         ]
         assert len(calls) == 1
-        assert calls[0].target == f"{path}::app.handle"
+        assert calls[0].target == f"{path.as_posix()}::app.handle"
 
     def test_member_assignment_survives_full_build_with_resolved_caller(
         self,
@@ -2153,8 +2156,8 @@ class TestJsMemberAssignedFunctions:
             "function start() { return app.handle(); }\n",
             encoding="utf-8",
         )
-        member_qn = f"{source}::app.handle"
-        caller_qn = f"{source}::start"
+        member_qn = f"{source.as_posix()}::app.handle"
+        caller_qn = f"{source.as_posix()}::start"
 
         with GraphStore(tmp_path / "graph.db") as store:
             built = full_build(tmp_path, store)
@@ -2239,8 +2242,9 @@ class TestTypeScriptTypeDeclarations:
                 for e in edges
                 if e.kind == "REFERENCES"
             }
-            assert (f"{use}::summarize", f"{types.resolve()}::Finding") in refs
-            assert (f"{use}::summarize", f"{types.resolve()}::Verdict") in refs
+            summarize = f"{use.as_posix()}::summarize"
+            assert (summarize, f"{types.resolve().as_posix()}::Finding") in refs
+            assert (summarize, f"{types.resolve().as_posix()}::Verdict") in refs
 
     def test_aliased_type_import_resolves_to_exported_symbol(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2263,11 +2267,11 @@ class TestTypeScriptTypeDeclarations:
                 if edge.kind == "REFERENCES"
             }
             assert (
-                f"{use}::summarize",
-                f"{types.resolve()}::Finding",
+                f"{use.as_posix()}::summarize",
+                f"{types.resolve().as_posix()}::Finding",
             ) in refs
             assert not any(
-                target == f"{types.resolve()}::ImportedFinding"
+                target == f"{types.resolve().as_posix()}::ImportedFinding"
                 for _, target in refs
             )
 
@@ -2281,8 +2285,8 @@ class TestTypeScriptTypeDeclarations:
             # Severity appears only as Map<string, Severity>.
             assert any(
                 e.kind == "REFERENCES"
-                and e.source == f"{use}::summarize"
-                and e.target == f"{types.resolve()}::Severity"
+                and e.source == f"{use.as_posix()}::summarize"
+                and e.target == f"{types.resolve().as_posix()}::Severity"
                 for e in edges
             )
 
@@ -2315,8 +2319,8 @@ class TestTypeScriptTypeDeclarations:
 
             assert any(
                 e.kind == "REFERENCES"
-                and e.source == f"{wrapper}::Wrapper"
-                and e.target == f"{types.resolve()}::Verdict"
+                and e.source == f"{wrapper.as_posix()}::Wrapper"
+                and e.target == f"{types.resolve().as_posix()}::Verdict"
                 for e in edges
             )
 
@@ -2346,8 +2350,8 @@ class TestTypeScriptTypeDeclarations:
             inherits = {
                 (e.source, e.target) for e in edges if e.kind == "INHERITS"
             }
-            assert (f"{impl}::Impl", "Base") in inherits
-            assert (f"{impl}::Impl", "Findable") in inherits
+            assert (f"{impl.as_posix()}::Impl", "Base") in inherits
+            assert (f"{impl.as_posix()}::Impl", "Findable") in inherits
 
     def test_interface_extends_emits_inherits_edge(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2366,7 +2370,7 @@ class TestTypeScriptTypeDeclarations:
             _, edges = self.parser.parse_file(wrapper)
 
             inherits = {(e.source, e.target) for e in edges if e.kind == "INHERITS"}
-            assert (f"{wrapper}::Wrapper", "Findable") in inherits
+            assert (f"{wrapper.as_posix()}::Wrapper", "Findable") in inherits
 
     def test_heritage_does_not_double_emit_a_reference(self):
         """A base is already an INHERITS edge; it must not also be REFERENCES."""
@@ -2416,13 +2420,13 @@ class TestTypeScriptTypeDeclarations:
             references = [
                 edge for edge in edges
                 if edge.kind == "REFERENCES"
-                and edge.target == f"{base.resolve()}::Box"
+                and edge.target == f"{base.resolve().as_posix()}::Box"
             ]
             assert len(inherits) == 2
             assert references == []
             assert any(
                 edge.kind == "REFERENCES"
-                and edge.target == f"{base.resolve()}::Payload"
+                and edge.target == f"{base.resolve().as_posix()}::Payload"
                 for edge in edges
             )
 
@@ -2443,7 +2447,7 @@ class TestTypeScriptTypeDeclarations:
 
             assert any(
                 e.kind == "REFERENCES"
-                and e.source == f"{panel}::Panel"
-                and e.target == f"{types.resolve()}::Finding"
+                and e.source == f"{panel.as_posix()}::Panel"
+                and e.target == f"{types.resolve().as_posix()}::Finding"
                 for e in edges
             )

--- a/tests/test_php_laravel.py
+++ b/tests/test_php_laravel.py
@@ -63,7 +63,7 @@ class TestComposerPsr4:
             "App\\Models\\User",
         )
 
-        assert resolved == str(target.resolve())
+        assert resolved == target.resolve().as_posix()
 
     def test_composer_uses_longest_matching_prefix(self, tmp_path):
         repo = tmp_path / "repo"
@@ -87,7 +87,7 @@ class TestComposerPsr4:
             "App\\Domain\\Thing",
         )
 
-        assert resolved == str(target.resolve())
+        assert resolved == target.resolve().as_posix()
 
     def test_composer_checks_every_directory_for_prefix(self, tmp_path):
         repo = tmp_path / "repo"
@@ -103,7 +103,7 @@ class TestComposerPsr4:
             "App\\Thing",
         )
 
-        assert resolved == str(target.resolve())
+        assert resolved == target.resolve().as_posix()
 
     def test_composer_merges_autoload_and_autoload_dev_directories(self, tmp_path):
         repo = tmp_path / "repo"
@@ -122,7 +122,7 @@ class TestComposerPsr4:
             "App\\Tests\\Factory",
         )
 
-        assert resolved == str(target.resolve())
+        assert resolved == target.resolve().as_posix()
 
     @pytest.mark.parametrize(
         "data",
@@ -300,7 +300,7 @@ class TestComposerPsr4:
             "App\\Domain\\Thing",
         )
 
-        assert resolved == str(target.resolve())
+        assert resolved == target.resolve().as_posix()
 
 
 class TestComposerCache:
@@ -342,7 +342,7 @@ class TestComposerCache:
             "App\\User", str(caller), "php",
         )
 
-        assert first == second == str(target.resolve())
+        assert first == second == target.resolve().as_posix()
         assert composer_reads == 1
 
     def test_composer_cache_reloads_after_stat_change(self, tmp_path):
@@ -370,7 +370,7 @@ class TestComposerCache:
         )
 
         assert first != second
-        assert second == str(updated.resolve())
+        assert second == updated.resolve().as_posix()
 
     def test_composer_cache_isolated_between_repositories(self, tmp_path):
         first_repo = tmp_path / "first"
@@ -395,8 +395,8 @@ class TestComposerCache:
             "App\\User", str(second_caller), "php",
         )
 
-        assert first == str(first_target.resolve())
-        assert second == str(second_target.resolve())
+        assert first == first_target.resolve().as_posix()
+        assert second == second_target.resolve().as_posix()
 
 
 class TestBladeParsing:
@@ -416,8 +416,8 @@ class TestBladeParsing:
         assert parser.detect_language(template) == "blade"
         assert len(nodes) == 1
         assert nodes[0].kind == "File"
-        assert nodes[0].name == str(template)
-        assert nodes[0].file_path == str(template)
+        assert nodes[0].name == template.as_posix()
+        assert nodes[0].file_path == template.as_posix()
         assert nodes[0].language == "blade"
         assert nodes[0].line_end == 7
 
@@ -543,7 +543,7 @@ Router::get('/users', [Users::class, 'index']);
 
         semantic = _laravel_edges(edges, "CALLS")
         assert [(edge.target, edge.extra["laravel_kind"]) for edge in semantic] == [
-            (f"{controller.resolve()}::UserController.index", "route"),
+            (f"{controller.resolve().as_posix()}::UserController.index", "route"),
         ]
         assert len([
             edge for edge in edges
@@ -569,7 +569,7 @@ Router::get('/users', [Users::class, 'index']);
 
         semantic = _laravel_edges(edges, "CALLS")
         assert [edge.target for edge in semantic] == [
-            f"{controller.resolve()}::UserController.store",
+            f"{controller.resolve().as_posix()}::UserController.store",
         ]
         assert len([
             edge for edge in edges
@@ -600,7 +600,7 @@ class User extends BaseModel {
 
         semantic = _laravel_edges(edges, "REFERENCES")
         assert [(edge.target, edge.extra["relationship"]) for edge in semantic] == [
-            (f"{post.resolve()}::Post", "hasMany"),
+            (f"{post.resolve().as_posix()}::Post", "hasMany"),
         ]
         assert len([
             edge for edge in edges
@@ -624,7 +624,7 @@ class User extends \Illuminate\Database\Eloquent\Model {
 
         semantic = _laravel_edges(edges, "REFERENCES")
         assert [edge.target for edge in semantic] == [
-            f"{post.resolve()}::Post",
+            f"{post.resolve().as_posix()}::Post",
         ]
         assert semantic[0].extra["relationship"] == "belongsTo"
 
@@ -651,7 +651,7 @@ namespace App\Bad {
 
         semantic = _laravel_edges(edges, "REFERENCES")
         assert [edge.target for edge in semantic] == [
-            f"{post.resolve()}::Post",
+            f"{post.resolve().as_posix()}::Post",
         ]
         assert semantic[0].source.endswith("::User.posts")
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -331,12 +331,12 @@ class TestToolBuildUsesSharedPipeline:
                 for row in store._conn.execute(
                     "SELECT target_qualified FROM edges "
                     "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
-                    (str(test_file),),
+                    (test_file.as_posix(),),
                 ).fetchall()
-            } == {str(runner)}
+            } == {runner.as_posix()}
 
             run_post_processing(store)
-            production = f"{runner}::render_thing"
+            production = f"{runner.as_posix()}::render_thing"
             tests = store.get_transitive_tests(production, max_depth=0)
             assert {test["name"] for test in tests} == {
                 "test_render_thing_basic",
@@ -355,7 +355,7 @@ class TestToolBuildUsesSharedPipeline:
             imported = store._conn.execute(
                 "SELECT target_qualified, extra FROM edges "
                 "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
-                (str(test_file),),
+                (test_file.as_posix(),),
             ).fetchone()
             assert imported["target_qualified"] == "mypkg.runner"
             assert '"import_resolution": "ambiguous"' in imported["extra"]
@@ -373,9 +373,9 @@ class TestToolBuildUsesSharedPipeline:
             imported = store._conn.execute(
                 "SELECT target_qualified FROM edges "
                 "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
-                (str(test_file),),
+                (test_file.as_posix(),),
             ).fetchone()
-            assert imported["target_qualified"] == str(runner)
+            assert imported["target_qualified"] == runner.as_posix()
 
             run_post_processing(store)
             tests = store.get_transitive_tests(production, max_depth=0)
@@ -418,7 +418,7 @@ class TestToolBuildUsesSharedPipeline:
         graph_dir = tmp_path / ".code-review-graph"
         graph_dir.mkdir()
         tracked = [
-            *(str(path.relative_to(tmp_path)) for path in production_files),
+            *(path.relative_to(tmp_path).as_posix() for path in production_files),
             "tests/test_runner.py",
         ]
 
@@ -435,7 +435,7 @@ class TestToolBuildUsesSharedPipeline:
             import_edge = store._conn.execute(
                 "SELECT target_qualified, extra FROM edges "
                 "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
-                (str(test_file),),
+                (test_file.as_posix(),),
             ).fetchone()
             assert import_edge["target_qualified"] == "mypkg.runner"
             assert '"import_resolution": "ambiguous"' in import_edge["extra"]
@@ -443,7 +443,7 @@ class TestToolBuildUsesSharedPipeline:
             endpoint_edges = store._conn.execute(
                 "SELECT kind, extra FROM edges "
                 "WHERE kind IN ('CALLS', 'TESTED_BY') AND file_path = ?",
-                (str(test_file),),
+                (test_file.as_posix(),),
             ).fetchall()
             assert {row["kind"] for row in endpoint_edges} == {
                 "CALLS",
@@ -457,7 +457,7 @@ class TestToolBuildUsesSharedPipeline:
             for runner in production_files:
                 callers = query_graph(
                     pattern="callers_of",
-                    target=f"{runner}::render_thing",
+                    target=f"{runner.as_posix()}::render_thing",
                     repo_root=str(tmp_path),
                 )
                 assert callers["results"] == []
@@ -541,11 +541,11 @@ class TestWatchCallbackIntegration:
             imported = store._conn.execute(
                 "SELECT target_qualified FROM edges "
                 "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
-                (str(test_file),),
+                (test_file.as_posix(),),
             ).fetchone()
-            assert imported["target_qualified"] == str(runner)
+            assert imported["target_qualified"] == runner.as_posix()
             tests = store.get_transitive_tests(
-                f"{runner}::render_thing",
+                f"{runner.as_posix()}::render_thing",
                 max_depth=0,
             )
             assert {test["name"] for test in tests} == {"test_render_thing"}

--- a/tests/test_python_reachability.py
+++ b/tests/test_python_reachability.py
@@ -215,8 +215,8 @@ def test_graph_consumers_do_not_observe_dead_branch_call(
 
     parser = CodeParser(repo_root=tmp_path)
     parsed = [parser.parse_file(path) for path in (targets_path, caller_path)]
-    dead_qualified = f"{targets_path}::dead_target"
-    live_qualified = f"{targets_path}::live_target"
+    dead_qualified = f"{targets_path.as_posix()}::dead_target"
+    live_qualified = f"{targets_path.as_posix()}::live_target"
 
     with GraphStore(tmp_path / "graph.db") as store:
         for nodes, edges in parsed:

--- a/tests/test_python_star_imports.py
+++ b/tests/test_python_star_imports.py
@@ -31,7 +31,7 @@ def test_star_import_resolves_public_function_from_direct_module(tmp_path: Path)
 
     targets = _call_targets(tmp_path, caller)
 
-    assert f"{helper}::public_helper" in targets
+    assert f"{helper.as_posix()}::public_helper" in targets
     assert "_private_helper" in targets
 
 
@@ -57,7 +57,7 @@ def test_star_import_honors_explicit_dunder_all(tmp_path: Path) -> None:
     targets = _call_targets(tmp_path, caller)
 
     assert "public_helper" in targets
-    assert f"{helper}::_selected_helper" in targets
+    assert f"{helper.as_posix()}::_selected_helper" in targets
 
 
 def test_star_import_resolves_transitive_relative_export(tmp_path: Path) -> None:
@@ -84,7 +84,7 @@ def test_star_import_resolves_transitive_relative_export(tmp_path: Path) -> None
 
     targets = _call_targets(tmp_path, caller)
 
-    assert f"{leaf}::transitive_helper" in targets
+    assert f"{leaf.as_posix()}::transitive_helper" in targets
 
 
 def test_star_import_does_not_follow_symlink_outside_repository(
@@ -210,7 +210,7 @@ def test_concurrent_parsers_compute_star_exports_once(
         )
 
     assert helper_reads == 1
-    assert all(f"{helper}::concurrent_helper" in result for result in targets)
+    assert all(f"{helper.as_posix()}::concurrent_helper" in result for result in targets)
 
 
 def test_star_export_parse_error_leaves_caller_parseable(
@@ -290,4 +290,4 @@ def test_notebook_star_import_resolves_repository_module(tmp_path: Path) -> None
 
     targets = _call_targets(tmp_path, notebook)
 
-    assert f"{helper}::notebook_helper" in targets
+    assert f"{helper.as_posix()}::notebook_helper" in targets

--- a/tests/test_spring_config.py
+++ b/tests/test_spring_config.py
@@ -133,7 +133,7 @@ def test_java_config_annotations_emit_key_only_dependencies(tmp_path: Path) -> N
         "config:payment.gateway.url",
         "config:payment.apiToken",
     }
-    assert {edge.source for edge in config_edges} == {f"{path}::KafkaSettings"}
+    assert {edge.source for edge in config_edges} == {f"{path.as_posix()}::KafkaSettings"}
     serialized_metadata = json.dumps([edge.extra for edge in config_edges])
     assert "do-not-store-this-default" not in serialized_metadata
 

--- a/tests/test_spring_endpoints.py
+++ b/tests/test_spring_endpoints.py
@@ -109,8 +109,8 @@ def test_endpoint_queries_follow_addressable_handles_edges(tmp_path: Path) -> No
         and node.extra["handler"] == "items"
         and node.extra["route"] == "/api/items"
     )
-    endpoint_qn = f"{path}::CatalogController.{endpoint.name}"
-    handler_qn = f"{path}::CatalogController.items"
+    endpoint_qn = f"{path.as_posix()}::CatalogController.{endpoint.name}"
+    handler_qn = f"{path.as_posix()}::CatalogController.items"
 
     handlers = query_graph("handlers_of", endpoint_qn, repo_root=str(tmp_path))
     assert handlers["status"] == "ok"

--- a/tests/test_spring_scheduling.py
+++ b/tests/test_spring_scheduling.py
@@ -46,11 +46,11 @@ def test_scheduled_annotations_create_addressable_nodes_and_edges(tmp_path: Path
         "initialDelay",
     }
     assert {edge.source for edge in triggers} == {
-        f"{path}::Tasks.{node.name}" for node in schedules
+        f"{path.as_posix()}::Tasks.{node.name}" for node in schedules
     }
     assert {edge.target for edge in triggers} == {
-        f"{path}::Tasks.sync",
-        f"{path}::Tasks.cleanup",
+        f"{path.as_posix()}::Tasks.sync",
+        f"{path.as_posix()}::Tasks.cleanup",
     }
 
 
@@ -88,7 +88,7 @@ def test_schedule_queries_follow_triggers_edges(tmp_path: Path) -> None:
         node for node in nodes
         if node.kind == "Scheduler" and node.extra["schedule_kind"] == "cron"
     )
-    cron_qn = f"{path}::Tasks.{cron.name}"
+    cron_qn = f"{path.as_posix()}::Tasks.{cron.name}"
 
     triggered = query_graph("triggers_of", cron_qn, repo_root=str(tmp_path))
     assert triggered["status"] == "ok"
@@ -99,7 +99,7 @@ def test_schedule_queries_follow_triggers_edges(tmp_path: Path) -> None:
 
     schedulers = query_graph(
         "triggered_by",
-        f"{path}::Tasks.sync",
+        f"{path.as_posix()}::Tasks.sync",
         repo_root=str(tmp_path),
         max_results=1,
     )

--- a/tests/test_spring_webflux_endpoints.py
+++ b/tests/test_spring_webflux_endpoints.py
@@ -40,11 +40,11 @@ def test_webflux_routes_link_endpoints_to_actual_typed_handlers(tmp_path: Path) 
         for node in endpoints
     } == {("GET", "/orders"), ("POST", "/orders")}
     assert {edge.source for edge in handles} == {
-        f"{path}::OrderHandler.list",
-        f"{path}::OrderHandler.create",
+        f"{path.as_posix()}::OrderHandler.list",
+        f"{path.as_posix()}::OrderHandler.create",
     }
     assert {edge.target for edge in handles} == {
-        f"{path}::Routes.{node.name}" for node in endpoints
+        f"{path.as_posix()}::Routes.{node.name}" for node in endpoints
     }
 
 
@@ -61,8 +61,8 @@ def test_webflux_endpoint_queries_use_addressable_nodes(tmp_path: Path) -> None:
         for node in nodes
         if node.kind == "Endpoint" and node.extra["http_method"] == "GET"
     )
-    endpoint_qn = f"{path}::Routes.{endpoint.name}"
-    handler_qn = f"{path}::OrderHandler.list"
+    endpoint_qn = f"{path.as_posix()}::Routes.{endpoint.name}"
+    handler_qn = f"{path.as_posix()}::OrderHandler.list"
 
     handlers = query_graph("handlers_of", endpoint_qn, repo_root=str(tmp_path))
     assert [result["qualified_name"] for result in handlers["results"]] == [

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -245,9 +245,9 @@ class TestQueryGraphCallTargetFallbacks:
         (self.root / ".git").mkdir()
         (self.root / ".code-review-graph").mkdir()
 
-        self.target_file = str(self.root / "target.m")
-        self.cross_file = str(self.root / "cross.m")
-        self.dispatch_file = str(self.root / "dispatch.m")
+        self.target_file = (self.root / "target.m").as_posix()
+        self.cross_file = (self.root / "cross.m").as_posix()
+        self.dispatch_file = (self.root / "dispatch.m").as_posix()
         self.db_path = str(self.root / ".code-review-graph" / "graph.db")
         self._seed_data()
 
@@ -352,9 +352,9 @@ class TestQueryGraphCallTargetFallbacks:
             build = full_build(self.root, store)
             assert build["errors"] == []
 
-        type_qn = f"{type_path}::Finding"
-        direct_qn = f"{use_path}::summarize"
-        alias_qn = f"{alias_path}::summarizeAlias"
+        type_qn = f"{type_path.as_posix()}::Finding"
+        direct_qn = f"{use_path.as_posix()}::summarize"
+        alias_qn = f"{alias_path.as_posix()}::summarizeAlias"
         result = query_graph(
             pattern="references_to",
             target=type_qn,
@@ -387,9 +387,9 @@ class TestQueryGraphCallTargetFallbacks:
 
     def test_callers_of_bare_fallback_uses_js_family_without_crossing_to_apex(self):
         """Regression for #708: JS-family callers match, unrelated Apex does not."""
-        js_file = str(self.root / "clone.js")
-        tsx_file = str(self.root / "caller.tsx")
-        apex_file = str(self.root / "Clone.cls")
+        js_file = (self.root / "clone.js").as_posix()
+        tsx_file = (self.root / "caller.tsx").as_posix()
+        apex_file = (self.root / "Clone.cls").as_posix()
         with GraphStore(self.db_path) as store:
             store.upsert_node(NodeInfo(
                 kind="Function", name="clone", file_path=js_file,
@@ -432,10 +432,10 @@ class TestQueryGraphCallTargetFallbacks:
 
     def test_inheritors_of_bare_fallback_uses_js_family_without_apex(self):
         """Bare INHERITS/IMPLEMENTS edges stay inside the JS language family."""
-        base_file = str(self.root / "base.js")
-        ts_file = str(self.root / "child.ts")
-        jsx_file = str(self.root / "implementer.jsx")
-        apex_file = str(self.root / "Child.cls")
+        base_file = (self.root / "base.js").as_posix()
+        ts_file = (self.root / "child.ts").as_posix()
+        jsx_file = (self.root / "implementer.jsx").as_posix()
+        apex_file = (self.root / "Child.cls").as_posix()
         with GraphStore(self.db_path) as store:
             store.upsert_node(NodeInfo(
                 kind="Class", name="BaseWidget", file_path=base_file,
@@ -1119,8 +1119,8 @@ class TestFlowTools:
         ))
 
         # CALLS edges: handle_request -> check_auth -> query_db
-        app_py = str(self.root / "app.py")
-        auth_py = str(self.root / "auth.py")
+        app_py = (self.root / "app.py").as_posix()
+        auth_py = (self.root / "auth.py").as_posix()
         self.store.upsert_edge(EdgeInfo(
             kind="CALLS",
             source=f"{app_py}::handle_request",
@@ -1130,7 +1130,7 @@ class TestFlowTools:
         self.store.upsert_edge(EdgeInfo(
             kind="CALLS",
             source=f"{auth_py}::check_auth",
-            target=f"{str(self.root / 'db.py')}::query_db",
+            target=f"{(self.root / 'db.py').as_posix()}::query_db",
             file_path=auth_py, line=10,
         ))
         self.store.commit()
@@ -1292,7 +1292,7 @@ class TestCommunityTools:
     def _seed_data(self):
         """Seed the store with two clusters of related nodes."""
         # Cluster 1: auth module
-        auth_py = str(self.root / "auth.py")
+        auth_py = (self.root / "auth.py").as_posix()
         self.store.upsert_node(NodeInfo(
             kind="File", name="auth.py",
             file_path=auth_py,
@@ -1317,7 +1317,7 @@ class TestCommunityTools:
         ))
 
         # Cluster 2: db module
-        db_py = str(self.root / "db.py")
+        db_py = (self.root / "db.py").as_posix()
         self.store.upsert_node(NodeInfo(
             kind="File", name="db.py",
             file_path=db_py,

--- a/tests/test_typed_receiver_calls.py
+++ b/tests/test_typed_receiver_calls.py
@@ -31,8 +31,8 @@ def test_python_imported_class_and_typed_receivers_resolve(tmp_path: Path) -> No
     _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
 
     targets = _calls_from(edges, "::run")
-    assert targets.count(f"{service.resolve()}::Service.build") == 1
-    assert targets.count(f"{service.resolve()}::Service.work") == 1
+    assert targets.count(f"{service.resolve().as_posix()}::Service.build") == 1
+    assert targets.count(f"{service.resolve().as_posix()}::Service.work") == 1
     assert "build" not in targets
     assert "work" not in targets
 
@@ -53,10 +53,10 @@ def test_python_typed_receiver_scope_does_not_leak(tmp_path: Path) -> None:
 
     _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
 
-    assert f"{source.resolve()}::OuterService.work" in _calls_from(edges, "::outer")
+    assert f"{source.resolve().as_posix()}::OuterService.work" in _calls_from(edges, "::outer")
     inner_targets = _calls_from(edges, "::inner")
-    assert f"{source.resolve()}::InnerService.work" in inner_targets
-    assert f"{source.resolve()}::OuterService.work" not in inner_targets
+    assert f"{source.resolve().as_posix()}::InnerService.work" in inner_targets
+    assert f"{source.resolve().as_posix()}::OuterService.work" not in inner_targets
 
 
 def test_unimported_cross_file_class_name_is_not_guessed(tmp_path: Path) -> None:
@@ -135,9 +135,9 @@ def test_kotlin_generic_parameter_local_and_field_types_resolve(tmp_path: Path) 
     _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
 
     targets = _calls_from(edges, "::Consumer.run")
-    assert f"{service.resolve()}::Service.work" in targets
-    assert f"{service.resolve()}::Service.done" in targets
-    assert f"{service.resolve()}::Service.save" in targets
+    assert f"{service.resolve().as_posix()}::Service.work" in targets
+    assert f"{service.resolve().as_posix()}::Service.done" in targets
+    assert f"{service.resolve().as_posix()}::Service.save" in targets
 
 
 def test_java_generic_parameter_local_and_field_types_resolve(tmp_path: Path) -> None:
@@ -174,9 +174,9 @@ def test_java_generic_parameter_local_and_field_types_resolve(tmp_path: Path) ->
     _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
 
     targets = _calls_from(edges, "::Consumer.run")
-    assert f"{service.resolve()}::Service.work" in targets
-    assert f"{service.resolve()}::Service.done" in targets
-    assert f"{service.resolve()}::Service.save" in targets
+    assert f"{service.resolve().as_posix()}::Service.work" in targets
+    assert f"{service.resolve().as_posix()}::Service.done" in targets
+    assert f"{service.resolve().as_posix()}::Service.save" in targets
 
 
 def test_typescript_generic_parameter_local_and_field_types_resolve(
@@ -205,9 +205,9 @@ def test_typescript_generic_parameter_local_and_field_types_resolve(
     _, edges = CodeParser(repo_root=tmp_path).parse_file(consumer)
 
     targets = _calls_from(edges, "::Consumer.run")
-    assert f"{service.resolve()}::Service.work" in targets
-    assert f"{service.resolve()}::Service.done" in targets
-    assert f"{service.resolve()}::Service.save" in targets
+    assert f"{service.resolve().as_posix()}::Service.work" in targets
+    assert f"{service.resolve().as_posix()}::Service.done" in targets
+    assert f"{service.resolve().as_posix()}::Service.save" in targets
 
 
 def test_typescript_block_shadowing_restores_outer_type(tmp_path: Path) -> None:
@@ -229,8 +229,8 @@ def test_typescript_block_shadowing_restores_outer_type(tmp_path: Path) -> None:
     _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
 
     targets = _calls_from(edges, "::run")
-    assert targets.count(f"{source.resolve()}::OuterService.work") == 2
-    assert targets.count(f"{source.resolve()}::InnerService.work") == 1
+    assert targets.count(f"{source.resolve().as_posix()}::OuterService.work") == 2
+    assert targets.count(f"{source.resolve().as_posix()}::InnerService.work") == 1
 
 
 def test_this_call_resolves_to_its_enclosing_class(tmp_path: Path) -> None:
@@ -243,5 +243,5 @@ def test_this_call_resolves_to_its_enclosing_class(tmp_path: Path) -> None:
     _, edges = CodeParser(repo_root=tmp_path).parse_file(source)
 
     assert _calls_from(edges, "::Second.run") == [
-        f"{source.resolve()}::Second.work",
+        f"{source.resolve().as_posix()}::Second.work",
     ]

--- a/tests/test_windows_path_identity.py
+++ b/tests/test_windows_path_identity.py
@@ -1,0 +1,252 @@
+"""Regression tests for issue #774: Windows path separators in node identity.
+
+Qualified names and ``file_path`` values are graph identity. They must be
+separator-stable across operating systems: a graph built on Windows has to
+produce the same identifiers as one built on Linux/macOS, and consumers that
+reconstruct identifiers from ``Path`` objects must agree with the parser.
+
+These tests simulate Windows behaviour on POSIX hosts by feeding
+``pathlib.PureWindowsPath`` objects (whose ``str()`` uses backslashes) into
+code paths that accept ``Path``-like values.
+"""
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import _reconcile_stale_files
+from code_review_graph.parser import CodeParser, EdgeInfo, NodeInfo, normalize_file_path
+
+# ---------------------------------------------------------------------------
+# The normalization helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_file_path_windows_path_object():
+    assert normalize_file_path(PureWindowsPath(r"C:\repo\src\app.py")) == "C:/repo/src/app.py"
+
+
+def test_normalize_file_path_backslash_string():
+    assert normalize_file_path("C:\\repo\\src\\app.py") == "C:/repo/src/app.py"
+
+
+def test_normalize_file_path_posix_inputs_unchanged():
+    assert normalize_file_path("/repo/src/app.py") == "/repo/src/app.py"
+    assert normalize_file_path(PurePosixPath("/repo/src/app.py")) == "/repo/src/app.py"
+    assert normalize_file_path(Path("infra") / "locals.tf") == "infra/locals.tf"
+
+
+def test_normalize_file_path_relative_windows_path():
+    assert normalize_file_path(PureWindowsPath("infra") / "locals.tf") == "infra/locals.tf"
+
+
+# ---------------------------------------------------------------------------
+# Parser identity: qualified names, node file_path, edge endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_julia_identity_uses_forward_slashes_for_windows_paths():
+    """The exact failure from issue #774: '\\repo\\case.jl::Demo.greet'."""
+    nodes, edges = CodeParser().parse_bytes(
+        PureWindowsPath(r"\repo\case.jl"),
+        b"module Demo\ngreet() = 1\ndelegate() = greet()\nend\n",
+    )
+
+    assert all(n.file_path == "/repo/case.jl" for n in nodes)
+    file_node = next(n for n in nodes if n.kind == "File")
+    assert file_node.name == "/repo/case.jl"
+
+    calls = [e for e in edges if e.kind == "CALLS"]
+    assert any(
+        e.source == "/repo/case.jl::Demo.delegate"
+        and e.target == "/repo/case.jl::Demo.greet"
+        for e in calls
+    )
+    assert all(e.file_path == "/repo/case.jl" for e in edges)
+
+
+def test_hcl_references_use_forward_slashes_for_windows_paths():
+    """The test_hcl_parser.py failure from issue #774, driven via a Windows path."""
+    source = b"""\
+variable "items" {}
+variable "enabled" {}
+
+locals {
+  selected = [
+    for item in var.items : item.name
+    if var.enabled
+  ]
+}
+"""
+    _, edges = CodeParser().parse_bytes(PureWindowsPath("infra") / "locals.tf", source)
+
+    targets = {
+        e.target
+        for e in edges
+        if e.kind == "REFERENCES" and e.source == "infra/locals.tf::local.selected"
+    }
+    assert targets == {
+        "infra/locals.tf::var.items",
+        "infra/locals.tf::var.enabled",
+    }
+
+
+def test_python_identity_uses_forward_slashes_for_windows_paths():
+    nodes, edges = CodeParser().parse_bytes(
+        PureWindowsPath(r"C:\repo\pkg\mod.py"),
+        b"class Greeter:\n    def greet(self):\n        return 1\n",
+    )
+
+    assert all(n.file_path == "C:/repo/pkg/mod.py" for n in nodes)
+    contains = {(e.source, e.target) for e in edges if e.kind == "CONTAINS"}
+    assert ("C:/repo/pkg/mod.py::Greeter", "C:/repo/pkg/mod.py::Greeter.greet") in contains
+
+
+def test_qualify_normalizes_file_path_component():
+    parser = CodeParser()
+    assert parser._qualify("greet", "\\repo\\case.jl", "Demo") == "/repo/case.jl::Demo.greet"
+    assert parser._qualify("greet", "/repo/case.jl", None) == "/repo/case.jl::greet"
+
+
+def test_php_namespace_backslashes_survive_normalization(tmp_path):
+    """Only the path component is normalized; PHP FQN identifiers keep '\\'."""
+    php = tmp_path / "service.php"
+    php.write_text(
+        "<?php\nnamespace App\\Service;\nuse App\\Domain\\Entity\\Job;\n"
+        "class Handler { function run() { return new Job(); } }\n",
+        encoding="utf-8",
+    )
+    nodes, edges = CodeParser().parse_file(php)
+
+    # The unresolved import target must keep its namespace backslashes.
+    imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+    assert any("App\\Domain\\Entity\\Job" == e.target for e in imports), (
+        [e.target for e in imports]
+    )
+    assert all(e.file_path == php.as_posix() for e in edges)
+
+
+def test_dataclass_file_path_is_normalized_defensively():
+    node = NodeInfo(
+        kind="Function",
+        name="greet",
+        file_path="C:\\repo\\mod.py",
+        line_start=1,
+        line_end=2,
+    )
+    assert node.file_path == "C:/repo/mod.py"
+
+    edge = EdgeInfo(
+        kind="CALLS",
+        source="a",
+        target="b",
+        file_path="C:\\repo\\mod.py",
+    )
+    assert edge.file_path == "C:/repo/mod.py"
+
+
+def test_file_node_name_is_normalized():
+    node = NodeInfo(
+        kind="File",
+        name="C:\\repo\\mod.py",
+        file_path="C:\\repo\\mod.py",
+        line_start=1,
+        line_end=1,
+    )
+    assert node.name == "C:/repo/mod.py"
+    assert node.file_path == "C:/repo/mod.py"
+
+
+# ---------------------------------------------------------------------------
+# GraphStore boundary: file-keyed lookups accept either separator spelling
+# ---------------------------------------------------------------------------
+
+
+def _store_with_windows_file(tmp_path):
+    store = GraphStore(tmp_path / "graph.db")
+    nodes = [
+        NodeInfo(
+            kind="File",
+            name="C:/repo/src/app.py",
+            file_path="C:/repo/src/app.py",
+            line_start=1,
+            line_end=3,
+        ),
+        NodeInfo(
+            kind="Function",
+            name="run",
+            file_path="C:/repo/src/app.py",
+            line_start=1,
+            line_end=3,
+        ),
+    ]
+    store.store_file_nodes_edges("C:\\repo\\src\\app.py", nodes, [], "hash")
+    return store
+
+
+def test_store_and_lookup_bridge_separator_spellings(tmp_path):
+    store = _store_with_windows_file(tmp_path)
+    try:
+        assert store.get_all_files() == ["C:/repo/src/app.py"]
+        # Native-Windows spelling of the same file must find the same rows.
+        assert len(store.get_nodes_by_file("C:\\repo\\src\\app.py")) == 2
+        assert len(store.get_nodes_by_file("C:/repo/src/app.py")) == 2
+    finally:
+        store.close()
+
+
+def test_remove_files_permanently_bridges_separator_spellings(tmp_path):
+    store = _store_with_windows_file(tmp_path)
+    try:
+        removed = store.remove_files_permanently(["C:\\repo\\src\\app.py"])
+        assert removed == 1
+        assert store.get_all_files() == []
+    finally:
+        store.close()
+
+
+def test_store_file_batch_normalizes_file_key(tmp_path):
+    store = GraphStore(tmp_path / "graph.db")
+    try:
+        node = NodeInfo(
+            kind="File",
+            name="C:/repo/src/app.py",
+            file_path="C:/repo/src/app.py",
+            line_start=1,
+            line_end=1,
+        )
+        store.store_file_nodes_edges("C:/repo/src/app.py", [node], [], "old")
+        # Re-storing under the native-Windows spelling must replace, not duplicate.
+        store.store_file_batch([("C:\\repo\\src\\app.py", [node], [], "new")])
+        assert len(store.get_nodes_by_file("C:/repo/src/app.py")) == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# incremental.py reconciliation: native-separator joins must not orphan files
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_does_not_remove_files_present_under_windows_separators(tmp_path):
+    store = GraphStore(tmp_path / "graph.db")
+    try:
+        node = NodeInfo(
+            kind="File",
+            name="C:/repo/src/app.py",
+            file_path="C:/repo/src/app.py",
+            line_start=1,
+            line_end=1,
+        )
+        store.store_file_nodes_edges("C:/repo/src/app.py", [node], [], "h")
+
+        # On Windows, repo_root / rel yields backslashes. The reconciliation
+        # must still recognise the stored POSIX identity as present.
+        stale = _reconcile_stale_files(
+            PureWindowsPath("C:/repo"),
+            store,
+            current_files=["src/app.py"],
+        )
+        assert stale == []
+        assert store.get_all_files() == ["C:/repo/src/app.py"]
+    finally:
+        store.close()


### PR DESCRIPTION
Fixes #774.

## Problem
18 tests fail on Windows; 15 share one cause: qualified names embed OS-native path separators (CodeParser._qualify builds f"{file_path}::{name}" from str(path), yielding backslashes on Windows while tests and cross-platform graph consumers expect forward slashes).

## Fix (two commits)
Commit 1: a shared normalize_file_path() helper (as_posix for PurePath, backslash-to-slash for str, matching the convention already used in communities/incremental/tools/_common), applied at all 14 str(path) producer sites, _qualify, NodeInfo/EdgeInfo __post_init__, and module-to-file resolution results, plus separator bridging for the file-keyed GraphStore methods. Symbol names are never normalized (PHP namespace identifiers legitimately contain backslashes).

Commit 2 (from adversarial review of commit 1, which showed the producer-side change alone would worsen Windows from 18 to 56 failures): the mechanical test-expectation sweep across 23 test files (str(path)-derived expectations converted to as_posix form, ~360 lines, no assertion weakened; native-spelling inputs to bridged entry points deliberately kept native so bridging stays exercised), and a _bridge_qualified_name() miss-then-retry in GraphStore.get_node (path part normalized, symbol part untouched), with regression tests covering a PureWindowsPath-derived lookup and a PHP FQN whose symbol part contains backslashes.

## Verification
All 19 PureWindowsPath re-simulations of the adversarial review's failure cases pass, including the two demonstrated regressions (test_parser module-scope CALLS assertions; test_cpp_overload_identity get_node crash site). Full suite: 2350 passed, 5 skipped, 2 xpassed. Ruff and mypy clean.

Known limits (from macOS): evidence is PureWindowsPath simulation, not native Windows execution; drive-letter case-insensitivity and UNC paths unverified; pre-fix Windows-built graphs need a rebuild (release-note item); the reporter's 3 non-path failures (symlink/chmod-dependent) are a separate cause and remain open territory. A Windows CI leg would be the durable guard.
