### PR TITLE
test(daemon): fix Windows PID-reuse flake in test_is_daemon_running_dead

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -311,13 +311,21 @@ class TestPIDManagement:
         assert is_daemon_running(pid_path) is True
         mock_kill.assert_called_once_with(1234, 0)
 
-    @patch("os.kill", side_effect=ProcessLookupError)
-    def test_is_daemon_running_dead(self, mock_kill, pid_path):
-        """ProcessLookupError clears stale PID and returns False."""
+    @patch("code_review_graph.daemon.pid_alive", return_value=False)
+    def test_is_daemon_running_dead(self, mock_alive, pid_path):
+        """A dead PID clears the stale PID file and returns False.
+
+        pid_alive is patched at the module seam rather than os.kill: on
+        Windows the liveness check goes through OpenProcess, so an os.kill
+        mock is bypassed and the test would probe the runner's real PID
+        space, where small PIDs like 9999 are routinely reused (flaked in
+        CI). The os.kill mapping itself is covered by TestPidAlive.
+        """
         write_pid(9999, pid_path)
         assert is_daemon_running(pid_path) is False
         # Stale PID file should be cleaned up
         assert not pid_path.exists()
+        mock_alive.assert_called_once_with(9999)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX os.kill branch")
     @patch("os.kill", side_effect=OSError(87, "The parameter is incorrect"))


### PR DESCRIPTION
The CI run on main at commit 86f9fa9 (docs-only change) failed the Windows daemon job: test_is_daemon_running_dead asserted a dead PID but got alive. Root cause: the test patches os.kill, but on Windows pid_alive takes the OpenProcess path, so the mock is bypassed and the test probes the runner's real PID space, where PID 9999 is occasionally a live reused PID. The sibling alive-test already carries a win32 skip for this exact reason.

Fix: patch pid_alive at the module seam instead of os.kill. This keeps the actual behavior under test (stale PID file cleanup in is_daemon_running) covered on all platforms including Windows, and adds an assertion that the liveness check received the parsed PID. The POSIX os.kill mapping remains covered by the dedicated TestPidAlive tests.

Verified: the identical tree passed CI one minute before the failure (3ea59a7 success, 86f9fa9 failure with only CHANGELOG.md differing), confirming flakiness rather than a regression. Local test_daemon run passes.