### PR TITLE
fix(parser): extract Java method names from the name field (#804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
 - C# methods with a non-generic return type are no longer named after that
   type: `public async Task Foo()` indexed as `Task`, collapsing every such
   method in a class onto one qualified name (#791).
+- Java method and constructor names now use the grammar `name` field (same
+  approach as C#), instead of walking for the first `identifier` child (#804).
 - Added a post-index Python import resolver using unique module suffixes, so
   `src/` layouts produce canonical `CALLS` and `TESTED_BY` edges while duplicate
   package candidates remain explicitly unresolved (#720).

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14420,21 +14420,13 @@ class CodeParser:
                     return child.text.decode("utf-8", errors="replace")
                 if child.type == "package" and child.text != b"package":
                     return child.text.decode("utf-8", errors="replace")
-        # Java: method_declaration has return type_identifier before the method
-        # identifier — skip straight to the first plain identifier child to
-        # avoid returning the return type as the function name.
-        if language == "java" and kind == "function" and node.type in (
-            "method_declaration", "constructor_declaration",
-        ):
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode("utf-8", errors="replace")
-            return None
-        # C#: unlike Java there is no type_identifier — a non-generic return
-        # type such as ``Task`` is itself an ``identifier``, so the generic
-        # loop below would return it instead of the method name. Read the
-        # ``name`` field; unusual shapes still fall through.
-        if language == "csharp" and kind == "function" and node.type in (
+        # Java / C#: read the grammar ``name`` field for methods and
+        # constructors. Java return types are usually ``type_identifier``, but
+        # walking for the first ``identifier`` is the same fragile pattern that
+        # misnamed C# methods when a non-generic return type is itself an
+        # ``identifier`` (e.g. ``Task``). Prefer the name field; unusual shapes
+        # still fall through.
+        if language in ("java", "csharp") and kind == "function" and node.type in (
             "method_declaration", "constructor_declaration",
         ):
             name_node = node.child_by_field_name("name")
@@ -14532,16 +14524,6 @@ class CodeParser:
         if language == "go" and node.type == "method_declaration":
             for child in node.children:
                 if child.type == "field_identifier":
-                    return child.text.decode("utf-8", errors="replace")
-        # Java methods: tree-sitter-java puts type_identifier or generic_type
-        # (return type) before identifier (method name).  Must run before
-        # the generic loop, which would match the return type's
-        # type_identifier (e.g. "String", "ConfigBean").
-        # Constructors are fine — they have no return type node.
-        # Kotlin is unaffected: its syntax places the name before the type.
-        if language == "java" and node.type == "method_declaration":
-            for child in node.children:
-                if child.type == "identifier":
                     return child.text.decode("utf-8", errors="replace")
         # Swift init/deinit/subscript: the grammar gives none of them a usable
         # name. `init_declaration`'s name field is the `init` keyword itself,

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -211,6 +211,42 @@ class TestJavaParsing:
         assert len(calls) >= 3
 
 
+class TestJavaMethodNames:
+    """Regression tests for #804: Java method/constructor names come from the
+    grammar ``name`` field (same approach as C# after #794), not the first
+    ``identifier`` child walk.
+    """
+
+    def _parse(self, source: str, tmp_path):
+        p = tmp_path / "x.java"
+        p.write_text(source, encoding="utf-8")
+        return CodeParser().parse_file(p)
+
+    def test_methods_and_constructors_use_name_field(self, tmp_path):
+        nodes, _ = self._parse(
+            "public class Suite {\n"
+            "    public Suite() { }\n"
+            "    public String getLabel() { return \"\"; }\n"
+            "    public User createUser() { return null; }\n"
+            "    public void plainVoid() { }\n"
+            "    public List<String> genericReturn() { return null; }\n"
+            "}\n",
+            tmp_path,
+        )
+        funcs = [n for n in nodes if n.kind == "Function"]
+        assert {f.name for f in funcs} == {
+            "Suite",
+            "getLabel",
+            "createUser",
+            "plainVoid",
+            "genericReturn",
+        }
+        assert len(funcs) == 5
+        assert "String" not in {f.name for f in funcs}
+        assert "User" not in {f.name for f in funcs}
+        assert "List" not in {f.name for f in funcs}
+
+
 class TestJavaImportResolution:
     """Test that Java imports are resolved to absolute file paths."""
 


### PR DESCRIPTION
## Linked issue

Fixes #804

## What & why

During the #794 review, C# `method_declaration` / `constructor_declaration` names were switched to the grammar `name` field via `child_by_field_name("name")`. The Java branch still walked for the first `identifier` child — the same fragile pattern that misnamed C# methods when a non-generic return type is itself an `identifier`.

Java return types usually parse as `type_identifier` today, so there is no known misnaming, but the name-field approach is more robust and keeps the Java and C# branches consistent. Also drops the redundant second Java-only `method_declaration` identifier walk further down `_get_name`.

## How it was tested

```bash
uv run pytest tests/test_multilang.py::TestJavaParsing tests/test_multilang.py::TestJavaMethodNames tests/test_multilang.py::TestCSharpMethodNames -v --tb=short -q
# 10 passed

uv run --extra dev ruff check code_review_graph/parser.py tests/test_multilang.py
# All checks passed
```

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: focused Java/C# name tests above
- [x] Linting passes: `uv run --extra dev ruff check code_review_graph/parser.py tests/test_multilang.py`
- [ ] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` (not re-run; change is a short name-field read with no new types)
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed (CHANGELOG.md)