### PR TITLE
fix(cli): detect-changes/visualize/wiki/watch no longer create empty graph.db

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1603,21 +1603,31 @@ def main() -> None:
         "wiki",
         "dead-code",
     )
-    status_data_dir = (
-        args.command == "status" and bool(getattr(args, "data_dir", None))
+    # Read-only consumers must not create graph.db / data dirs / registry
+    # entries when the graph is missing (follow-up to #777 / #782; see #803).
+    _read_only_db_cmds = frozenset({
+        "status",
+        "detect-changes",
+        "visualize",
+        "wiki",
+        "watch",
+    })
+    explicit_data_dir = bool(getattr(args, "data_dir", None))
+    read_only_explicit_data_dir = (
+        args.command in _read_only_db_cmds and explicit_data_dir
     )
-    if args.command in _data_dir_cmds and not status_data_dir:
+    if args.command in _data_dir_cmds and not read_only_explicit_data_dir:
         _handle_data_dir_option(args, repo_root)
 
-    if args.command == "status":
-        if status_data_dir:
+    if args.command in _read_only_db_cmds:
+        if read_only_explicit_data_dir:
             db_path = Path(args.data_dir).expanduser().resolve() / "graph.db"
         else:
             db_path = get_db_path(repo_root, read_only=True)
         legacy_db = repo_root / ".code-review-graph.db"
         default_db = repo_root / ".code-review-graph" / "graph.db"
         if (
-            not status_data_dir
+            not read_only_explicit_data_dir
             and not db_path.exists()
             and db_path.resolve() == default_db.resolve()
             and legacy_db.exists()
@@ -1627,7 +1637,10 @@ def main() -> None:
             db_path = get_db_path(repo_root)
     else:
         db_path = get_db_path(repo_root)
-    if args.command in ("dead-code", "forget", "status") and not db_path.exists():
+    if (
+        args.command in ("dead-code", "forget", *_read_only_db_cmds)
+        and not db_path.exists()
+    ):
         print(
             f"No graph found at {db_path}. Run `code-review-graph build` first.",
             file=sys.stderr,
@@ -1896,7 +1909,13 @@ def main() -> None:
         elif args.command == "visualize":
             from .incremental import get_data_dir
 
-            data_dir = get_data_dir(repo_root)
+            # Prefer an explicit --data-dir so read-only resolution still
+            # writes exports next to the graph without registry side-effects.
+            if getattr(args, "data_dir", None):
+                data_dir = Path(args.data_dir).expanduser().resolve()
+                data_dir.mkdir(parents=True, exist_ok=True)
+            else:
+                data_dir = get_data_dir(repo_root)
             fmt = getattr(args, "format", "html") or "html"
 
             if fmt == "json":
@@ -1960,7 +1979,12 @@ def main() -> None:
             from .incremental import get_data_dir
             from .wiki import generate_wiki
 
-            wiki_dir = get_data_dir(repo_root) / "wiki"
+            if getattr(args, "data_dir", None):
+                data_dir = Path(args.data_dir).expanduser().resolve()
+                data_dir.mkdir(parents=True, exist_ok=True)
+            else:
+                data_dir = get_data_dir(repo_root)
+            wiki_dir = data_dir / "wiki"
             result = generate_wiki(store, wiki_dir, force=args.force)
             total = result["pages_generated"] + result["pages_updated"] + result["pages_unchanged"]
             print(

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -320,14 +320,14 @@ code-review-graph update --embedding-provider local --embedding-model all-MiniLM
                                                 # Explicitly refresh an existing index (default: off)
 
 # Monitor and inspect
-code-review-graph status                       # Graph statistics
-code-review-graph watch                        # Auto-update on file changes
-code-review-graph visualize                    # Generate interactive HTML graph
+code-review-graph status                       # Graph statistics (no graph → exit 1, does not create DB)
+code-review-graph watch                        # Auto-update on file changes (requires existing graph)
+code-review-graph visualize                    # Generate interactive HTML graph (requires existing graph)
 code-review-graph visualize --format graphml   # Export GraphML
 code-review-graph visualize --serve            # Serve graph.html on localhost:8765
 
 # Analysis
-code-review-graph detect-changes               # Risk-scored change analysis
+code-review-graph detect-changes               # Risk-scored change analysis (read-only; no empty DB)
 code-review-graph detect-changes --base HEAD~3 # Custom base ref
 code-review-graph detect-changes --brief       # Compact panel with token-savings estimate
 code-review-graph detect-changes --brief --verify  # ...and cross-check vs tiktoken
@@ -341,9 +341,12 @@ code-review-graph detect-changes --churn       # Add opt-in change-frequency ris
 #   runs the same analysis at the end. Use this after a rebase, a big
 #   change set, or whenever you suspect the graph is stale.
 # Both end with an identical "Token Savings" panel.
+#
+# Incomplete / empty graphs: run `code-review-graph build` (full re-parse).
+# See docs/TROUBLESHOOTING.md "Empty or incomplete graph".
 
 # Wiki
-code-review-graph wiki                         # Generate markdown wiki from communities
+code-review-graph wiki                         # Generate markdown wiki from communities (requires graph)
 
 # Multi-repo
 code-review-graph register <path> [--alias name]  # Register a repository

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -141,6 +141,32 @@ The graph uses SQLite with WAL mode. If you see lock errors:
 - Check that the file isn't matched by an ignore pattern
 - Run with `full_rebuild=True` to force a complete re-parse
 
+## Empty or incomplete graph (poisoned `graph.db`)
+
+Older releases could create an empty `.code-review-graph/graph.db` when
+commands like `status`, `detect-changes`, `visualize`, `wiki`, or `watch`
+ran before the first full build. Incremental `update` then only re-parsed
+changed files, so the graph stayed incomplete while looking "valid."
+
+Current CLI behavior:
+
+- `status`, `detect-changes`, `visualize`, `wiki`, and `watch` **do not**
+  create a database when none exists — they exit with
+  `No graph found … Run code-review-graph build first.`
+- `update` auto-repairs **missing** or **zero-node** graphs by falling back
+  to a full rebuild.
+
+If a graph was already poisoned (schema present, some nodes, but far fewer
+indexed files than the repo has — e.g. only files touched after an empty DB
+was created), run a full rebuild:
+
+```bash
+code-review-graph build
+```
+
+`build` always re-parses the whole tree (there is no separate `--force`
+flag). After that, `update` / hooks / `watch` can safely stay incremental.
+
 ## Graph seems stale
 - Hooks auto-update on edit/commit
 - If stale, run `/code-review-graph:build-graph` manually

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,13 +112,17 @@ def test_visualize_json_uses_local_export(tmp_path, capsys):
         "json",
     ]
     data_dir = tmp_path / ".code-review-graph"
+    data_dir.mkdir()
+    # visualize is read-only for missing graphs (#803); the path must exist.
+    db_path = data_dir / "graph.db"
+    db_path.touch()
     store = MagicMock()
 
     with patch.object(sys, "argv", argv):
         with patch("code_review_graph.graph.GraphStore", return_value=store):
             with patch(
                 "code_review_graph.incremental.get_db_path",
-                return_value=data_dir / "graph.db",
+                return_value=db_path,
             ):
                 with patch(
                     "code_review_graph.incremental.get_data_dir",

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -150,6 +150,82 @@ def test_status_missing_graph_exits_without_creating_data_tree(
     assert not data_dir.exists()
 
 
+@pytest.mark.parametrize(
+    "command",
+    ["status", "detect-changes", "visualize", "wiki", "watch"],
+)
+def test_read_only_commands_missing_graph_do_not_create_empty_db(
+    command, tmp_path, monkeypatch, capsys,
+):
+    """#803: read-only consumers must not poison a repo with empty graph.db."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    # detect-changes requires a real git worktree for root discovery.
+    if command == "detect-changes":
+        import subprocess
+
+        subprocess.run(
+            ["git", "-C", str(repo), "init", "-q"],
+            check=True,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+    data_dir = tmp_path / "missing-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(data_dir))
+    monkeypatch.delenv("CRG_HOME", raising=False)
+    argv = ["code-review-graph", command, "--repo", str(repo)]
+
+    with patch(
+        "code_review_graph.registry.default_registry_path",
+        return_value=tmp_path / "missing-registry.json",
+    ):
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "No graph found" in err
+    assert not data_dir.exists()
+    assert not (repo / ".code-review-graph").exists()
+
+
+@pytest.mark.parametrize("command", ["visualize", "wiki", "watch", "status"])
+def test_read_only_commands_data_dir_option_is_read_only(
+    command, tmp_path, monkeypatch, capsys,
+):
+    """Explicit --data-dir must not create dirs/registry when the graph is missing."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    data_dir = tmp_path / "explicit-data"
+    registry_path = tmp_path / "registry" / "registry.json"
+    monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+    argv = [
+        "code-review-graph",
+        command,
+        "--repo",
+        str(repo),
+        "--data-dir",
+        str(data_dir),
+    ]
+
+    with patch(
+        "code_review_graph.registry.default_registry_path",
+        return_value=registry_path,
+    ):
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not data_dir.exists()
+    assert not registry_path.exists()
+
+
 def test_status_preserves_legacy_graph_migration(tmp_path, monkeypatch, capsys):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Follow-up to #777 / #782: `status` already resolved the DB path read-only when the graph was missing, but **`detect-changes`**, **`visualize`**, **`wiki`**, and **`watch`** still called `get_db_path()` (create) + `GraphStore()` and could materialize an empty schema `graph.db`. Later incremental `update`s then only re-parsed changed files, leaving the graph incomplete.

### Changes
- Treat those commands like `status`: resolve DB path with `read_only=True` (or explicit `--data-dir` without registry/mkdir side effects).
- Exit with `No graph found … Run code-review-graph build first.` when the DB is missing (same message as `status` / `dead-code` / `forget`).
- Keep the default-path legacy `.code-review-graph.db` migration for these commands.
- `visualize` / `wiki` still write exports next to an explicit `--data-dir` when a graph is present, without forcing a registry write when the graph is absent.
- Document recovery for already-poisoned graphs: full `code-review-graph build` (see `docs/TROUBLESHOOTING.md`). Auto-heal heuristics for incomplete non-empty graphs left out of scope (issue gap 2).

## Test plan

- [x] `uv run pytest tests/test_cli_reconciliation.py tests/test_cli.py::test_visualize_json_uses_local_export tests/test_cli.py::TestWatchInteraction -k "detect_changes or missing_graph or read_only" -q`
- [x] Parametrized tests: missing graph for status/detect-changes/visualize/wiki/watch does **not** create data dir or empty `graph.db`
- [x] Explicit `--data-dir` for visualize/wiki/watch/status is read-only when missing
- [x] Existing status / visualize / watch regressions still green
- [x] `ruff check` on touched Python files

Fixes #803