### PR TITLE
fix(parser): load C/C++/Bash probes with parent language-pack path (#807)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- Grammar-load probes reuse the parent process's `tree_sitter_language_pack`
+  import path (via `PYTHONPATH`) and print installable recovery guidance when a
+  probe fails, so `pip install --user` / non-standard site layouts no longer
+  skip C, C++, Bash, Python, and other bundled grammars with opaque
+  "unavailable" warnings (#807; builds on #760).
 - C# receiver calls (`Service.StaticCall()`, `obj.Method()`, `obj?.Method()`)
   now resolve to canonical method nodes using receiver-type and namespace
   evidence recorded at parse time, so `callers_of`, `get_impact_radius`, and

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -470,6 +470,60 @@ def _parser_load_timeout_seconds() -> float:
     return timeout
 
 
+def _parser_probe_env() -> dict[str, str]:
+    """Build the environment for a disposable grammar-load probe.
+
+    The probe runs in a child interpreter so a hanging or crashing native
+    grammar cannot take down the parent. The child must still be able to
+    import the same ``tree_sitter_language_pack`` the parent can see
+    (venv site-packages, ``pip install --user``, or a non-standard
+    ``sys.path`` entry). Isolated mode (``python -I``) is intentionally
+    avoided for this reason (#760, #807).
+    """
+    env = os.environ.copy()
+    try:
+        module = importlib.import_module("tree_sitter_language_pack")
+    except ImportError:
+        return env
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        return env
+    pack_parent = str(Path(module_file).resolve().parent.parent)
+    existing = env.get("PYTHONPATH", "")
+    parts = [part for part in existing.split(os.pathsep) if part]
+    if pack_parent not in parts:
+        env["PYTHONPATH"] = (
+            os.pathsep.join([pack_parent, *parts]) if parts else pack_parent
+        )
+    return env
+
+
+def _install_hint_for_probe_failure(detail: str) -> str | None:
+    """Return installable guidance for common probe failure modes."""
+    lowered = detail.lower()
+    if "tree_sitter_language_pack" in lowered and (
+        "modulenotfounderror" in lowered
+        or "no module named" in lowered
+        or "import error" in lowered
+        or "importerror" in lowered
+    ):
+        return (
+            "Install tree-sitter-language-pack for the same Python that runs "
+            "code-review-graph: pip install 'tree-sitter-language-pack>=0.3.0,<1'"
+        )
+    if (
+        "could not find language library" in lowered
+        or "lookuperror" in lowered
+    ):
+        return (
+            "This grammar may be missing from the installed "
+            "tree-sitter-language-pack; upgrade it "
+            "(pip install -U 'tree-sitter-language-pack>=0.3.0,<1') "
+            "or rebuild its native extensions"
+        )
+    return None
+
+
 def _run_parser_load_probe(grammar: str, timeout_seconds: float) -> bool:
     """Probe one native grammar in a disposable interpreter process."""
     code = (
@@ -485,6 +539,7 @@ def _run_parser_load_probe(grammar: str, timeout_seconds: float) -> bool:
             stderr=subprocess.PIPE,
             timeout=timeout_seconds,
             check=False,
+            env=_parser_probe_env(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _PARSER_PROBE_FAILURE_DETAILS[grammar] = str(exc)
@@ -531,11 +586,20 @@ def _parser_load_probe_succeeds(
         if not result:
             detail = _PARSER_PROBE_FAILURE_DETAILS.get(grammar)
             if detail:
-                logger.warning(
-                    "Skipping unavailable tree-sitter parser for %s: %s",
-                    grammar,
-                    detail,
-                )
+                hint = _install_hint_for_probe_failure(detail)
+                if hint:
+                    logger.warning(
+                        "Skipping unavailable tree-sitter parser for %s: %s. %s",
+                        grammar,
+                        detail,
+                        hint,
+                    )
+                else:
+                    logger.warning(
+                        "Skipping unavailable tree-sitter parser for %s: %s",
+                        grammar,
+                        detail,
+                    )
             else:
                 logger.warning(
                     "Skipping unavailable tree-sitter parser for %s",

--- a/tests/test_parser_load_probe.py
+++ b/tests/test_parser_load_probe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import subprocess
 import sys
@@ -128,6 +129,56 @@ def test_nonzero_probe_logs_the_subprocess_failure_reason(monkeypatch, caplog):
         "ModuleNotFoundError: No module named 'tree_sitter_language_pack'"
         in caplog.text
     )
+    assert "pip install 'tree-sitter-language-pack>=0.3.0,<1'" in caplog.text
+
+
+def test_install_hint_for_missing_language_pack():
+    hint = parser_module._install_hint_for_probe_failure(
+        "ModuleNotFoundError: No module named 'tree_sitter_language_pack'"
+    )
+    assert hint is not None
+    assert "pip install" in hint
+    assert "tree-sitter-language-pack" in hint
+
+
+def test_install_hint_for_missing_grammar_library():
+    hint = parser_module._install_hint_for_probe_failure(
+        "LookupError: Could not find language library for c"
+    )
+    assert hint is not None
+    assert "upgrade" in hint.lower() or "tree-sitter-language-pack" in hint
+
+
+def test_parser_probe_env_includes_parent_language_pack_path(tmp_path, monkeypatch):
+    """Probe env must surface the pack the parent process can import."""
+    pack_root = tmp_path / "custom_site"
+    package_dir = pack_root / "tree_sitter_language_pack"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text(
+        "def get_parser(grammar):\n    return object()\n",
+        encoding="utf-8",
+    )
+
+    real_module = sys.modules.get("tree_sitter_language_pack")
+    monkeypatch.syspath_prepend(str(pack_root))
+    monkeypatch.delitem(sys.modules, "tree_sitter_language_pack", raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    try:
+        env = parser_module._parser_probe_env()
+        assert str(pack_root.resolve()) in env.get("PYTHONPATH", "").split(
+            os.pathsep
+        )
+    finally:
+        # Restore the real install so later tests (and the package import) work.
+        monkeypatch.delitem(sys.modules, "tree_sitter_language_pack", raising=False)
+        if real_module is not None:
+            sys.modules["tree_sitter_language_pack"] = real_module
+        else:
+            try:
+                importlib.import_module("tree_sitter_language_pack")
+            except ImportError:
+                pass
 
 
 def test_probe_can_load_language_pack_from_user_site(tmp_path, monkeypatch):
@@ -161,10 +212,44 @@ def test_probe_can_load_language_pack_from_user_site(tmp_path, monkeypatch):
         encoding="utf-8",
     )
 
+    real_module = sys.modules.get("tree_sitter_language_pack")
     monkeypatch.setenv("PYTHONUSERBASE", env["PYTHONUSERBASE"])
+    # Parent must resolve the user-site pack (not a preinstalled venv copy)
+    # so _parser_probe_env injects that path for the child.
+    monkeypatch.syspath_prepend(str(user_site_path))
+    monkeypatch.delitem(sys.modules, "tree_sitter_language_pack", raising=False)
     monkeypatch.setattr(parser_module.sys, "executable", base_executable)
 
-    assert parser_module._run_parser_load_probe("user-site-only", 5.0)
+    try:
+        assert parser_module._run_parser_load_probe("user-site-only", 5.0)
+    finally:
+        monkeypatch.delitem(sys.modules, "tree_sitter_language_pack", raising=False)
+        if real_module is not None:
+            sys.modules["tree_sitter_language_pack"] = real_module
+        else:
+            try:
+                importlib.import_module("tree_sitter_language_pack")
+            except ImportError:
+                pass
+
+
+def test_probe_passes_env_with_language_pack_path(monkeypatch):
+    """Child probe must receive the env that includes the pack path."""
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _completed()
+
+    monkeypatch.setattr(parser_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        parser_module,
+        "_parser_probe_env",
+        lambda: {"PYTHONPATH": "/fake/site", "PATH": "/bin"},
+    )
+
+    assert parser_module._run_parser_load_probe("python", 5.0)
+    assert captured["env"] == {"PYTHONPATH": "/fake/site", "PATH": "/bin"}
 
 
 def test_expected_parent_load_failure_is_cached(monkeypatch):


### PR DESCRIPTION
## Summary

`pip install --user code-review-graph` (and similar non-standard site layouts) could skip every bundled tree-sitter grammar (`c`, `cpp`, `bash`, `python`, …) with:

```text
WARNING: Skipping unavailable tree-sitter parser for c
```

…and finish a full build with **0 nodes / 0 edges**.

### Root cause

Grammar availability is probed in a short-lived child interpreter so a hanging/crashing native grammar cannot take down the parent. Historically that child used `python -I` (isolated mode), which hides user-site packages even when the parent process can import them (`#760` removed `-I` for the classic `--user` case).

Residual gap after `#760`: if the parent found `tree_sitter_language_pack` via a path the child would not scan by default, the probe still failed and the warning gave no installable guidance. On 2.3.7 from PyPI the opaque form still matches what #807 reported.

### Fix

1. Build the probe subprocess env with `_parser_probe_env()` so the child gets the same pack directory the parent imported (prepended on `PYTHONPATH`).
2. When a probe fails, append installable recovery text for the common cases:
   - missing `tree_sitter_language_pack` → `pip install 'tree-sitter-language-pack>=0.3.0,<1'`
   - missing grammar library → upgrade / rebuild guidance
3. Keep the child non-isolated (no `-I`) so `--user` installs keep working.

## Test plan

- [x] `pytest tests/test_parser_load_probe.py` → **11 passed**
- [x] `ruff check code_review_graph/parser.py tests/test_parser_load_probe.py`
- [x] Live load: `c` / `cpp` / `bash` / `python` parsers load successfully with installed pack
- [x] Re-checked no open prior PR for #807 (related merged work: #760 / #459)

Fixes #807