### PR TITLE
feat(parser): index generic YAML structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The bigger the repository, the more token waste hurts. Instead of feeding a whol
   <img src="diagrams/diagram9_language_coverage.png" alt="Language coverage organized by category: Web, Backend, Systems, Mobile, Scripting, Shells, Domain, and Other, plus Jupyter and Databricks notebook support" width="90%" />
 </p>
 
-Parser support covers functions, classes, imports, call sites, inheritance, and test detection across the current parser surface, using Tree-sitter where available and targeted fallbacks where needed. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`). Generic YAML is not treated as source code.
+Parser support covers functions, classes, imports, call sites, inheritance, and test detection across the current parser surface, using Tree-sitter where available and targeted fallbacks where needed. Current support includes Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, value-free generic YAML structure, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
 PHP projects additionally get repository-bounded Composer PSR-4 resolution,
 Blade template references, and Laravel Route/Eloquent semantic edges when the
@@ -293,7 +293,7 @@ The benchmark also runs an honest **co-change mode**: the predictor is seeded wi
 | Feature | Details |
 |---------|---------|
 | **Incremental updates** | Re-parses only the files whose hash changed. On a ~3,000-file repo a two-file edit takes ~2.5s on the hook path ([measured](docs/REPRODUCING.md#incremental-update-latency)). |
-| **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are file-only), Ansible playbooks/roles/tasks, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
+| **Broad language + notebook support** | Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are file-only), Ansible playbooks/roles/tasks, value-free generic YAML structure, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks (.ipynb), and Perl XS (.xs) |
 | **Framework-aware PHP parsing** | Repository-bounded Composer PSR-4 imports, Blade template references, and evidence-gated Laravel Route-to-controller and Eloquent relationship edges |
 | **Blast-radius analysis** | Shows which functions, classes, and files are likely affected by a change |
 | **Auto-update hooks** | Hooks and watch mode can update the graph on file saves and supported commit hooks |
@@ -314,7 +314,7 @@ The benchmark also runs an honest **co-change mode**: the predictor is seeded wi
 | **Execution flows** | Trace call chains from entry points, sorted by weighted criticality |
 | **Community detection** | Cluster related code via Leiden algorithm with resolution scaling for large graphs |
 | **Architecture overview** | Auto-generated architecture map with coupling warnings |
-| **Risk-scored reviews** | `detect_changes` maps diffs to affected functions, flows, and test gaps |
+| **Risk-scored reviews** | `detect_changes` maps diffs to affected functions, YAML paths, flows, and test gaps |
 | **Custom languages** | Add new languages via `.code-review-graph/languages.toml` — no fork or code changes needed |
 | **GitHub Action** | Sticky risk-scored PR review comments in CI, with an optional `fail-on-risk` merge gate |
 | **Refactoring tools** | Rename preview, framework-aware dead code detection, community-driven suggestions |

--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -295,6 +295,26 @@ def map_changes_to_nodes(
                 continue
             if node.line_start is None or node.line_end is None:
                 continue
+            yaml_ranges = node.extra.get("range_samples")
+            if (
+                node.kind == "YamlPath"
+                and isinstance(yaml_ranges, list)
+                and not node.extra.get("lines_truncated")
+            ):
+                overlaps = any(
+                    isinstance(sample, list)
+                    and len(sample) == 2
+                    and isinstance(sample[0], int)
+                    and isinstance(sample[1], int)
+                    and sample[0] <= end
+                    and sample[1] >= start
+                    for sample in yaml_ranges
+                    for start, end in ranges
+                )
+                if overlaps:
+                    result.append(node)
+                    seen.add(node.qualified_name)
+                continue
             # Check overlap with any changed range.
             for start, end in ranges:
                 if node.line_start <= end and node.line_end >= start:
@@ -436,12 +456,22 @@ def analyze_changes(
         if n.kind in ("Function", "Test", "Class")
         and not n.extra.get("verilog_kind")
     ]
+    changed_yaml_paths = [n for n in changed_nodes if n.kind == "YamlPath"]
 
     # Cap to prevent O(N*M) query explosion on large PRs.
     _max_funcs = int(os.environ.get("CRG_MAX_CHANGED_FUNCS", "500"))
     funcs_truncated = len(changed_funcs) > _max_funcs
     if funcs_truncated:
         changed_funcs = changed_funcs[:_max_funcs]
+
+    _max_yaml_paths = int(os.environ.get("CRG_MAX_CHANGED_YAML_PATHS", "200"))
+    yaml_paths_truncated = len(changed_yaml_paths) > _max_yaml_paths
+    if yaml_paths_truncated:
+        changed_yaml_paths = changed_yaml_paths[:_max_yaml_paths]
+
+    # Keep one public YAML metadata contract. ``node_to_dict`` owns
+    # sanitization and output limits for query, search, and change analysis.
+    yaml_path_results = [node_to_dict(node) for node in changed_yaml_paths]
 
     churn_counts: dict[str, int] | None = None
     if include_churn and repo_root is not None:
@@ -491,6 +521,7 @@ def analyze_changes(
     summary_parts = [
         f"Analyzed {len(changed_files)} changed file(s):",
         f"  - {len(changed_funcs)} changed function(s)/class(es)",
+        f"  - {len(changed_yaml_paths)} changed YAML path(s)",
         f"  - {affected['total']} affected flow(s)",
         f"  - {len(test_gaps)} test gap(s)",
         f"  - Overall risk score: {overall_risk:.2f}",
@@ -519,13 +550,20 @@ def analyze_changes(
             f"  - Warning: analysis capped at {_max_funcs} functions "
             f"(set CRG_MAX_CHANGED_FUNCS to adjust)"
         )
+    if yaml_paths_truncated:
+        summary_parts.append(
+            f"  - Warning: analysis capped at {_max_yaml_paths} YAML paths "
+            f"(set CRG_MAX_CHANGED_YAML_PATHS to adjust)"
+        )
 
     return {
         "summary": "\n".join(summary_parts),
         "risk_score": overall_risk,
         "changed_functions": node_risks,
+        "changed_yaml_paths": yaml_path_results,
         "affected_flows": affected["affected_flows"],
         "test_gaps": test_gaps,
         "review_priorities": review_priorities,
         "functions_truncated": funcs_truncated,
+        "yaml_paths_truncated": yaml_paths_truncated,
     }

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1081,7 +1081,7 @@ def main() -> None:
     search_cmd.add_argument("query", help="Search string")
     search_cmd.add_argument(
         "--kind",
-        choices=["File", "Class", "Function", "Type", "Test"],
+        choices=["File", "Class", "Function", "Type", "Test", "YamlPath"],
         default=None,
     )
     search_cmd.add_argument("--limit", type=_positive_int, default=20)

--- a/code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md
+++ b/code_review_graph/docs/LLM-OPTIMIZED-REFERENCE.md
@@ -50,7 +50,7 @@ Configure via provider/model parameters, CRG_EMBEDDING_MODEL for local, CRG_OPEN
 </section>
 
 <section name="languages">
-Supported: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files. Generic YAML is not treated as source code.
+Supported: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, value-free generic YAML structure, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
 Parser: Tree-sitter via tree-sitter-language-pack
 Custom languages: add .code-review-graph/languages.toml (extensions + node types per grammar) — no fork needed, see docs/CUSTOM_LANGUAGES.md. Built-ins cannot be overridden.
 </section>

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1,6 +1,6 @@
 """SQLite-backed knowledge graph storage and query engine.
 
-Stores code structure as nodes (File, Class, Function, Type, Test) and
+Stores code structure as nodes (File, Class, Function, Type, Test, YamlPath) and
 edges (CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON, REFERENCES).
 Supports impact-radius queries and subgraph extraction.
 """
@@ -2217,7 +2217,7 @@ def _sanitize_name(s: str, max_len: int = 256) -> str:
 
 
 def node_to_dict(n: GraphNode) -> dict:
-    return {
+    result = {
         "id": n.id, "kind": n.kind, "name": _sanitize_name(n.name),
         "qualified_name": _sanitize_name(n.qualified_name), "file_path": n.file_path,
         "line_start": n.line_start, "line_end": n.line_end,
@@ -2225,6 +2225,86 @@ def node_to_dict(n: GraphNode) -> dict:
         "parent_name": _sanitize_name(n.parent_name) if n.parent_name else n.parent_name,
         "is_test": n.is_test,
     }
+    if n.kind == "YamlPath":
+        yaml_metadata: dict[str, Any] = {}
+        for key in (
+            "schema_path",
+            "example_path",
+            "value_type",
+        ):
+            value = n.extra.get(key)
+            if isinstance(value, str):
+                yaml_metadata[key] = _sanitize_name(value)
+        for key in (
+            "document_index",
+            "occurrence_count",
+            "duplicate_key_occurrence_count",
+            "duplicate_group_count",
+        ):
+            value = n.extra.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                yaml_metadata[key] = value
+        for key in (
+            "duplicate_key",
+            "duplicate_groups_truncated",
+            "is_alias",
+            "anchor_definition",
+            "yaml_merge",
+            "lines_truncated",
+        ):
+            value = n.extra.get(key)
+            if isinstance(value, bool):
+                yaml_metadata[key] = value
+        value_types = n.extra.get("value_types")
+        if isinstance(value_types, list):
+            yaml_metadata["value_types"] = [
+                _sanitize_name(value)
+                for value in value_types[:20]
+                if isinstance(value, str)
+            ]
+        line_samples = n.extra.get("line_samples")
+        if isinstance(line_samples, list):
+            yaml_metadata["line_samples"] = [
+                line for line in line_samples[:20]
+                if isinstance(line, int) and not isinstance(line, bool)
+            ]
+            occurrence_count = n.extra.get("occurrence_count", len(line_samples))
+            if isinstance(occurrence_count, int) and not isinstance(occurrence_count, bool):
+                yaml_metadata["line_samples_omitted"] = max(
+                    0,
+                    occurrence_count - len(yaml_metadata["line_samples"]),
+                )
+        result["yaml"] = yaml_metadata
+    elif n.kind == "File" and "values_indexed" in n.extra:
+        file_yaml_metadata: dict[str, Any] = {
+            "document_count": n.extra.get("yaml_document_count", 0),
+            "duplicate_key_count": n.extra.get("yaml_duplicate_key_count", 0),
+            "unsupported_key_count": n.extra.get("yaml_unsupported_key_count", 0),
+            "truncated": bool(n.extra.get("yaml_truncated")),
+            "values_indexed": False,
+        }
+        duplicate_keys = n.extra.get("yaml_duplicate_keys")
+        if isinstance(duplicate_keys, list):
+            safe_duplicate_keys: list[dict[str, Any]] = []
+            for item in duplicate_keys[:100]:
+                if not isinstance(item, dict):
+                    continue
+                item_lines = item.get("line_samples")
+                if not isinstance(item_lines, list):
+                    item_lines = []
+                safe_duplicate_keys.append({
+                    "document_index": item.get("document_index"),
+                    "path": _sanitize_name(str(item.get("path", ""))),
+                    "occurrence_count": item.get("occurrence_count"),
+                    "line_samples": [
+                        line for line in item_lines[:20]
+                        if isinstance(line, int) and not isinstance(line, bool)
+                    ],
+                    "lines_truncated": bool(item.get("lines_truncated")),
+                })
+            file_yaml_metadata["duplicate_keys"] = safe_duplicate_keys
+        result["yaml"] = file_yaml_metadata
+    return result
 
 
 def edge_to_dict(e: GraphEdge) -> dict:

--- a/code_review_graph/main.py
+++ b/code_review_graph/main.py
@@ -338,7 +338,7 @@ def semantic_search_nodes_tool(
 
     Args:
         query: Search string to match against node names.
-        kind: Optional filter: File, Class, Function, Type, or Test.
+        kind: Optional filter: File, Class, Function, Type, Test, or YamlPath.
         limit: Maximum results. Default: 20.
         repo_root: Repository root path. Auto-detected if omitted.
         model: Embedding model for query vectors. Must match the model used
@@ -457,7 +457,7 @@ def find_large_functions_tool(
 
     Args:
         min_lines: Minimum line count to flag. Default: 50.
-        kind: Optional filter: Function, Class, File, or Test.
+        kind: Optional filter: Function, Class, File, Test, or YamlPath.
         file_path_pattern: Filter by file path substring (e.g. "components/").
         limit: Maximum results. Default: 50.
         repo_root: Repository root path. Auto-detected if omitted.
@@ -641,8 +641,9 @@ async def detect_changes_tool(
     """Detect changes and produce risk-scored, priority-ordered review guidance.
 
     Primary tool for code review. Maps git diffs to affected functions,
-    flows, communities, and test coverage gaps. Returns risk scores and
-    prioritized review items. Replaces get_review_context for change-aware reviews.
+    YAML paths, flows, communities, and test coverage gaps. Returns risk
+    scores and prioritized review items. Replaces get_review_context for
+    change-aware reviews.
 
     Offloaded to a thread via ``asyncio.to_thread`` — runs `git diff`
     subprocesses and BFS traversals that can take several seconds on
@@ -959,7 +960,7 @@ def cross_repo_search_tool(
 
     Args:
         query: Search string to match against node names.
-        kind: Optional filter: File, Class, Function, Type, or Test.
+        kind: Optional filter: File, Class, Function, Type, Test, or YamlPath.
         limit: Maximum results per repo. Default: 20.
     """
     return cross_repo_search_func(query=query, kind=kind, limit=limit)

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -36,9 +36,11 @@ try:
     from yaml import MappingNode as _YamlMapping
     from yaml import ScalarNode as _YamlScalar
     from yaml import SequenceNode as _YamlSequence
+    from yaml.events import AliasEvent as _YamlAliasEvent  # type: ignore[import-untyped]
 except ImportError:
     _yaml = None  # type: ignore[assignment]
     _YamlMapping = _YamlSequence = _YamlScalar = None  # type: ignore[assignment,misc]
+    _YamlAliasEvent = None  # type: ignore[assignment,misc]
 
 from .tsconfig_resolver import TsconfigResolver
 
@@ -2375,6 +2377,30 @@ def _yaml_scalar(node: object) -> Optional[str]:
     return None
 
 
+_YAML_SIMPLE_PATH_SEGMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+def _yaml_path_child(prefix: str, segment: str) -> str:
+    """Append a mapping key to a path without making dotted keys ambiguous."""
+    if _YAML_SIMPLE_PATH_SEGMENT.fullmatch(segment):
+        return f"{prefix}.{segment}" if prefix else segment
+    quoted = json.dumps(segment, ensure_ascii=False)
+    return f"{prefix}[{quoted}]" if prefix else f"[{quoted}]"
+
+
+def _yaml_value_type(node: object) -> str:
+    """Return a bounded structural/scalar type label without exposing its value."""
+    if isinstance(node, _YamlMapping):
+        return "mapping"
+    if isinstance(node, _YamlSequence):
+        return "sequence"
+    tag = str(getattr(node, "tag", ""))
+    scalar_type = tag.rsplit(":", 1)[-1]
+    if scalar_type in {"binary", "bool", "float", "int", "null", "str", "timestamp"}:
+        return scalar_type
+    return "scalar"
+
+
 def _ansible_is_play_item(item: object) -> bool:
     """True if this top-level sequence item is a definitive Ansible play or playbook import.
 
@@ -2404,6 +2430,12 @@ class CodeParser:
     """Parses source files using Tree-sitter and extracts structural information."""
 
     _MODULE_CACHE_MAX = 15_000  # Evict cache to cap memory on huge monorepos
+    _MAX_YAML_DEPTH = 100
+    _MAX_YAML_NODES = 10_000
+    _MAX_YAML_PATH_LENGTH = 512
+    _MAX_YAML_OCCURRENCE_SAMPLES = 10_000
+    _MAX_YAML_DUPLICATE_GROUP_SAMPLES = 100
+    _MAX_YAML_DUPLICATE_LINE_SAMPLES = 20
     _BLADE_COMMENT_RE = re.compile(r"\{\{--.*?(?:--\}\}|$)", re.DOTALL)
     _BLADE_DIRECTIVE_RE = re.compile(
         r"""(?<!@)@(extends|include|component|livewire)\s*\(\s*(['"])([^'"]+)\2\s*\)""",
@@ -2668,7 +2700,9 @@ class CodeParser:
         if language == "sql":
             return self._parse_sql(path, source)
 
-        # Ansible YAML: path heuristic promoted to "ansible".
+        # Ansible YAML: path heuristic promoted to "ansible". A directory
+        # name alone is not enough evidence; fall back to generic YAML so a
+        # repository's ordinary tasks/*.yml files still get structural nodes.
         if language == "ansible":
             if _yaml is None:
                 return [], []
@@ -2679,7 +2713,7 @@ class CodeParser:
             # directory names, so require Ansible content evidence there.
             if file_type in ("vars", "meta") or _is_ansible_content(source):
                 return self._parse_ansible(path, source)
-            return [], []
+            return self._parse_yaml(path, source)
 
         # Spring configuration: only conventional application files reach
         # this branch. Generic YAML and arbitrary .properties files stay out.
@@ -2688,11 +2722,18 @@ class CodeParser:
                 return [], []
             if path.suffix.lower() in (".yaml", ".yml") and _is_ansible_content(source):
                 return self._parse_ansible(path, source)
-            return self._parse_spring_config(path, source)
+            spring_nodes, spring_edges = self._parse_spring_config(path, source)
+            if spring_nodes or path.suffix.lower() == ".properties":
+                return spring_nodes, spring_edges
+            return self._parse_yaml(path, source)
 
-        # Generic YAML: no tree-sitter grammar bundled; skip.
+        # Generic YAML: index paths and structure while deliberately discarding
+        # scalar values. PyYAML is already a runtime dependency for the
+        # specialised Ansible and Spring parsers.
         if language == "yaml":
-            return [], []
+            if _yaml is None:
+                return [], []
+            return self._parse_yaml(path, source)
 
         if parser is None:
             parser = self._get_parser(language)
@@ -5536,6 +5577,553 @@ class CodeParser:
         return None
 
     # -----------------------------------------------------------------------
+    # Generic YAML parser
+    # -----------------------------------------------------------------------
+
+    def _parse_yaml(
+        self,
+        path: Path,
+        source: bytes,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Index generic YAML structure while deliberately discarding values.
+
+        Repeated sequence shapes are aggregated under ``[*]`` paths to keep
+        large configuration repositories bounded. Nodes retain occurrence and
+        source-line samples, while duplicate keys and aliases receive explicit
+        diagnostics. Scalar values never enter node or edge metadata.
+        """
+        text = source.decode("utf-8", errors="replace")
+        try:
+            documents = list(_yaml.compose_all(text))
+            yaml_events = list(_yaml.parse(text))
+            anchor_definitions = {
+                event.start_mark.index: str(event.anchor)
+                for event in yaml_events
+                if not isinstance(event, _YamlAliasEvent)
+                and getattr(event, "anchor", None) is not None
+            }
+            alias_lines_by_anchor: dict[str, list[int]] = {}
+            for event in yaml_events:
+                if isinstance(event, _YamlAliasEvent):
+                    alias_lines_by_anchor.setdefault(str(event.anchor), []).append(
+                        event.start_mark.line + 1,
+                    )
+        except (_yaml.YAMLError, RecursionError) as exc:
+            logger.debug("YAML parse error in %s: %s", path, exc)
+            return [], []
+
+        file_path = normalize_file_path(path)
+        file_extra: dict[str, Any] = {
+            "config_format": path.suffix.lower().lstrip("."),
+            "yaml_document_count": len(documents),
+            "yaml_duplicate_key_count": 0,
+            "yaml_duplicate_keys": [],
+            "yaml_unsupported_key_count": 0,
+            "yaml_truncated": False,
+            "values_indexed": False,
+        }
+        nodes = [NodeInfo(
+            kind="File",
+            name=file_path,
+            file_path=file_path,
+            line_start=1,
+            line_end=source.count(b"\n") + 1,
+            language="yaml",
+            extra=file_extra,
+        )]
+        edges: list[EdgeInfo] = []
+        shared_targets: dict[int, str] = {}
+        shared_anchor_names: dict[int, str] = {}
+        path_nodes: dict[tuple[int, str], NodeInfo] = {}
+        path_value_types: dict[tuple[int, str], set[str]] = {}
+        path_key_tags: dict[tuple[int, str], set[str]] = {}
+        contains_edges: set[tuple[str, str]] = set()
+        duplicate_summaries: list[dict[str, Any]] = []
+        duplicate_count = 0
+        unsupported_key_count = 0
+        alias_indices: dict[str, int] = {}
+        truncated = False
+
+        def qualified(schema_path: str, document_index: int) -> str:
+            return f"{file_path}::yaml:{document_index}:{schema_path}"
+
+        def can_emit(
+            schema_path: str,
+            depth: int,
+            *source_paths: str,
+        ) -> bool:
+            nonlocal truncated
+            if (
+                len(nodes) - 1 >= self._MAX_YAML_NODES
+                or depth > self._MAX_YAML_DEPTH
+                or len(schema_path) > self._MAX_YAML_PATH_LENGTH
+                or any(
+                    len(source_path) > self._MAX_YAML_PATH_LENGTH
+                    for source_path in source_paths
+                )
+            ):
+                truncated = True
+                return False
+            return True
+
+        def add_contains(parent: str, target: str, line: int) -> None:
+            edge_key = (parent, target)
+            if edge_key in contains_edges:
+                return
+            contains_edges.add(edge_key)
+            edges.append(EdgeInfo(
+                kind="CONTAINS",
+                source=parent,
+                target=target,
+                file_path=file_path,
+                line=line,
+            ))
+
+        def next_alias_line(value_node: object, fallback: int) -> int:
+            anchor_name = shared_anchor_names.get(id(value_node))
+            if anchor_name is None:
+                return fallback
+            lines = alias_lines_by_anchor.get(anchor_name, [])
+            alias_index = alias_indices.get(anchor_name, 0)
+            if alias_index >= len(lines):
+                return fallback
+            line = lines[alias_index]
+            alias_indices[anchor_name] = alias_index + 1
+            return line
+
+        def emit_alias(
+            value_node: object,
+            exact_path: str,
+            schema_path: str,
+            identity_path: str,
+            parent_qualified: str,
+            document_index: int,
+            depth: int,
+            line_start: int,
+            line_end: int,
+            extra: dict[str, Any],
+            yaml_merge: bool,
+            line_is_key: bool,
+        ) -> None:
+            if not can_emit(schema_path, depth, exact_path, identity_path):
+                return
+            original_target = shared_targets[id(value_node)]
+            reference_line = next_alias_line(value_node, line_start)
+            node_line_start = min(line_start, reference_line) if line_is_key else reference_line
+            node_line_end = max(node_line_start, line_end, reference_line)
+            alias_identity = f"alias:{identity_path}@{reference_line}"
+            target = qualified(alias_identity, document_index)
+            nodes.append(NodeInfo(
+                kind="YamlPath",
+                name=exact_path,
+                file_path=file_path,
+                line_start=node_line_start,
+                line_end=node_line_end,
+                language="yaml",
+                extra={
+                    "document_index": document_index,
+                    "path": exact_path,
+                    "schema_path": schema_path,
+                    "source_file": path.name,
+                    "value_type": "alias",
+                    "is_alias": True,
+                    "yaml_merge": yaml_merge,
+                    **extra,
+                },
+                identity_name=f"yaml:{document_index}:{alias_identity}",
+            ))
+            add_contains(parent_qualified, target, node_line_start)
+            edges.append(EdgeInfo(
+                kind="REFERENCES",
+                source=target,
+                target=original_target,
+                file_path=file_path,
+                line=reference_line,
+                extra={"yaml_alias": True, "yaml_merge": yaml_merge},
+            ))
+
+        def emit_node(
+            value_node: object,
+            exact_path: str,
+            schema_path: str,
+            identity_path: str,
+            parent_qualified: str,
+            document_index: int,
+            depth: int,
+            line_start: int,
+            line_end: int,
+            extra: dict[str, Any],
+            ancestors: frozenset[int],
+            yaml_merge: bool = False,
+            line_is_key: bool = False,
+        ) -> None:
+            if not can_emit(schema_path, depth, exact_path, identity_path):
+                return
+            value_id = id(value_node)
+            if value_id in shared_targets:
+                emit_alias(
+                    value_node,
+                    exact_path,
+                    schema_path,
+                    identity_path,
+                    parent_qualified,
+                    document_index,
+                    depth,
+                    line_start,
+                    line_end,
+                    extra,
+                    yaml_merge,
+                    line_is_key,
+                )
+                return
+
+            node_mark = getattr(value_node, "start_mark", None)
+            anchor_name = anchor_definitions.get(getattr(node_mark, "index", -1))
+            if anchor_name is not None:
+                anchor_identity = (
+                    f"anchor:{getattr(node_mark, 'index', line_start)}:{identity_path}"
+                )
+                target = qualified(anchor_identity, document_index)
+                value_type = _yaml_value_type(value_node)
+                node_extra = {
+                    "document_index": document_index,
+                    "path": schema_path,
+                    "schema_path": schema_path,
+                    "example_path": exact_path,
+                    "source_file": path.name,
+                    "value_type": value_type,
+                    "value_types": [value_type],
+                    "occurrence_count": 1,
+                    "line_samples": [line_start],
+                    "range_samples": [[line_start, max(line_start, line_end)]],
+                    "lines_truncated": False,
+                    "is_alias": False,
+                    "anchor_definition": True,
+                    **extra,
+                }
+                key_tag = extra.get("key_tag")
+                if isinstance(key_tag, str):
+                    node_extra["key_tags"] = [key_tag]
+                if extra.get("duplicate_key"):
+                    node_extra["duplicate_key_occurrence_count"] = 1
+                    if extra.get("duplicate_group_start"):
+                        node_extra["duplicate_group_count"] = 1
+                        node_extra["duplicate_group_samples"] = [
+                            extra["duplicate_group"],
+                        ]
+                nodes.append(NodeInfo(
+                    kind="YamlPath",
+                    name=schema_path,
+                    file_path=file_path,
+                    line_start=line_start,
+                    line_end=max(line_start, line_end),
+                    language="yaml",
+                    extra=node_extra,
+                    identity_name=f"yaml:{document_index}:{anchor_identity}",
+                ))
+                add_contains(parent_qualified, target, line_start)
+                shared_targets[value_id] = target
+                shared_anchor_names[value_id] = anchor_name
+                value_ancestors = ancestors | {value_id}
+                if isinstance(value_node, _YamlMapping):
+                    visit_mapping(
+                        value_node,
+                        exact_path,
+                        schema_path,
+                        identity_path,
+                        target,
+                        document_index,
+                        depth + 1,
+                        value_ancestors,
+                    )
+                elif isinstance(value_node, _YamlSequence):
+                    visit_sequence(
+                        value_node,
+                        exact_path,
+                        schema_path,
+                        identity_path,
+                        target,
+                        document_index,
+                        depth + 1,
+                        value_ancestors,
+                        merge_context=yaml_merge or bool(extra.get("merge_key")),
+                    )
+                return
+
+            path_key = (document_index, schema_path)
+            node = path_nodes.get(path_key)
+            if node is None:
+                target = qualified(schema_path, document_index)
+                value_type = _yaml_value_type(value_node)
+                node_extra = {
+                    "document_index": document_index,
+                    "path": schema_path,
+                    "schema_path": schema_path,
+                    "example_path": exact_path,
+                    "source_file": path.name,
+                    "value_type": value_type,
+                    "value_types": [value_type],
+                    "occurrence_count": 1,
+                    "line_samples": [line_start],
+                    "range_samples": [[line_start, max(line_start, line_end)]],
+                    "lines_truncated": False,
+                    "is_alias": False,
+                    **extra,
+                }
+                node = NodeInfo(
+                    kind="YamlPath",
+                    name=schema_path,
+                    file_path=file_path,
+                    line_start=line_start,
+                    line_end=max(line_start, line_end),
+                    language="yaml",
+                    extra=node_extra,
+                    identity_name=f"yaml:{document_index}:{schema_path}",
+                )
+                nodes.append(node)
+                path_nodes[path_key] = node
+                path_value_types[path_key] = {value_type}
+                key_tag = extra.get("key_tag")
+                path_key_tags[path_key] = {key_tag} if isinstance(key_tag, str) else set()
+                add_contains(parent_qualified, target, line_start)
+            else:
+                add_contains(
+                    parent_qualified,
+                    qualified(schema_path, document_index),
+                    line_start,
+                )
+                node.line_start = min(node.line_start, line_start)
+                node.line_end = max(node.line_end, line_end)
+                node.extra["occurrence_count"] += 1
+                line_samples = node.extra["line_samples"]
+                if len(line_samples) < self._MAX_YAML_OCCURRENCE_SAMPLES:
+                    line_samples.append(line_start)
+                    node.extra["range_samples"].append([
+                        line_start,
+                        max(line_start, line_end),
+                    ])
+                else:
+                    node.extra["lines_truncated"] = True
+                value_types = path_value_types[path_key]
+                value_types.add(_yaml_value_type(value_node))
+                node.extra["value_types"] = sorted(value_types)
+                node.extra["value_type"] = (
+                    next(iter(value_types)) if len(value_types) == 1 else "mixed"
+                )
+                key_tag = extra.get("key_tag")
+                if isinstance(key_tag, str):
+                    key_tags = path_key_tags[path_key]
+                    key_tags.add(key_tag)
+                    node.extra["key_tags"] = sorted(key_tags)
+
+            if extra.get("duplicate_key"):
+                node.extra["duplicate_key"] = True
+                node.extra["duplicate_key_occurrence_count"] = (
+                    node.extra.get("duplicate_key_occurrence_count", 0) + 1
+                )
+                if extra.get("duplicate_group_start"):
+                    node.extra["duplicate_group_count"] = (
+                        node.extra.get("duplicate_group_count", 0) + 1
+                    )
+                    group_samples = node.extra.setdefault("duplicate_group_samples", [])
+                    if len(group_samples) < self._MAX_YAML_DUPLICATE_GROUP_SAMPLES:
+                        group_samples.append(extra["duplicate_group"])
+                    else:
+                        node.extra["duplicate_groups_truncated"] = True
+
+            shared_targets[value_id] = qualified(schema_path, document_index)
+            value_ancestors = ancestors | {value_id}
+            if isinstance(value_node, _YamlMapping):
+                visit_mapping(
+                    value_node,
+                    exact_path,
+                    schema_path,
+                    identity_path,
+                    qualified(schema_path, document_index),
+                    document_index,
+                    depth + 1,
+                    value_ancestors,
+                )
+            elif isinstance(value_node, _YamlSequence):
+                visit_sequence(
+                    value_node,
+                    exact_path,
+                    schema_path,
+                    identity_path,
+                    qualified(schema_path, document_index),
+                    document_index,
+                    depth + 1,
+                    value_ancestors,
+                    merge_context=yaml_merge or bool(extra.get("merge_key")),
+                )
+
+        def consume_skipped_aliases(
+            skipped_node: object,
+            ancestors: frozenset[int] = frozenset(),
+        ) -> None:
+            """Advance alias positions hidden below unsupported complex keys."""
+            skipped_id = id(skipped_node)
+            if skipped_id in shared_targets:
+                next_alias_line(skipped_node, _yaml_line(skipped_node))
+                return
+            if skipped_id in ancestors:
+                return
+            skipped_ancestors = ancestors | {skipped_id}
+            if isinstance(skipped_node, _YamlMapping):
+                for child_key, child_value in skipped_node.value:
+                    consume_skipped_aliases(child_key, skipped_ancestors)
+                    consume_skipped_aliases(child_value, skipped_ancestors)
+            elif isinstance(skipped_node, _YamlSequence):
+                for child in skipped_node.value:
+                    consume_skipped_aliases(child, skipped_ancestors)
+
+        def visit_mapping(
+            mapping_node: object,
+            exact_prefix: str,
+            schema_prefix: str,
+            identity_prefix: str,
+            parent_qualified: str,
+            document_index: int,
+            depth: int,
+            ancestors: frozenset[int],
+        ) -> None:
+            nonlocal duplicate_count, unsupported_key_count
+            pairs = list(mapping_node.value)  # type: ignore[attr-defined]
+            key_counts: dict[tuple[str, str], int] = {}
+            key_line_samples: dict[tuple[str, str], list[int]] = {}
+            for key_node, _ in pairs:
+                raw_key = _yaml_scalar(key_node)
+                if raw_key is None:
+                    continue
+                signature = (str(getattr(key_node, "tag", "")), raw_key)
+                key_counts[signature] = key_counts.get(signature, 0) + 1
+                samples = key_line_samples.setdefault(signature, [])
+                if len(samples) < self._MAX_YAML_DUPLICATE_LINE_SAMPLES:
+                    samples.append(_yaml_line(key_node))
+
+            occurrences: dict[tuple[str, str], int] = {}
+            identity_occurrences: dict[str, int] = {}
+            for key_node, value_node in pairs:
+                raw_key = _yaml_scalar(key_node)
+                if raw_key is None:
+                    unsupported_key_count += 1
+                    consume_skipped_aliases(key_node)
+                    consume_skipped_aliases(value_node)
+                    continue
+                key_tag = str(getattr(key_node, "tag", ""))
+                signature = (key_tag, raw_key)
+                occurrence = occurrences.get(signature, 0) + 1
+                occurrences[signature] = occurrence
+                exact_path = _yaml_path_child(exact_prefix, raw_key)
+                schema_path = _yaml_path_child(schema_prefix, raw_key)
+                base_identity = _yaml_path_child(identity_prefix, raw_key)
+                identity_occurrence = identity_occurrences.get(base_identity, 0) + 1
+                identity_occurrences[base_identity] = identity_occurrence
+                identity_path = (
+                    f"{base_identity}#{identity_occurrence}"
+                    if identity_occurrence > 1
+                    else base_identity
+                )
+                duplicate = key_counts[signature] > 1
+                bounded_exact_path = exact_path[: self._MAX_YAML_PATH_LENGTH]
+                duplicate_group = {
+                    "example_path": bounded_exact_path,
+                    "occurrence_count": key_counts[signature],
+                    "line_samples": key_line_samples[signature],
+                    "lines_truncated": (
+                        key_counts[signature] > self._MAX_YAML_DUPLICATE_LINE_SAMPLES
+                    ),
+                }
+                extra: dict[str, Any] = {
+                    "raw_key": raw_key,
+                    "key_tag": key_tag,
+                    "duplicate_key": duplicate,
+                    "key_occurrence": occurrence,
+                }
+                if duplicate:
+                    extra["duplicate_group"] = duplicate_group
+                    extra["duplicate_group_start"] = occurrence == 1
+                    if occurrence == 1:
+                        duplicate_count += 1
+                        if len(duplicate_summaries) < self._MAX_YAML_DUPLICATE_GROUP_SAMPLES:
+                            duplicate_summaries.append({
+                                "document_index": document_index,
+                                "path": bounded_exact_path,
+                                **duplicate_group,
+                            })
+                is_merge = raw_key == "<<"
+                if is_merge:
+                    extra["merge_key"] = True
+                emit_node(
+                    value_node,
+                    exact_path,
+                    schema_path,
+                    identity_path,
+                    parent_qualified,
+                    document_index,
+                    depth,
+                    _yaml_line(key_node),
+                    _yaml_end_line(value_node),
+                    extra,
+                    ancestors,
+                    yaml_merge=is_merge,
+                    line_is_key=True,
+                )
+
+        def visit_sequence(
+            sequence_node: object,
+            exact_prefix: str,
+            schema_prefix: str,
+            identity_prefix: str,
+            parent_qualified: str,
+            document_index: int,
+            depth: int,
+            ancestors: frozenset[int],
+            merge_context: bool = False,
+        ) -> None:
+            for index, item in enumerate(sequence_node.value):  # type: ignore[attr-defined]
+                exact_path = f"{exact_prefix}[{index}]"
+                schema_path = f"{schema_prefix}[*]"
+                identity_path = f"{identity_prefix}[{index}]"
+                emit_node(
+                    item,
+                    exact_path,
+                    schema_path,
+                    identity_path,
+                    parent_qualified,
+                    document_index,
+                    depth,
+                    _yaml_line(item),
+                    _yaml_end_line(item),
+                    {"sequence_index_sample": index},
+                    ancestors,
+                    yaml_merge=merge_context,
+                )
+
+        for document_index, document in enumerate(documents):
+            if document is None:
+                continue
+            emit_node(
+                document,
+                "$",
+                "$",
+                "$",
+                file_path,
+                document_index,
+                0,
+                _yaml_line(document),
+                _yaml_end_line(document),
+                {"document_root": True},
+                frozenset(),
+            )
+
+        file_extra["yaml_duplicate_key_count"] = duplicate_count
+        file_extra["yaml_duplicate_keys"] = duplicate_summaries
+        file_extra["yaml_unsupported_key_count"] = unsupported_key_count
+        file_extra["yaml_truncated"] = truncated
+        return nodes, edges
+
+    # -----------------------------------------------------------------------
     # Spring application configuration parser
     # -----------------------------------------------------------------------
 
@@ -5570,7 +6158,7 @@ class CodeParser:
         """Flatten Spring YAML keys using PyYAML's syntax tree, never values."""
         try:
             documents = list(_yaml.compose_all(source.decode("utf-8", errors="replace")))
-        except _yaml.YAMLError as exc:
+        except (_yaml.YAMLError, RecursionError) as exc:
             logger.debug("Spring YAML parse error in %s: %s", path, exc)
             return [], []
 
@@ -5751,7 +6339,7 @@ class CodeParser:
         """
         try:
             root = _yaml.compose(source.decode("utf-8", errors="replace"))
-        except _yaml.YAMLError as exc:
+        except (_yaml.YAMLError, RecursionError) as exc:
             logger.debug("Ansible YAML parse error in %s: %s", path, exc)
             return [], []
         if root is None:

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -366,8 +366,8 @@ def detect_changes_func(
     """Detect changes and produce risk-scored review guidance.
 
     [REVIEW] Primary tool for code review.  Maps git diffs to affected
-    functions, flows, communities, and test coverage gaps.  Returns
-    priority-ordered review guidance with risk scores.
+    functions, YAML paths, flows, communities, and test coverage gaps.
+    Returns priority-ordered review guidance with risk scores.
 
     Args:
         base: Git ref to diff against (default: HEAD~1).
@@ -379,12 +379,13 @@ def detect_changes_func(
         repo_root: Repository root path.  Auto-detected if omitted.
         detail_level: Output detail level.  "standard" returns full analysis;
             "minimal" returns only summary, risk_score, changed_file_count,
-            test_gap_count, and top 3 review priorities (text only).
+            changed_yaml_path_count, test_gap_count, and the top three code
+            review priorities (text only).
             Default: "standard".
 
     Returns:
-        Risk-scored analysis with changed functions, affected flows,
-        test gaps, and review priorities.
+        Risk-scored analysis with changed functions, YAML paths, affected
+        flows, test gaps, and review priorities.
     """
     store, root = _get_store(repo_root)
     try:
@@ -400,6 +401,7 @@ def detect_changes_func(
                 "summary": "No changed files detected.",
                 "risk_score": 0.0,
                 "changed_functions": [],
+                "changed_yaml_paths": [],
                 "affected_flows": [],
                 "test_gaps": [],
                 "review_priorities": [],
@@ -460,6 +462,7 @@ def detect_changes_func(
                 "summary": analysis.get("summary", ""),
                 "risk_score": analysis.get("risk_score", 0.0),
                 "changed_file_count": len(changed_files),
+                "changed_yaml_path_count": len(analysis.get("changed_yaml_paths", [])),
                 "test_gap_count": len(analysis.get("test_gaps", [])),
                 "review_priorities": top_priorities,
             }

--- a/code_review_graph/visualization.py
+++ b/code_review_graph/visualization.py
@@ -789,6 +789,7 @@ __D3_SCRIPTS__
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><polygon points="0,-6 6,5 -6,5" fill="#3fb950"/></svg> Function</div>
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><polygon points="0,-6 6,0 0,6 -6,0" fill="#d2a8ff"/></svg> Test</div>
     <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><path d="M-2,-6v4h-4v4h4v4h4v-4h4v-4h-4v-4z" fill="#8b949e"/></svg> Type</div>
+    <div class="legend-item"><svg width="16" height="16" viewBox="-8 -8 16 16" aria-hidden="true"><circle r="5" fill="#39c5cf"/></svg> YAML Path</div>
   </div>
   <h3>Edges</h3>
   <div class="legend-section">
@@ -799,6 +800,7 @@ __D3_SCRIPTS__
     <button class="legend-item legend-edge" data-edge-kind="IMPLEMENTS" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #f9e2af"></span> Implements</button>
     <button class="legend-item legend-edge" data-edge-kind="TESTED_BY" aria-pressed="true"><span class="legend-line" style="border-top:2px dotted #f38ba8"></span> Tested By</button>
     <button class="legend-item legend-edge" data-edge-kind="DEPENDS_ON" aria-pressed="true"><span class="legend-line" style="border-top:2px dashed #fab387"></span> Depends On</button>
+    <button class="legend-item legend-edge" data-edge-kind="REFERENCES" aria-pressed="true"><span class="legend-line" style="border-top:2px dotted #39c5cf"></span> References</button>
   </div>
 </nav>
 <div id="filter-panel">
@@ -808,6 +810,7 @@ __D3_SCRIPTS__
   <label class="filter-item"><input type="checkbox" data-kind="Function" checked> Function</label>
   <label class="filter-item"><input type="checkbox" data-kind="Test" checked> Test</label>
   <label class="filter-item"><input type="checkbox" data-kind="Type" checked> Type</label>
+  <label class="filter-item"><input type="checkbox" data-kind="YamlPath" checked> YAML Path</label>
 </div>
 <div id="controls">
   <input id="search" type="text" placeholder="Search nodes&#8230;" autocomplete="off" spellcheck="false" aria-label="Search graph nodes by name" aria-controls="search-results" aria-expanded="false">
@@ -863,11 +866,11 @@ __D3_SCRIPTS__
 <script>
 "use strict";
 var graphData = __GRAPH_DATA__;
-var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#d2a8ff", Type:"#8b949e" };
-var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5 };
-var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79 };
-var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross };
-var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387" };
+var KIND_COLOR  = { File:"#58a6ff", Class:"#f0883e", Function:"#3fb950", Test:"#d2a8ff", Type:"#8b949e", YamlPath:"#39c5cf" };
+var KIND_RADIUS = { File:18, Class:12, Function:6, Test:6, Type:5, YamlPath:5 };
+var KIND_AREA   = { File:1018, Class:452, Function:113, Test:113, Type:79, YamlPath:79 };
+var KIND_SHAPE  = { File:d3.symbolCircle, Class:d3.symbolSquare, Function:d3.symbolTriangle, Test:d3.symbolDiamond, Type:d3.symbolCross, YamlPath:d3.symbolWye };
+var EDGE_COLOR  = { CALLS:"#3fb950", IMPORTS_FROM:"#f0883e", INHERITS:"#d2a8ff", CONTAINS:"rgba(139,148,158,0.15)", IMPLEMENTS:"#f9e2af", TESTED_BY:"#f38ba8", DEPENDS_ON:"#fab387", REFERENCES:"#39c5cf" };
 var communityColorScale = d3.scaleOrdinal(d3.schemeTableau10);
 var communityColoringOn = false;
 function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;").replace(/`/g,"&#96;"); }
@@ -1760,12 +1763,13 @@ function escH(s) { return !s ? "" : s.replace(/&/g,"&amp;").replace(/</g,"&lt;")
 
 var KIND_COLOR = {
   Community: "#1f6feb", File: "#58a6ff", Class: "#f0883e",
-  Function: "#3fb950", Test: "#d2a8ff", Type: "#8b949e"
+  Function: "#3fb950", Test: "#d2a8ff", Type: "#8b949e", YamlPath: "#39c5cf"
 };
 var EDGE_COLOR = {
   CROSS_COMMUNITY: "#58a6ff", DEPENDS_ON: "#f0883e",
   CALLS: "#3fb950", IMPORTS_FROM: "#f0883e",
-  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)"
+  INHERITS: "#d2a8ff", CONTAINS: "rgba(139,148,158,0.15)",
+  REFERENCES: "#39c5cf"
 };
 var EDGE_CFG = {
   CROSS_COMMUNITY: { dash: null, width: 2, opacity: 0.6, marker: "" },
@@ -1774,6 +1778,7 @@ var EDGE_CFG = {
   CALLS:           { dash: null, width: 1.5, opacity: 0.7, marker: "url(#arrow-calls)" },
   IMPORTS_FROM:    { dash: "6,3", width: 1.5, opacity: 0.65, marker: "url(#arrow-imports)" },
   INHERITS:        { dash: "3,4", width: 2, opacity: 0.7, marker: "url(#arrow-inherits)" },
+  REFERENCES:      { dash: "2,3", width: 1.5, opacity: 0.7, marker: "" },
 };
 function eStyle(d) { return EDGE_CFG[d.kind] || { dash: null, width: 1, opacity: 0.3, marker: "" }; }
 function eColor(d) { return EDGE_COLOR[d.kind] || "#484f58"; }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -93,7 +93,7 @@ repo_root: str | None
 #### `semantic_search_nodes_tool`
 ```
 query: str           # Search string
-kind: str | None     # File, Class, Function, Type, Test
+kind: str | None     # File, Class, Function, Type, Test, YamlPath
 limit: int = 20
 repo_root: str | None
 model: str | None    # Embedding model (falls back to provider-specific env vars)
@@ -117,7 +117,7 @@ repo_root: str | None
 #### `find_large_functions_tool`
 ```
 min_lines: int = 50                # Minimum line count threshold
-kind: str | None                   # File, Class, Function, or Test
+kind: str | None                   # File, Class, Function, Test, or YamlPath
 file_path_pattern: str | None      # Filter by file path substring
 limit: int = 50                    # Max results to return
 repo_root: str | None
@@ -220,7 +220,7 @@ max_depth: int = 2
 repo_root: str | None
 detail_level: str = "standard"
 ```
-Primary tool for code review. Maps changed files to affected functions, flows, communities, and test coverage gaps. Returns risk scores and prioritized review items.
+Primary tool for code review. Maps changed files to affected functions, YAML paths, flows, communities, and test coverage gaps. Returns `changed_yaml_paths` separately from function risk/test-gap scoring, plus risk scores and prioritized code review items.
 Relevant responses may include compact estimated `context_savings` metadata.
 
 #### `refactor_tool`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -37,7 +37,7 @@
 - **Graph lookup correctness**: Review, impact, and file-summary tools resolve user-facing paths to stored graph paths; `callers_of` includes cross-file callers even when same-file callers exist.
 - **Install/runtime reliability**: Generated Codex/Claude hooks drain stdin, bundled docs are available from wheels, missing local embeddings report unavailable status, and `.svn` roots pass validation.
 - **CLI reliability**: `build --skip-postprocess` and `update --skip-flows` honor the requested post-processing level.
-- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files. Generic YAML is not treated as source code.
+- **Broad parser surface**: Python, JavaScript/TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Terraform/OpenTofu structure (`.tf`; generic `.hcl` files are recognized as file nodes), Ansible playbooks/roles/tasks, value-free generic YAML structure, Vue/Svelte SFCs, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks, and Perl XS files.
 - **Local-first by design**: SQLite graph storage remains local, with no telemetry and no cloud-default behavior.
 
 ## v2.0.0
@@ -47,7 +47,7 @@
 - **Execution flows**: Trace call chains from entry points (HTTP handlers, CLI commands, tests), sorted by criticality score.
 - **Community detection**: Cluster related code entities via Leiden algorithm (igraph) or file-based grouping.
 - **Architecture overview**: Auto-generated architecture map with module summaries and cross-community coupling warnings.
-- **Risk-scored change detection**: `detect_changes` maps git diffs to affected functions, flows, communities, and test coverage gaps with priority ordering.
+- **Risk-scored change detection**: `detect_changes` maps git diffs to affected functions, YAML paths, flows, communities, and test coverage gaps with priority ordering.
 - **Refactoring tools**: Rename preview with edit list, dead code detection, community-driven refactoring suggestions.
 - **Wiki generation**: Auto-generate markdown wiki pages for each community with optional LLM summaries (ollama).
 - **Multi-repo registry**: Register multiple repositories, search across all of them with `cross_repo_search`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -109,7 +109,7 @@ vectors, and degrades provider or transport failures to graph-build warnings.
 ```
 Ask your MCP client: "Review my recent changes with risk scoring"
 ```
-Uses `detect_changes_tool` to map diffs to affected functions, flows, communities, and test gaps.
+Uses `detect_changes_tool` to map diffs to affected functions, YAML paths, flows, communities, and test gaps.
 
 ### 8. Explore architecture (v2)
 ```
@@ -141,7 +141,7 @@ Since v2.3.4, review and impact tools include compact `context_savings` metadata
 
 ## Supported Languages
 
-The parser currently covers Python, JavaScript, TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, Vue/Svelte single-file components, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
+The parser currently covers Python, JavaScript, TypeScript/TSX, Go, Rust, Java, C/C++, C#, VB.NET, Ruby, Kotlin, Swift, PHP, Scala, Solidity, Dart, R, Perl, Lua/Luau, Objective-C, shell scripts, Elixir, Zig, PowerShell, Julia, ReScript, GDScript, Nix, Verilog/SystemVerilog, SQL, value-free generic YAML structure, Vue/Svelte single-file components, Astro files parsed through the TypeScript parser, Jupyter/Databricks notebooks (`.ipynb`), and Perl XS files (`.xs`).
 
 Extension-less scripts are detected by shebang for common bash/sh/zsh/ksh/dash/ash, Python, Node, Ruby, Perl, Lua, Rscript, and PHP interpreters.
 
@@ -149,7 +149,7 @@ Languages not covered yet can be added without a fork via a `.code-review-graph/
 
 ## What Gets Indexed
 
-- **Nodes**: Files, Classes, Functions/Methods, Types, Tests — plus Endpoints, Schedulers and ConfigProperties where framework enrichment applies
+- **Nodes**: Files, Classes, Functions/Methods, Types, Tests, YamlPaths — plus Endpoints, Schedulers and ConfigProperties where framework enrichment applies
 - **Edges**: CALLS, IMPORTS_FROM, INHERITS, IMPLEMENTS, CONTAINS, TESTED_BY, DEPENDS_ON, REFERENCES — plus framework-specific kinds (INJECTS, HANDLES, TRIGGERS, PUBLISHES, CONSUMES/PRODUCES, DEPENDS_ON_CONFIG, TEMPORAL_STUB)
 
 See [schema.md](schema.md) for full details.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -68,6 +68,24 @@ A synthesised node representing a scheduled invocation, emitted for `@Scheduled`
 ### ConfigProperty
 An externalised configuration key parsed out of Spring `application.properties` / `application.yml` files. Values are deliberately discarded — only the key is stored. Linked to the code that binds it by a `DEPENDS_ON_CONFIG` edge.
 
+### YamlPath
+A path-addressable mapping key or sequence shape parsed from generic `.yml` / `.yaml` files. Repeated sequence entries are aggregated under `[*]` paths with bounded occurrence/range samples, allowing similarly shaped files to be compared without one graph node per list item. Scalar values are deliberately discarded.
+
+The persisted `extra` JSON is the internal source of truth. Query, search, and change-analysis responses expose its safe public subset under one nested `yaml` object:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| schema_path | string | Aggregated structural path, such as `$.services[*].metadata.tier` |
+| example_path | string | One concrete occurrence used as a navigation example |
+| value_type / value_types | string / string[] | Structural or scalar YAML tag types; never scalar values |
+| document_index | int | Zero-based YAML document index |
+| occurrence_count | int | Number of occurrences represented by this node |
+| line_samples | int[] | Bounded occurrence-line samples |
+| duplicate_key / duplicate_group_count | bool / int | Mapping-scoped duplicate-key diagnostics |
+| is_alias / anchor_definition / yaml_merge | bool | Alias, anchor, and merge relationship metadata |
+
+`CONTAINS` connects files and nested paths. Alias nodes use `REFERENCES` with canonical qualified endpoints. Generic YAML `File` responses use the same `yaml` object for document, duplicate-key, unsupported-key, truncation, and `values_indexed: false` metadata.
+
 ## Edge Types
 
 ### CALLS
@@ -168,6 +186,12 @@ Nodes are uniquely identified by qualified names:
 
 # Nested class method
 /absolute/path/to/file.py::OuterClass.InnerClass.method_name
+
+# Aggregated YAML path in document 0
+/absolute/path/to/file.yml::yaml:0:$.services[*].metadata.tier
+
+# Alias or anchor identities add a source-stable identity segment
+/absolute/path/to/file.yml::yaml:0:alias:$.service["<<"]@12
 ```
 
 ## SQLite Tables

--- a/tests/test_ansible_parser.py
+++ b/tests/test_ansible_parser.py
@@ -28,8 +28,9 @@ def test_ordinary_yaml_in_tasks_directory_is_not_treated_as_ansible() -> None:
         source,
     )
 
-    assert nodes == []
-    assert edges == []
+    assert any(node.kind == "YamlPath" for node in nodes)
+    assert not any(node.language == "ansible" for node in nodes)
+    assert all(edge.kind == "CONTAINS" for edge in edges)
 
 
 def test_ansible_relationships_reference_real_unique_nodes(tmp_path: Path) -> None:

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -353,9 +353,48 @@ class TestChanges:
         assert "summary" in result
         assert "risk_score" in result
         assert "changed_functions" in result
+        assert "changed_yaml_paths" in result
         assert "affected_flows" in result
         assert "test_gaps" in result
         assert "review_priorities" in result
+
+    def test_yaml_changes_use_occurrence_ranges_without_test_gap_scoring(self):
+        node = NodeInfo(
+            kind="YamlPath",
+            name="$.services[*].metadata.tier",
+            file_path="config.yml",
+            line_start=2,
+            line_end=100,
+            language="yaml",
+            identity_name="yaml:0:$.services[*].metadata.tier",
+            extra={
+                "schema_path": "$.services[*].metadata.tier",
+                "value_type": "str",
+                "occurrence_count": 2,
+                "range_samples": [[2, 10], [90, 100]],
+                "lines_truncated": False,
+            },
+        )
+        self.store.upsert_node(node, file_hash="yaml")
+        self.store.commit()
+
+        assert map_changes_to_nodes(self.store, {"config.yml": [(50, 50)]}) == []
+        result = analyze_changes(
+            self.store,
+            changed_files=["config.yml"],
+            changed_ranges={"config.yml": [(95, 95)]},
+        )
+
+        assert result["changed_functions"] == []
+        assert result["test_gaps"] == []
+        yaml_path = result["changed_yaml_paths"][0]
+        assert yaml_path["name"] == "$.services[*].metadata.tier"
+        assert yaml_path["yaml"]["schema_path"] == "$.services[*].metadata.tier"
+        assert yaml_path["yaml"]["value_type"] == "str"
+        assert yaml_path["yaml"]["occurrence_count"] == 2
+        assert "schema_path" not in yaml_path
+        assert "value_type" not in yaml_path
+        assert "1 changed YAML path(s)" in result["summary"]
 
     def test_analyze_changes_risk_score_range(self):
         """Overall risk score is between 0 and 1."""

--- a/tests/test_spring_config.py
+++ b/tests/test_spring_config.py
@@ -50,7 +50,9 @@ def test_only_conventional_spring_files_are_classified(tmp_path: Path) -> None:
     assert parser.detect_language(tmp_path / "app.properties") is None
     assert parser.detect_language(tmp_path / "workflow.yml") == "yaml"
 
-    assert parser.parse_bytes(tmp_path / "workflow.yml", YAML_SOURCE) == ([], [])
+    workflow_nodes, _ = parser.parse_bytes(tmp_path / "workflow.yml", YAML_SOURCE)
+    assert any(node.kind == "YamlPath" for node in workflow_nodes)
+    assert not any(node.kind == "ConfigProperty" for node in workflow_nodes)
     assert parser.parse_bytes(tmp_path / "app.properties", PROPERTIES_SOURCE) == ([], [])
 
 
@@ -70,8 +72,13 @@ def test_non_spring_application_yaml_is_not_indexed_as_config(tmp_path: Path) ->
     github_actions = b"name: CI\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
     kubernetes = b"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api\n"
 
-    assert parser.parse_bytes(tmp_path / "application.yml", github_actions) == ([], [])
-    assert parser.parse_bytes(tmp_path / "application.yaml", kubernetes) == ([], [])
+    for filename, source in (
+        ("application.yml", github_actions),
+        ("application.yaml", kubernetes),
+    ):
+        nodes, _ = parser.parse_bytes(tmp_path / filename, source)
+        assert any(node.kind == "YamlPath" for node in nodes)
+        assert not any(node.kind == "ConfigProperty" for node in nodes)
 
 
 def test_ansible_content_wins_even_without_ansible_path(tmp_path: Path) -> None:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -436,15 +436,32 @@ def test_export_includes_communities(store_with_data):
 
 
 def test_generate_html_includes_all_edge_types(store_with_data, tmp_path):
-    """Generated HTML should define colors and legend entries for all 7 edge types."""
+    """Generated HTML should define colors and legend entries for graph edge types."""
     from code_review_graph.visualization import generate_html
 
     output_path = tmp_path / "graph.html"
     generate_html(store_with_data, output_path)
     content = output_path.read_text()
     for edge_kind in ["CALLS", "IMPORTS_FROM", "INHERITS", "CONTAINS",
-                       "IMPLEMENTS", "TESTED_BY", "DEPENDS_ON"]:
+                       "IMPLEMENTS", "TESTED_BY", "DEPENDS_ON", "REFERENCES"]:
         assert edge_kind in content, f"Edge type {edge_kind} missing from HTML"
+
+
+def test_generate_html_includes_yaml_path_visuals(store_with_data, tmp_path):
+    from code_review_graph.visualization import generate_html
+
+    full_path = tmp_path / "full.html"
+    community_path = tmp_path / "community.html"
+    generate_html(store_with_data, full_path, mode="full")
+    generate_html(store_with_data, community_path, mode="community")
+
+    full = full_path.read_text()
+    community = community_path.read_text()
+    assert "YamlPath" in full
+    assert 'data-kind="YamlPath"' in full
+    assert 'data-edge-kind="REFERENCES"' in full
+    assert "YamlPath" in community
+    assert 'REFERENCES: "#39c5cf"' in community
 
 
 def test_generate_html_includes_interactive_features(store_with_data, tmp_path):

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -1,0 +1,388 @@
+import json
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.parser import CodeParser
+from code_review_graph.tools.query import query_graph
+
+YAML_SOURCE = b"""
+services:
+  - id: api
+    metadata:
+      tier: frontend
+    options:
+      enabled: true
+  - id: worker
+    metadata:
+      tier: backend
+secret-token: never-index-this
+"""
+
+
+def _yaml_paths(nodes):
+    return [node for node in nodes if node.kind == "YamlPath"]
+
+
+def test_generic_yaml_indexes_nested_paths_without_values(tmp_path: Path) -> None:
+    path = tmp_path / "config.yml"
+    nodes, edges = CodeParser().parse_bytes(path, YAML_SOURCE)
+    yaml_paths = _yaml_paths(nodes)
+
+    assert any(node.kind == "File" for node in nodes)
+    assert {node.name for node in yaml_paths} >= {
+        "$",
+        "$.services",
+        "$.services[*]",
+        "$.services[*].id",
+        "$.services[*].metadata.tier",
+        "$.services[*].options.enabled",
+        "$.secret-token",
+    }
+    tier = next(
+        node for node in yaml_paths
+        if node.name == "$.services[*].metadata.tier"
+    )
+    assert tier.extra["schema_path"] == "$.services[*].metadata.tier"
+    assert tier.extra["value_type"] == "str"
+    assert tier.extra["occurrence_count"] == 2
+    assert tier.extra["line_samples"] == [5, 10]
+    assert all(edge.kind == "CONTAINS" for edge in edges)
+
+    serialized = json.dumps([
+        [node.name, node.extra] for node in nodes
+    ] + [
+        [edge.source, edge.target, edge.extra] for edge in edges
+    ])
+    assert "never-index-this" not in serialized
+    assert "frontend" not in serialized
+    assert "worker" not in serialized
+    assert all(node.extra.get("values_indexed") is False for node in nodes[:1])
+
+
+def test_duplicate_keys_are_distinct_and_scoped_to_one_mapping(tmp_path: Path) -> None:
+    source = b"""
+record:
+  label: first
+  label: second
+  nested:
+    label: not-a-duplicate
+---
+record:
+  label: another-document
+"""
+    path = tmp_path / "duplicate.yml"
+    nodes, edges = CodeParser().parse_bytes(path, source)
+    labels = [node for node in _yaml_paths(nodes) if node.name == "$.record.label"]
+
+    assert len(labels) == 2
+    first_document = [node for node in labels if node.extra["document_index"] == 0]
+    assert len(first_document) == 1
+    assert first_document[0].extra["occurrence_count"] == 2
+    assert first_document[0].extra["duplicate_key_occurrence_count"] == 2
+    assert first_document[0].extra["duplicate_group_count"] == 1
+    assert first_document[0].extra["duplicate_key"] is True
+    assert labels[-1].extra["duplicate_key"] is False
+    assert all(
+        node.extra["duplicate_key"] is False
+        for node in _yaml_paths(nodes)
+        if node.name == "$.record.nested.label"
+    )
+
+    file_node = nodes[0]
+    assert file_node.extra["yaml_duplicate_key_count"] == 1
+    assert file_node.extra["yaml_duplicate_keys"] == [{
+        "document_index": 0,
+        "path": "$.record.label",
+        "example_path": "$.record.label",
+        "occurrence_count": 2,
+        "line_samples": [3, 4],
+        "lines_truncated": False,
+    }]
+
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    with GraphStore(graph_dir / "graph.db") as store:
+        store.store_file_nodes_edges(str(path), nodes, edges, "yaml")
+        stored = [
+            node for node in store.get_nodes_by_file(str(path))
+            if node.name == "$.record.label"
+        ]
+        assert len(stored) == 2
+        assert len({node.qualified_name for node in stored}) == 2
+
+
+def test_typed_and_complex_mapping_keys_cannot_collide(tmp_path: Path) -> None:
+    source = b"""
+1: integer-key
+"1": string-key
+? [one, two]
+: complex-key
+"""
+    nodes, edges = CodeParser().parse_bytes(tmp_path / "keys.yml", source)
+    numeric_paths = [node for node in _yaml_paths(nodes) if node.name == '$["1"]']
+
+    assert len(numeric_paths) == 1
+    assert numeric_paths[0].extra["duplicate_key"] is False
+    assert numeric_paths[0].extra["occurrence_count"] == 2
+    assert len(numeric_paths[0].extra["key_tags"]) == 2
+    assert nodes[0].extra["yaml_unsupported_key_count"] == 1
+    assert len(edges) == 2  # File -> document root -> the supported aggregated path.
+
+
+def test_alias_and_merge_emit_canonical_reference_edges(tmp_path: Path) -> None:
+    source = b"""
+defaults: &defaults
+  tier: primary
+service:
+  <<: *defaults
+  tier: secondary
+"""
+    path = tmp_path / "aliases.yml"
+    nodes, edges = CodeParser().parse_bytes(path, source)
+    yaml_paths = _yaml_paths(nodes)
+    merge = next(node for node in yaml_paths if node.name == '$.service["<<"]')
+    local_tier = next(node for node in yaml_paths if node.name == "$.service.tier")
+    references = [edge for edge in edges if edge.kind == "REFERENCES"]
+    anchor = next(
+        node for node in yaml_paths
+        if node.name == "$.defaults" and node.extra.get("anchor_definition")
+    )
+
+    assert len(references) == 1
+    assert references[0].source.endswith(merge.identity_name)
+    assert references[0].target.endswith(anchor.identity_name)
+    assert references[0].extra == {"yaml_alias": True, "yaml_merge": True}
+    assert local_tier.extra["duplicate_key"] is False
+
+
+def test_root_and_sequence_aliases_keep_canonical_targets_and_lines(tmp_path: Path) -> None:
+    root_nodes, root_edges = CodeParser().parse_bytes(
+        tmp_path / "root.yml",
+        b"&root\nname: app\nself: *root\n",
+    )
+    root_reference = next(edge for edge in root_edges if edge.kind == "REFERENCES")
+    root_alias = next(node for node in _yaml_paths(root_nodes) if node.extra["is_alias"])
+
+    root_anchor = next(
+        node for node in _yaml_paths(root_nodes)
+        if node.name == "$" and node.extra.get("anchor_definition")
+    )
+    assert root_reference.target.endswith(root_anchor.identity_name)
+    assert root_reference.line == 3
+    assert root_alias.name == "$.self"
+    assert not any(node.name.startswith("$.self.") for node in _yaml_paths(root_nodes))
+
+    sequence_nodes, sequence_edges = CodeParser().parse_bytes(
+        tmp_path / "sequence.yml",
+        b"refs:\n  - &item value\n  - *item\n",
+    )
+    sequence_alias = next(
+        node for node in _yaml_paths(sequence_nodes) if node.extra["is_alias"]
+    )
+    sequence_reference = next(
+        edge for edge in sequence_edges if edge.kind == "REFERENCES"
+    )
+
+    assert sequence_alias.name == "$.refs[1]"
+    assert sequence_alias.line_start == 3
+    assert sequence_reference.line == 3
+
+
+def test_alias_lines_ignore_aliases_below_unsupported_complex_keys(
+    tmp_path: Path,
+) -> None:
+    source = b"base: &base {x: one}\n? [*base]\n: ignored\ncopy: *base\n"
+    nodes, edges = CodeParser().parse_bytes(tmp_path / "complex-key.yml", source)
+    copy = next(node for node in _yaml_paths(nodes) if node.name == "$.copy")
+    reference = next(edge for edge in edges if edge.kind == "REFERENCES")
+
+    assert nodes[0].extra["yaml_unsupported_key_count"] == 1
+    assert copy.extra["is_alias"] is True
+    assert copy.line_start == 4
+    assert reference.line == 4
+
+
+def test_anchored_typed_keys_keep_distinct_reference_targets(tmp_path: Path) -> None:
+    source = b'''1: &int-key {x: one}
+"1": &str-key {y: two}
+copy_int: *int-key
+copy_str: *str-key
+'''
+    nodes, edges = CodeParser().parse_bytes(tmp_path / "typed-anchors.yml", source)
+    definitions = [
+        node for node in _yaml_paths(nodes)
+        if node.name == '$["1"]' and node.extra.get("anchor_definition")
+    ]
+    references = [edge for edge in edges if edge.kind == "REFERENCES"]
+
+    assert len(definitions) == 2
+    assert len({node.identity_name for node in definitions}) == 2
+    assert {tuple(node.extra["key_tags"]) for node in definitions} == {
+        ("tag:yaml.org,2002:int",),
+        ("tag:yaml.org,2002:str",),
+    }
+    assert len(references) == 2
+    assert len({edge.target for edge in references}) == 2
+    assert {edge.line for edge in references} == {3, 4}
+
+
+def test_duplicate_anchored_keys_keep_distinct_reference_targets(tmp_path: Path) -> None:
+    source = b'''item: &first {field: one}
+item: &second {field: two}
+copy_first: *first
+copy_second: *second
+'''
+    nodes, edges = CodeParser().parse_bytes(tmp_path / "duplicate-anchors.yml", source)
+    definitions = [
+        node for node in _yaml_paths(nodes)
+        if node.name == "$.item" and node.extra.get("anchor_definition")
+    ]
+    references = [edge for edge in edges if edge.kind == "REFERENCES"]
+
+    assert len(definitions) == 2
+    assert all(node.extra["duplicate_key"] is True for node in definitions)
+    assert len({node.identity_name for node in definitions}) == 2
+    assert len({edge.target for edge in references}) == 2
+
+
+def test_merge_sequence_marks_every_alias_reference(tmp_path: Path) -> None:
+    source = b"""
+first: &first {field: primary}
+second: &second {tier: one}
+service:
+  <<: [*first, *second]
+"""
+    _, edges = CodeParser().parse_bytes(tmp_path / "merge.yml", source)
+    references = [edge for edge in edges if edge.kind == "REFERENCES"]
+
+    assert len(references) == 2
+    assert all(edge.extra["yaml_merge"] is True for edge in references)
+    assert all(edge.line == 5 for edge in references)
+
+
+def test_malformed_and_recursive_yaml_fail_safely(tmp_path: Path) -> None:
+    parser = CodeParser()
+    assert parser.parse_bytes(tmp_path / "broken.yml", b"a: [unterminated") == ([], [])
+
+    nodes, _ = parser.parse_bytes(
+        tmp_path / "recursive.yml",
+        b"root: &root\n  self: *root\n",
+    )
+    assert len(nodes) < 10
+    recursive = next(node for node in _yaml_paths(nodes) if node.name == "$.root.self")
+    assert recursive.extra["is_alias"] is True
+
+
+def test_deep_yaml_and_duplicate_metadata_are_bounded(tmp_path: Path) -> None:
+    parser = CodeParser()
+    deep = "root:\n" + "".join(
+        f"{'  ' * depth}child:\n" for depth in range(1, 800)
+    )
+    assert parser.parse_bytes(tmp_path / "deep.yml", deep.encode()) == ([], [])
+
+    parser._MAX_YAML_DUPLICATE_LINE_SAMPLES = 3
+    duplicate_source = (
+        b"root:\n  repeated: one\n  repeated: two\n"
+        b"  repeated: three\n  repeated: four\n"
+    )
+    nodes, _ = parser.parse_bytes(tmp_path / "bounded.yml", duplicate_source)
+    repeated = next(node for node in _yaml_paths(nodes) if node.name == "$.root.repeated")
+    group = repeated.extra["duplicate_group_samples"][0]
+
+    assert group["occurrence_count"] == 4
+    assert group["line_samples"] == [2, 3, 4]
+    assert group["lines_truncated"] is True
+
+
+def test_yaml_node_limit_marks_file_as_truncated(tmp_path: Path) -> None:
+    parser = CodeParser()
+    parser._MAX_YAML_NODES = 2
+
+    nodes, _ = parser.parse_bytes(
+        tmp_path / "large.yml",
+        b"one: 1\ntwo: 2\nthree: 3\n",
+    )
+
+    assert len(_yaml_paths(nodes)) == 2
+    assert nodes[0].extra["yaml_truncated"] is True
+
+
+def test_long_duplicate_paths_are_bounded_in_internal_metadata(tmp_path: Path) -> None:
+    long_key = "x" * 600
+    source = f'"{long_key}": one\n"{long_key}": two\n'.encode()
+
+    nodes, _ = CodeParser().parse_bytes(tmp_path / "long-key.yml", source)
+    duplicate = nodes[0].extra["yaml_duplicate_keys"][0]
+    serialized = json.dumps([node.extra for node in nodes])
+
+    assert nodes[0].extra["yaml_truncated"] is True
+    assert duplicate["occurrence_count"] == 2
+    assert len(duplicate["path"]) == CodeParser._MAX_YAML_PATH_LENGTH
+    assert len(duplicate["example_path"]) == CodeParser._MAX_YAML_PATH_LENGTH
+    assert long_key not in serialized
+
+
+def test_spring_and_ansible_keep_precedence(tmp_path: Path) -> None:
+    parser = CodeParser()
+    spring_nodes, _ = parser.parse_bytes(
+        tmp_path / "application.yml",
+        b"spring:\n  datasource:\n    url: jdbc:test\n",
+    )
+    ansible_nodes, _ = parser.parse_bytes(
+        tmp_path / "playbooks" / "site.yml",
+        b"- name: run check\n  hosts: all\n  tasks:\n    - debug:\n        msg: ready\n",
+    )
+
+    assert any(node.kind == "ConfigProperty" for node in spring_nodes)
+    assert not any(node.kind == "YamlPath" for node in spring_nodes)
+    assert any(node.language == "ansible" for node in ansible_nodes)
+    assert not any(node.kind == "YamlPath" for node in ansible_nodes)
+
+
+def test_full_build_query_has_no_dangling_yaml_edges(tmp_path: Path) -> None:
+    path = tmp_path / "config.yml"
+    path.write_bytes(YAML_SOURCE)
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+
+    with GraphStore(graph_dir / "graph.db") as store:
+        result = full_build(tmp_path, store)
+        dangling = store._conn.execute(
+            "SELECT COUNT(*) FROM edges e "
+            "LEFT JOIN nodes s ON s.qualified_name = e.source_qualified "
+            "LEFT JOIN nodes t ON t.qualified_name = e.target_qualified "
+            "WHERE e.kind IN ('CONTAINS', 'REFERENCES') "
+            "AND (s.id IS NULL OR t.id IS NULL)"
+        ).fetchone()[0]
+
+    assert result["errors"] == []
+    assert result["files_parsed"] == 1
+    assert dangling == 0
+
+    children = query_graph("children_of", str(path), repo_root=str(tmp_path))
+    assert children["status"] == "ok"
+    assert {node["name"] for node in children["results"]} == {"$"}
+    assert children["results"][0]["yaml"]["value_type"] == "mapping"
+
+    root = query_graph(
+        "children_of",
+        f"{path.as_posix()}::yaml:0:$",
+        repo_root=str(tmp_path),
+    )
+    assert {node["name"] for node in root["results"]} == {"$.services", "$.secret-token"}
+
+    summary = query_graph("file_summary", str(path), repo_root=str(tmp_path))
+    file_result = next(node for node in summary["results"] if node["kind"] == "File")
+    services_result = next(
+        node for node in summary["results"] if node["name"] == "$.services"
+    )
+    assert file_result["yaml"] == {
+        "document_count": 1,
+        "duplicate_key_count": 0,
+        "unsupported_key_count": 0,
+        "truncated": False,
+        "values_indexed": False,
+        "duplicate_keys": [],
+    }
+    assert services_result["yaml"]["schema_path"] == "$.services"


### PR DESCRIPTION
Partially addresses #436. JSON support remains out of scope for this PR.

## What changed

Generic `.yml` / `.yaml` files now produce value-free, path-addressable graph
structure:

- aggregated `YamlPath` nodes for mappings and repeated sequence shapes
- occurrence counts plus bounded source-line/range samples
- scoped duplicate mapping-key diagnostics with exact line samples
- canonical `CONTAINS` edges and `REFERENCES` edges for aliases/merge keys
- distinct reference targets for typed and duplicate anchored definitions
- `changed_yaml_paths` in change/review output
- CLI kind filtering, graph serialization, visualization, and docs support

Scalar values are deliberately discarded. The graph stores structural key paths
and YAML types, not configuration values.

## Safety and compatibility

This incorporates the earlier YAML review feedback from #539, #577, and #462:

- malformed or pathologically recursive YAML fails safely
- aliases, root/self aliases, merge sequences, and complex mapping keys have
  regression coverage
- per-file limits bound node count, nesting depth, path length, and diagnostic
  samples
- repeated sequence shapes aggregate under `[*]` paths
- existing Ansible and Spring parsers retain precedence
- files rejected by a specialized path heuristic fall back to generic YAML
- full-build/query coverage asserts zero dangling YAML edges

## How this differs from earlier attempts

| Earlier review concern | This PR |
|---|---|
| Bare or dangling graph endpoints | Canonical persisted identities plus full-build dangling-edge assertions |
| Raw configuration values in metadata | Values are never stored |
| Framework- or organization-specific YAML schema | Generic structural paths and YAML types |
| One node per repeated list item | Aggregated `[*]` schema paths with bounded occurrence samples |
| Missing malformed/cycle/size handling | Error, recursion, node, depth, path, and metadata bounds |
| Parser-only coverage | Persistence, query, change analysis, visualization, and specialization regressions |

## Deliberate non-goals

This first phase does not add JSON indexing, scalar-value indexing,
duplicate-value detection, cross-file business-rule validation, business-owner
inference, or Helm values-to-template resolution (#199). Those require explicit
policy and privacy semantics on top of structural indexing.

## Verification

Verification uses only synthetic fixtures and the public project test suite:

```bash
uv run --python 3.13 pytest tests/ --tb=short -q
uv run pytest tests/test_yaml_parser.py tests/test_incremental.py -q --tb=short
uv run ruff check code_review_graph/
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

- synthetic full-build/query fixture asserts zero dangling YAML edges
- privacy regressions assert scalar values never enter node or edge metadata
- malformed, recursive, oversized, duplicate-key, alias, and merge fixtures are
  covered
