### PR TITLE
fix(parser): stop folding trailing comments into Kotlin import targets

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -15276,6 +15276,20 @@ class CodeParser:
             parts = text.split()
             if len(parts) >= 2:
                 imports.append(parts[-1].rstrip(";"))
+        elif language == "kotlin":
+            # tree-sitter-kotlin folds any comment that follows the LAST import
+            # into that import_header node, so the node text is not a module
+            # name (it can be a whole KDoc block). Read the identifier child
+            # instead; re-append ".*" when a wildcard_import sibling is present.
+            base = ""
+            wildcard = False
+            for child in node.children:
+                if child.type == "identifier":
+                    base = child.text.decode("utf-8", errors="replace")
+                elif child.type == "wildcard_import":
+                    wildcard = True
+            if base:
+                imports.append(f"{base}.*" if wildcard else base)
         elif language == "solidity":
             # import "path/to/file.sol" or import {Symbol} from "path"
             for child in node.children:

--- a/tests/test_kotlin_imports.py
+++ b/tests/test_kotlin_imports.py
@@ -1,0 +1,132 @@
+"""Regression tests for Kotlin import extraction.
+
+tree-sitter-kotlin folds any comment following the *last* import into that
+``import_header`` node. Without a dedicated Kotlin branch in
+``_extract_import`` the node text was recorded verbatim as the module name,
+so an import trailed by a long KDoc block produced a module name containing
+the whole comment. ``_do_resolve_module`` then joined it into a filesystem
+path and called ``os.stat``, raising ``OSError: [Errno 63] File name too
+long`` and failing the whole file.
+"""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _import_targets(repo_root: Path, source_file: Path) -> set[str]:
+    _, edges = CodeParser(repo_root).parse_file(source_file)
+    return {edge.target for edge in edges if edge.kind == "IMPORTS_FROM"}
+
+
+def _write_kotlin(tmp_path: Path, body: str) -> Path:
+    source = tmp_path / "Main.kt"
+    source.write_text(body, encoding="utf-8")
+    return source
+
+
+def test_plain_import_records_module_name(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\nimport kotlinx.coroutines.delay\n\nclass Main\n",
+    )
+
+    assert "kotlinx.coroutines.delay" in _import_targets(tmp_path, source)
+
+
+def test_last_import_ignores_trailing_block_comment(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\n"
+        "import javax.inject.Inject\n\n"
+        "/** Doc comment attached to the class below. */\n"
+        "class Main\n",
+    )
+
+    targets = _import_targets(tmp_path, source)
+
+    assert "javax.inject.Inject" in targets
+    assert not any("/**" in target for target in targets)
+
+
+def test_last_import_ignores_trailing_line_comment(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\n"
+        "import javax.inject.Inject\n\n"
+        "// Explanatory note\n"
+        "class Main\n",
+    )
+
+    targets = _import_targets(tmp_path, source)
+
+    assert "javax.inject.Inject" in targets
+    assert not any("//" in target for target in targets)
+
+
+def test_only_trailing_comment_of_last_import_is_dropped(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\n"
+        "import kotlinx.coroutines.delay\n"
+        "import javax.inject.Inject\n\n"
+        "/** Doc comment. */\n"
+        "class Main\n",
+    )
+
+    targets = _import_targets(tmp_path, source)
+
+    assert {"kotlinx.coroutines.delay", "javax.inject.Inject"} <= targets
+
+
+def test_aliased_import_records_original_module(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\nimport kotlinx.coroutines.delay as pause\n\nclass Main\n",
+    )
+
+    assert "kotlinx.coroutines.delay" in _import_targets(tmp_path, source)
+
+
+def test_wildcard_import_keeps_star_suffix(tmp_path: Path) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\nimport kotlinx.coroutines.*\n\nclass Main\n",
+    )
+
+    assert "kotlinx.coroutines.*" in _import_targets(tmp_path, source)
+
+
+def test_wildcard_import_with_trailing_comment_keeps_star_suffix(
+    tmp_path: Path,
+) -> None:
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\n"
+        "import kotlinx.coroutines.*\n\n"
+        "/** Doc comment. */\n"
+        "class Main\n",
+    )
+
+    targets = _import_targets(tmp_path, source)
+
+    assert "kotlinx.coroutines.*" in targets
+    assert not any("/**" in target for target in targets)
+
+
+def test_long_trailing_kdoc_does_not_break_parsing(tmp_path: Path) -> None:
+    """The original crash: a KDoc long enough to overflow the path limit."""
+    source = _write_kotlin(
+        tmp_path,
+        "package app\n\n"
+        "import javax.inject.Inject\n\n"
+        "/**\n"
+        + "".join(f" * {'detail ' * 12}\n" for _ in range(40))
+        + " */\n"
+        "class Main\n",
+    )
+
+    targets = _import_targets(tmp_path, source)
+
+    assert "javax.inject.Inject" in targets
+    assert all(len(target) < 200 for target in targets)


### PR DESCRIPTION
## Linked issue

No separate issue filed — the repro and root cause are self-contained below.

## What & why

Kotlin files whose **last** import is followed by a long KDoc block fail to
parse entirely, with:

```
OSError: [Errno 63] File name too long: '<repo>/<dir>/import javax/inject/Inject\n\n/**\n * ...
```

Note the "path" in that error is actually a whole source comment.

### Root cause

Three layers:

1. `tree-sitter-kotlin` folds any comment that follows the **last** import into
   that `import_header` node. Minimal case — the node text for `import b.C`
   below is `'import b.C\n\n/** hi */'`:

   ```kotlin
   package a
   import b.C

   /** hi */
   class D
   ```

2. `_extract_import` has branches for python, javascript, go, rust, c/cpp,
   java/csharp, solidity, scala, r, ruby, dart, verilog and julia — but not for
   Kotlin. Kotlin therefore falls through to the generic fallback:

   ```python
   else:
       # Fallback: just record the text
       imports.append(text)
   ```

   so the module name becomes the import statement *plus* the trailing comment.

3. `_do_resolve_module` joins that string into a filesystem path and calls
   `target.is_file()` → `os.stat`. When the trailing comment is long enough the
   path exceeds the OS limit and raises `OSError`. `_extract_imports` has no
   `try/except`, so the exception propagates and the whole file is dropped.

### Blast radius is wider than the crash

Every Kotlin file was affected — the last import always produced an
`IMPORTS_FROM` edge whose target carried the trailing comment. Only files whose
comment was long enough to overflow the path limit actually raised; the rest
silently emitted an unresolvable edge. In one 398-file Kotlin repo exactly one
file crashed, but every file with a trailing comment had a polluted edge.

### Fix

Add a Kotlin branch to `_extract_import` that reads the `identifier` child
rather than the node text. Comments are separate `multiline_comment` siblings,
so this is immune to the folding. `wildcard_import` siblings get `.*`
re-appended, and `import_alias` is ignored so the original module is recorded.

The node structure this relies on:

| Source | children of `import_header` |
| --- | --- |
| `import b.C` | `import`, `identifier('b.C')` |
| `import b.C` + trailing comment | `import`, `identifier('b.C')`, `multiline_comment` |
| `import b.C as E` | `import`, `identifier('b.C')`, `import_alias('as E')` |
| `import b.*` | `import`, `identifier('b')`, `.`, `wildcard_import('*')` |

14 lines, no behavior change for any other language.

## How it was tested

New `tests/test_kotlin_imports.py` (8 cases: plain, trailing block comment,
trailing line comment, multi-import, alias, wildcard, wildcard + comment, and
the long-KDoc crash). **All 8 fail on `main` and pass with this change** — the
long-KDoc case reproduces the original `OSError` exactly.

```bash
$ uv run pytest tests/test_kotlin_imports.py --tb=line -q   # before the fix
8 failed in 0.17s

$ uv run pytest tests/test_kotlin_imports.py --tb=short -q  # after
8 passed in 0.12s

$ uv run pytest tests/ --tb=short -q
2406 passed, 5 skipped, 2 xpassed, 1 warning in 35.91s

$ uv run ruff check code_review_graph/
All checks passed!

$ uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
Success: no issues found in 70 source files
```

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [x] Docs updated where behavior changed — no user-facing docs cover per-language import extraction; the rationale is captured in the new branch's comment and the test module docstring.
