### PR TITLE
feat(container): add multi-architecture Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+ARG CRG_VERSION=2.3.7
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m pip install --no-cache-dir "code-review-graph==${CRG_VERSION}"
+
+RUN groupadd --gid 1001 crg \
+    && useradd --uid 1001 --gid crg --create-home --shell /usr/sbin/nologin crg
+
+WORKDIR /workspace
+
+RUN chown crg:crg /workspace
+
+USER crg
+
+ENTRYPOINT ["code-review-graph"]
+CMD ["--help"]


### PR DESCRIPTION
## Linked issue

Closes #232

## What & why

Adds a single standard `Dockerfile` for running code-review-graph with Docker or Podman.

The image:

- Uses `python:3.12-slim`
- Pins the default package through the configurable `CRG_VERSION` build argument
- Includes Git in the runtime image for repository discovery and incremental analysis
- Runs as a non-root `crg` user with UID/GID 1001
- Uses `/workspace` as the working directory
- Exposes `code-review-graph` as the entrypoint
- Builds and runs on both `linux/arm64` and `linux/amd64`

GHCR publishing is intentionally left for a separate follow-up.

## How it was tested

Project baseline:

```bash
uv run pytest tests/ --tb=short -q
```

Result: 2,398 passed, 5 skipped, 2 xpassed.

Quality checks:

```bash
uv run ruff check code_review_graph/
uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

Results:

- Ruff: all checks passed
- Mypy: no issues found in 70 source files

Architecture builds:

```bash
docker buildx build \
  --platform linux/arm64 \
  --load \
  --tag code-review-graph:local-arm64 \
  .

docker buildx build \
  --platform linux/amd64 \
  --load \
  --tag code-review-graph:local-amd64 \
  .
```

Both images built successfully.

Runtime validation on both architectures confirmed:

- `code-review-graph 2.3.7`
- Runtime UID/GID is `1001`
- Git is available (`git version 2.47.3`)

A real graph build was also run inside each image against this repository using a read-only bind mount and temporary `CRG_DATA_DIR`.

Both architectures produced:

```text
Full build: 260 files, 5205 nodes, 43218 edges (postprocess=full)
```

## Checklist

- [ ] Tests added for new functionality — not applicable; this is a Dockerfile-only change validated through container builds
- [x] All tests pass: `uv run pytest tests/ --tb=short -q`
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [x] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- [x] Lines are at most 100 characters
- [ ] Docs updated where behavior changed — not applicable; no existing application behavior was changed