### PR TITLE
fix(cli): render Unicode output with legacy encodings

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -98,6 +98,21 @@ def _supports_color() -> bool:
     return sys.stdout.isatty()
 
 
+def _configure_utf8_stdio() -> None:
+    """Allow Unicode CLI decoration on streams using a legacy encoding."""
+    for stream in (sys.stdout, sys.stderr):
+        encoding = getattr(stream, "encoding", None)
+        if not encoding or encoding.lower().replace("-", "") == "utf8":
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+
+
 def _print_banner() -> None:
     """Print the startup banner with graph art and available commands."""
     color = _supports_color()
@@ -602,6 +617,7 @@ def _run_graph_tool_command(args, repo_root: Path) -> None:
 
 def main() -> None:
     """Main CLI entry point."""
+    _configure_utf8_stdio()
     ap = argparse.ArgumentParser(
         prog="code-review-graph",
         description="Persistent incremental knowledge graph for code reviews",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI helpers and MCP serve command wiring."""
 
+import io
 import json
 import logging
 import sys
@@ -7,6 +8,26 @@ from importlib.metadata import PackageNotFoundError
 from unittest.mock import MagicMock, patch
 
 from code_review_graph import cli
+
+
+def test_main_handles_legacy_stdio_encoding(monkeypatch):
+    """Unicode CLI output must not crash when stdio starts as cp1252."""
+    raw_stdout = io.BytesIO()
+    legacy_stdout = io.TextIOWrapper(raw_stdout, encoding="cp1252")
+    raw_stderr = io.BytesIO()
+    legacy_stderr = io.TextIOWrapper(raw_stderr, encoding="cp1252")
+    monkeypatch.setattr(sys, "stdout", legacy_stdout)
+    monkeypatch.setattr(sys, "stderr", legacy_stderr)
+    monkeypatch.setattr(sys, "argv", ["code-review-graph"])
+
+    cli.main()
+
+    legacy_stdout.flush()
+    output = raw_stdout.getvalue().decode(legacy_stdout.encoding)
+    assert legacy_stdout.encoding == "utf-8"
+    assert legacy_stderr.encoding == "utf-8"
+    assert "code-review-graph" in output
+    assert "Commands:" in output
 
 
 def test_get_version_falls_back_to_package_attr_when_metadata_missing(


### PR DESCRIPTION
## Summary

On Windows and redirected streams configured as CP1252, the CLI could raise `UnicodeEncodeError` before showing its banner or graph summaries because those views use box-drawing characters. Reconfigurable standard streams now switch to UTF-8 at startup, while UTF-8, encoding-less, and non-reconfigurable streams keep their existing behavior.

## Validation

- Reproduced the crash on clean `main` with a CP1252 `TextIOWrapper` before applying the fix.
- The real `main()` regression passes on Python 3.10 and 3.13 and verifies both `stdout` and `stderr`.
- `tests/test_cli.py`: 18 passed; the one deselected test is an existing Windows failure reproduced on clean `main`.
- Full Windows suite: 2,353 passed; 37 unrelated platform or fixture failures, with representative cases reproduced on clean `main`.
- Ruff, targeted mypy, and the configured Bandit scan pass.
- Real processes launched with `PYTHONIOENCODING=cp1252` render both the startup banner and graph summaries and exit successfully.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes local CLI output and has no deployed service surface. During review and the next Windows release, a healthy run exits successfully and renders readable Unicode when `PYTHONIOENCODING=cp1252`; `UnicodeEncodeError`, `charmap`, or unreadable redirected output are failure signals. Revert this commit to restore the previous stream behavior if those signals appear.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
