### PR TITLE
fix(go): preserve generic receiver method ownership

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14697,31 +14697,25 @@ class CodeParser:
         """Extract the receiver type from a Go method_declaration.
 
         For ``func (s *T) Foo() {...}`` returns ``"T"``. For ``func (T) Foo()``
-        also returns ``"T"``. Returns None if no receiver is present.
-
-        The receiver is always the first ``parameter_list`` child of a
-        Go ``method_declaration`` and contains a single ``parameter_declaration``
-        whose type is either a ``type_identifier`` or a ``pointer_type``
-        wrapping one. See: #190
+        also returns ``"T"``. Generic receivers ``T[P]`` and ``*T[P]`` return
+        ``"T"``. Returns None if no receiver is present. See: #190, #832
         """
-        for child in node.children:
-            if child.type != "parameter_list":
-                continue
-            for param in child.children:
-                if param.type != "parameter_declaration":
-                    continue
-                for sub in param.children:
-                    if sub.type == "type_identifier":
-                        return sub.text.decode("utf-8", errors="replace")
-                    if sub.type == "pointer_type":
-                        for ptr_child in sub.children:
-                            if ptr_child.type == "type_identifier":
-                                return ptr_child.text.decode(
-                                    "utf-8", errors="replace"
-                                )
-            # First parameter_list is always the receiver; stop searching.
+        receiver = node.child_by_field_name("receiver")
+        if receiver is None:
             return None
-        return None
+        parameter = next(
+            (child for child in receiver.named_children
+             if child.type == "parameter_declaration"),
+            None,
+        )
+        receiver_type = parameter.child_by_field_name("type") if parameter else None
+        while receiver_type is not None and receiver_type.type in {
+            "generic_type", "pointer_type",
+        }:
+            receiver_type = next(iter(receiver_type.named_children), None)
+        if receiver_type is None or receiver_type.type != "type_identifier":
+            return None
+        return receiver_type.text.decode("utf-8", errors="replace")
 
     @staticmethod
     def _cpp_scope_join(

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -83,7 +83,7 @@ class TestGoParsing:
         assert save_contains[0][0].endswith("::InMemoryRepo")
 
     def test_generic_methods_attached_to_receiver(self):
-        nodes, _ = self.parser.parse_bytes(
+        nodes, edges = self.parser.parse_bytes(
             Path("generic.go"),
             b"""package sample
 type Box[T any] struct{}
@@ -98,6 +98,11 @@ func (b *Box[T]) Pointer() {}
             if node.kind == "Function"
         }
         assert parents == {"Value": "Box", "Pointer": "Box"}
+        assert {
+            edge.target.rsplit("::", 1)[-1]
+            for edge in edges
+            if edge.kind == "CONTAINS" and edge.source.endswith("::Box")
+        } == {"Box.Value", "Box.Pointer"}
 
 
 class TestRustParsing:

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -82,6 +82,23 @@ class TestGoParsing:
         assert find_by_id_contains[0][0].endswith("::InMemoryRepo")
         assert save_contains[0][0].endswith("::InMemoryRepo")
 
+    def test_generic_methods_attached_to_receiver(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("generic.go"),
+            b"""package sample
+type Box[T any] struct{}
+func (b Box[T]) Value() {}
+func (b *Box[T]) Pointer() {}
+""",
+        )
+
+        parents = {
+            node.name: node.parent_name
+            for node in nodes
+            if node.kind == "Function"
+        }
+        assert parents == {"Value": "Box", "Pointer": "Box"}
+
 
 class TestRustParsing:
     def setup_method(self):


### PR DESCRIPTION
## Summary

Fixes #832.

Go methods declared on generic receiver types were emitted as top-level
functions because the receiver parser did not unwrap `generic_type` nodes.
The fix unwraps generic and pointer receiver nodes to their base type
identifier, preserving method ownership for both `T[P]` and `*T[P]` receivers.

## Validation

- `uv run --extra dev pytest -q` — 2399 passed, 5 skipped, 2 xpassed
- `uv run --extra dev ruff check code_review_graph/parser.py tests/test_multilang.py`
- Validated against Terraform's `internal/addrs/graph.go`: all 11
  `DirectedGraph[T]` methods now have `parent_name='DirectedGraph'`.

Repository-wide Ruff still reports unrelated pre-existing violations in other
test files.
