### PR TITLE
fix(go): model and resolve embedded type relationships

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -743,6 +743,235 @@ class GraphStore:
         """
         return self._resolve_bare_endpoints("CALLS", "target_qualified")
 
+    def resolve_go_embedding_targets(self) -> int:
+        """Resolve Go embeddings and reject concrete interface type terms.
+
+        Struct fields are unambiguous embeddings. An interface ``type_elem``
+        can instead be a concrete type-set term, so it remains inheritance only
+        when its target resolves to an interface. Repository-local imports are
+        mapped through their module's ``go.mod`` to canonical graph nodes.
+        """
+        edges = self._conn.execute(
+            "SELECT e.id, e.kind, e.source_qualified, e.target_qualified, "
+            "e.file_path, e.extra "
+            "FROM edges e JOIN nodes s ON s.qualified_name = e.source_qualified "
+            "WHERE s.language = 'go' AND e.kind IN ('INHERITS', 'REFERENCES') "
+            "AND e.extra LIKE '%\"go_embedding_target\"%'",
+        ).fetchall()
+        if not edges:
+            return 0
+
+        def load_extra(raw: str | None) -> dict:
+            try:
+                value = json.loads(raw or "{}")
+            except (TypeError, json.JSONDecodeError):
+                return {}
+            return value if isinstance(value, dict) else {}
+
+        by_qualified: dict[str, dict[str, Any]] = {}
+        by_location: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        by_directory_name: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        candidate_dirs: set[str] = set()
+        for row in self._conn.execute(
+            "SELECT name, qualified_name, file_path, extra FROM nodes "
+            "WHERE language = 'go' AND kind = 'Class'",
+        ).fetchall():
+            extra = load_extra(row["extra"])
+            directory = normalize_file_path(str(Path(row["file_path"]).parent.resolve()))
+            candidate = {
+                "name": row["name"],
+                "qualified_name": row["qualified_name"],
+                "file_path": row["file_path"],
+                "directory": directory,
+                "package": extra.get("go_package", ""),
+                "extra": extra,
+            }
+            by_qualified[row["qualified_name"]] = candidate
+            by_location.setdefault(
+                (directory, candidate["package"], row["name"]), [],
+            ).append(candidate)
+            by_directory_name.setdefault(
+                (directory, row["name"]), [],
+            ).append(candidate)
+            candidate_dirs.add(directory)
+
+        imports_by_file: dict[str, list[str]] = {}
+        for row in self._conn.execute(
+            "SELECT file_path, target_qualified FROM edges "
+            "WHERE kind = 'IMPORTS_FROM'",
+        ).fetchall():
+            imports_by_file.setdefault(row["file_path"], []).append(
+                row["target_qualified"],
+            )
+
+        import_dir_cache: dict[tuple[str, str], str | None] = {}
+
+        def import_directory(source_file: str, import_path: str) -> str | None:
+            cache_key = (source_file, import_path)
+            if cache_key in import_dir_cache:
+                return import_dir_cache[cache_key]
+            source_dir = Path(source_file).resolve().parent
+            for root in (source_dir, *source_dir.parents):
+                go_mod = root / "go.mod"
+                if not go_mod.is_file():
+                    continue
+                try:
+                    module = next(
+                        (
+                            fields[1].strip('"')
+                            for line in go_mod.read_text(
+                                encoding="utf-8", errors="replace",
+                            ).splitlines()
+                            if len(fields := line.split()) >= 2
+                            and fields[0] == "module"
+                        ),
+                        None,
+                    )
+                except OSError:
+                    continue
+                if module and (
+                    import_path == module
+                    or import_path.startswith(f"{module}/")
+                ):
+                    suffix = import_path[len(module):].lstrip("/")
+                    target = normalize_file_path(str(Path(root, suffix).resolve()))
+                    if target in candidate_dirs:
+                        import_dir_cache[cache_key] = target
+                        return target
+
+            # Keep a moved graph useful only when the import path has one
+            # unambiguous directory-suffix match.
+            if "/" not in import_path:
+                import_dir_cache[cache_key] = None
+                return None
+            segments = import_path.split("/")
+            for index in range(max(len(segments) - 1, 1)):
+                suffix = "/".join(segments[index:])
+                suffix_matches = {
+                    directory
+                    for directory in candidate_dirs
+                    if directory == suffix or directory.endswith(f"/{suffix}")
+                }
+                if len(suffix_matches) == 1:
+                    target = next(iter(suffix_matches))
+                    import_dir_cache[cache_key] = target
+                    return target
+                if suffix_matches:
+                    break
+            import_dir_cache[cache_key] = None
+            return None
+
+        def resolve_type(
+            raw_target: str,
+            source_file: str,
+            source_package: str,
+            import_path: str | None = None,
+        ) -> dict[str, Any] | None:
+            qualifier, separator, name = raw_target.partition(".")
+            if not separator:
+                directory = normalize_file_path(
+                    str(Path(source_file).parent.resolve()),
+                )
+                candidates = by_location.get(
+                    (directory, source_package, raw_target), [],
+                )
+                return candidates[0] if len(candidates) == 1 else None
+
+            matches: dict[str, dict[str, Any]] = {}
+            for imported in (
+                [import_path] if import_path else imports_by_file.get(source_file, [])
+            ):
+                imported_directory = import_directory(source_file, imported)
+                if imported_directory is None:
+                    continue
+                for candidate in by_directory_name.get(
+                    (imported_directory, name), [],
+                ):
+                    if import_path is None and candidate["package"] != qualifier:
+                        continue
+                    matches[candidate["qualified_name"]] = candidate
+            return next(iter(matches.values())) if len(matches) == 1 else None
+
+        interface_builtins = frozenset({"any", "comparable", "error"})
+        concrete_builtins = frozenset({
+            "bool", "byte", "complex64", "complex128", "float32", "float64",
+            "int", "int8", "int16", "int32", "int64", "rune", "string",
+            "uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+        })
+
+        def interface_status(
+            candidate: dict[str, Any],
+            seen: frozenset[str] = frozenset(),
+        ) -> bool | None:
+            qualified = candidate["qualified_name"]
+            if qualified in seen:
+                return None
+            extra = candidate["extra"]
+            kind = extra.get("go_type_kind")
+            if kind == "interface":
+                return True
+            if kind == "struct":
+                return False
+            underlying = extra.get("go_underlying_type")
+            if not isinstance(underlying, str):
+                return False
+            if underlying in interface_builtins:
+                return True
+            if underlying in concrete_builtins:
+                return False
+            target = resolve_type(
+                underlying,
+                candidate["file_path"],
+                candidate["package"],
+                extra.get("go_underlying_import"),
+            )
+            if target is None:
+                return None
+            return interface_status(target, seen | {qualified})
+
+        changed = 0
+        for edge in edges:
+            extra = load_extra(edge["extra"])
+            raw_target = extra.get("go_embedding_target")
+            if not isinstance(raw_target, str):
+                continue
+            source = by_qualified.get(edge["source_qualified"])
+            if source is None:
+                continue
+            target = resolve_type(
+                raw_target,
+                edge["file_path"],
+                source["package"],
+                extra.get("go_import_path"),
+            )
+            desired_target = (
+                target["qualified_name"] if target is not None else raw_target
+            )
+            desired_kind = "INHERITS"
+            if extra.get("go_embedding_context") == "interface":
+                status = (
+                    interface_status(target)
+                    if target is not None
+                    else raw_target in interface_builtins
+                )
+                if status is not True:
+                    desired_kind = "REFERENCES"
+            if (
+                edge["kind"] == desired_kind
+                and edge["target_qualified"] == desired_target
+            ):
+                continue
+            self._conn.execute(
+                "UPDATE edges SET kind = ?, target_qualified = ? WHERE id = ?",
+                (desired_kind, desired_target, edge["id"]),
+            )
+            changed += 1
+
+        if changed:
+            self._conn.commit()
+            self._invalidate_cache()
+        return changed
+
     def resolve_cpp_scoped_call_targets(self) -> int:
         """Resolve cross-file C++ ``Scope::call`` targets by stable scope identity.
 

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -795,14 +795,19 @@ class GraphStore:
             ).append(candidate)
             candidate_dirs.add(directory)
 
+        source_files = tuple({edge["file_path"] for edge in edges})
         imports_by_file: dict[str, list[str]] = {}
-        for row in self._conn.execute(
-            "SELECT file_path, target_qualified FROM edges "
-            "WHERE kind = 'IMPORTS_FROM'",
-        ).fetchall():
-            imports_by_file.setdefault(row["file_path"], []).append(
-                row["target_qualified"],
-            )
+        for start in range(0, len(source_files), 500):
+            batch = source_files[start:start + 500]
+            placeholders = ",".join("?" for _ in batch)
+            for row in self._conn.execute(
+                "SELECT file_path, target_qualified FROM edges "
+                f"WHERE kind = 'IMPORTS_FROM' AND file_path IN ({placeholders})",
+                batch,
+            ):
+                imports_by_file.setdefault(row["file_path"], []).append(
+                    row["target_qualified"],
+                )
 
         import_dir_cache: dict[tuple[str, str], str | None] = {}
 
@@ -887,6 +892,11 @@ class GraphStore:
                 for candidate in by_directory_name.get(
                     (imported_directory, name), [],
                 ):
+                    # Normal imports never expose declarations from _test.go;
+                    # including external-test packages here creates a false
+                    # ambiguity with production types of the same name.
+                    if candidate["file_path"].endswith("_test.go"):
+                        continue
                     if import_path is None and candidate["package"] != qualifier:
                         continue
                     matches[candidate["qualified_name"]] = candidate
@@ -929,7 +939,7 @@ class GraphStore:
                 return None
             return interface_status(target, seen | {qualified})
 
-        changed = 0
+        updates: list[tuple[str, str, int]] = []
         for edge in edges:
             extra = load_extra(edge["extra"])
             raw_target = extra.get("go_embedding_target")
@@ -961,16 +971,18 @@ class GraphStore:
                 and edge["target_qualified"] == desired_target
             ):
                 continue
-            self._conn.execute(
-                "UPDATE edges SET kind = ?, target_qualified = ? WHERE id = ?",
+            updates.append(
                 (desired_kind, desired_target, edge["id"]),
             )
-            changed += 1
 
-        if changed:
+        if updates:
+            self._conn.executemany(
+                "UPDATE edges SET kind = ?, target_qualified = ? WHERE id = ?",
+                updates,
+            )
             self._conn.commit()
             self._invalidate_cache()
-        return changed
+        return len(updates)
 
     def resolve_cpp_scoped_call_targets(self) -> int:
         """Resolve cross-file C++ ``Scope::call`` targets by stable scope identity.

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -74,6 +74,8 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
+GO_TYPE_MODEL_VERSION = "1"
+_GO_TYPE_MODEL_METADATA_KEY = "go_type_model_version"
 
 
 def _run_python_resolver(store: GraphStore) -> Optional[dict]:
@@ -1131,6 +1133,7 @@ def full_build(
     store.set_metadata("last_build_type", "full")
     if not cpp_errors:
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+    store.set_metadata(_GO_TYPE_MODEL_METADATA_KEY, GO_TYPE_MODEL_VERSION)
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
@@ -1172,9 +1175,12 @@ def incremental_update(
     if (
         store.get_metadata(_CPP_IDENTITY_METADATA_KEY) != CPP_IDENTITY_VERSION
         and store.has_nodes_for_language("cpp")
+    ) or (
+        store.get_metadata(_GO_TYPE_MODEL_METADATA_KEY) != GO_TYPE_MODEL_VERSION
+        and store.has_nodes_for_language("go")
     ):
         logger.info(
-            "C++ identity format changed; rebuilding the graph before incremental update",
+            "Stored language model changed; rebuilding before incremental update",
         )
         rebuilt = full_build(repo_root, store)
         return {
@@ -1302,6 +1308,7 @@ def incremental_update(
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+        store.set_metadata(_GO_TYPE_MODEL_METADATA_KEY, GO_TYPE_MODEL_VERSION)
         _store_vcs_metadata(repo_root, store)
         store.commit()
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2712,25 +2712,6 @@ class CodeParser:
         # File node
         test_file = _is_test_file(file_path_str)
         file_extra: dict = {}
-        if language == "go":
-            package_clause = next(
-                (
-                    child for child in tree.root_node.children
-                    if child.type == "package_clause"
-                ),
-                None,
-            )
-            if package_clause is not None:
-                package_name = next(
-                    (
-                        child.text.decode("utf-8", errors="replace")
-                        for child in package_clause.children
-                        if child.type == "package_identifier"
-                    ),
-                    None,
-                )
-                if package_name:
-                    file_extra["go_package"] = package_name
         # C#: record the namespace(s) this file declares so query-time
         # fallbacks can resolve namespace-form IMPORTS_FROM targets (from
         # `using X.Y;` directives) back to the declaring file. See: #310

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -911,7 +911,10 @@ _CLASS_TYPES: dict[str, list[str]] = {
         "class_declaration", "class",
         "interface_declaration", "type_alias_declaration", "enum_declaration",
     ],
-    "go": ["type_declaration"],
+    # A declaration may group multiple specs (``type (A ...; B ...)``), so the
+    # spec -- not its wrapper -- is the graph entity. Aliases are separate AST
+    # nodes in tree-sitter-go and are addressable types too.
+    "go": ["type_spec", "type_alias"],
     # impl_item is a scope for methods, not a second type definition. It is
     # dispatched separately so repeated impl blocks cannot overwrite structs.
     "rust": ["struct_item", "enum_item", "trait_item"],
@@ -1305,6 +1308,7 @@ _SPRING_SCHEDULED_ANNOTATIONS = frozenset({"Scheduled", "Schedules"})
 _SPRING_EVENT_LISTENER_ANNOTATIONS = frozenset({"EventListener"})
 _SPRING_EVENT_PUBLISH_METHODS = frozenset({"publishEvent"})
 _JAVA_PACKAGE_KEY = "__crg_java_package__"
+_GO_PACKAGE_KEY = "__crg_go_package__"
 _SPRING_REQUEST_PREFIX_KEY = "__crg_spring_request_prefix__:"
 _JS_IMPORT_ORIGINAL_PREFIX_KEY = "__crg_js_import_original__:"
 _SPRING_REQUEST_MAPPINGS = {
@@ -2708,6 +2712,25 @@ class CodeParser:
         # File node
         test_file = _is_test_file(file_path_str)
         file_extra: dict = {}
+        if language == "go":
+            package_clause = next(
+                (
+                    child for child in tree.root_node.children
+                    if child.type == "package_clause"
+                ),
+                None,
+            )
+            if package_clause is not None:
+                package_name = next(
+                    (
+                        child.text.decode("utf-8", errors="replace")
+                        for child in package_clause.children
+                        if child.type == "package_identifier"
+                    ),
+                    None,
+                )
+                if package_name:
+                    file_extra["go_package"] = package_name
         # C#: record the namespace(s) this file declares so query-time
         # fallbacks can resolve namespace-form IMPORTS_FROM targets (from
         # `using X.Y;` directives) back to the declaring file. See: #310
@@ -10063,6 +10086,14 @@ class CodeParser:
     def _preceding_doc_comment(self, node, language: str) -> Optional[str]:
         """Return documentation directly attached above a definition."""
         anchor = node
+        if (
+            language == "go"
+            and node.type in ("type_spec", "type_alias")
+            and node.parent is not None
+            and node.parent.type == "type_declaration"
+            and not any(child.type == "(" for child in node.parent.children)
+        ):
+            anchor = node.parent
         while (
             anchor.parent is not None
             and anchor.parent.type in _DOC_COMMENT_WRAPPER_TYPES
@@ -10140,6 +10171,28 @@ class CodeParser:
         # Tree-sitter maps struct/enum/actor/extension all to class_declaration;
         # protocol uses its own protocol_declaration node type.
         extra: dict = {}
+        if language == "go":
+            type_node = child.child_by_field_name("type")
+            if type_node is not None:
+                if type_node.type == "interface_type":
+                    extra["go_type_kind"] = "interface"
+                elif type_node.type == "struct_type":
+                    extra["go_type_kind"] = "struct"
+                else:
+                    extra["go_type_kind"] = (
+                        "alias" if child.type == "type_alias" else "defined"
+                    )
+                    underlying = self._go_named_type(type_node)
+                    if underlying:
+                        extra["go_underlying_type"] = underlying
+                        prefix, separator, _ = underlying.partition(".")
+                        if separator and import_map is not None:
+                            imported = import_map.get(prefix)
+                            if imported:
+                                extra["go_underlying_import"] = imported
+            package_name = (import_map or {}).get(_GO_PACKAGE_KEY)
+            if package_name:
+                extra["go_package"] = package_name
         if language == "swift":
             if child.type == "class_declaration":
                 _swift_keywords = {"class", "struct", "enum", "actor", "extension"}
@@ -10234,6 +10287,17 @@ class CodeParser:
         # Inheritance edges
         bases = self._get_bases(child, language, source)
         for base in bases:
+            edge_extra: dict = {}
+            if language == "go":
+                edge_extra = {
+                    "go_embedding_target": base,
+                    "go_embedding_context": extra.get("go_type_kind"),
+                }
+                prefix, separator, _ = base.partition(".")
+                if separator and import_map is not None:
+                    imported = import_map.get(prefix)
+                    if imported:
+                        edge_extra["go_import_path"] = imported
             edges.append(EdgeInfo(
                 kind="INHERITS",
                 source=self._qualify(
@@ -10242,6 +10306,7 @@ class CodeParser:
                 target=base,
                 file_path=file_path,
                 line=child.start_point[0] + 1,
+                extra=edge_extra,
             ))
 
         # Spring DI: emit INJECTS edges for injected dependencies
@@ -12888,6 +12953,28 @@ class CodeParser:
         for child in root.children:
             node_type = child.type
 
+            if language == "go" and node_type == "package_clause":
+                package_name = next(
+                    (
+                        part.text.decode("utf-8", errors="replace")
+                        for part in child.children
+                        if part.type == "package_identifier"
+                    ),
+                    None,
+                )
+                if package_name:
+                    import_map[_GO_PACKAGE_KEY] = package_name
+                continue
+
+            if language == "go" and node_type == "type_declaration":
+                for spec in child.named_children:
+                    if spec.type not in ("type_spec", "type_alias"):
+                        continue
+                    name = self._get_name(spec, language, "class")
+                    if name:
+                        defined_names.add(name)
+                continue
+
             if language == "java" and node_type == "package_declaration":
                 package = child.text.decode("utf-8", errors="replace").strip()
                 package = package.removeprefix("package ").removesuffix(";").strip()
@@ -13345,6 +13432,47 @@ class CodeParser:
                 for child in node.children:
                     if child.type == "import_clause":
                         self._collect_js_import_names(child, module, import_map)
+
+        elif language == "go":
+            specs = (
+                [node]
+                if node.type == "import_spec"
+                else [
+                    spec
+                    for child in node.children
+                    for spec in (
+                        [child]
+                        if child.type == "import_spec"
+                        else child.children
+                        if child.type == "import_spec_list"
+                        else []
+                    )
+                    if spec.type == "import_spec"
+                ]
+            )
+            for spec in specs:
+                path_node = next(
+                    (
+                        child for child in spec.children
+                        if child.type == "interpreted_string_literal"
+                    ),
+                    None,
+                )
+                if path_node is None:
+                    continue
+                module = path_node.text.decode(
+                    "utf-8", errors="replace",
+                ).strip('"')
+                alias = next(
+                    (
+                        child.text.decode("utf-8", errors="replace")
+                        for child in spec.children
+                        if child.type == "package_identifier"
+                    ),
+                    module.rsplit("/", 1)[-1],
+                )
+                if alias not in ("_", "."):
+                    import_map[alias] = module
 
         elif language == "rust":
             for local_name, original_path in self._parse_rust_use_node(node):
@@ -14686,11 +14814,6 @@ class CodeParser:
                 "simple_identifier", "constant", "field_identifier",
             ):
                 return child.text.decode("utf-8", errors="replace")
-        # For Go type declarations, look for type_spec
-        if language == "go" and node.type == "type_declaration":
-            for child in node.children:
-                if child.type == "type_spec":
-                    return self._get_name(child, language, kind)
         return None
 
     def _get_go_receiver_type(self, node) -> Optional[str]:
@@ -15018,6 +15141,15 @@ class CodeParser:
                     return node.children[i + 1].text.decode("utf-8", errors="replace")
         return None
 
+    @staticmethod
+    def _go_named_type(node) -> Optional[str]:
+        """Return the named head of a Go type expression, when it has one."""
+        if node.type == "generic_type":
+            node = node.child_by_field_name("type")
+        if node is not None and node.type in ("type_identifier", "qualified_type"):
+            return node.text.decode("utf-8", errors="replace")
+        return None
+
     def _get_bases(self, node, language: str, source: bytes) -> list[str]:
         """Extract base classes / implemented interfaces."""
         bases = []
@@ -15136,19 +15268,7 @@ class CodeParser:
                                     bases.append(ident.text.decode("utf-8", errors="replace"))
         elif language == "go":
             # Embedded structs / interface composition
-            type_spec = next(
-                (child for child in node.children if child.type == "type_spec"),
-                None,
-            )
-            if type_spec is None:
-                return bases
-            type_body = next(
-                (
-                    child for child in type_spec.children
-                    if child.type in ("struct_type", "interface_type")
-                ),
-                None,
-            )
+            type_body = node.child_by_field_name("type")
             if type_body is None:
                 return bases
 
@@ -15179,12 +15299,9 @@ class CodeParser:
             for embedded in embedded_types:
                 if embedded is None:
                     continue
-                if embedded.type == "generic_type":
-                    embedded = embedded.child_by_field_name("type")
-                if embedded is not None:
-                    bases.append(
-                        embedded.text.decode("utf-8", errors="replace"),
-                    )
+                named_type = self._go_named_type(embedded)
+                if named_type:
+                    bases.append(named_type)
         elif language == "dart":
             # class Foo extends Bar with Mixin implements Iface { ... }
             # AST: superclass contains type_identifier (base) and mixins (with clause);

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -15136,15 +15136,55 @@ class CodeParser:
                                     bases.append(ident.text.decode("utf-8", errors="replace"))
         elif language == "go":
             # Embedded structs / interface composition
-            for child in node.children:
-                if child.type == "type_spec":
-                    for sub in child.children:
-                        if sub.type in ("struct_type", "interface_type"):
-                            for field_node in sub.children:
-                                if field_node.type == "field_declaration_list":
-                                    for f in field_node.children:
-                                        if f.type == "type_identifier":
-                                            bases.append(f.text.decode("utf-8", errors="replace"))
+            type_spec = next(
+                (child for child in node.children if child.type == "type_spec"),
+                None,
+            )
+            if type_spec is None:
+                return bases
+            type_body = next(
+                (
+                    child for child in type_spec.children
+                    if child.type in ("struct_type", "interface_type")
+                ),
+                None,
+            )
+            if type_body is None:
+                return bases
+
+            embedded_types = []
+            if type_body.type == "struct_type":
+                for child in type_body.children:
+                    if child.type != "field_declaration_list":
+                        continue
+                    for field in child.named_children:
+                        if (
+                            field.type == "field_declaration"
+                            and field.child_by_field_name("name") is None
+                        ):
+                            embedded_types.append(
+                                field.child_by_field_name("type"),
+                            )
+            else:
+                for element in type_body.named_children:
+                    if (
+                        element.type == "type_elem"
+                        and len(element.named_children) == 1
+                        and element.named_children[0].type in (
+                            "type_identifier", "qualified_type", "generic_type",
+                        )
+                    ):
+                        embedded_types.append(element.named_children[0])
+
+            for embedded in embedded_types:
+                if embedded is None:
+                    continue
+                if embedded.type == "generic_type":
+                    embedded = embedded.child_by_field_name("type")
+                if embedded is not None:
+                    bases.append(
+                        embedded.text.decode("utf-8", errors="replace"),
+                    )
         elif language == "dart":
             # class Foo extends Bar with Mixin implements Iface { ... }
             # AST: superclass contains type_identifier (base) and mixins (with clause);

--- a/code_review_graph/postprocessing.py
+++ b/code_review_graph/postprocessing.py
@@ -77,6 +77,7 @@ def _resolve_bare_endpoints(
 ) -> None:
     """Resolve bare and C++ scoped call targets before derived graph steps."""
     try:
+        result["go_embeddings_resolved"] = store.resolve_go_embedding_targets()
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
         result["bare_edges_resolved"] = resolved

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -83,6 +83,9 @@ def _run_postprocess(
 
     # Resolve bare and C++ scoped call targets before derived graph steps.
     try:
+        build_result["go_embeddings_resolved"] = (
+            store.resolve_go_embedding_targets()
+        )
         resolved = store.resolve_bare_call_targets()
         resolved += store.resolve_bare_tested_by_sources()
         build_result["bare_edges_resolved"] = resolved

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -127,7 +127,7 @@ A function is tested by a test function.
 General dependency relationship (used for non-specific dependencies).
 
 ### REFERENCES
-A value-level reference to another symbol, often used for function-as-value patterns such as callback maps, arrays, or assignment.
+A dependency on another symbol that is not a stronger relationship such as `CALLS` or `INHERITS`. Examples include function-as-value patterns (callback maps, arrays, or assignments), type-position references, and Go interface type-set terms that do not resolve to an interface.
 
 ### INJECTS
 A dependency-injection relationship, currently used by Java/Spring enrichment for injected fields and constructor parameters.

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -44,6 +44,50 @@ class TestGoParsing:
         contains = [e for e in self.edges if e.kind == "CONTAINS"]
         assert len(contains) >= 3
 
+    def test_finds_embedded_types(self):
+        source = b"""
+package sample
+
+import pkg "example.com/pkg"
+
+type Local struct{}
+type Generic[T any] struct{}
+type LocalInterface interface { Method() }
+type GenericInterface[T any] interface { Method(T) }
+
+type EmbeddedStruct struct {
+    Local
+    *pkg.Remote
+    Generic[int]
+    pkg.Generic[string]
+    Named Local
+}
+
+type EmbeddedInterface interface {
+    LocalInterface
+    pkg.RemoteInterface
+    GenericInterface[int]
+    ~int | string
+    OwnMethod()
+}
+"""
+        _, edges = self.parser.parse_bytes(Path("sample.go"), source)
+
+        inherits = {
+            (edge.source.rsplit("::", 1)[-1], edge.target)
+            for edge in edges
+            if edge.kind == "INHERITS"
+        }
+        assert inherits == {
+            ("EmbeddedStruct", "Local"),
+            ("EmbeddedStruct", "pkg.Remote"),
+            ("EmbeddedStruct", "Generic"),
+            ("EmbeddedStruct", "pkg.Generic"),
+            ("EmbeddedInterface", "LocalInterface"),
+            ("EmbeddedInterface", "pkg.RemoteInterface"),
+            ("EmbeddedInterface", "GenericInterface"),
+        }
+
     def test_methods_attached_to_receiver(self):
         """Go methods should be attached to their receiver type (#190).
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -87,6 +87,175 @@ type EmbeddedInterface interface {
             ("EmbeddedInterface", "pkg.RemoteInterface"),
             ("EmbeddedInterface", "GenericInterface"),
         }
+        qualified = next(
+            edge for edge in edges
+            if edge.kind == "INHERITS" and edge.target == "pkg.Remote"
+        )
+        assert qualified.extra["go_import_path"] == "example.com/pkg"
+
+    def test_grouped_type_declarations_preserve_every_spec(self):
+        source = b"""
+package sample
+
+type (
+    Base interface { Method() }
+    Child interface { Base }
+    Alias = Base
+    Count int
+)
+"""
+        nodes, edges = self.parser.parse_bytes(Path("sample.go"), source)
+
+        classes = {node.name: node for node in nodes if node.kind == "Class"}
+        assert set(classes) == {"Base", "Child", "Alias", "Count"}
+        assert classes["Base"].extra["go_type_kind"] == "interface"
+        assert classes["Alias"].extra == {
+            "go_type_kind": "alias",
+            "go_underlying_type": "Base",
+            "go_package": "sample",
+        }
+        assert any(
+            edge.kind == "INHERITS"
+            and edge.source.endswith("::Child")
+            and edge.target == "Base"
+            for edge in edges
+        )
+
+    def test_postprocessing_resolves_and_classifies_embeddings(self, tmp_path):
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.postprocessing import run_post_processing
+        from code_review_graph.tools.query import query_graph
+
+        (tmp_path / "base").mkdir()
+        (tmp_path / "consumer").mkdir()
+        (tmp_path / "strange-path").mkdir()
+        (tmp_path / ".code-review-graph").mkdir()
+        (tmp_path / "go.mod").write_text(
+            "module example.com/project\n\ngo 1.24\n",
+            encoding="utf-8",
+        )
+        base_file = tmp_path / "base" / "types.go"
+        base_file.write_text(
+            "package graph\n"
+            "type Vertex interface { ID() }\n"
+            "type Concrete struct{}\n"
+            "type Alias = Vertex\n",
+            encoding="utf-8",
+        )
+        strange_file = tmp_path / "strange-path" / "types.go"
+        strange_file.write_text(
+            "package odd\n"
+            "type Strange interface { Method() }\n",
+            encoding="utf-8",
+        )
+        consumer_file = tmp_path / "consumer" / "types.go"
+        consumer_file.write_text(
+            "package consumer\n"
+            "import (\n"
+            '    dag "example.com/project/base"\n'
+            '    "example.com/project/strange-path"\n'
+            ")\n"
+            "type (\n"
+            "    StructEmbedding struct { dag.Vertex }\n"
+            "    InterfaceEmbedding interface { dag.Vertex }\n"
+            "    AliasEmbedding interface { dag.Alias }\n"
+            "    PackageNameEmbedding interface { odd.Strange }\n"
+            "    Constraint interface { dag.Concrete; int }\n"
+            ")\n",
+            encoding="utf-8",
+        )
+
+        store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
+        try:
+            parser = CodeParser(tmp_path)
+            for path in (base_file, strange_file, consumer_file):
+                nodes, edges = parser.parse_file(path)
+                store.store_file_nodes_edges(str(path), nodes, edges)
+
+            result = run_post_processing(store)
+            assert result["go_embeddings_resolved"] == 6
+            assert store.resolve_go_embedding_targets() == 0
+
+            rows = store._conn.execute(
+                "SELECT kind, source_qualified, target_qualified FROM edges "
+                "WHERE source_qualified LIKE ? "
+                "AND kind IN ('INHERITS', 'REFERENCES')",
+                (f"{consumer_file}::%",),
+            ).fetchall()
+            relations = {
+                (
+                    row["kind"],
+                    row["source_qualified"].rsplit("::", 1)[-1],
+                    row["target_qualified"],
+                )
+                for row in rows
+            }
+            assert (
+                "INHERITS", "StructEmbedding", f"{base_file}::Vertex",
+            ) in relations
+            assert (
+                "INHERITS", "InterfaceEmbedding", f"{base_file}::Vertex",
+            ) in relations
+            assert (
+                "INHERITS", "AliasEmbedding", f"{base_file}::Alias",
+            ) in relations
+            assert (
+                "INHERITS", "PackageNameEmbedding", f"{strange_file}::Strange",
+            ) in relations
+            assert (
+                "REFERENCES", "Constraint", f"{base_file}::Concrete",
+            ) in relations
+            assert ("REFERENCES", "Constraint", "int") in relations
+
+            query = query_graph(
+                "inheritors_of",
+                f"{base_file}::Vertex",
+                repo_root=str(tmp_path),
+            )
+            assert {item["name"] for item in query["results"]} == {
+                "StructEmbedding", "InterfaceEmbedding",
+            }
+        finally:
+            store.close()
+
+    def test_incremental_rebuilds_the_legacy_go_type_model(
+        self, tmp_path, monkeypatch,
+    ):
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.incremental import full_build, incremental_update
+
+        (tmp_path / ".git").mkdir()
+        source_file = tmp_path / "types.go"
+        source_file.write_text(
+            "package sample\n"
+            "type (\n"
+            "    Base interface { Method() }\n"
+            "    Child interface { Base }\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "code_review_graph.incremental.get_all_tracked_files",
+            lambda *_args, **_kwargs: ["types.go"],
+        )
+        store = GraphStore(tmp_path / "graph.db")
+        try:
+            full_build(tmp_path, store)
+            store._conn.execute(
+                "DELETE FROM metadata WHERE key = 'go_type_model_version'",
+            )
+            store.commit()
+
+            result = incremental_update(tmp_path, store, changed_files=[])
+
+            assert result["identity_rebuild"] is True
+            assert store.get_metadata("go_type_model_version") == "1"
+            assert {
+                node.name for node in store.get_all_nodes()
+                if node.language == "go" and node.kind == "Class"
+            } == {"Base", "Child"}
+        finally:
+            store.close()
 
     def test_methods_attached_to_receiver(self):
         """Go methods should be attached to their receiver type (#190).

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -142,6 +142,12 @@ type (
             "type Alias = Vertex\n",
             encoding="utf-8",
         )
+        external_test_file = tmp_path / "base" / "shadow_test.go"
+        external_test_file.write_text(
+            "package graph_test\n"
+            "type Vertex interface { Fake() }\n",
+            encoding="utf-8",
+        )
         strange_file = tmp_path / "strange-path" / "types.go"
         strange_file.write_text(
             "package odd\n"
@@ -168,7 +174,9 @@ type (
         store = GraphStore(tmp_path / ".code-review-graph" / "graph.db")
         try:
             parser = CodeParser(tmp_path)
-            for path in (base_file, strange_file, consumer_file):
+            for path in (
+                base_file, external_test_file, strange_file, consumer_file,
+            ):
                 nodes, edges = parser.parse_file(path)
                 store.store_file_nodes_edges(str(path), nodes, edges)
 
@@ -196,6 +204,10 @@ type (
             assert (
                 "INHERITS", "InterfaceEmbedding", f"{base_file}::Vertex",
             ) in relations
+            assert not any(
+                target == f"{external_test_file}::Vertex"
+                for _, _, target in relations
+            )
             assert (
                 "INHERITS", "AliasEmbedding", f"{base_file}::Alias",
             ) in relations


### PR DESCRIPTION
Closes #834

## Summary

- model each Go `type_spec` or alias as its own graph node, including grouped declarations
- extract struct and interface embedding candidates from the actual tree-sitter Go AST
- resolve same-package and imported embedding targets to canonical graph nodes using package/import and `go.mod` evidence
- exclude `_test.go` declarations from imported-package resolution so external test packages cannot shadow production types
- keep interface `type_elem` relationships as `INHERITS` only when they resolve to interfaces; represent concrete or unresolved constraint terms as `REFERENCES`
- scope import-edge loading to files with embedding candidates and batch edge reconciliation
- remove unused file-level Go package metadata and document the expanded `REFERENCES` semantics
- force a one-time full rebuild for graphs created with the legacy Go type model

## Root cause

The parser treated a whole `type_declaration` as one type and expected embedded identifiers at the wrong AST depth. Its raw relationship targets also lacked enough package evidence for graph queries, while a single interface `type_elem` is syntactically ambiguous between interface composition and a concrete type-set term. Imported resolution additionally treated declarations from external `_test.go` packages as normal package exports, creating false ambiguity when production and test packages defined the same type name.

## Impact

Go embedding and composition now participate in canonical graph traversal without making false inheritance claims for resolved concrete constraints. Grouped declarations and aliases are no longer silently omitted. Qualified imports resolve to production declarations even when a same-directory external test package shadows the type name.

On Terraform main at `da3a115efef0de2e817a8c3ef57c5df9297c99ce`:

- parsed all 1,993 Go files
- `inheritors_of Vertex` returns all 12 embedding sites, including the nine formerly disconnected `dag.Vertex` relationships
- `inheritors_of GraphNodeConfigResource` returns all five embedding sites
- all remaining raw qualified embedding targets belong to standard-library or third-party packages absent from the repository graph

## Validation

- `uv run pytest -q` — 2,402 passed, 5 skipped, 2 xpassed
- focused Go parser/resolver tests — 11 passed
- `uv run ruff check code_review_graph/ tests/test_multilang.py`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- full Terraform graph build with minimal post-processing — 4,314 files, 28,918 parsed nodes, 314,844 parsed edges
- Terraform queries after rebuild — 12 `Vertex` inheritors and 5 `GraphNodeConfigResource` inheritors
