### PR TITLE
Fix affected flow path normalization

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -464,7 +464,18 @@ def analyze_changes(
     overall_risk = max((nr["risk_score"] for nr in node_risks), default=0.0)
 
     # Affected flows.
-    affected = get_affected_flows(store, changed_files)
+    # Git reports changed files relative to repo_root, while graph nodes
+    # store normalized paths rooted at the repository. Normalize the paths
+    # here so flow impact analysis uses the same identity as the graph.
+    flow_changed_files = changed_files
+    if repo_root is not None:
+        root_path = Path(repo_root)
+        flow_changed_files = [
+            normalize_file_path(root_path / path)
+            for path in changed_files
+        ]
+
+    affected = get_affected_flows(store, flow_changed_files)
 
     # Detect test gaps: changed functions without TESTED_BY edges.
     test_gaps: list[dict[str, Any]] = []

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -403,6 +403,43 @@ class TestChanges:
         )
         assert len(result["affected_flows"]) >= 1
 
+    def test_analyze_changes_normalizes_relative_paths_for_affected_flows(self):
+        """Affected flows resolve when Git paths are relative but graph paths are absolute."""
+        repo_root = Path("/fake/repo")
+
+        self._add_func(
+            "handler",
+            path="/fake/repo/src/routes.py",
+            line_start=1,
+            line_end=10,
+        )
+        self._add_func(
+            "service",
+            path="/fake/repo/src/services.py",
+            line_start=1,
+            line_end=10,
+        )
+        self._add_call(
+            "/fake/repo/src/routes.py::handler",
+            "/fake/repo/src/services.py::service",
+            "/fake/repo/src/routes.py",
+        )
+
+        flows = trace_flows(self.store)
+        store_flows(self.store, flows)
+
+        result = analyze_changes(
+            self.store,
+            changed_files=["src/services.py"],
+            changed_ranges={
+                "/fake/repo/src/services.py": [(1, 10)],
+            },
+            repo_root=str(repo_root),
+        )
+
+        assert result["affected_flows"]
+        assert result["affected_flows"][0]["name"] == "handler"
+
     def test_analyze_changes_review_priorities_ordered(self):
         """Review priorities are ordered by descending risk score."""
         # Create several functions with varying risk levels.


### PR DESCRIPTION
## Problem

`analyze_changes()` passes `changed_files` directly to
`get_affected_flows()`.

Git reports changed files relative to `repo_root`, while graph nodes
store normalized repository-rooted paths. This causes affected-flow
analysis to miss impacted flows when the changed file paths are
repository-relative.

## Fix

Normalize `changed_files` against `repo_root` before passing them to
`get_affected_flows()`.

Absolute paths continue to work because `Path` preserves an already
absolute path when joined with the repository root.

## Regression test

Added a regression test covering the case where:

- Git reports `src/services.py`
- graph nodes store `/fake/repo/src/services.py`

The test verifies that the affected `handler` flow is correctly
identified.

## Validation

- `tests/test_changes.py` + `tests/test_flows.py`: 73 passed
- `git diff upstream/main...HEAD --check`: clean

The broader test suite currently contains unrelated platform /
environment-dependent failures, including Windows symlink privilege
requirements and missing async pytest support.