### PR TITLE
fix(parser): handle IF NOT EXISTS in SQL table references

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -51,7 +51,8 @@ class CellInfo(NamedTuple):
 
 
 _SQL_TABLE_RE = re.compile(
-    r"(?:FROM|JOIN|INTO|CREATE\s+(?:OR\s+REPLACE\s+)?(?:TABLE|VIEW)|INSERT\s+OVERWRITE)"
+    r"(?:FROM|JOIN|INTO|CREATE\s+(?:OR\s+REPLACE\s+)?(?:TABLE|VIEW)"
+    r"(?:\s+IF\s+NOT\s+EXISTS)?|INSERT\s+OVERWRITE)"
     r"\s+((?:`[^`]+`|\w+)(?:\.(?:`[^`]+`|\w+))*)",
     re.IGNORECASE,
 )
@@ -443,7 +444,7 @@ _SQL_KEYWORDS: frozenset[str] = frozenset({
     "UNION", "INTERSECT", "EXCEPT", "AS", "ON", "USING", "SET",
     "VALUES", "DEFAULT", "NULL", "TRUE", "FALSE",
     "INNER", "OUTER", "LEFT", "RIGHT", "FULL", "CROSS", "NATURAL",
-    "LATERAL", "RECURSIVE", "ONLY", "WITH",
+    "LATERAL", "RECURSIVE", "ONLY", "WITH", "IF", "NOT", "EXISTS",
 })
 
 logger = logging.getLogger(__name__)

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -3635,6 +3635,17 @@ class TestSQLParsing:
         targets = {e.target for e in imports}
         # active_orders view and archive procedure both reference orders/users
         assert "orders" in targets or "users" in targets
+
+    def test_multiple_if_not_exists_creates_keep_distinct_references(self):
+        _, edges = self.parser.parse_bytes(
+            Path("idempotent_schema.sql"),
+            b"CREATE TABLE IF NOT EXISTS customers (id INT);\n"
+            b"CREATE TABLE IF NOT EXISTS invoices (id INT);\n",
+        )
+        targets = [e.target for e in edges if e.kind == "IMPORTS_FROM"]
+        assert targets == ["customers", "invoices"]
+
+
 class TestZigParsing:
     def setup_method(self):
         self.parser = CodeParser()

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -131,13 +131,25 @@ class TestSqlTableExtraction:
 
     def test_create_table(self):
         matches = _SQL_TABLE_RE.findall("CREATE TABLE my_db.new_table (id INT)")
-        assert "my_db.new_table" in matches
+        assert matches == ["my_db.new_table"]
+
+    def test_create_table_if_not_exists(self):
+        matches = _SQL_TABLE_RE.findall(
+            "CREATE TABLE IF NOT EXISTS my_db.new_table (id INT)"
+        )
+        assert matches == ["my_db.new_table"]
 
     def test_create_or_replace_view(self):
         matches = _SQL_TABLE_RE.findall(
             "CREATE OR REPLACE VIEW my_view AS SELECT 1"
         )
         assert "my_view" in matches
+
+    def test_create_or_replace_view_if_not_exists(self):
+        matches = _SQL_TABLE_RE.findall(
+            "CREATE OR REPLACE VIEW IF NOT EXISTS my_view AS SELECT 1"
+        )
+        assert matches == ["my_view"]
 
     def test_insert_overwrite(self):
         matches = _SQL_TABLE_RE.findall(


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #820

## What & why

`_SQL_TABLE_RE` currently captures the literal `IF` from `CREATE TABLE IF NOT EXISTS ...`. Because references are deduplicated, later idempotent creates in the same file can then disappear as well.

This change:

- allows an optional `IF NOT EXISTS` clause when extracting `CREATE TABLE` and `CREATE VIEW` targets
- classifies `IF`, `NOT`, and `EXISTS` as SQL keywords as a defensive fallback
- adds regex and end-to-end regressions proving ordinary creates still work and multiple idempotent creates retain distinct edges

The adjacent TEMP/UNLOGGED/MATERIALIZED gaps described in the issue are intentionally left out to keep this PR atomic.

## How it was tested

```bash
uv run pytest tests/test_notebook.py::TestSqlTableExtraction tests/test_multilang.py::TestSQLParsing --tb=short -q
# 21 passed

uv run ruff check code_review_graph/
# passed

uv run mypy code_review_graph/parser.py --ignore-missing-imports --no-strict-optional
# passed
```

Broader local runs also completed 481 tests in the two touched test modules; the remaining failures were existing Windows path-separator assertions. Whole-project mypy reached an existing Windows-only `SIGKILL` error in `daemon_cli.py`.

## AI assistance

OpenAI Codex was used for repository inspection, implementation and test drafting, local verification, and review of the resulting diff.

## Checklist

- [x] Tests added for new functionality
- [ ] All tests pass: `uv run pytest tests/ --tb=short -q` (targeted tests pass; full supported-platform suite was not available on Windows)
- [x] Linting passes: `uv run ruff check code_review_graph/`
- [ ] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` (the touched parser passes; see existing Windows `SIGKILL` failure above)
- [x] Lines are at most 100 characters
- [ ] Docs updated where behavior changed (no user-facing documentation change required)