### PR TITLE
fix(daemon): stop cleanly on Windows

### DIFF
--- a/code_review_graph/daemon_cli.py
+++ b/code_review_graph/daemon_cli.py
@@ -57,7 +57,7 @@ def _handle_start(args: argparse.Namespace) -> None:
 
 def _handle_stop(_args: argparse.Namespace) -> None:
     """Stop the running daemon process."""
-    from .daemon import clear_pid, is_daemon_running, read_pid
+    from .daemon import clear_pid, is_daemon_running, pid_alive, read_pid
 
     if not is_daemon_running():
         print("Daemon is not running.")
@@ -79,22 +79,22 @@ def _handle_stop(_args: argparse.Namespace) -> None:
         print(f"Error: Permission denied sending signal to PID {pid}.")
         sys.exit(1)
 
-    # Wait up to 5 seconds for process to die
-    for _ in range(50):
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            break
-        time.sleep(0.1)
-    else:
-        # Still alive after 5s — send SIGKILL
-        print("Daemon did not stop gracefully, sending SIGKILL...")
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+    try:
+        # Wait up to 5 seconds for process to die.
+        for _ in range(50):
+            if not pid_alive(pid):
+                break
+            time.sleep(0.1)
+        else:
+            print("Daemon did not stop gracefully, force-stopping...")
+            force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
+            try:
+                os.kill(pid, force_signal)
+            except ProcessLookupError:
+                pass
+    finally:
+        clear_pid()
 
-    clear_pid()
     print("Daemon stopped.")
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1029,6 +1029,83 @@ class TestDaemonCLI:
 
         assert exc_info.value.code == 1
 
+    def test_handle_stop_windows_uses_sigterm_for_forced_stop(self):
+        """Windows falls back to SIGTERM when SIGKILL is unavailable."""
+        from code_review_graph.daemon_cli import _handle_stop
+
+        args = MagicMock()
+        pid = 4242
+        windows_signal = MagicMock(spec=["SIGTERM"])
+        windows_signal.SIGTERM = signal.SIGTERM
+
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=pid),
+            patch("code_review_graph.daemon.pid_alive", return_value=True) as mock_alive,
+            patch("code_review_graph.daemon.clear_pid") as mock_clear_pid,
+            patch("code_review_graph.daemon_cli.signal", windows_signal),
+            patch("code_review_graph.daemon_cli.os.kill") as mock_kill,
+            patch("code_review_graph.daemon_cli.time.sleep"),
+        ):
+            _handle_stop(args)
+
+        assert [entry.args for entry in mock_kill.call_args_list] == [
+            (pid, signal.SIGTERM),
+            (pid, signal.SIGTERM),
+        ]
+        assert mock_alive.call_count == 50
+        mock_clear_pid.assert_called_once_with()
+
+    def test_handle_restart_windows_starts_after_process_exits(self):
+        """A Windows restart continues to start after the old process exits."""
+        from code_review_graph.daemon_cli import _handle_restart
+
+        args = MagicMock()
+        pid = 4242
+        windows_signal = MagicMock(spec=["SIGTERM"])
+        windows_signal.SIGTERM = signal.SIGTERM
+
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=pid),
+            patch("code_review_graph.daemon.pid_alive", return_value=False) as mock_alive,
+            patch("code_review_graph.daemon.clear_pid") as mock_clear_pid,
+            patch("code_review_graph.daemon_cli.signal", windows_signal),
+            patch("code_review_graph.daemon_cli.os.kill") as mock_kill,
+            patch("code_review_graph.daemon_cli.time.sleep") as mock_sleep,
+            patch("code_review_graph.daemon_cli._handle_start") as mock_start,
+        ):
+            _handle_restart(args)
+
+        mock_kill.assert_called_once_with(pid, signal.SIGTERM)
+        mock_alive.assert_called_once_with(pid)
+        mock_sleep.assert_not_called()
+        mock_clear_pid.assert_called_once_with()
+        mock_start.assert_called_once_with(args)
+
+    def test_handle_stop_clears_pid_if_forced_stop_fails(self):
+        """A failed forced stop must not leave a stale daemon PID file."""
+        from code_review_graph.daemon_cli import _handle_stop
+
+        args = MagicMock()
+        pid = 4242
+
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=pid),
+            patch("code_review_graph.daemon.pid_alive", return_value=True),
+            patch("code_review_graph.daemon.clear_pid") as mock_clear_pid,
+            patch(
+                "code_review_graph.daemon_cli.os.kill",
+                side_effect=[None, OSError("forced stop failed")],
+            ),
+            patch("code_review_graph.daemon_cli.time.sleep"),
+            pytest.raises(OSError, match="forced stop failed"),
+        ):
+            _handle_stop(args)
+
+        mock_clear_pid.assert_called_once_with()
+
     def test_handle_status_not_running(self):
         """_handle_status displays 'not running' when daemon is down."""
         from code_review_graph.daemon_cli import _handle_status


### PR DESCRIPTION
## Linked issue

Closes #843

## What & why

`crg-daemon stop` polled process state with `os.kill(pid, 0)` and escalated with `signal.SIGKILL`. Both assumptions are POSIX-specific: on Windows the liveness probe does not reliably report an exited process, and `SIGKILL` is unavailable.

The resulting `AttributeError` also skipped PID cleanup and prevented `crg-daemon restart` from starting the daemon again.

This change:

- reuses the existing cross-platform `pid_alive()` helper while waiting for shutdown
- uses `SIGKILL` when available and falls back to `SIGTERM` on platforms without it
- clears the daemon PID in a `finally` block so a failed forced stop cannot leave stale state
- adds mocked Windows regressions for forced stop, restart after exit, and PID cleanup after an escalation failure

## How it was tested

```bash
uv run --python 3.13 pytest tests/ --tb=short -q
# 2401 passed, 5 skipped, 2 xpassed

uv run pytest tests/test_daemon.py --tb=short -q
# 69 passed

uv run ruff check code_review_graph/ tests/test_daemon.py
# All checks passed

uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
# Success: no issues found in 70 source files

bandit -r code_review_graph/ -c pyproject.toml
# No issues identified
```

## Checklist

- [x] Tests added for the corrected behavior
- [x] All tests pass
- [x] Linting passes
- [x] Type checking passes
- [x] Lines are at most 100 characters
- [x] Documentation is not required because the CLI interface and expected behavior are unchanged