### PR TITLE
fix(parser): resolve dotted-stem relative imports in JS/TS and Dart

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -13573,11 +13573,25 @@ class CodeParser:
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
-                # Try with extensions
+                # APPEND the extension — never `with_suffix`, which REPLACES the
+                # final suffix and so resolves `./outlet.entity` to `outlet.ts`
+                # instead of `outlet.entity.ts`. Dotted stems are the dominant
+                # NestJS convention (*.entity.ts, *.service.ts, *.controller.ts,
+                # *.guard.ts, *.module.ts), so the replace form silently dropped
+                # every relative import between them — a confident, wrong `0`
+                # from importers_of. Mirrors `_probe_path` in tsconfig_resolver.py,
+                # which already had this right for alias imports.
                 for ext in extensions:
-                    target = base.with_suffix(ext)
+                    target = Path(str(base) + ext)
                     if target.is_file():
                         return str(target.resolve())
+                # ESM/NodeNext writes `./foo.js` for a file that is `foo.ts` on
+                # disk; only here does replacing the suffix become correct.
+                if base.suffix in (".js", ".jsx", ".mjs", ".cjs"):
+                    for ext in (".ts", ".tsx"):
+                        target = base.with_suffix(ext)
+                        if target.is_file():
+                            return str(target.resolve())
                 # Try index file in directory
                 if base.is_dir():
                     for ext in extensions:
@@ -13596,8 +13610,13 @@ class CodeParser:
                 base = caller_dir / module
                 if base.is_file():
                     return str(base.resolve())
-                # Fallback: try appending .dart
-                target = base.with_suffix(".dart")
+                # Fallback: try appending .dart. APPEND, never `with_suffix`,
+                # which REPLACES the final suffix — same bug class as the
+                # JS/TS resolver above. Imports normally already carry the
+                # `.dart` extension (caught by `base.is_file()` above), so
+                # this only bites an omitted extension on a dotted stem
+                # (e.g. `./thing.model` where `thing.model.dart` exists).
+                target = Path(str(base) + ".dart")
                 if target.is_file():
                     return str(target.resolve())
             elif module.startswith("package:"):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -692,6 +692,83 @@ class Plain:
             imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
             assert any("@/bar" in e.target for e in imports)
 
+    # --- Relative import resolution: dotted stems and NodeNext ---
+
+    def test_relative_import_dotted_stem_resolves_to_full_filename(self):
+        """`./outlet.entity` must resolve to `outlet.entity.ts`, not `outlet.ts`.
+
+        `Path.with_suffix()` REPLACES the final suffix, so appending an
+        extension via `with_suffix` mistook the `.entity` in the stem for an
+        existing suffix and probed `outlet.ts` instead. Dotted stems are the
+        dominant NestJS convention (`*.entity.ts`, `*.service.ts`,
+        `*.controller.ts`, `*.guard.ts`, `*.module.ts`), so relative imports
+        between them resolved to the wrong file (or a sibling file that
+        happens to share the truncated name), and `importers_of` reported a
+        confident, wrong zero for the real target.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "outlet.entity.ts").write_text(
+                "export class Outlet {}\n", encoding="utf-8",
+            )
+            # A decoy at the truncated name: proves a wrong resolution
+            # lands here instead of raising or returning None.
+            (root / "outlet.ts").write_text(
+                "export const wrongFile = true;\n", encoding="utf-8",
+            )
+            importer = root / "outlet.service.ts"
+
+            resolved = self.parser._resolve_module_to_file(
+                "./outlet.entity", str(importer), "typescript",
+            )
+
+            assert resolved == str((root / "outlet.entity.ts").resolve()), (
+                f"expected outlet.entity.ts, got {resolved!r}"
+            )
+
+    def test_relative_import_nodenext_js_extension_resolves_ts_source(self):
+        """NodeNext/ESM TypeScript writes `./foo.js` for a source that is
+        `foo.ts` on disk. This is the one case where replacing the suffix
+        is correct, and must survive alongside the append-first fix above —
+        a future simplification that drops the ESM fallback should turn
+        this test red.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "foo.ts").write_text("export const foo = 1;\n", encoding="utf-8")
+            importer = root / "bar.ts"
+
+            resolved = self.parser._resolve_module_to_file(
+                "./foo.js", str(importer), "typescript",
+            )
+
+            assert resolved == str((root / "foo.ts").resolve())
+
+    def test_relative_import_dart_dotted_stem_resolves_to_full_filename(self):
+        """Same bug class as the TS resolver: Dart's `with_suffix(".dart")`
+        fallback replaces a dotted stem's final segment instead of
+        appending. Imports normally already carry the `.dart` extension, so
+        this only bites when one is omitted, but the fallback exists
+        precisely for that case and should not silently mis-resolve it.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "thing.model.dart").write_text(
+                "class Thing {}\n", encoding="utf-8",
+            )
+            (root / "thing.dart").write_text(
+                "class WrongFile {}\n", encoding="utf-8",
+            )
+            importer = root / "consumer.dart"
+
+            resolved = self.parser._resolve_module_to_file(
+                "./thing.model", str(importer), "dart",
+            )
+
+            assert resolved == str((root / "thing.model.dart").resolve()), (
+                f"expected thing.model.dart, got {resolved!r}"
+            )
+
     # --- Vitest/Jest test detection ---
 
     def test_vitest_test_detection(self):


### PR DESCRIPTION
## The bug

The JS/TS/TSX/Vue relative-import resolver in `code_review_graph/parser.py`
used `Path.with_suffix(ext)` to try candidate extensions:

```python
for ext in extensions:
    target = base.with_suffix(ext)
```

`with_suffix()` **replaces** the final path suffix, it doesn't append one. So
a relative import like `./outlet.entity` gets probed as `outlet.ts` (the
`.entity` segment is mistaken for an existing suffix) and the resolver never
finds the real file, `outlet.entity.ts`.

Dotted stems are the dominant NestJS convention — `*.entity.ts`,
`*.service.ts`, `*.controller.ts`, `*.guard.ts`, `*.module.ts` — so relative
imports between files that follow this convention silently produce no
`IMPORTS_FROM` edge. Downstream, `importers_of` returns a confident, wrong
`0` for the real target file: it looks like the file has no importers when
in fact the resolver just never reached it.

## The fix

Switch the primary probe to extension-append (`Path(str(base) + ext)`),
matching the idiom `tsconfig_resolver.py`'s `_probe_path` already used for
alias imports — that path is right, this one was wrong.

This can't be a blind swap though: NodeNext/ESM TypeScript writes `./foo.js`
in import statements for a source file that is actually `foo.ts` on disk.
That's the one case where replacing the suffix *is* correct, so a fallback
is kept for it, gated on the import literally ending in
`.js`/`.jsx`/`.mjs`/`.cjs`:

```python
for ext in extensions:
    target = Path(str(base) + ext)
    if target.is_file():
        return str(target.resolve())
if base.suffix in (".js", ".jsx", ".mjs", ".cjs"):
    for ext in (".ts", ".tsx"):
        target = base.with_suffix(ext)
        if target.is_file():
            return str(target.resolve())
```

## The Dart sibling

`_do_resolve_module`'s Dart branch had the exact same bug shape:
`target = base.with_suffix(".dart")`. Dart imports normally already carry
the `.dart` extension (caught by the `base.is_file()` check just above), so
this only bites when an extension is omitted on a dotted stem — e.g.
`./thing.model` where `thing.model.dart` exists on disk. Fixed the same way
(append, don't replace).

## What I did NOT touch

I surveyed the other relative/dotted-path resolvers in the same function
(Python and Rust) for the same shape. Both also call `with_suffix`, but
their candidate paths are built from module-name *segments* that can't
contain a literal dot (Python: `module.split(".")`; Rust: identifier path
parts), so there's no dotted-stem collision possible there and `with_suffix`
is correct as-is. Left them alone.

## Tests

Added three tests to `tests/test_parser.py`, calling
`CodeParser._resolve_module_to_file` directly against real files in a temp
dir:

1. `test_relative_import_dotted_stem_resolves_to_full_filename` — the actual
   bug: `./outlet.entity` must resolve to `outlet.entity.ts`, with a decoy
   `outlet.ts` present to prove a *wrong* resolution (not just a crash) is
   what happens today. This is RED against `main` (fails as
   `.../outlet.ts` instead of `.../outlet.entity.ts`) and green after the
   fix.
2. `test_relative_import_nodenext_js_extension_resolves_ts_source` — the
   NodeNext `./foo.js` -> `foo.ts` case. This already passes on `main`
   (with_suffix happens to work when the import already ends in `.js`), and
   must keep passing after the fix — it's a regression guard so a future
   "simplify this" pass that drops the ESM fallback goes red instead of
   silently reintroducing the class of bug this PR fixes.
3. `test_relative_import_dart_dotted_stem_resolves_to_full_filename` — same
   shape as (1), for the Dart fallback.

```
$ uv run pytest tests/ -k relative_import -v
...
tests/test_parser.py::TestCodeParser::test_relative_import_dotted_stem_resolves_to_full_filename PASSED
tests/test_parser.py::TestCodeParser::test_relative_import_nodenext_js_extension_resolves_ts_source PASSED
tests/test_parser.py::TestCodeParser::test_relative_import_dart_dotted_stem_resolves_to_full_filename PASSED

$ uv run pytest tests/
2401 passed, 5 skipped, 2 xpassed

$ uv run ruff check code_review_graph/
All checks passed!
```
