### PR TITLE
fix(review): use merge-base for branch diffs

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -985,7 +985,11 @@ def main() -> None:
         help="Analyze change impact against the existing graph (read-only). "
              "Does NOT re-parse files — for that, use 'update --brief'.",
     )
-    detect_cmd.add_argument("--base", default="HEAD~1", help="Git diff base (default: HEAD~1)")
+    detect_cmd.add_argument(
+        "--base",
+        default="HEAD~1",
+        help="Git diff base (branch refs use their merge base with HEAD; default: HEAD~1)",
+    )
     detect_cmd.add_argument(
         "--brief",
         action="store_true",
@@ -1977,9 +1981,9 @@ def main() -> None:
                 attach_context_savings,
                 estimate_file_tokens,
             )
-            from .incremental import get_changed_files, get_staged_and_unstaged
+            from .incremental import get_changed_files, get_staged_and_unstaged, resolve_review_base
 
-            base = args.base
+            base = resolve_review_base(repo_root, args.base)
             changed = get_changed_files(repo_root, base)
             if not changed:
                 changed = get_staged_and_unstaged(repo_root)

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -667,6 +667,64 @@ def resolve_incremental_base(repo_root: Path, store: "GraphStore") -> str | None
     return None
 
 
+def resolve_review_base(repo_root: Path, base: str) -> str:
+    """Resolve a branch-like Git review base to its common ancestor with HEAD.
+
+    ``git diff <branch>`` compares the two tips and therefore includes commits
+    made only on the base branch after the reviewed branch diverged.  GitHub's
+    "Files changed" view instead uses the merge base.  Preserve explicit
+    commit/revision inputs, but translate local and remote-tracking branch
+    refs to that common ancestor.
+
+    If ref detection or merge-base resolution fails (for example in a shallow
+    clone), return *base* unchanged so callers retain the existing diff
+    behaviour rather than silently reporting no changes.
+    """
+    if (
+        detect_vcs(repo_root) != "git"
+        or not base
+        or base.startswith("-")
+        or not _SAFE_GIT_REF.fullmatch(base)
+    ):
+        return base
+
+    try:
+        symbolic = subprocess.run(
+            ["git", "rev-parse", "--symbolic-full-name", "--verify", base],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(repo_root),
+            timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        symbolic_ref = symbolic.stdout.strip()
+        if symbolic.returncode != 0 or not symbolic_ref.startswith(
+            ("refs/heads/", "refs/remotes/")
+        ):
+            return base
+
+        result = subprocess.run(
+            ["git", "merge-base", base, "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(repo_root),
+            timeout=_GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        resolved = result.stdout.strip()
+        if result.returncode == 0 and re.fullmatch(r"[0-9a-fA-F]{40,64}", resolved):
+            return resolved
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    logger.debug("Could not resolve review merge base for %s; using it directly", base)
+    return base
+
+
 def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
     """Get list of changed files via git diff or svn status.
 

--- a/code_review_graph/prompts.py
+++ b/code_review_graph/prompts.py
@@ -52,17 +52,17 @@ def review_changes_prompt(base: str = "HEAD~1") -> list[Message]:
         f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
         f"## Review Workflow\n"
         f'1. Call `get_minimal_context(task="review changes against '
-        f'{base}")` to get risk overview.\n'
+        f'{base}", base="{base}")` to get risk overview.\n'
         f'2. If risk is "low": call '
-        f'`detect_changes(detail_level="minimal")` → report summary '
+        f'`detect_changes(base="{base}", detail_level="minimal")` → report summary '
         f"+ any test gaps.\n"
         f'3. If risk is "medium" or "high":\n'
-        f'   a. Call `detect_changes(detail_level="standard")` for '
+        f'   a. Call `detect_changes(base="{base}", detail_level="standard")` for '
         f"full change list.\n"
         f"   b. For each high-risk function, call "
         f'`query_graph(pattern="callers_of", target=<func>, '
         f'detail_level="minimal")`.\n'
-        f'   c. Call `get_affected_flows(detail_level="minimal")` '
+        f'   c. Call `get_affected_flows(base="{base}", detail_level="minimal")` '
         f"only if >3 changed functions.\n"
         f"4. Summarize: risk level, what changed, test gaps, "
         f"specific improvements needed.\n\n"
@@ -141,11 +141,11 @@ def pre_merge_check_prompt(base: str = "HEAD~1") -> list[Message]:
     return _user(
         f"{_TOKEN_EFFICIENCY_PREAMBLE}\n"
         "## Pre-Merge Check Workflow\n"
-        '1. Call `get_minimal_context(task="pre-merge check")`.\n'
-        '2. Call `detect_changes(detail_level="minimal")` for risk '
+        f'1. Call `get_minimal_context(task="pre-merge check", base="{base}")`.\n'
+        f'2. Call `detect_changes(base="{base}", detail_level="minimal")` for risk '
         "score and test gaps.\n"
         "3. If risk > 0.4: call "
-        '`get_affected_flows(detail_level="minimal")`.\n'
+        f'`get_affected_flows(base="{base}", detail_level="minimal")`.\n'
         "4. If test_gap_count > 0: call "
         '`query_graph(pattern="tests_for", '
         'target=<each untested function>, detail_level="minimal")` '

--- a/code_review_graph/tools/context.py
+++ b/code_review_graph/tools/context.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from ..incremental import get_db_path
+from ..incremental import get_db_path, resolve_review_base
 from ..parser import normalize_file_path
 from ._common import _get_store, _resolve_root, compact_response, graph_provenance
 
@@ -78,6 +78,7 @@ def get_minimal_context(
 
     store, root = _get_store(str(root))
     try:
+        base = resolve_review_base(root, base)
         # 1. Quick stats
         stats = store.get_stats()
         if stats.total_nodes == 0:

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -12,7 +12,12 @@ from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..embeddings import EmbeddingStore
 from ..graph import GraphNode, GraphStore, _sanitize_name, edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
-from ..incremental import get_changed_files, get_db_path, get_staged_and_unstaged
+from ..incremental import (
+    get_changed_files,
+    get_db_path,
+    get_staged_and_unstaged,
+    resolve_review_base,
+)
 from ..parser import normalize_file_path
 from ..search import hybrid_search
 from ._common import _BUILTIN_CALL_NAMES, _get_store, _resolve_graph_file_paths
@@ -133,6 +138,7 @@ def get_impact_radius(
     store, root = _get_store(repo_root)
     try:
         if changed_files is None:
+            base = resolve_review_base(root, base)
             changed_files = get_changed_files(root, base)
             if not changed_files:
                 changed_files = get_staged_and_unstaged(root)

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -11,7 +11,11 @@ from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
 from ..hints import generate_hints, get_session
-from ..incremental import get_changed_files, get_staged_and_unstaged
+from ..incremental import (
+    get_changed_files,
+    get_staged_and_unstaged,
+    resolve_review_base,
+)
 from ..parser import normalize_file_path
 from ._common import _get_store, _resolve_graph_file_paths
 
@@ -56,6 +60,7 @@ def get_review_context(
     try:
         # Get impact radius first
         if changed_files is None:
+            base = resolve_review_base(root, base)
             changed_files = get_changed_files(root, base)
             if not changed_files:
                 changed_files = get_staged_and_unstaged(root)
@@ -312,6 +317,7 @@ def get_affected_flows_func(
     store, root = _get_store(repo_root)
     try:
         if changed_files is None:
+            base = resolve_review_base(root, base)
             changed_files = get_changed_files(root, base)
             if not changed_files:
                 changed_files = get_staged_and_unstaged(root)
@@ -388,6 +394,7 @@ def detect_changes_func(
     """
     store, root = _get_store(repo_root)
     try:
+        base = resolve_review_base(root, base)
         # Detect changed files if not provided.
         if changed_files is None:
             changed_files = get_changed_files(root, base)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -328,7 +328,8 @@ code-review-graph visualize --serve            # Serve graph.html on localhost:8
 
 # Analysis
 code-review-graph detect-changes               # Risk-scored change analysis
-code-review-graph detect-changes --base HEAD~3 # Custom base ref
+code-review-graph detect-changes --base HEAD~3 # Custom base revision
+code-review-graph detect-changes --base origin/main # Branch refs use merge-base semantics
 code-review-graph detect-changes --brief       # Compact panel with token-savings estimate
 code-review-graph detect-changes --brief --verify  # ...and cross-check vs tiktoken
 code-review-graph detect-changes --churn       # Add opt-in change-frequency risk

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -20,6 +20,12 @@ On each PR run the action:
 5. Optionally fails the job when the overall risk score crosses a threshold
    (`fail-on-risk`).
 
+`detect-changes` resolves local and remote branch refs to their merge base
+with `HEAD`, matching GitHub's **Files changed** scope on divergent branches
+when the common ancestor is available locally. In shallow clones where Git
+cannot resolve that ancestor, it falls back to the supplied branch ref.
+Commit IDs and revision expressions remain exact diff bases.
+
 ## Quick start (external repositories)
 
 ```yaml

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -484,6 +484,39 @@ class TestChanges:
             assert "review_priorities" in result
         assert getattr(self.store.close, "__func__", None) is GraphStore.close
 
+    def test_detect_changes_tool_uses_one_resolved_review_base(self):
+        """File discovery and line ranges must use the same merge base."""
+        from code_review_graph.tools import detect_changes_func
+
+        self._add_func("my_func", path="/fake/repo/app.py", line_start=1, line_end=10)
+
+        with (
+            patch("code_review_graph.tools.review._get_store") as mock_get_store,
+            patch(
+                "code_review_graph.tools.review.resolve_review_base",
+                return_value="merge-base-sha",
+            ) as resolve,
+            patch(
+                "code_review_graph.tools.review.get_changed_files",
+                return_value=["app.py"],
+            ) as get_changed,
+            patch(
+                "code_review_graph.tools.review.parse_diff_ranges",
+                return_value={"app.py": [(1, 10)]},
+            ) as parse_ranges,
+            patch.object(self.store, "close"),
+        ):
+            root = Path("/fake/repo")
+            mock_get_store.return_value = (self.store, root)
+
+            result = detect_changes_func(base="origin/main", repo_root=str(root))
+
+        assert result["status"] == "ok"
+        resolve.assert_called_once_with(root, "origin/main")
+        get_changed.assert_called_once_with(root, "merge-base-sha")
+        parse_ranges.assert_called_once_with(str(root), "merge-base-sha")
+        assert getattr(self.store.close, "__func__", None) is GraphStore.close
+
 
 class TestAnalyzeChangesFunctionCap:
     """Regression tests for O(N) slowdown when PR touches many functions."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -309,6 +309,48 @@ class TestDetectChangesCommand:
         assert json.loads(capsys.readouterr().out)["summary"] == "with churn"
         assert analyze.call_args.kwargs["include_churn"] is True
 
+    def test_branch_base_is_resolved_once_for_detection_and_analysis(
+        self, tmp_path, capsys,
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+        argv = [
+            "code-review-graph",
+            "detect-changes",
+            "--repo",
+            str(repo),
+            "--base",
+            "origin/main",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            with patch("code_review_graph.graph.GraphStore") as mock_store:
+                mock_store.return_value = MagicMock()
+                with patch("code_review_graph.incremental.get_db_path") as mock_db:
+                    mock_db.return_value = MagicMock()
+                    with (
+                        patch(
+                            "code_review_graph.incremental.resolve_review_base",
+                            return_value="merge-base-sha",
+                        ) as resolve,
+                        patch(
+                            "code_review_graph.incremental.get_changed_files",
+                            return_value=["app.py"],
+                        ) as get_changed,
+                        patch(
+                            "code_review_graph.changes.analyze_changes",
+                            return_value={"summary": "resolved"},
+                        ) as analyze,
+                    ):
+                        cli.main()
+
+        assert json.loads(capsys.readouterr().out)["summary"] == "resolved"
+        resolve.assert_called_once_with(repo.resolve(), "origin/main")
+        get_changed.assert_called_once_with(repo.resolve(), "merge-base-sha")
+        assert analyze.call_args.kwargs["base"] == "merge-base-sha"
+
     def test_brief_output_includes_token_savings_panel(self, tmp_path, capsys):
         """v2.3.5: --brief output renders a boxed Token Savings panel.
 

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -30,6 +30,7 @@ from code_review_graph.incremental import (
     get_staged_and_unstaged,
     incremental_update,
     resolve_incremental_base,
+    resolve_review_base,
 )
 from code_review_graph.tools.build import build_or_update_graph
 from code_review_graph.wiki import get_wiki_page
@@ -210,6 +211,57 @@ def test_parse_git_diff_ranges_real_git(git_repo: Path) -> None:
     for start, end in ranges["hello.py"]:
         assert start >= 1
         assert end >= start
+
+
+def test_review_base_excludes_commits_unique_to_base_branch(tmp_path: Path) -> None:
+    """A branch review should compare from the common ancestor, not base tip."""
+    repo = _init_repo(tmp_path)
+
+    _git_ok(repo, "checkout", "-b", "feature")
+    _commit_file(repo, "feature_only")
+
+    _git_ok(repo, "checkout", "main")
+    _commit_file(repo, "base_only")
+    base_tip = _git_ok(repo, "rev-parse", "HEAD").stdout.strip()
+    _git_ok(repo, "update-ref", "refs/remotes/origin/main", base_tip)
+    _git_ok(repo, "tag", "base-release")
+    _git_ok(repo, "checkout", "feature")
+
+    # A two-dot diff against the current base tip wrongly attributes both
+    # sides of the divergence to the feature branch.
+    assert set(get_changed_files(repo, "main")) == {
+        "base_only.py",
+        "feature_only.py",
+    }
+
+    review_base = resolve_review_base(repo, "main")
+    assert review_base == _git_ok(repo, "merge-base", "main", "HEAD").stdout.strip()
+    assert resolve_review_base(repo, "origin/main") == review_base
+    assert get_changed_files(repo, review_base) == ["feature_only.py"]
+    assert set(parse_git_diff_ranges(str(repo), review_base)) == {"feature_only.py"}
+
+    # A caller can still request an exact two-tip comparison with a commit ID.
+    assert resolve_review_base(repo, base_tip) == base_tip
+    assert resolve_review_base(repo, "base-release") == "base-release"
+    assert resolve_review_base(repo, "HEAD~1") == "HEAD~1"
+
+
+def test_review_base_falls_back_when_merge_base_is_unavailable(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shallow or incomplete history must retain the caller's original base."""
+    real_run = subprocess.run
+
+    def fail_merge_base(*args, **kwargs):
+        command = args[0]
+        if command[:2] == ["git", "merge-base"]:
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="no ancestor")
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr("code_review_graph.incremental.subprocess.run", fail_merge_base)
+
+    branch = _git_ok(git_repo, "branch", "--show-current").stdout.strip()
+    assert resolve_review_base(git_repo, branch) == branch
 
 
 # ------------------------------------------------------------------

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -34,8 +34,11 @@ class TestReviewChangesPrompt:
         assert "HEAD~1" in _text(result[0])
 
     def test_custom_base(self):
-        result = review_changes_prompt(base="main")
-        assert "main" in _text(result[0])
+        content = _text(review_changes_prompt(base="origin/main")[0])
+        assert 'get_minimal_context(task="review changes against origin/main", base="origin/main")' in content
+        assert 'detect_changes(base="origin/main", detail_level="minimal")' in content
+        assert 'detect_changes(base="origin/main", detail_level="standard")' in content
+        assert 'get_affected_flows(base="origin/main", detail_level="minimal")' in content
 
     def test_mentions_detect_changes(self):
         result = review_changes_prompt()
@@ -143,16 +146,15 @@ class TestPreMergeCheckPrompt:
             assert _text(msg)
 
     def test_default_base(self):
-        result = pre_merge_check_prompt()
-        # The pre-merge prompt is now generic (doesn't embed the base ref)
-        assert "pre-merge" in _text(result[0]).lower()
+        content = _text(pre_merge_check_prompt()[0])
+        assert 'get_minimal_context(task="pre-merge check", base="HEAD~1")' in content
+        assert 'detect_changes(base="HEAD~1", detail_level="minimal")' in content
 
     def test_custom_base(self):
-        # pre_merge_check_prompt still accepts base but the workflow
-        # is now generic — just verify it returns valid prompt
-        result = pre_merge_check_prompt(base="develop")
-        assert isinstance(result, list)
-        assert len(result) >= 1
+        content = _text(pre_merge_check_prompt(base="origin/develop")[0])
+        assert 'get_minimal_context(task="pre-merge check", base="origin/develop")' in content
+        assert 'detect_changes(base="origin/develop", detail_level="minimal")' in content
+        assert 'get_affected_flows(base="origin/develop", detail_level="minimal")' in content
 
     def test_mentions_risk_scoring(self):
         result = pre_merge_check_prompt()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2052,6 +2052,30 @@ class TestGetMinimalContext:
         assert "summary" in result
         assert "next_tool_suggestions" in result
 
+    def test_review_base_is_shared_by_probe_discovery_and_analysis(self, monkeypatch):
+        import code_review_graph.tools.context as context_module
+
+        resolve = MagicMock(return_value="merge-base-sha")
+        has_changes = MagicMock(return_value=True)
+        get_changed = MagicMock(return_value=["app.py"])
+        analyze = MagicMock(return_value={"risk_score": 0.2, "changed_functions": []})
+        monkeypatch.setattr(context_module, "resolve_review_base", resolve)
+        monkeypatch.setattr(context_module, "_has_git_changes", has_changes)
+        monkeypatch.setattr("code_review_graph.incremental.get_changed_files", get_changed)
+        monkeypatch.setattr("code_review_graph.changes.analyze_changes", analyze)
+
+        result = context_module.get_minimal_context(
+            task="review changes",
+            repo_root=str(self.root),
+            base="origin/main",
+        )
+
+        assert result["status"] == "ok"
+        resolve.assert_called_once_with(self.root, "origin/main")
+        has_changes.assert_called_once_with(self.root, "merge-base-sha")
+        get_changed.assert_called_once_with(self.root, "merge-base-sha")
+        assert analyze.call_args.kwargs["base"] == "merge-base-sha"
+
     def test_missing_graph_returns_not_ready_without_creating_database(self, tmp_path):
         from code_review_graph.tools.context import get_minimal_context
 


### PR DESCRIPTION
Fixes #842.

## Summary

- resolve local and remote branch bases to their merge base with `HEAD`, matching pull-request review semantics
- preserve explicit commit IDs, tags, and revision expressions as exact comparison points, with the previous behavior retained when a merge base cannot be resolved
- apply the resolved base consistently across CLI, MCP tools, minimal context, prompts, changed-file discovery, and line-range analysis
- add a real divergent Git history regression plus caller and fallback coverage

## Testing

- `uv run pytest tests/test_integration_git.py tests/test_changes.py tests/test_cli.py tests/test_prompts.py tests/test_tools.py -q` - 108 passed, 1 skipped
- `uv run ruff check code_review_graph/`
- `uv run mypy code_review_graph/cli.py code_review_graph/incremental.py code_review_graph/prompts.py code_review_graph/tools/context.py code_review_graph/tools/query.py code_review_graph/tools/review.py --ignore-missing-imports --no-strict-optional --follow-imports=skip`
- `uv run bandit -q -r code_review_graph/`
- `git diff --check`

The complete Windows suite also ran: 2,355 passed, 14 skipped, 2 xpassed, with 37 pre-existing Windows path/symlink/D3-fixture failures unrelated to this change.

## AI assistance

OpenAI Codex assisted with issue analysis, implementation, tests, and review. I reviewed the final diff and verified the commands and results above locally.