### PR TITLE
Exempt lifecycle and construction methods from test gaps (part of #850)

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -20,6 +20,17 @@ from .parser import normalize_file_path
 
 logger = logging.getLogger(__name__)
 
+
+# Lifecycle and construction methods are exercised implicitly by every test
+# that touches their class, so listing them as test gaps is noise that
+# inflates the gap count and the Untested summary (#850). Names cover
+# PHPUnit/xUnit and Python unittest conventions.
+_TEST_GAP_EXEMPT_NAMES = frozenset({
+    "setUp", "tearDown", "setUpBeforeClass", "tearDownAfterClass",
+    "setup_method", "teardown_method", "setUpClass", "tearDownClass",
+    "__construct", "__init__", "__destruct",
+})
+
 _GIT_TIMEOUT = int(os.environ.get("CRG_GIT_TIMEOUT", "30"))  # seconds, configurable
 
 _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
@@ -470,6 +481,8 @@ def analyze_changes(
     test_gaps: list[dict[str, Any]] = []
     for node in changed_funcs:
         if node.is_test:
+            continue
+        if node.name in _TEST_GAP_EXEMPT_NAMES:
             continue
         # TESTED_BY edges are stored as source=production, target=test by the
         # parser, so a changed production function finds its tests by source.

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -403,6 +403,31 @@ class TestChanges:
         )
         assert len(result["affected_flows"]) >= 1
 
+    def test_analyze_changes_lifecycle_methods_not_test_gaps(self):
+        """Lifecycle and construction methods are exempt from gaps (#850)."""
+        self._add_func("setUp", path="thing_test_helper.py",
+                       line_start=1, line_end=5)
+        self._add_func("tearDown", path="thing_test_helper.py",
+                       line_start=6, line_end=10)
+        self._add_func("__construct", path="thing.php",
+                       line_start=1, line_end=5)
+        self._add_func("realMethod", path="thing.php",
+                       line_start=6, line_end=20)
+
+        result = analyze_changes(
+            self.store,
+            changed_files=["thing_test_helper.py", "thing.php"],
+            changed_ranges={
+                "thing_test_helper.py": [(1, 10)],
+                "thing.php": [(1, 20)],
+            },
+        )
+        gap_names = {g["name"] for g in result["test_gaps"]}
+        assert "setUp" not in gap_names
+        assert "tearDown" not in gap_names
+        assert "__construct" not in gap_names
+        assert "realMethod" in gap_names
+
     def test_analyze_changes_review_priorities_ordered(self):
         """Review priorities are ordered by descending risk score."""
         # Create several functions with varying risk levels.


### PR DESCRIPTION
Addresses suggestion 1 of #850 (the noise part). The container-resolution linkage remains open there and in #851.

## Problem

`analyze_changes` lists `setUp`, `tearDown`, `__construct` and friends as test gaps. These are exercised implicitly by every test touching their class, so they inflate the gap count and the `Untested:` summary line. In the report that motivated #850, 5 of the 6 gaps on a 2-file diff were lifecycle noise.

## Change

A module-level `_TEST_GAP_EXEMPT_NAMES` frozenset (PHPUnit/xUnit and Python unittest lifecycle names plus constructors) checked in the test-gap loop. Deliberately name-based and conservative: migration `up`/`down` are NOT excluded here because bare names are too generic to exempt safely; ignore patterns handle migration dirs better.

## Test

New test asserts lifecycle names and constructors stay out of `test_gaps` while a real uncovered method still appears. Full suite 2,399 passed, ruff and mypy clean.