### PR TITLE
fix: make daemon stop work on Windows

### DIFF
--- a/code_review_graph/daemon_cli.py
+++ b/code_review_graph/daemon_cli.py
@@ -57,7 +57,7 @@ def _handle_start(args: argparse.Namespace) -> None:
 
 def _handle_stop(_args: argparse.Namespace) -> None:
     """Stop the running daemon process."""
-    from .daemon import clear_pid, is_daemon_running, read_pid
+    from .daemon import clear_pid, is_daemon_running, pid_alive, read_pid
 
     if not is_daemon_running():
         print("Daemon is not running.")
@@ -81,16 +81,14 @@ def _handle_stop(_args: argparse.Namespace) -> None:
 
     # Wait up to 5 seconds for process to die
     for _ in range(50):
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
+        if not pid_alive(pid):
             break
         time.sleep(0.1)
     else:
         # Still alive after 5s — send SIGKILL
         print("Daemon did not stop gracefully, sending SIGKILL...")
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         except ProcessLookupError:
             pass
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1028,6 +1028,33 @@ class TestDaemonCLI:
             _handle_stop(args)
 
         assert exc_info.value.code == 1
+    def test_handle_stop_waits_for_daemon_to_exit(self):
+        """_handle_stop waits until the daemon process exits."""
+        from code_review_graph.daemon_cli import _handle_stop
+        args = MagicMock()
+        with (
+            patch(
+                "code_review_graph.daemon.is_daemon_running",
+                return_value=True,
+            ),
+            patch(
+                "code_review_graph.daemon.read_pid",
+                return_value=1234,
+            ),
+            patch(
+                "code_review_graph.daemon.pid_alive",
+                side_effect=[True, False],
+            ),
+            patch("code_review_graph.daemon.clear_pid") as mock_clear_pid,
+            patch("os.kill") as mock_kill,
+            patch("builtins.print"),
+        ):
+            _handle_stop(args)
+
+        mock_kill.assert_called_once_with(1234, signal.SIGTERM)
+        mock_clear_pid.assert_called_once()
+
+
 
     def test_handle_status_not_running(self):
         """_handle_status displays 'not running' when daemon is down."""


### PR DESCRIPTION
# Pull Request

## Linked issue

<!-- Link the issue this PR addresses, e.g. "Closes #123".
     If there is no issue, briefly say why (e.g. trivial typo fix). -->

Closes #843

## What & why

<!-- What does this PR change, and why is the change needed? -->

Fix the daemon stop behavior on Windows.

The daemon was not stopping correctly on Windows. This change fixes the Windows-specific stop behavior and adds tests to verify that the daemon can shut down correctly.

## How it was tested

<!-- Paste the exact commands you ran and summarise their results. Typical commands
     (see CONTRIBUTING.md "Running Tests" and "Linting and Type Checking"): -->

```bash id="8y6qwl"
uv run pytest tests/test_daemon.py --tb=short -q
uv run ruff check code_review_graph/
uvx mypy code_review_graph/ --ignore-missing-imports --no-strict-optional
```

Daemon tests: 62 passed, 5 skipped.

Ruff: All checks passed.

Mypy: Success, no issues found in 70 source files.

The full test suite was also run on Windows and resulted in 2344 passed, 46 failed, 14 skipped, and 2 xpassed. The failures are primarily related to Windows-specific path normalization, text encoding, symlink privileges, and file mode behavior.

## Checklist

<!-- Mirrors the requirements in CONTRIBUTING.md ("Making Changes" and "Code Style"). -->

* [x] Tests added for new functionality
* [ ] All tests pass: `uv run pytest tests/ --tb=short -q`
* [x] Linting passes: `uv run ruff check code_review_graph/`
* [ ] Type checking passes: `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
* [ ] Lines are at most 100 characters
* [ ] Docs updated where behavior changed (README, `docs/`, docstrings)
