### PR TITLE
fix(incremental): reconcile reverted file content

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1190,6 +1190,16 @@ class GraphStore:
         ).fetchall()
         return [r["file_path"] for r in rows]
 
+    def get_file_hashes(self) -> dict[str, str]:
+        """Return indexed file paths mapped to the hash last stored for each file."""
+        rows = self._conn.execute(
+            "SELECT file_path, file_hash FROM nodes WHERE kind = 'File'"
+        ).fetchall()
+        return {
+            normalize_file_path(row["file_path"]): row["file_hash"] or ""
+            for row in rows
+        }
+
     def search_nodes(self, query: str, limit: int = 20) -> list[GraphNode]:
         """Keyword search across node names.
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -708,7 +708,10 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
         return []
 
 
-def _find_content_mismatches(repo_root: Path, store: "GraphStore") -> list[str]:
+def _find_content_mismatches(
+    repo_root: Path,
+    store: "GraphStore",
+) -> tuple[list[str], dict[str, str]]:
     """Find indexed files whose bytes differ from the graph's last parsed hash.
 
     Git diffs compare the working tree with a base commit.  If a file is
@@ -719,6 +722,7 @@ def _find_content_mismatches(repo_root: Path, store: "GraphStore") -> list[str]:
     git diff non-empty.
     """
     mismatched_files: list[str] = []
+    current_hashes: dict[str, str] = {}
 
     for stored_path, stored_hash in store.get_file_hashes().items():
         path = Path(stored_path)
@@ -726,7 +730,9 @@ def _find_content_mismatches(repo_root: Path, store: "GraphStore") -> list[str]:
             path = repo_root / path
         try:
             relative_path = path.relative_to(repo_root).as_posix()
-            current_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+            raw = path.read_bytes()
+            current_hash = hashlib.sha256(raw).hexdigest()
+            current_hashes[relative_path] = current_hash
         except (OSError, ValueError):
             # Missing files are handled by stale-file reconciliation.  Paths
             # outside the repository cannot be represented as relative update
@@ -735,7 +741,7 @@ def _find_content_mismatches(repo_root: Path, store: "GraphStore") -> list[str]:
         if current_hash != stored_hash:
             mismatched_files.append(relative_path)
 
-    return mismatched_files
+    return mismatched_files, current_hashes
 
 
 def _get_svn_changed_files(repo_root: Path, rev_range: str | None = None) -> list[str]:
@@ -1227,9 +1233,17 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
-    changed_files = list(
-        dict.fromkeys([*changed_files, *_find_content_mismatches(repo_root, store)]),
-    )
+    content_mismatches: list[str] = []
+    current_hashes: dict[str, str] = {}
+    if reconcile_stale:
+        # The content scan reads every indexed file.  Watch batches disable stale
+        # reconciliation to remain proportional to filesystem events; reverted
+        # content arrives in those events and is covered by the normal hash check.
+        content_mismatches, current_hashes = _find_content_mismatches(
+            repo_root,
+            store,
+        )
+    changed_files = list(dict.fromkeys([*changed_files, *content_mismatches]))
     stale_files = _reconcile_stale_files(repo_root, store) if reconcile_stale else []
 
     if not changed_files and not stale_files:
@@ -1276,11 +1290,21 @@ def incremental_update(
         if parser.detect_language(abs_path) is None:
             continue
         # Quick hash check to skip unchanged files
+        normalized_path = normalize_file_path(rel_path)
+        fhash = current_hashes.get(normalized_path)
+        if fhash is None:
+            try:
+                raw = abs_path.read_bytes()
+                fhash = hashlib.sha256(raw).hexdigest()
+            except (OSError, PermissionError):
+                fhash = None
         try:
-            raw = abs_path.read_bytes()
-            fhash = hashlib.sha256(raw).hexdigest()
             existing_nodes = store.get_nodes_by_file(str(abs_path))
-            if existing_nodes and existing_nodes[0].file_hash == fhash:
+            if (
+                fhash is not None
+                and existing_nodes
+                and existing_nodes[0].file_hash == fhash
+            ):
                 continue
         except (OSError, PermissionError):
             pass

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -707,6 +707,37 @@ def get_changed_files(repo_root: Path, base: str = "HEAD~1") -> list[str]:
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return []
 
+
+def _find_content_mismatches(repo_root: Path, store: "GraphStore") -> list[str]:
+    """Find indexed files whose bytes differ from the graph's last parsed hash.
+
+    Git diffs compare the working tree with a base commit.  If a file is
+    changed, incrementally indexed, and then reverted before the next update,
+    that diff is empty even though the graph still represents the intermediate
+    content.  Comparing indexed hashes with the files on disk catches that
+    round trip and also catches a reverted file when another path keeps the
+    git diff non-empty.
+    """
+    mismatched_files: list[str] = []
+
+    for stored_path, stored_hash in store.get_file_hashes().items():
+        path = Path(stored_path)
+        if not path.is_absolute():
+            path = repo_root / path
+        try:
+            relative_path = path.relative_to(repo_root).as_posix()
+            current_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        except (OSError, ValueError):
+            # Missing files are handled by stale-file reconciliation.  Paths
+            # outside the repository cannot be represented as relative update
+            # inputs and are left to that reconciliation path as well.
+            continue
+        if current_hash != stored_hash:
+            mismatched_files.append(relative_path)
+
+    return mismatched_files
+
+
 def _get_svn_changed_files(repo_root: Path, rev_range: str | None = None) -> list[str]:
     """Return changed files in an SVN working copy.
 
@@ -1196,6 +1227,9 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
+    changed_files = list(
+        dict.fromkeys([*changed_files, *_find_content_mismatches(repo_root, store)]),
+    )
     stale_files = _reconcile_stale_files(repo_root, store) if reconcile_stale else []
 
     if not changed_files and not stale_files:

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1769,3 +1769,82 @@ class TestRenamePurgeParity:
             assert store.get_nodes_by_file(str(tmp_path / "b.py"))
         finally:
             store.close()
+
+
+class TestRevertedContentParity:
+    """Issue #817: an edit/revert round trip must not leave ghost nodes."""
+
+    def test_reverted_file_with_empty_diff_is_reparsed(self, tmp_path):
+        source = tmp_path / "source.py"
+        original = "def foo():\n    return 1\n"
+        intermediate = original + "\n\ndef bar():\n    return 2\n"
+        source.write_text(original)
+
+        store = GraphStore(tmp_path / "graph.db")
+        try:
+            incremental_update(tmp_path, store, changed_files=["source.py"])
+            function_names = {
+                node.name for node in store.get_nodes_by_file(str(source))
+                if node.kind == "Function"
+            }
+            assert function_names == {"foo"}
+
+            source.write_text(intermediate)
+            incremental_update(tmp_path, store, changed_files=["source.py"])
+            function_names = {
+                node.name for node in store.get_nodes_by_file(str(source))
+                if node.kind == "Function"
+            }
+            assert function_names == {"foo", "bar"}
+
+            source.write_text(original)
+            result = incremental_update(tmp_path, store, changed_files=[])
+
+            assert result["changed_files"] == ["source.py"]
+            assert result["files_updated"] == 1
+            function_names = {
+                node.name for node in store.get_nodes_by_file(str(source))
+                if node.kind == "Function"
+            }
+            assert function_names == {"foo"}
+        finally:
+            store.close()
+
+    def test_reverted_file_is_reconciled_alongside_another_change(self, tmp_path):
+        source = tmp_path / "source.py"
+        other = tmp_path / "other.py"
+        original = "def foo():\n    return 1\n"
+        intermediate = original + "\n\ndef bar():\n    return 2\n"
+        source.write_text(original)
+        other.write_text("def other():\n    return 3\n")
+
+        store = GraphStore(tmp_path / "graph.db")
+        try:
+            incremental_update(
+                tmp_path,
+                store,
+                changed_files=["source.py", "other.py"],
+            )
+
+            source.write_text(intermediate)
+            incremental_update(tmp_path, store, changed_files=["source.py"])
+
+            source.write_text(original)
+            other.write_text("def other():\n    return 4\n")
+            result = incremental_update(tmp_path, store, changed_files=["other.py"])
+
+            assert set(result["changed_files"]) == {"other.py", "source.py"}
+            assert result["files_updated"] == 2
+
+            source_functions = {
+                node.name for node in store.get_nodes_by_file(str(source))
+                if node.kind == "Function"
+            }
+            assert source_functions == {"foo"}
+            other_functions = {
+                node.name for node in store.get_nodes_by_file(str(other))
+                if node.kind == "Function"
+            }
+            assert other_functions == {"other"}
+        finally:
+            store.close()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1774,6 +1774,45 @@ class TestRenamePurgeParity:
 class TestRevertedContentParity:
     """Issue #817: an edit/revert round trip must not leave ghost nodes."""
 
+    def test_content_scan_runs_only_for_reconciling_updates(self, tmp_path, monkeypatch):
+        source = tmp_path / "source.py"
+        source.write_text("def foo():\n    return 1\n")
+        scan_calls = []
+
+        def fake_content_scan(repo_root, store):
+            scan_calls.append(repo_root)
+            return [], {}
+
+        monkeypatch.setattr(
+            incremental_module,
+            "_find_content_mismatches",
+            fake_content_scan,
+        )
+
+        store = GraphStore(tmp_path / "graph.db")
+        try:
+            disabled_result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=["source.py"],
+                reconcile_stale=False,
+            )
+
+            assert disabled_result["files_updated"] == 1
+            assert scan_calls == []
+
+            reconciled_result = incremental_update(
+                tmp_path,
+                store,
+                changed_files=[],
+                reconcile_stale=True,
+            )
+
+            assert reconciled_result["files_updated"] == 0
+            assert scan_calls == [tmp_path]
+        finally:
+            store.close()
+
     def test_reverted_file_with_empty_diff_is_reparsed(self, tmp_path):
         source = tmp_path / "source.py"
         original = "def foo():\n    return 1\n"


### PR DESCRIPTION
## Problem

An incremental update discovers work solely from the VCS diff. If a file is edited, indexed, and then reverted to bytes identical to the diff base, that file disappears from the next diff. The graph keeps nodes and edges from the intermediate content until an unrelated event causes that path to be reparsed.

This also happens when another file keeps the diff non-empty: the reverted file is simply absent from the changed-path set and is never considered.

## Fix

- Expose the file hashes already stored on `File` nodes.
- Before dispatching incremental work, compare those hashes with current file bytes and merge mismatched paths into the changed-file set.
- The existing per-file hash check and atomic replacement then purge the intermediate nodes and replace them with the reverted content.

Hash comparison is independent of git history, so it works regardless of which valid diff base the caller selects.

## Tests

- Added a direct edit/revert regression: an intermediate function is indexed, then removed after an otherwise-empty update.
- Added a mixed-path regression: a reverted file is reconciled even when another changed file keeps the update non-empty.
- Verified the first regression fails on `main` and passes with this change.

Closes #817