### PR TITLE
fix(graph): purge orphan rows during reconciliation

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1185,8 +1185,17 @@ class GraphStore:
         return resolved
 
     def get_all_files(self) -> list[str]:
+        # A partially failed file update can leave Function/Class nodes or
+        # edges behind after their File marker is gone. Reconciliation must see
+        # every represented path so those orphans can be purged, while explicit
+        # virtual nodes (such as Spring Event markers) remain outside the file
+        # inventory and are managed by their owning resolver.
         rows = self._conn.execute(
-            "SELECT DISTINCT file_path FROM nodes WHERE kind = 'File'"
+            "SELECT file_path FROM nodes "
+            "WHERE json_extract(extra, '$.virtual') IS NULL "
+            "UNION "
+            "SELECT file_path FROM edges "
+            "ORDER BY file_path"
         ).fetchall()
         return [r["file_path"] for r in rows]
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -748,6 +748,50 @@ class TestFullBuild:
         finally:
             store.close()
 
+    def test_full_build_removes_nodes_left_without_a_file_node(self, tmp_path):
+        from code_review_graph.parser import EdgeInfo, NodeInfo
+
+        current = tmp_path / "sample.py"
+        current.write_text("def hello():\n    pass\n")
+        orphan_path = str(tmp_path / "generated" / "orphan.js")
+        orphan_edge_path = str(tmp_path / "generated" / "orphan-edge.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store.upsert_node(
+                NodeInfo(
+                    kind="Function",
+                    name="loadData",
+                    file_path=orphan_path,
+                    line_start=1,
+                    line_end=2,
+                    language="javascript",
+                )
+            )
+            store.upsert_edge(
+                EdgeInfo(
+                    kind="CALLS",
+                    source=f"{orphan_edge_path}::caller",
+                    target=f"{orphan_edge_path}::target",
+                    file_path=orphan_edge_path,
+                )
+            )
+            store.commit()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["sample.py"],
+            ):
+                result = full_build(tmp_path, store)
+
+            assert result["stale_files_removed"] == 2
+            assert store.get_nodes_by_file(orphan_path) == []
+            assert store._conn.execute(
+                "SELECT COUNT(*) FROM edges WHERE file_path = ?",
+                (orphan_edge_path,),
+            ).fetchone()[0] == 0
+        finally:
+            store.close()
+
 
 class TestIncrementalUpdate:
     def test_incremental_with_no_changes(self, tmp_path):


### PR DESCRIPTION
## Linked issue

Fixes #812

## What changed

- Reconciliation now inventories file paths from all non-virtual node rows and edge rows, not only rows with `kind = 'File'`.
- Partially failed updates that leave Function/Class nodes or edge rows without their File marker are now visible as stale paths and can be purged by the next full build.
- Resolver-owned virtual nodes (notably Spring Event nodes) remain excluded from the filesystem inventory and continue to be managed by their resolver.
- Added a regression covering both an orphan Function node and an edge-only orphan path.

## Testing

- `python -m pytest tests/test_incremental.py -q -k without_a_file_node`
- `python -m pytest tests/test_graph.py tests/test_incremental.py tests/test_status_stats.py tests/test_windows_path_identity.py -q --deselect tests/test_incremental.py::TestWatchReconciliation::test_watch_symlink_events_are_rejected --deselect tests/test_incremental.py::TestWatchReconciliation::test_watch_rejects_file_below_symlinked_ancestor_outside_repo`
- `python -m ruff check code_review_graph/graph.py tests/test_incremental.py`
- `python -m mypy --ignore-missing-imports code_review_graph/graph.py tests/test_incremental.py`

The two deselected watch tests require Windows symlink privileges that are unavailable in this environment; the remaining 194 selected tests pass.