### PR TITLE
test: adversarial edge coverage from the August PR review sweep

### DIFF
--- a/tests/test_pr778_edges.py
+++ b/tests/test_pr778_edges.py
@@ -1,0 +1,320 @@
+"""Extreme edge cases for the Hermes Agent YAML install/uninstall (PR #778).
+
+These stress the line-oriented YAML editing beyond the PR's own coverage:
+odd indentation, header comments, duplicate top-level keys, flow-style
+entries, column-zero comments splitting a section, CRLF input, unicode,
+and repeated install/uninstall cycles. The contract under test: CRG may
+add or remove exactly ``mcp_servers.code-review-graph`` and must either
+preserve everything else or refuse to touch the file at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from code_review_graph import skills, uninstall
+
+ENTRY = {"command": "code-review-graph", "args": ["serve"]}
+
+
+@pytest.fixture
+def hermes_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def config(hermes_home: Path) -> Path:
+    return hermes_home / "config.yaml"
+
+
+def _install(config: Path) -> bool | None:
+    return skills._merge_yaml_mcp_server(config, "mcp_servers", "code-review-graph", ENTRY)
+
+
+def _uninstall(config: Path, hermes_home: Path) -> uninstall.UninstallReport:
+    report = uninstall.UninstallReport()
+    uninstall._remove_yaml_entry(config, "mcp_servers", hermes_home, report, dry_run=False)
+    return report
+
+
+class TestInstallEdges:
+    def test_header_with_trailing_comment_is_still_a_block(self, config: Path) -> None:
+        config.write_text(
+            "mcp_servers:  # user comment on the header\n"
+            "  other:\n"
+            "    command: npx\n",
+            encoding="utf-8",
+        )
+        assert _install(config) is True
+        text = config.read_text(encoding="utf-8")
+        assert "# user comment on the header" in text
+        data = yaml.safe_load(text)
+        assert set(data["mcp_servers"]) == {"other", "code-review-graph"}
+
+    def test_comment_only_null_section(self, config: Path) -> None:
+        config.write_text("mcp_servers:\n  # none yet\n", encoding="utf-8")
+        assert _install(config) is True
+        text = config.read_text(encoding="utf-8")
+        assert "# none yet" in text
+        data = yaml.safe_load(text)
+        assert data["mcp_servers"]["code-review-graph"] == ENTRY
+
+    def test_four_space_child_indent(self, config: Path) -> None:
+        config.write_text(
+            "mcp_servers:\n"
+            "    other:\n"
+            "        command: npx\n"
+            "after: 1\n",
+            encoding="utf-8",
+        )
+        assert _install(config) is True
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert data["mcp_servers"]["other"] == {"command": "npx"}
+        assert data["mcp_servers"]["code-review-graph"] == ENTRY
+        assert data["after"] == 1
+
+    def test_file_without_trailing_newline(self, config: Path) -> None:
+        config.write_text("mcp_servers:\n  other:\n    command: npx", encoding="utf-8")
+        assert _install(config) is True
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert set(data["mcp_servers"]) == {"other", "code-review-graph"}
+
+    def test_duplicate_top_level_sections_refused_unchanged(self, config: Path) -> None:
+        # PyYAML resolves duplicate keys last-wins; a text edit into the
+        # first block would silently vanish. The validator must refuse.
+        original = (
+            "mcp_servers:\n"
+            "  first: {command: a}\n"
+            "mcp_servers:\n"
+            "  second: {command: b}\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        assert _install(config) is None
+        assert config.read_text(encoding="utf-8") == original
+
+    def test_crlf_file_stays_semantically_intact(self, config: Path) -> None:
+        crlf = (
+            "# top\r\nmodel:\r\n  default: x\r\n\r\n"
+            "mcp_servers:\r\n  other:\r\n    command: npx\r\n\r\ntheme: dark\r\n"
+        )
+        config.write_bytes(crlf.encode("utf-8"))
+        assert _install(config) is True
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert data["model"] == {"default": "x"}
+        assert data["theme"] == "dark"
+        assert data["mcp_servers"]["other"] == {"command": "npx"}
+        assert data["mcp_servers"]["code-review-graph"] == ENTRY
+        assert "# top" in config.read_text(encoding="utf-8")
+
+    def test_unicode_comments_and_values_survive(self, config: Path) -> None:
+        config.write_text(
+            "# café ☕配置\nmodel:\n  default: 模型\nmcp_servers:\n"
+            "  other:\n    command: npx\n",
+            encoding="utf-8",
+        )
+        assert _install(config) is True
+        text = config.read_text(encoding="utf-8")
+        assert "# café ☕配置" in text
+        data = yaml.safe_load(text)
+        assert data["model"]["default"] == "模型"
+
+    def test_append_to_comment_only_file(self, config: Path) -> None:
+        config.write_text("# just a comment\n", encoding="utf-8")
+        assert _install(config) is True
+        text = config.read_text(encoding="utf-8")
+        assert text.startswith("# just a comment\n")
+        data = yaml.safe_load(text)
+        assert data["mcp_servers"]["code-review-graph"] == ENTRY
+
+    def test_tab_indented_file_refused(self, config: Path) -> None:
+        # Tabs are illegal YAML indentation; the parse fails and the
+        # installer must refuse rather than guess.
+        broken = "mcp_servers:\n\tother:\n\t\tcommand: npx\n"
+        config.write_text(broken, encoding="utf-8")
+        assert _install(config) is None
+        assert config.read_text(encoding="utf-8") == broken
+
+    def test_section_last_line_comment_keeps_separator(self, config: Path) -> None:
+        config.write_text(
+            "mcp_servers:\n"
+            "  other:\n"
+            "    command: npx\n"
+            "  # trailing note\n"
+            "\n"
+            "theme: dark\n",
+            encoding="utf-8",
+        )
+        assert _install(config) is True
+        text = config.read_text(encoding="utf-8")
+        assert "  # trailing note\n" in text
+        data = yaml.safe_load(text)
+        assert data["theme"] == "dark"
+        assert set(data["mcp_servers"]) == {"other", "code-review-graph"}
+
+
+class TestUninstallEdges:
+    def test_similarly_named_sibling_survives(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        config.write_text(
+            "mcp_servers:\n"
+            "  code-review-graph-extra:\n"
+            "    command: keepme\n"
+            "  code-review-graph:\n"
+            "    command: code-review-graph\n"
+            "    args:\n"
+            "    - serve\n",
+            encoding="utf-8",
+        )
+        report = _uninstall(config, hermes_home)
+        assert not report.skipped_paths
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert set(data["mcp_servers"]) == {"code-review-graph-extra"}
+
+    def test_flow_style_entry_removed(self, config: Path, hermes_home: Path) -> None:
+        config.write_text(
+            "mcp_servers:\n"
+            "  code-review-graph: {command: code-review-graph, args: [serve]}\n"
+            "  other: {command: npx}\n",
+            encoding="utf-8",
+        )
+        report = _uninstall(config, hermes_home)
+        assert not report.skipped_paths
+        data = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert set(data["mcp_servers"]) == {"other"}
+
+    def test_entry_mid_section_removes_only_entry(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        original = (
+            "mcp_servers:\n"
+            "  before:\n"
+            "    command: a\n"
+            "  code-review-graph:\n"
+            "    command: code-review-graph\n"
+            "    # comment inside our entry, removed with it\n"
+            "    args:\n"
+            "    - serve\n"
+            "  after:\n"
+            "    command: b\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        report = _uninstall(config, hermes_home)
+        assert not report.skipped_paths
+        text = config.read_text(encoding="utf-8")
+        assert "comment inside our entry" not in text
+        data = yaml.safe_load(text)
+        assert set(data["mcp_servers"]) == {"before", "after"}
+        assert data["mcp_servers"]["before"] == {"command": "a"}
+        assert data["mcp_servers"]["after"] == {"command": "b"}
+
+    def test_column_zero_comment_hiding_entry_refuses_safely(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        # A column-0 comment ends the scanned section early, so the entry
+        # below it cannot be located. The only acceptable outcome is an
+        # untouched file plus a skip report -- never a partial edit.
+        original = (
+            "mcp_servers:\n"
+            "  other:\n"
+            "    command: npx\n"
+            "# column-zero comment splits the section\n"
+            "  code-review-graph:\n"
+            "    command: code-review-graph\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        report = _uninstall(config, hermes_home)
+        assert config.read_text(encoding="utf-8") == original
+        assert report.skipped_paths
+
+    def test_duplicate_sections_both_holding_entry_refuse(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        original = (
+            "mcp_servers:\n"
+            "  code-review-graph:\n"
+            "    command: a\n"
+            "mcp_servers:\n"
+            "  code-review-graph:\n"
+            "    command: b\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        report = _uninstall(config, hermes_home)
+        assert config.read_text(encoding="utf-8") == original
+        assert report.skipped_paths
+
+    def test_entry_rewritten_with_space_before_colon_refuses(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        # Valid YAML the text scanner cannot anchor on: refuse, do not guess.
+        original = (
+            "mcp_servers:\n"
+            "  code-review-graph : {command: code-review-graph}\n"
+            "  other: {command: npx}\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        report = _uninstall(config, hermes_home)
+        assert config.read_text(encoding="utf-8") == original
+        assert report.skipped_paths
+
+    def test_alias_into_entry_refuses(self, config: Path, hermes_home: Path) -> None:
+        # Another server aliases a node inside our entry; removing the
+        # anchor would orphan the alias. The reparse must catch it.
+        original = (
+            "mcp_servers:\n"
+            "  code-review-graph:\n"
+            "    command: &crg code-review-graph\n"
+            "  other:\n"
+            "    command: *crg\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        report = _uninstall(config, hermes_home)
+        assert config.read_text(encoding="utf-8") == original
+        assert report.skipped_paths
+
+
+class TestRoundTrips:
+    def test_three_install_uninstall_cycles_restore_bytes(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        original = (
+            "# Hermes Agent configuration\n"
+            "model:\n"
+            "  default: claude-opus-5   # trailing comment\n"
+            "\n"
+            "mcp_servers:\n"
+            "  browsermcp:\n"
+            "    command: npx\n"
+            "\n"
+            "tool_output:\n"
+            "  max_bytes: 50000\n"
+        )
+        config.write_text(original, encoding="utf-8")
+        for _ in range(3):
+            assert _install(config) is True
+            assert _install(config) is False  # idempotent
+            report = _uninstall(config, hermes_home)
+            assert not report.skipped_paths
+            assert config.read_text(encoding="utf-8") == original
+
+    def test_crlf_round_trip_is_semantically_lossless(
+        self, config: Path, hermes_home: Path
+    ) -> None:
+        crlf = (
+            "# top\r\nmodel:\r\n  default: x\r\n\r\n"
+            "mcp_servers:\r\n  other:\r\n    command: npx\r\n\r\ntheme: dark\r\n"
+        )
+        config.write_bytes(crlf.encode("utf-8"))
+        before = yaml.safe_load(crlf)
+        assert _install(config) is True
+        report = _uninstall(config, hermes_home)
+        assert not report.skipped_paths
+        after_text = config.read_text(encoding="utf-8")
+        assert yaml.safe_load(after_text) == before
+        assert "# top" in after_text

--- a/tests/test_pr779_edges.py
+++ b/tests/test_pr779_edges.py
@@ -1,0 +1,132 @@
+"""Edge-case tests for PR #779: skill templates must match the exported MCP schema.
+
+These go beyond the PR's own regression test:
+- byte-identical generated vs bundled skills (drift in either direction fails)
+- every backticked ``*_tool`` reference in every skill resolves to a tool
+  actually registered with ``@mcp.tool()`` in main.py (catches typos and
+  references to tools that later get renamed or removed)
+- no skill references any exported tool by its bare (un-suffixed) name
+  for the full tool surface, not just the six names the PR renamed
+- generate_skills is robust to unicode/space paths and regenerates
+  (overwrites) stale content
+"""
+
+import ast
+import re
+from pathlib import Path
+
+from code_review_graph.skills import _SKILLS, generate_skills
+
+REPO_ROOT = Path(__file__).parents[1]
+SKILL_NAMES = ["explore-codebase", "review-changes", "debug-issue", "refactor-safely"]
+
+_BACKTICK = re.compile(r"`([^`]+)`")
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _exported_tool_names() -> set[str]:
+    """Collect function names registered via @mcp.tool() in main.py."""
+    src = (REPO_ROOT / "code_review_graph" / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(target, ast.Attribute) and target.attr == "tool":
+                names.add(node.name)
+    return names
+
+
+def _backticked_identifiers(markdown: str) -> list[str]:
+    """Leading identifier of every backticked span, e.g. `foo(task="x")` -> foo."""
+    out = []
+    for span in _BACKTICK.findall(markdown):
+        m = _IDENT.match(span)
+        if m:
+            out.append(m.group(0))
+    return out
+
+
+def _all_skill_files(tmp_path: Path) -> list[Path]:
+    generated = generate_skills(tmp_path)
+    files = []
+    for name in SKILL_NAMES:
+        files.append(generated / name / "SKILL.md")
+        files.append(REPO_ROOT / "skills" / name / "SKILL.md")
+    return files
+
+
+def test_exported_schema_is_nonempty_and_contains_renamed_tools():
+    exported = _exported_tool_names()
+    assert len(exported) >= 20, exported
+    for tool in [
+        "get_minimal_context_tool",
+        "list_graph_stats_tool",
+        "get_community_tool",
+        "list_flows_tool",
+        "get_flow_tool",
+        "find_large_functions_tool",
+    ]:
+        assert tool in exported
+
+
+def test_generated_and_bundled_skills_byte_identical(tmp_path):
+    """The sdist ships skills/; the installer generates from _SKILLS.
+
+    Any divergence between the two copies is the exact bug class this
+    PR fixed, so guard it with strict equality rather than token lists.
+    """
+    generated = generate_skills(tmp_path)
+    for name in SKILL_NAMES:
+        gen = (generated / name / "SKILL.md").read_text(encoding="utf-8")
+        bundled = (REPO_ROOT / "skills" / name / "SKILL.md").read_text(encoding="utf-8")
+        assert gen == bundled, f"generated and bundled {name}/SKILL.md diverged"
+
+
+def test_every_tool_reference_resolves_to_exported_schema(tmp_path):
+    exported = _exported_tool_names()
+    for skill_file in _all_skill_files(tmp_path):
+        content = skill_file.read_text(encoding="utf-8")
+        for ident in _backticked_identifiers(content):
+            if ident.endswith("_tool"):
+                assert ident in exported, (
+                    f"{skill_file} references `{ident}` which is not a registered MCP tool"
+                )
+
+
+def test_no_bare_name_of_any_exported_tool(tmp_path):
+    """Broader than the PR's legacy list: derive bare names from the schema."""
+    bare_names = {name.removesuffix("_tool") for name in _exported_tool_names()}
+    for skill_file in _all_skill_files(tmp_path):
+        content = skill_file.read_text(encoding="utf-8")
+        for ident in _backticked_identifiers(content):
+            assert ident not in bare_names, (
+                f"{skill_file} references stale bare tool name `{ident}`"
+            )
+
+
+def test_generate_skills_unicode_and_space_path(tmp_path):
+    target = tmp_path / "üñí code (v2)" / "deep" / "nested"
+    out = generate_skills(target)
+    assert out == target / ".claude" / "skills"
+    for name in SKILL_NAMES:
+        content = (out / name / "SKILL.md").read_text(encoding="utf-8")
+        assert "get_minimal_context_tool" in content
+        assert content.startswith("---\n")
+
+
+def test_generate_skills_overwrites_stale_content(tmp_path):
+    out = generate_skills(tmp_path)
+    stale = out / "debug-issue" / "SKILL.md"
+    stale.write_text("Use `get_flow` and `get_minimal_context`.\n", encoding="utf-8")
+    out2 = generate_skills(tmp_path)
+    assert out2 == out
+    refreshed = stale.read_text(encoding="utf-8")
+    assert "`get_flow`" not in refreshed
+    assert "get_flow_tool" in refreshed
+
+
+def test_skills_dict_covers_exactly_four_known_skills():
+    assert sorted(f.removesuffix(".md") for f in _SKILLS) == sorted(SKILL_NAMES)

--- a/tests/test_pr808_edges.py
+++ b/tests/test_pr808_edges.py
@@ -1,0 +1,147 @@
+"""Edge-case tests for #804 / PR #808: Java method and constructor names come
+from the grammar ``name`` field in ``_get_name`` (shared branch with C#).
+
+Stresses shapes beyond the PR's own regression test: generic methods and
+constructors, array and qualified-generic return types, annotations, records,
+interfaces, enums, unicode identifiers, nested and anonymous classes, and
+malformed input. Also guards that the now-shared branch left C# behavior
+untouched.
+"""
+
+from code_review_graph.parser import CodeParser
+
+
+def _java_funcs(source: str, tmp_path):
+    p = tmp_path / "Edge.java"
+    p.write_text(source, encoding="utf-8")
+    nodes, _ = CodeParser().parse_file(p)
+    return {n.name for n in nodes if n.kind == "Function"}
+
+
+class TestJavaNameFieldEdges:
+    def test_generic_methods_and_constructors(self, tmp_path):
+        names = _java_funcs(
+            "public class Box<T> {\n"
+            "    public <T> Box() { }\n"
+            "    public <T extends Comparable<T>> T max(T a, T b) { return a; }\n"
+            "    public T[] toArray() { return null; }\n"
+            "    public String[] names() { return null; }\n"
+            "    public java.util.List<String> qualified() { return null; }\n"
+            "}\n",
+            tmp_path,
+        )
+        assert names == {"Box", "max", "toArray", "names", "qualified"}
+        # Return types and type parameters must never leak in as names.
+        assert names.isdisjoint({"T", "String", "List", "Comparable", "java"})
+
+    def test_annotated_methods_and_constructors(self, tmp_path):
+        names = _java_funcs(
+            "public class Annotated {\n"
+            "    @Override\n"
+            '    @SuppressWarnings("unchecked")\n'
+            '    public String toString() { return ""; }\n'
+            "    @Deprecated public Annotated(@NonNull String s) { }\n"
+            "}\n",
+            tmp_path,
+        )
+        assert names == {"toString", "Annotated"}
+        assert "Override" not in names
+        assert "SuppressWarnings" not in names
+
+    def test_record_members(self, tmp_path):
+        names = _java_funcs(
+            "public record Point(int x, int y) {\n"
+            "    public Point(int x) { this(x, 0); }\n"
+            "    public int sum() { return x + y; }\n"
+            "    public static Point origin() { return new Point(0, 0); }\n"
+            "}\n",
+            tmp_path,
+        )
+        # Explicit constructor and methods inside a record body use the name
+        # field like any other method_declaration/constructor_declaration.
+        assert {"Point", "sum", "origin"} <= names
+
+    def test_interface_default_static_and_abstract_methods(self, tmp_path):
+        names = _java_funcs(
+            "public interface Svc {\n"
+            "    String name();\n"
+            "    default int count() { return 0; }\n"
+            "    static Svc create() { return null; }\n"
+            "}\n",
+            tmp_path,
+        )
+        assert names == {"name", "count", "create"}
+        assert "Svc" not in names
+
+    def test_enum_constructor_and_method(self, tmp_path):
+        names = _java_funcs(
+            "public enum Color {\n"
+            "    RED, GREEN;\n"
+            "    private Color() { }\n"
+            "    public Color next() { return GREEN; }\n"
+            "}\n",
+            tmp_path,
+        )
+        assert names == {"Color", "next"}
+
+    def test_unicode_identifiers(self, tmp_path):
+        names = _java_funcs(
+            "public class Unicodé {\n"
+            "    public Unicodé() { }\n"
+            '    public String grüße() { return "hallo"; }\n'
+            "}\n",
+            tmp_path,
+        )
+        assert "Unicodé" in names
+        assert "grüße" in names
+        assert "String" not in names
+
+    def test_nested_and_anonymous_class_methods(self, tmp_path):
+        names = _java_funcs(
+            "public class Outer {\n"
+            "    public class Inner {\n"
+            "        public Inner() { }\n"
+            "        public Outer outer() { return null; }\n"
+            "    }\n"
+            "    public Runnable anon() {\n"
+            "        return new Runnable() {\n"
+            "            public void run() { }\n"
+            "        };\n"
+            "    }\n"
+            "}\n",
+            tmp_path,
+        )
+        assert {"Inner", "outer", "anon", "run"} <= names
+        assert "Runnable" not in names
+
+    def test_malformed_source_does_not_crash(self, tmp_path):
+        # A method with no name plus an unclosed class body: parsing must not
+        # raise, and the well-formed sibling must still be extracted.
+        names = _java_funcs(
+            "public class Broken {\n"
+            '    public String () { return ""; }\n'
+            "    public int good() { return 1; }\n",
+            tmp_path,
+        )
+        assert "good" in names
+
+
+class TestCSharpBranchUntouched:
+    """The Java fix merged into the C# name-field branch; C# results from the
+    #791 fix must be byte-for-byte identical."""
+
+    def test_csharp_names_unchanged(self, tmp_path):
+        p = tmp_path / "Edge.cs"
+        p.write_text(
+            "public class Suite {\n"
+            "    public async Task Should_do_thing() { }\n"
+            "    public async Task<int> Returns_generic() { return 1; }\n"
+            "    public Suite() { }\n"
+            "    public void PlainVoid() { }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        nodes, _ = CodeParser().parse_file(p)
+        names = {n.name for n in nodes if n.kind == "Function"}
+        assert names == {"Should_do_thing", "Returns_generic", "Suite", "PlainVoid"}
+        assert "Task" not in names

--- a/tests/test_pr809_edges.py
+++ b/tests/test_pr809_edges.py
@@ -1,0 +1,270 @@
+"""Edge-case regressions for the read-only DB path of status/detect-changes/
+visualize/wiki/watch (#803, PR #809).
+
+Covers resolution branches the PR's own tests leave untouched: registry
+entries, deep CRG_DATA_DIR trees, legacy migration for the newly read-only
+commands, CRG_DATA_DIR vs legacy interaction, relative and unicode
+--data-dir paths, and registry side effects when a graph IS present.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from code_review_graph import cli
+from code_review_graph.graph import GraphStore
+
+READ_ONLY_COMMANDS = ["status", "detect-changes", "visualize", "wiki", "watch"]
+
+
+@pytest.fixture()
+def isolated_env(tmp_path, monkeypatch):
+    """Redirect all per-user state into tmp_path and clear overrides."""
+    crg_home = tmp_path / "crg-home"
+    monkeypatch.setenv("CRG_HOME", str(crg_home))
+    monkeypatch.delenv("CRG_DATA_DIR", raising=False)
+    monkeypatch.delenv("CRG_REPO_ROOT", raising=False)
+    return crg_home
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    return repo
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "gitrepo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "-C", str(repo), "init", "-q"],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    return repo
+
+
+def _run_cli(argv: list[str]) -> pytest.ExceptionInfo:
+    with patch.object(sys, "argv", ["code-review-graph", *argv]):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+    return exc_info
+
+
+def _run_cli_ok(argv: list[str]) -> None:
+    with patch.object(sys, "argv", ["code-review-graph", *argv]):
+        cli.main()
+
+
+def _build_min_graph(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = GraphStore(db_path)
+    store.close()
+
+
+@pytest.mark.parametrize("command", READ_ONLY_COMMANDS)
+def test_registry_pointed_data_dir_is_not_created(
+    command, tmp_path, isolated_env, capsys,
+):
+    """A registry entry naming a missing data dir must stay a no-op."""
+    repo = _make_repo(tmp_path)
+    if command == "detect-changes":
+        repo = _make_git_repo(tmp_path)
+    registry_dir = isolated_env
+    registry_dir.mkdir(parents=True)
+    pointed = tmp_path / "registry-pointed-data"
+    registry_file = registry_dir / "registry.json"
+    registry_file.write_text(
+        '{"repos": [{"path": "%s", "alias": "", "data_dir": "%s"}]}'
+        % (str(repo).replace("\\\\", "\\\\\\\\"), str(pointed).replace("\\\\", "\\\\\\\\")),
+        encoding="utf-8",
+    )
+    before = registry_file.read_bytes()
+
+    exc_info = _run_cli([command, "--repo", str(repo)])
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not pointed.exists()
+    assert registry_file.read_bytes() == before
+    assert not (repo / ".code-review-graph").exists()
+
+
+@pytest.mark.parametrize("command", READ_ONLY_COMMANDS)
+def test_deep_missing_crg_data_dir_tree_not_created(
+    command, tmp_path, isolated_env, monkeypatch, capsys,
+):
+    """No level of a deeply nested CRG_DATA_DIR may be materialized."""
+    repo = _make_repo(tmp_path)
+    if command == "detect-changes":
+        repo = _make_git_repo(tmp_path)
+    deep = tmp_path / "a" / "b" / "c" / "d"
+    monkeypatch.setenv("CRG_DATA_DIR", str(deep))
+
+    exc_info = _run_cli([command, "--repo", str(repo)])
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not (tmp_path / "a").exists()
+
+
+def test_legacy_migration_still_runs_for_wiki(tmp_path, isolated_env, capsys):
+    """wiki on a legacy .code-review-graph.db migrates it instead of failing."""
+    repo = _make_repo(tmp_path)
+    legacy = repo / ".code-review-graph.db"
+    _build_min_graph(legacy)
+
+    _run_cli_ok(["wiki", "--repo", str(repo)])
+
+    out = capsys.readouterr().out
+    assert "Output:" in out
+    assert not legacy.exists()
+    assert (repo / ".code-review-graph" / "graph.db").exists()
+
+
+def test_legacy_migration_still_runs_for_visualize_json(
+    tmp_path, isolated_env, capsys,
+):
+    repo = _make_repo(tmp_path)
+    legacy = repo / ".code-review-graph.db"
+    _build_min_graph(legacy)
+
+    _run_cli_ok(["visualize", "--repo", str(repo), "--format", "json"])
+
+    assert "JSON exported" in capsys.readouterr().out
+    assert not legacy.exists()
+    assert (repo / ".code-review-graph" / "graph.db").exists()
+    assert (repo / ".code-review-graph" / "graph.json").exists()
+
+
+def test_crg_data_dir_blocks_legacy_migration(
+    tmp_path, isolated_env, monkeypatch, capsys,
+):
+    """With CRG_DATA_DIR set, the legacy DB must be left alone and no dir made."""
+    repo = _make_repo(tmp_path)
+    legacy = repo / ".code-review-graph.db"
+    _build_min_graph(legacy)
+    external = tmp_path / "external-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(external))
+
+    exc_info = _run_cli(["visualize", "--repo", str(repo)])
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert legacy.exists()
+    assert not external.exists()
+
+
+@pytest.mark.parametrize("command", ["status", "visualize", "wiki", "watch"])
+def test_existing_empty_explicit_data_dir_gains_nothing(
+    command, tmp_path, isolated_env, capsys,
+):
+    """--data-dir on an existing but graph-less dir: exit 1, dir stays empty."""
+    repo = _make_repo(tmp_path)
+    data_dir = tmp_path / "existing-empty"
+    data_dir.mkdir()
+
+    exc_info = _run_cli(
+        [command, "--repo", str(repo), "--data-dir", str(data_dir)],
+    )
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert list(data_dir.iterdir()) == []
+    assert not (isolated_env / "registry.json").exists()
+
+
+def test_relative_explicit_data_dir_not_created(
+    tmp_path, isolated_env, monkeypatch, capsys,
+):
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    exc_info = _run_cli(
+        ["status", "--repo", str(repo), "--data-dir", "rel-data"],
+    )
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not (tmp_path / "rel-data").exists()
+
+
+def test_visualize_with_graph_and_data_dir_writes_no_registry(
+    tmp_path, isolated_env, capsys,
+):
+    """A present graph under --data-dir exports there without registry writes."""
+    repo = _make_repo(tmp_path)
+    data_dir = tmp_path / "présent data dir"
+    _build_min_graph(data_dir / "graph.db")
+
+    _run_cli_ok(
+        ["visualize", "--repo", str(repo), "--format", "json",
+         "--data-dir", str(data_dir)],
+    )
+
+    assert "JSON exported" in capsys.readouterr().out
+    assert (data_dir / "graph.json").exists()
+    assert not (isolated_env / "registry.json").exists()
+    assert not (repo / ".code-review-graph").exists()
+
+
+def test_wiki_with_graph_and_data_dir_writes_no_registry(
+    tmp_path, isolated_env, capsys,
+):
+    repo = _make_repo(tmp_path)
+    data_dir = tmp_path / "wiki-data"
+    _build_min_graph(data_dir / "graph.db")
+
+    _run_cli_ok(["wiki", "--repo", str(repo), "--data-dir", str(data_dir)])
+
+    assert "Output:" in capsys.readouterr().out
+    assert (data_dir / "wiki").is_dir()
+    assert not (isolated_env / "registry.json").exists()
+    assert not (repo / ".code-review-graph").exists()
+
+
+def test_status_with_graph_and_data_dir_reads_in_place(
+    tmp_path, isolated_env, capsys,
+):
+    repo = _make_repo(tmp_path)
+    data_dir = tmp_path / "status-data"
+    _build_min_graph(data_dir / "graph.db")
+
+    _run_cli_ok(["status", "--repo", str(repo), "--data-dir", str(data_dir)])
+
+    assert "Nodes: 0" in capsys.readouterr().out
+    assert not (isolated_env / "registry.json").exists()
+    assert not (repo / ".code-review-graph").exists()
+
+
+def test_detect_changes_no_graph_real_git_repo_with_commit(
+    tmp_path, isolated_env, capsys,
+):
+    """Even with real history, detect-changes must not materialize a graph."""
+    repo = _make_git_repo(tmp_path)
+    (repo / "mod.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "-A"],
+        check=True, capture_output=True, timeout=30,
+    )
+    subprocess.run(
+        [
+            "git", "-C", str(repo),
+            "-c", "user.email=t@example.com", "-c", "user.name=t",
+            "commit", "-q", "-m", "init",
+        ],
+        check=True, capture_output=True, timeout=30,
+    )
+
+    exc_info = _run_cli(["detect-changes", "--repo", str(repo)])
+
+    assert exc_info.value.code == 1
+    assert "No graph found" in capsys.readouterr().err
+    assert not (repo / ".code-review-graph").exists()

--- a/tests/test_pr824_edges.py
+++ b/tests/test_pr824_edges.py
@@ -1,0 +1,202 @@
+"""Extreme edge cases for Kotlin import extraction (PR #824).
+
+tree-sitter-kotlin folds comments that trail an import into the preceding
+``import_header`` node. PR #824 reads the ``identifier`` child instead of the
+node text so IMPORTS_FROM targets stay clean module names. These tests push
+beyond the PR's own coverage: comments between imports, same-line comments,
+comments that themselves look like imports or aliases, unicode identifiers,
+CRLF endings, malformed imports, scale, and end-to-end file resolution.
+"""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _import_targets(repo_root: Path, source_file: Path) -> set[str]:
+    _, edges = CodeParser(repo_root).parse_file(source_file)
+    return {edge.target for edge in edges if edge.kind == "IMPORTS_FROM"}
+
+
+def _write(tmp_path: Path, body: str, name: str = "Main.kt") -> Path:
+    source = tmp_path / name
+    source.write_text(body, encoding="utf-8")
+    return source
+
+
+def test_block_comment_between_imports_folds_into_first(tmp_path: Path) -> None:
+    # The grammar folds "/* mid */" into the FIRST import_header, not just
+    # comments after the last import. Both targets must stay clean.
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import aaa.First\n"
+        "/* mid-list comment */\n"
+        "import bbb.Second\n\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert {"aaa.First", "bbb.Second"} <= targets
+    assert not any("/*" in t or "\n" in t for t in targets)
+
+
+def test_same_line_trailing_comment(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import aaa.First // same-line note\n"
+        "import bbb.Second /* inline block */\n\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert {"aaa.First", "bbb.Second"} <= targets
+    assert not any("//" in t or "/*" in t for t in targets)
+
+
+def test_comment_that_looks_like_an_import_is_not_recorded(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import real.Thing\n\n"
+        "/** import fake.Ghost */\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+    assert not any("fake.Ghost" in t for t in targets)
+
+
+def test_comment_containing_as_keyword_does_not_alias(tmp_path: Path) -> None:
+    # " as " inside the folded comment must not be mistaken for an alias.
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import real.Thing\n\n"
+        "/** used as helper as needed */\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+    assert all(" as " not in t for t in targets)
+
+
+def test_kdoc_adjacent_without_blank_line(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import real.Thing\n"
+        "/** doc right below the import */\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+    assert not any("/**" in t for t in targets)
+
+
+def test_aliased_import_with_same_line_comment(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import real.Thing as Alias // why we alias\n\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+    assert not any("Alias" in t or "//" in t for t in targets)
+
+
+def test_semicolon_terminated_import(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\nimport real.Thing;\n\nclass Main\n",
+    )
+    assert "real.Thing" in _import_targets(tmp_path, source)
+
+
+def test_unicode_identifier_import(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import pkg.日本語クラス\n\n"
+        "/** doc */\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "pkg.日本語クラス" in targets
+
+
+def test_crlf_line_endings(tmp_path: Path) -> None:
+    source = tmp_path / "Main.kt"
+    source.write_bytes(
+        b"package app\r\n\r\n"
+        b"import real.Thing\r\n\r\n"
+        b"/** doc */\r\n"
+        b"class Main\r\n"
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+    assert not any("/**" in t for t in targets)
+
+
+def test_deep_wildcard_with_trailing_line_comment(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import a.b.c.d.e.*\n\n"
+        "// trailing note\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "a.b.c.d.e.*" in targets
+    assert not any("//" in t for t in targets)
+
+
+def test_import_only_file_with_trailing_comment(tmp_path: Path) -> None:
+    # No declaration after the comment at all.
+    source = _write(
+        tmp_path,
+        "package app\n\nimport real.Thing\n\n/** dangling doc */\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert "real.Thing" in targets
+
+
+def test_bare_import_keyword_does_not_crash(tmp_path: Path) -> None:
+    # Malformed: "import" with no target must not emit a garbage edge.
+    source = _write(
+        tmp_path,
+        "package app\n\nimport\n\nclass Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert not any(t.strip() == "import" for t in targets)
+    assert not any("class" in t for t in targets)
+
+
+def test_many_imports_with_trailing_kdoc_all_clean(tmp_path: Path) -> None:
+    imports = "".join(f"import pkg.mod{i}.Cls{i}\n" for i in range(300))
+    source = _write(
+        tmp_path,
+        "package app\n\n" + imports + "\n/** " + "x " * 5000 + "*/\nclass Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    expected = {f"pkg.mod{i}.Cls{i}" for i in range(300)}
+    assert expected <= targets
+    assert all(len(t) < 200 for t in targets)
+
+
+def test_trailing_comment_import_resolves_to_local_file(tmp_path: Path) -> None:
+    # End to end: the cleaned module name must now resolve to a real file,
+    # which the folded text never could.
+    dep_dir = tmp_path / "dep"
+    dep_dir.mkdir()
+    dep = dep_dir / "Helper.kt"
+    dep.write_text("package dep\n\nclass Helper\n", encoding="utf-8")
+    source = _write(
+        tmp_path,
+        "package app\n\n"
+        "import dep.Helper\n\n"
+        "/** doc after last import */\n"
+        "class Main\n",
+    )
+    targets = _import_targets(tmp_path, source)
+    assert str(dep.resolve()) in {str(Path(t)) for t in targets}

--- a/tests/test_pr826_edges.py
+++ b/tests/test_pr826_edges.py
@@ -1,0 +1,220 @@
+"""Edge-case tests for the UTF-8 stdio reconfiguration done at CLI startup.
+
+Covers stream shapes the happy-path regression test does not: absent
+streams (pythonw), streams without ``encoding`` or ``reconfigure``,
+closed and detached wrappers, UTF-8 spelling variants, idempotency,
+buffered-data preservation across the implicit flush, non-BMP output,
+and a real subprocess honoring ``PYTHONIOENCODING=cp1252``.
+"""
+
+import io
+import os
+import subprocess
+import sys
+
+from code_review_graph import cli
+
+
+def _legacy_stream(encoding: str = "cp1252", **kwargs):
+    raw = io.BytesIO()
+    return raw, io.TextIOWrapper(raw, encoding=encoding, **kwargs)
+
+
+class _RecordingStream:
+    """Minimal stream double that records reconfigure calls."""
+
+    def __init__(self, encoding):
+        self.encoding = encoding
+        self.calls = []
+
+    def write(self, text):
+        return len(text)
+
+    def reconfigure(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _FailingReconfigureStream:
+    def __init__(self, exc):
+        self.encoding = "cp1252"
+        self._exc = exc
+
+    def write(self, text):
+        return len(text)
+
+    def reconfigure(self, **kwargs):
+        raise self._exc
+
+
+def test_none_streams_do_not_crash(monkeypatch):
+    """pythonw-style None streams must be skipped and main() must survive."""
+    monkeypatch.setattr(sys, "stdout", None)
+    monkeypatch.setattr(sys, "stderr", None)
+    monkeypatch.setattr(sys, "argv", ["code-review-graph"])
+    cli._configure_utf8_stdio()
+    cli.main()  # print() to a None stdout is a silent no-op
+
+
+def test_stream_with_none_encoding_is_left_alone(monkeypatch):
+    """StringIO reports encoding=None; banner must still print."""
+    fake_out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_out)
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    monkeypatch.setattr(sys, "argv", ["code-review-graph"])
+    cli.main()
+    assert "code-review-graph" in fake_out.getvalue()
+    assert fake_out.encoding is None
+
+
+def test_legacy_stream_without_reconfigure_is_untouched(monkeypatch):
+    """No reconfigure method: keep the stream as-is without raising."""
+
+    class _Plain:
+        encoding = "cp1252"
+
+        def write(self, text):
+            return len(text)
+
+    plain = _Plain()
+    monkeypatch.setattr(sys, "stdout", plain)
+    monkeypatch.setattr(sys, "stderr", plain)
+    cli._configure_utf8_stdio()
+    assert plain.encoding == "cp1252"
+
+
+def test_reconfigure_failures_are_swallowed(monkeypatch):
+    for exc in (
+        io.UnsupportedOperation("boom"),
+        OSError("boom"),
+        ValueError("boom"),
+    ):
+        failing = _FailingReconfigureStream(exc)
+        monkeypatch.setattr(sys, "stdout", failing)
+        monkeypatch.setattr(sys, "stderr", failing)
+        cli._configure_utf8_stdio()  # must not raise
+
+
+def test_closed_stream_is_swallowed(monkeypatch):
+    _, wrapper = _legacy_stream()
+    wrapper.close()
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", wrapper)
+    cli._configure_utf8_stdio()  # reconfigure raises ValueError internally
+    assert wrapper.encoding == "cp1252"
+
+
+def test_detached_stream_is_swallowed(monkeypatch):
+    _, wrapper = _legacy_stream()
+    wrapper.detach()
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", wrapper)
+    cli._configure_utf8_stdio()  # must not raise
+
+
+def test_utf8_spelling_variants_skip_reconfigure(monkeypatch):
+    """Any common spelling of UTF-8 must not trigger a reconfigure."""
+    for spelling in ("utf-8", "UTF-8", "utf8", "UTF8", "Utf-8"):
+        probe = _RecordingStream(spelling)
+        monkeypatch.setattr(sys, "stdout", probe)
+        monkeypatch.setattr(sys, "stderr", probe)
+        cli._configure_utf8_stdio()
+        assert probe.calls == [], spelling
+
+
+def test_double_configure_is_idempotent(monkeypatch):
+    raw, wrapper = _legacy_stream()
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", wrapper)
+    cli._configure_utf8_stdio()
+    cli._configure_utf8_stdio()
+    assert wrapper.encoding == "utf-8"
+    wrapper.write("\U0001f680─│●")
+    wrapper.flush()
+    assert raw.getvalue().decode("utf-8") == "\U0001f680─│●"
+
+
+def test_buffered_output_is_flushed_not_lost(monkeypatch):
+    """Text written before the switch is flushed in the old encoding."""
+    raw, wrapper = _legacy_stream()
+    wrapper.write("caf\xe9")  # encodable in cp1252, still buffered
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    cli._configure_utf8_stdio()
+    wrapper.write("●")
+    wrapper.flush()
+    assert raw.getvalue() == "caf\xe9".encode("cp1252") + "●".encode()
+
+
+def test_ascii_stream_is_upgraded_and_banner_prints(monkeypatch):
+    raw, wrapper = _legacy_stream(encoding="ascii")
+    raw_err, wrapper_err = _legacy_stream(encoding="ascii")
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", wrapper_err)
+    monkeypatch.setattr(sys, "argv", ["code-review-graph"])
+    cli.main()
+    wrapper.flush()
+    out = raw.getvalue().decode("utf-8")
+    assert "●──●──●" in out  # box art
+    assert "Commands:" in out
+
+
+def test_errors_replace_stream_round_trips_exactly(monkeypatch):
+    """errors='replace' legacy stream must emit exact UTF-8 after switch."""
+    raw, wrapper = _legacy_stream(errors="replace")
+    monkeypatch.setattr(sys, "stdout", wrapper)
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    cli._configure_utf8_stdio()
+    wrapper.write("◆\U0001f9ea")
+    wrapper.flush()
+    assert raw.getvalue().decode("utf-8") == "◆\U0001f9ea"
+
+
+def test_stdin_is_never_touched(monkeypatch):
+    raw_in = io.BytesIO(b"data")
+    stdin = io.TextIOWrapper(raw_in, encoding="cp1252")
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    cli._configure_utf8_stdio()
+    assert stdin.encoding == "cp1252"
+
+
+def test_subprocess_with_pythonioencoding_cp1252_renders_banner():
+    """Real process: PYTHONIOENCODING=cp1252 must not crash the banner."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    env["NO_COLOR"] = "1"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from code_review_graph.cli import main; "
+            "sys.argv = ['code-review-graph']; main()",
+        ],
+        capture_output=True,
+        env=env,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    out = result.stdout.decode("utf-8")
+    assert "●──●──●" in out
+    assert "Commands:" in out
+
+
+def test_subprocess_version_flag_with_ascii_encoding():
+    """--version path also survives a pure-ASCII stdio configuration."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "ascii"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from code_review_graph.cli import main; "
+            "sys.argv = ['code-review-graph', '--version']; main()",
+        ],
+        capture_output=True,
+        env=env,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert b"code-review-graph" in result.stdout

--- a/tests/test_pr830_edges.py
+++ b/tests/test_pr830_edges.py
@@ -1,0 +1,332 @@
+"""Adversarial edge tests for Go receiver method call resolution (#829).
+
+These stress the lexical-scope walk beyond the shipped fixture coverage:
+closures and goroutines capturing the receiver, shadow leakage between
+sibling scopes, else-branch sharing of an if-init binding, assignment (as
+opposed to declaration) forms, unicode identifiers with multibyte byte
+offsets, labels, method values, cross-package selectors, and deep nesting.
+"""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse(source: str):
+    parser = CodeParser()
+    return parser.parse_bytes(Path("edge_case.go"), source.encode())
+
+
+def _receiver_calls(edges, method_suffix: str, receiver: str = "a"):
+    return [
+        edge for edge in edges
+        if edge.kind == "CALLS"
+        and edge.source.endswith(method_suffix)
+        and edge.extra.get("receiver") == receiver
+    ]
+
+
+def _resolution(edges, method_suffix: str, target_suffix: str, receiver: str = "a"):
+    return [
+        edge.target.endswith(target_suffix)
+        for edge in _receiver_calls(edges, method_suffix, receiver)
+    ]
+
+
+class TestClosureCapture:
+    def test_goroutine_and_defer_closures_keep_receiver(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\tgo func() { a.Save() }()\n"
+            "\tdefer func() { a.Save() }()\n"
+            "\tfunc() { func() { a.Save() }() }()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [True, True, True]
+
+    def test_shadow_inside_closure_body_blocks_resolution(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\tfunc() {\n"
+            "\t\tvar a *B\n"
+            "\t\ta.Save()\n"
+            "\t}()\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+
+class TestScopeBoundaries:
+    def test_else_branch_shares_if_init_shadow(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() bool { return true }\n"
+            "func (b *B) Save() bool { return true }\n"
+            "func (a *A) M() {\n"
+            "\tif a := (&B{}); a.Save() {\n"
+            "\t\ta.Save()\n"
+            "\t} else {\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [
+            False, False, False, True,
+        ]
+
+    def test_sibling_switch_cases_do_not_leak_shadow(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M(x int) {\n"
+            "\tswitch x {\n"
+            "\tcase 1:\n"
+            "\t\tvar a *B\n"
+            "\t\ta.Save()\n"
+            "\tcase 2:\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+    def test_sibling_blocks_do_not_leak_shadow(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\t{\n"
+            "\t\ta := &B{}\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "\t{\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+    def test_range_assignment_form_keeps_receiver(self):
+        # ``for _, a = range`` assigns to the receiver variable; it does not
+        # declare a new one, so the static type (and method set) is unchanged.
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\tfor _, a = range []*A{nil} {\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [True, True]
+
+    def test_multi_name_var_declaration_shadows(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\t{\n"
+            "\t\tvar x, a *B\n"
+            "\t\t_ = x\n"
+            "\t\ta.Save()\n"
+            "\t}\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+    def test_label_does_not_shadow_receiver(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (a *A) M() {\n"
+            "a:\n"
+            "\tfor {\n"
+            "\t\tbreak a\n"
+            "\t}\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [True]
+
+
+class TestFalseEdgeGuards:
+    def test_sibling_file_method_does_not_bind_to_free_function(self):
+        # ``Missing`` the method is defined on A in a sibling file of the
+        # same package; this file only has an unrelated free ``Missing``.
+        # The parser sees one file at a time, so the call must stay bare
+        # rather than bind to the free function.
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func Missing() {}\n"
+            "func (a *A) M() { a.Missing() }\n"
+        )
+        calls = _receiver_calls(edges, "::A.M")
+        assert len(calls) == 1
+        assert calls[0].target == "Missing"
+
+    def test_cross_package_selector_stays_unresolved(self):
+        # ``fmt.Println`` must not bind to a same-file free ``Println``.
+        _, edges = _parse(
+            "package edge\n"
+            'import "fmt"\n'
+            "func Println() {}\n"
+            "type A struct{}\n"
+            "func (a *A) M() {\n"
+            '\tfmt.Println("x")\n'
+            "}\n"
+        )
+        calls = [
+            edge for edge in edges
+            if edge.kind == "CALLS" and edge.source.endswith("::A.M")
+        ]
+        assert len(calls) == 1
+        assert calls[0].target == "Println"
+        assert "go_method_receiver" not in calls[0].extra
+
+    def test_two_types_resolve_to_their_own_methods(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Help() {}\n"
+            "func (a *A) Do() { a.Help() }\n"
+            "func (b *B) Help() {}\n"
+            "func (b *B) Do() { b.Help() }\n"
+        )
+        assert _resolution(edges, "::A.Do", "::A.Help") == [True]
+        assert _resolution(edges, "::B.Do", "::B.Help", receiver="b") == [True]
+
+    def test_method_value_creates_no_call_edge_to_method(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\tf := a.Save\n"
+            "\tf()\n"
+            "}\n"
+        )
+        targets = [
+            edge.target for edge in edges
+            if edge.kind == "CALLS" and edge.source.endswith("::A.M")
+        ]
+        assert all(not target.endswith("::A.Save") for target in targets)
+
+
+class TestReceiverForms:
+    def test_value_receiver_resolves(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a A) Save() {}\n"
+            "func (a A) M() { a.Save() }\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [True]
+
+    def test_parenthesized_receiver_resolves(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\t(a).Save()\n"
+            "\t((a)).Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [True, True]
+
+    def test_pointer_deref_of_shadowed_binding_stays_unresolved(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b B) Save() {}\n"
+            "func (a *A) M() {\n"
+            "\t{\n"
+            "\t\tvar a *B\n"
+            "\t\t(*a).Save()\n"
+            "\t}\n"
+            "\ta.Save()\n"
+            "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+    def test_unicode_receiver_and_method_names(self):
+        _, edges = _parse(
+            "package edge\n"
+            "type Alpha struct{}\n"
+            "type Beta struct{}\n"
+            "func (α *Alpha) Σ() {}\n"
+            "func (β *Beta) Σ() {}\n"
+            "func (α *Alpha) Μέθοδος() {\n"
+            "\tα.Σ()\n"
+            "\t{\n"
+            "\t\tvar α *Beta\n"
+            "\t\tα.Σ()\n"
+            "\t}\n"
+            "\tα.Σ()\n"
+            "}\n"
+        )
+        assert _resolution(
+            edges, "::Alpha.Μέθοδος", "::Alpha.Σ", receiver="α",
+        ) == [True, False, True]
+
+
+class TestScale:
+    def test_deeply_nested_shadow_blocks(self):
+        # Stay inside _MAX_AST_DEPTH (180): each Go block adds two AST
+        # levels, and deeper nesting is dropped by the extraction recursion
+        # guard before call edges are ever emitted.
+        depth = 80
+        inner = "var a *B\na.Save()\n"
+        body = "{\n" * depth + inner + "}\n" * depth + "a.Save()\n"
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M() {\n" + body + "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True]
+
+    def test_many_alternating_scopes(self):
+        blocks = []
+        for _ in range(150):
+            blocks.append("{\nvar a *B\na.Save()\n}\na.Save()\n")
+        _, edges = _parse(
+            "package edge\n"
+            "type A struct{}\n"
+            "type B struct{}\n"
+            "func (a *A) Save() {}\n"
+            "func (b *B) Save() {}\n"
+            "func (a *A) M() {\n" + "".join(blocks) + "}\n"
+        )
+        assert _resolution(edges, "::A.M", "::A.Save") == [False, True] * 150

--- a/tests/test_pr831_edges.py
+++ b/tests/test_pr831_edges.py
@@ -1,0 +1,176 @@
+"""Edge-case tests for the dotted-stem relative-import fix (PR #831).
+
+Stress the JS/TS relative-import resolver in ``_do_resolve_module`` beyond
+the PR's own coverage: probe-order precedence, multi-dot stems, unicode,
+directory-vs-file collisions, dotted directory names, extension priority,
+parent-relative traversal, and the no-false-edge guarantee when the dotted
+file is missing.
+"""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse(tmp_path: Path, source: str, suffix: str = ".js", name: str = "app"):
+    path = tmp_path / f"{name}{suffix}"
+    path.write_text(source, encoding="utf-8")
+    return path, CodeParser().parse_file(path)
+
+
+def _import_targets(edges):
+    return [edge.target for edge in edges if edge.kind == "IMPORTS_FROM"]
+
+
+def test_multi_dot_stem_resolves_full_filename(tmp_path):
+    # More than one dot in the stem: only appending survives all of them.
+    target = tmp_path / "a.b.c.ts"
+    target.write_text("export const x = 1;\n", encoding="utf-8")
+    (tmp_path / "a.b.ts").write_text("export const wrong = 1;\n", encoding="utf-8")
+    (tmp_path / "a.ts").write_text("export const wrong = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./a.b.c');\n")
+
+    assert _import_targets(edges) == [target.resolve().as_posix()]
+
+
+def test_missing_dotted_file_does_not_produce_false_edge_to_decoy(tmp_path):
+    # The dotted file does NOT exist; a truncated-name sibling does. The old
+    # with_suffix code resolved to the sibling (a wrong edge). The fix must
+    # leave the specifier unresolved instead of inventing a false import.
+    (tmp_path / "outlet.ts").write_text("export const wrong = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./outlet.entity');\n")
+
+    assert _import_targets(edges) == ["./outlet.entity"]
+
+
+def test_dotted_file_beats_directory_index_with_same_name(tmp_path):
+    # Both `mod.entity.ts` and `mod.entity/index.ts` exist. The appended-
+    # extension probe runs before the directory-index probe, so the file wins
+    # (matches Node's own file-before-directory resolution order).
+    file_target = tmp_path / "mod.entity.ts"
+    file_target.write_text("export const x = 1;\n", encoding="utf-8")
+    pkg = tmp_path / "mod.entity"
+    pkg.mkdir()
+    (pkg / "index.ts").write_text("export const wrong = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./mod.entity');\n")
+
+    assert _import_targets(edges) == [file_target.resolve().as_posix()]
+
+
+def test_dotted_directory_name_still_resolves_via_index(tmp_path):
+    # A directory whose own name contains a dot: no `v1.2.ts` file exists,
+    # the ESM fallback gate (.js/.jsx/.mjs/.cjs) must not fire for `.2`,
+    # and the index probe must still run.
+    pkg = tmp_path / "v1.2"
+    pkg.mkdir()
+    index = pkg / "index.ts"
+    index.write_text("export const x = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./v1.2');\n")
+
+    assert _import_targets(edges) == [index.resolve().as_posix()]
+
+
+def test_extension_priority_ts_wins_over_js_for_dotted_stem(tmp_path):
+    # Both `.ts` and `.js` variants of the dotted file exist; the extensions
+    # list probes `.ts` first, so it must win deterministically.
+    ts_target = tmp_path / "user.service.ts"
+    ts_target.write_text("export const x = 1;\n", encoding="utf-8")
+    (tmp_path / "user.service.js").write_text("module.exports = {};\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./user.service');\n")
+
+    assert _import_targets(edges) == [ts_target.resolve().as_posix()]
+
+
+def test_exact_js_file_on_disk_beats_esm_ts_fallback(tmp_path):
+    # `./helper.js` where helper.js itself exists AND helper.ts exists:
+    # the exact-path probe runs first, so the .js file must win.
+    js_target = tmp_path / "helper.js"
+    js_target.write_text("module.exports = {};\n", encoding="utf-8")
+    (tmp_path / "helper.ts").write_text("export const x = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./helper.js');\n")
+
+    assert _import_targets(edges) == [js_target.resolve().as_posix()]
+
+
+def test_appended_probe_beats_esm_fallback_for_js_suffixed_specifier(tmp_path):
+    # `./helper.js` where helper.js.ts (append probe) and helper.ts (ESM
+    # fallback) both exist but helper.js itself does not. The append loop
+    # runs before the fallback, so helper.js.ts wins. Guards the documented
+    # probe order against accidental reordering.
+    appended = tmp_path / "helper.js.ts"
+    appended.write_text("export const x = 1;\n", encoding="utf-8")
+    (tmp_path / "helper.ts").write_text("export const y = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./helper.js');\n")
+
+    assert _import_targets(edges) == [appended.resolve().as_posix()]
+
+
+def test_mjs_specifier_falls_back_to_ts_source(tmp_path):
+    # The ESM fallback gate includes `.mjs`.
+    ts_target = tmp_path / "worker.ts"
+    ts_target.write_text("export const x = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./worker.mjs');\n")
+
+    assert _import_targets(edges) == [ts_target.resolve().as_posix()]
+
+
+def test_parent_relative_dotted_stem_resolves(tmp_path):
+    # `../models/user.entity` from a sibling subdirectory.
+    models = tmp_path / "models"
+    models.mkdir()
+    target = models / "user.entity.ts"
+    target.write_text("export class User {}\n", encoding="utf-8")
+    services = tmp_path / "services"
+    services.mkdir()
+
+    _path, (_nodes, edges) = _parse(
+        services, "const { User } = require('../models/user.entity');\n"
+    )
+
+    assert _import_targets(edges) == [target.resolve().as_posix()]
+
+
+def test_unicode_dotted_stem_resolves(tmp_path):
+    target = tmp_path / "café.entity.ts"
+    target.write_text("export const x = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(
+        tmp_path, "const m = require('./café.entity');\n"
+    )
+
+    assert _import_targets(edges) == [target.resolve().as_posix()]
+
+
+def test_trailing_dot_specifier_does_not_crash_and_stays_unresolved(tmp_path):
+    # Malformed specifier ending in a bare dot: must not raise, must not
+    # invent an edge to anything on disk.
+    (tmp_path / "weird.ts").write_text("export const x = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(tmp_path, "const m = require('./weird.');\n")
+
+    assert _import_targets(edges) == ["./weird."]
+
+
+def test_dotted_stem_from_typescript_importer(tmp_path):
+    # Same fix exercised through a .ts importer (language "typescript"),
+    # not just the .js/CommonJS path.
+    target = tmp_path / "outlet.entity.ts"
+    target.write_text("export class Outlet {}\n", encoding="utf-8")
+    (tmp_path / "outlet.ts").write_text("export const wrong = 1;\n", encoding="utf-8")
+
+    _path, (_nodes, edges) = _parse(
+        tmp_path,
+        "import { Outlet } from './outlet.entity';\n",
+        suffix=".ts",
+        name="outlet.service",
+    )
+
+    assert target.resolve().as_posix() in _import_targets(edges)

--- a/tests/test_pr833_edges.py
+++ b/tests/test_pr833_edges.py
@@ -1,0 +1,104 @@
+"""Edge-case tests for Go generic receiver unwrapping (PR #833 / issue #832)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _parents(nodes):
+    return {n.name: n.parent_name for n in nodes if n.kind == "Function"}
+
+
+class TestGoGenericReceiverEdges:
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def parse(self, src: bytes):
+        return self.parser.parse_bytes(Path("edge.go"), src)
+
+    def test_multiple_type_params_value_and_pointer(self):
+        nodes, edges = self.parse(
+            b"package s\n"
+            b"type Map[K comparable, V any] struct{}\n"
+            b"func (m Map[K, V]) Get() {}\n"
+            b"func (m *Map[K, V]) Set() {}\n"
+        )
+        assert _parents(nodes) == {"Get": "Map", "Set": "Map"}
+        contains = {
+            e.target.rsplit("::", 1)[-1]
+            for e in edges
+            if e.kind == "CONTAINS" and e.source.endswith("::Map")
+        }
+        assert contains == {"Map.Get", "Map.Set"}
+
+    def test_unnamed_generic_receivers(self):
+        nodes, _ = self.parse(
+            b"package s\n"
+            b"type Box[T any] struct{}\n"
+            b"func (Box[T]) A() {}\n"
+            b"func (*Box[T]) B() {}\n"
+        )
+        assert _parents(nodes) == {"A": "Box", "B": "Box"}
+
+    def test_underscore_receiver_name(self):
+        nodes, _ = self.parse(
+            b"package s\n"
+            b"type Box[T any] struct{}\n"
+            b"func (_ Box[T]) C() {}\n"
+        )
+        assert _parents(nodes) == {"C": "Box"}
+
+    def test_non_generic_receivers_unchanged(self):
+        nodes, _ = self.parse(
+            b"package s\n"
+            b"type T struct{}\n"
+            b"func (s T) K() {}\n"
+            b"func (s *T) L() {}\n"
+            b"func (T) M() {}\n"
+            b"func (*T) N() {}\n"
+        )
+        assert _parents(nodes) == {"K": "T", "L": "T", "M": "T", "N": "T"}
+
+    def test_unicode_receiver_type_name(self):
+        nodes, _ = self.parse(
+            "package s\n"
+            "type Böx[T any] struct{}\n"
+            "func (b Böx[T]) J() {}\n".encode()
+        )
+        assert _parents(nodes) == {"J": "Böx"}
+
+    def test_nested_generic_receiver_does_not_crash(self):
+        # Illegal Go (receiver type params must be plain identifiers) but
+        # tree-sitter parses it; the base type must still win, never Pair.
+        nodes, _ = self.parse(b"package s\nfunc (b Box[Pair[K, V]]) D() {}\n")
+        assert _parents(nodes).get("D") == "Box"
+
+    def test_comment_inside_receiver_before_pointer(self):
+        nodes, _ = self.parse(
+            b"package s\ntype T struct{}\nfunc (b /*c*/ *T) G() {}\n"
+        )
+        assert _parents(nodes) == {"G": "T"}
+
+    def test_comment_between_generic_base_and_type_args(self):
+        nodes, _ = self.parse(
+            b"package s\n"
+            b"type Box[T any] struct{}\n"
+            b"func (b Box /*c*/ [T]) E() {}\n"
+        )
+        assert _parents(nodes) == {"E": "Box"}
+
+    def test_malformed_receivers_do_not_crash(self):
+        nodes, _ = self.parse(b"package s\nfunc () H() {}\nfunc (,) I() {}\n")
+        parents = _parents(nodes)
+        # Both must degrade to top-level functions, never raise.
+        assert parents.get("H") is None
+        assert parents.get("I") is None
+
+    def test_many_generic_methods_scale(self):
+        src = [b"package s", b"type Big[T any] struct{}"]
+        for i in range(200):
+            src.append(b"func (b *Big[T]) M%d() {}" % i)
+        nodes, _ = self.parse(b"\n".join(src) + b"\n")
+        parents = _parents(nodes)
+        assert len(parents) == 200
+        assert set(parents.values()) == {"Big"}

--- a/tests/test_pr838_edges.py
+++ b/tests/test_pr838_edges.py
@@ -1,0 +1,127 @@
+"""Edge-case regressions for SQL ``IF NOT EXISTS`` handling (PR #838 / issue #820).
+
+Stresses ``_SQL_TABLE_RE`` and the ``.sql`` table-reference pass beyond the
+PR's own coverage: case and whitespace variants, quoted and qualified names,
+identifiers that merely start with clause keywords, keyword-filter precision,
+unicode names, and scale.
+"""
+
+from pathlib import Path
+
+from code_review_graph.parser import _SQL_KEYWORDS, _SQL_TABLE_RE, CodeParser
+
+
+class TestIfNotExistsRegex:
+    def test_lowercase_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "create table if not exists foo (id INT);"
+        ) == ["foo"]
+
+    def test_mixed_case_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "Create Table If Not Exists Foo (id INT);"
+        ) == ["Foo"]
+
+    def test_newlines_and_tabs_inside_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "CREATE TABLE\n  IF\tNOT\nEXISTS bar (id INT);"
+        ) == ["bar"]
+
+    def test_backtick_quoted_name_after_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "CREATE TABLE IF NOT EXISTS `my table` (id INT);"
+        ) == ["`my table`"]
+
+    def test_schema_qualified_name_after_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "CREATE TABLE IF NOT EXISTS db.schema.tbl (id INT);"
+        ) == ["db.schema.tbl"]
+
+    def test_or_replace_combined_with_if_not_exists(self):
+        # BigQuery-style CREATE OR REPLACE TABLE IF NOT EXISTS.
+        assert _SQL_TABLE_RE.findall(
+            "CREATE OR REPLACE TABLE IF NOT EXISTS bq_tbl (id INT);"
+        ) == ["bq_tbl"]
+
+    def test_view_lowercase_clause(self):
+        assert _SQL_TABLE_RE.findall(
+            "create view if not exists v1 as select 1;"
+        ) == ["v1"]
+
+    def test_names_starting_with_clause_keywords_are_not_swallowed(self):
+        # The optional clause must not eat identifiers that merely start
+        # with IF / NOT / EXISTS.
+        for name in ("ifnotexists_log", "if_not_exists", "ifs", "nothing", "existsq"):
+            sql = f"CREATE TABLE {name} (id INT);"
+            assert _SQL_TABLE_RE.findall(sql) == [name], sql
+
+    def test_unicode_table_name(self):
+        assert _SQL_TABLE_RE.findall(
+            "CREATE TABLE IF NOT EXISTS façade_übersicht (id INT);"
+        ) == ["façade_übersicht"]
+
+    def test_plain_statements_unchanged(self):
+        assert _SQL_TABLE_RE.findall("CREATE TABLE t (id INT);") == ["t"]
+        assert _SQL_TABLE_RE.findall(
+            "INSERT OVERWRITE cat.sch.tbl SELECT * FROM src"
+        ) == ["cat.sch.tbl", "src"]
+
+    def test_new_keywords_registered(self):
+        assert {"IF", "NOT", "EXISTS"} <= _SQL_KEYWORDS
+
+
+class TestIfNotExistsEndToEnd:
+    def setup_method(self):
+        self.parser = CodeParser()
+
+    def _imports(self, sql: bytes) -> list:
+        _, edges = self.parser.parse_bytes(Path("pr838_schema.sql"), sql)
+        return [e for e in edges if e.kind == "IMPORTS_FROM"]
+
+    def test_many_idempotent_creates_all_recorded_with_lines(self):
+        n = 200
+        sql = b"".join(
+            b"CREATE TABLE IF NOT EXISTS tbl_%d (id INT);\n" % i for i in range(n)
+        )
+        imports = self._imports(sql)
+        assert [e.target for e in imports] == [f"tbl_{i}" for i in range(n)]
+        assert [e.line for e in imports] == list(range(1, n + 1))
+
+    def test_create_then_read_dedups_to_single_edge(self):
+        imports = self._imports(
+            b"CREATE TABLE IF NOT EXISTS a1 (id INT);\n"
+            b"CREATE TABLE IF NOT EXISTS a2 (id INT);\n"
+            b"SELECT * FROM a1 JOIN a2 ON a1.id = a2.id;\n"
+        )
+        assert [e.target for e in imports] == ["a1", "a2"]
+
+    def test_keyword_filter_is_exact_match_not_prefix(self):
+        # Names that contain filter keywords as a prefix must survive.
+        imports = self._imports(
+            b"SELECT * FROM notifications;\n"
+            b"SELECT * FROM if_config;\n"
+            b"SELECT * FROM exists_flags;\n"
+        )
+        assert [e.target for e in imports] == [
+            "notifications", "if_config", "exists_flags",
+        ]
+
+    def test_where_not_exists_subquery_adds_no_keyword_edges(self):
+        imports = self._imports(
+            b"SELECT * FROM orders o WHERE NOT EXISTS "
+            b"(SELECT 1 FROM refunds r WHERE r.oid = o.id);\n"
+        )
+        assert [e.target for e in imports] == ["orders", "refunds"]
+
+    def test_no_space_before_backtick_never_emits_if_edge(self):
+        # MySQL allows the quoted name to abut the clause. The regex cannot
+        # see past the missing space, but the keyword fallback must ensure
+        # no bogus "IF" edge is emitted (missing edge, not a wrong one).
+        imports = self._imports(b"CREATE TABLE IF NOT EXISTS`t`(id INT);\n")
+        assert all(e.target.upper() != "IF" for e in imports)
+
+    def test_qualified_create_strips_schema_prefix(self):
+        imports = self._imports(
+            b"CREATE TABLE IF NOT EXISTS warehouse.public.facts (id INT);\n"
+        )
+        assert [e.target for e in imports] == ["facts"]

--- a/tests/test_pr844_edges.py
+++ b/tests/test_pr844_edges.py
@@ -1,0 +1,248 @@
+"""Edge-case tests for the cross-platform daemon stop path (PR #844, issue #843).
+
+Covers boundaries and interleavings beyond the PR's own tests:
+- process dying mid-wait and on the very last poll (no escalation)
+- the missing-SIGKILL fallback simulated with a plain namespace, so the
+  behavior cannot pass by accident of MagicMock attribute magic
+- escalation racing with process death (ProcessLookupError swallowed)
+- PID cleanup when the liveness probe itself blows up mid-loop
+- restart interleavings: escalation succeeding vs. failing
+- real-process integration on POSIX: graceful SIGTERM stop and a child
+  that ignores SIGTERM and must be force-stopped
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_review_graph.daemon_cli import _handle_restart, _handle_stop
+
+REAL_SLEEP = time.sleep
+PID = 4242
+
+
+def _win_signal() -> types.SimpleNamespace:
+    """A signal-module stand-in without SIGKILL, as on Windows.
+
+    A plain namespace (unlike MagicMock) cannot fabricate attributes, so
+    ``getattr(signal, "SIGKILL", ...)`` genuinely falls back.
+    """
+    return types.SimpleNamespace(SIGTERM=signal.SIGTERM)
+
+
+class TestStopWaitLoopEdges:
+    def test_stop_breaks_when_process_dies_mid_wait(self, capsys):
+        """Death partway through the wait loop stops polling and skips escalation."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch(
+                "code_review_graph.daemon.pid_alive",
+                side_effect=[True] * 10 + [False],
+            ) as alive,
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch("code_review_graph.daemon_cli.os.kill") as kill,
+            patch("code_review_graph.daemon_cli.time.sleep") as sleep,
+        ):
+            _handle_stop(MagicMock())
+
+        assert kill.call_count == 1  # only the initial SIGTERM
+        assert alive.call_count == 11
+        assert sleep.call_count == 10
+        clear.assert_called_once()
+        out = capsys.readouterr().out
+        assert "force-stopping" not in out
+        assert "Daemon stopped." in out
+
+    def test_stop_death_on_final_poll_avoids_escalation(self, capsys):
+        """A False on the 50th and last liveness check must still break, not escalate."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch(
+                "code_review_graph.daemon.pid_alive",
+                side_effect=[True] * 49 + [False],
+            ) as alive,
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch("code_review_graph.daemon_cli.os.kill") as kill,
+            patch("code_review_graph.daemon_cli.time.sleep"),
+        ):
+            _handle_stop(MagicMock())
+
+        assert kill.call_count == 1
+        assert alive.call_count == 50
+        clear.assert_called_once()
+        assert "force-stopping" not in capsys.readouterr().out
+
+    def test_wait_loop_crash_still_clears_pid(self):
+        """An unexpected error from the liveness probe must not leave a stale PID file."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch(
+                "code_review_graph.daemon.pid_alive",
+                side_effect=RuntimeError("probe blew up"),
+            ),
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch("code_review_graph.daemon_cli.os.kill"),
+            patch("code_review_graph.daemon_cli.time.sleep"),
+            pytest.raises(RuntimeError, match="probe blew up"),
+        ):
+            _handle_stop(MagicMock())
+
+        clear.assert_called_once()
+
+
+class TestForcedStopEdges:
+    def test_missing_sigkill_falls_back_to_sigterm_plain_namespace(self, capsys):
+        """The SIGTERM fallback must work with a real attribute miss, not a mock quirk."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch("code_review_graph.daemon.pid_alive", return_value=True),
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch("code_review_graph.daemon_cli.signal", _win_signal()),
+            patch("code_review_graph.daemon_cli.os.kill") as kill,
+            patch("code_review_graph.daemon_cli.time.sleep"),
+        ):
+            _handle_stop(MagicMock())
+
+        assert [c.args for c in kill.call_args_list] == [
+            (PID, signal.SIGTERM),
+            (PID, signal.SIGTERM),
+        ]
+        clear.assert_called_once()
+        out = capsys.readouterr().out
+        assert "force-stopping" in out
+        assert "Daemon stopped." in out
+
+    def test_forced_stop_process_already_gone_is_swallowed(self, capsys):
+        """The process dying exactly at the 5s boundary must not crash the escalation."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch("code_review_graph.daemon.pid_alive", return_value=True),
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch(
+                "code_review_graph.daemon_cli.os.kill",
+                side_effect=[None, ProcessLookupError()],
+            ),
+            patch("code_review_graph.daemon_cli.time.sleep"),
+        ):
+            _handle_stop(MagicMock())
+
+        clear.assert_called_once()
+        assert "Daemon stopped." in capsys.readouterr().out
+
+
+class TestRestartInterleavings:
+    def test_windows_restart_with_forced_stop_still_starts(self):
+        """Escalation during restart on Windows must not prevent the new start."""
+        args = MagicMock()
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch("code_review_graph.daemon.pid_alive", return_value=True),
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch("code_review_graph.daemon_cli.signal", _win_signal()),
+            patch("code_review_graph.daemon_cli.os.kill") as kill,
+            patch("code_review_graph.daemon_cli.time.sleep"),
+            patch("code_review_graph.daemon_cli._handle_start") as start,
+        ):
+            _handle_restart(args)
+
+        assert kill.call_count == 2
+        clear.assert_called_once()
+        start.assert_called_once_with(args)
+
+    def test_restart_aborts_start_when_forced_stop_fails(self):
+        """A hard escalation failure aborts the restart but still clears the PID file."""
+        with (
+            patch("code_review_graph.daemon.is_daemon_running", return_value=True),
+            patch("code_review_graph.daemon.read_pid", return_value=PID),
+            patch("code_review_graph.daemon.pid_alive", return_value=True),
+            patch("code_review_graph.daemon.clear_pid") as clear,
+            patch(
+                "code_review_graph.daemon_cli.os.kill",
+                side_effect=[None, OSError("kill rejected")],
+            ),
+            patch("code_review_graph.daemon_cli.time.sleep"),
+            patch("code_review_graph.daemon_cli._handle_start") as start,
+            pytest.raises(OSError, match="kill rejected"),
+        ):
+            _handle_restart(MagicMock())
+
+        start.assert_not_called()
+        clear.assert_called_once()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX real-process integration")
+class TestStopRealProcess:
+    def test_graceful_stop_of_real_process(self, tmp_path, monkeypatch, capsys):
+        """End to end on POSIX: SIGTERM stops a real child and removes the PID file."""
+        monkeypatch.setenv("CRG_HOME", str(tmp_path))
+        from code_review_graph.daemon import default_pid_path, write_pid
+
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            write_pid(proc.pid)
+            # Reap concurrently: an unreaped zombie would read as alive forever.
+            reaper = threading.Thread(target=proc.wait, daemon=True)
+            reaper.start()
+
+            _handle_stop(MagicMock())
+
+            reaper.join(timeout=10)
+            assert not reaper.is_alive()
+            assert proc.returncode == -signal.SIGTERM
+            assert not default_pid_path().exists()
+            out = capsys.readouterr().out
+            assert "Daemon stopped." in out
+            assert "force-stopping" not in out
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_sigterm_ignoring_process_is_force_stopped(self, tmp_path, monkeypatch, capsys):
+        """A child that ignores SIGTERM must be escalated to SIGKILL and reaped."""
+        monkeypatch.setenv("CRG_HOME", str(tmp_path))
+        from code_review_graph.daemon import default_pid_path, write_pid
+
+        child_src = (
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "print('ready', flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", child_src], stdout=subprocess.PIPE
+        )
+        try:
+            assert proc.stdout is not None
+            assert proc.stdout.readline().strip() == b"ready"
+            write_pid(proc.pid)
+
+            # Shrink the 5s wait to ~0.5s of real polling.
+            with patch(
+                "code_review_graph.daemon_cli.time.sleep",
+                new=lambda _s: REAL_SLEEP(0.01),
+            ):
+                _handle_stop(MagicMock())
+
+            proc.wait(timeout=10)
+            assert proc.returncode == -signal.SIGKILL
+            assert not default_pid_path().exists()
+            assert "force-stopping" in capsys.readouterr().out
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()

--- a/tests/test_pr845_edges.py
+++ b/tests/test_pr845_edges.py
@@ -1,0 +1,250 @@
+"""Edge-case tests for dotted-stem relative import resolution (PR #845).
+
+Stresses `CodeParser._resolve_module_to_file` beyond the PR's own tests:
+multi-dot stems, dotted directory names, file-vs-directory precedence,
+`.`/`..` specifiers, unicode stems, trailing slashes, the `.jsx` -> `.tsx`
+NodeNext fallback, exact-extension precedence, unresolvable garbage, and an
+end-to-end IMPORTS_FROM edge through `parse_file`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from code_review_graph.parser import CodeParser
+
+
+@pytest.fixture()
+def parser():
+    return CodeParser()
+
+
+def _touch(root: Path, name: str, text: str = "export const x = 1;\n") -> Path:
+    p = root / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestDottedStemEdges:
+    def test_multi_dot_stem_with_decoys_at_every_truncation(self, tmp_path, parser):
+        """`./a.b.c` must hit `a.b.c.ts`, not the `a.b.ts` / `a.ts` decoys."""
+        want = _touch(tmp_path, "a.b.c.ts")
+        _touch(tmp_path, "a.b.ts")
+        _touch(tmp_path, "a.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./a.b.c", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_extension_priority_ts_beats_js_for_dotted_stem(self, tmp_path, parser):
+        """When both `x.entity.ts` and `x.entity.js` exist, `.ts` wins (probe order)."""
+        want = _touch(tmp_path, "x.entity.ts")
+        _touch(tmp_path, "x.entity.js")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./x.entity", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dotted_stem_file_beats_same_named_directory_index(self, tmp_path, parser):
+        """Node semantics: `outlet.entity.ts` file wins over `outlet.entity/index.ts`."""
+        want = _touch(tmp_path, "outlet.entity.ts")
+        _touch(tmp_path, "outlet.entity/index.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./outlet.entity", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dotted_directory_still_resolves_to_index(self, tmp_path, parser):
+        """A dotted *directory* import (`./styles.module/` layout) falls through
+        the append probes to the index-file branch instead of mis-resolving to
+        a truncated sibling (`styles.ts`), which the old with_suffix probe hit.
+        """
+        _touch(tmp_path, "styles.ts", "export const decoy = 1;\n")
+        want = _touch(tmp_path, "styles.module/index.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./styles.module", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_unicode_dotted_stem(self, tmp_path, parser):
+        want = _touch(tmp_path, "café.entité.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./café.entité", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_many_dots_stem(self, tmp_path, parser):
+        want = _touch(tmp_path, "a.b.c.d.e.f.g.spec.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./a.b.c.d.e.f.g.spec", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_vue_dotted_stem(self, tmp_path, parser):
+        want = _touch(tmp_path, "modal.confirm.vue", "<template><div/></template>\n")
+        importer = tmp_path / "app.vue"
+        resolved = parser._resolve_module_to_file(
+            "./modal.confirm", str(importer), "vue",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_unresolvable_dotted_stem_returns_none_not_truncated_decoy(
+        self, tmp_path, parser,
+    ):
+        """`./gone.entity` with only a truncated decoy present must be None,
+        never the decoy: a missing edge is recoverable, a wrong edge is not.
+        """
+        _touch(tmp_path, "gone.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./gone.entity", str(importer), "typescript",
+        )
+        assert resolved is None
+
+
+class TestSpecifierShapes:
+    def test_parent_directory_import_resolves_index(self, tmp_path, parser):
+        """`import x from ".."` — dotty base path must not break the probes."""
+        want = _touch(tmp_path, "index.ts")
+        importer = tmp_path / "sub" / "main.ts"
+        importer.parent.mkdir()
+        resolved = parser._resolve_module_to_file(
+            "..", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_current_directory_import_resolves_index(self, tmp_path, parser):
+        want = _touch(tmp_path, "index.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            ".", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_trailing_slash_directory_import(self, tmp_path, parser):
+        want = _touch(tmp_path, "utils/index.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./utils/", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_explicit_ts_extension_exact_match_wins(self, tmp_path, parser):
+        """An import that already carries `.ts` and exists must short-circuit
+        before any append probe (which would look for `foo.ts.ts`)."""
+        want = _touch(tmp_path, "foo.ts")
+        _touch(tmp_path, "foo.ts.ts", "export const trap = 1;\n")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./foo.ts", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+
+class TestNodeNextFallback:
+    def test_jsx_specifier_resolves_tsx_source(self, tmp_path, parser):
+        want = _touch(tmp_path, "comp.tsx", "export const C = () => null;\n")
+        importer = tmp_path / "main.tsx"
+        resolved = parser._resolve_module_to_file(
+            "./comp.jsx", str(importer), "tsx",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_cjs_specifier_resolves_ts_source(self, tmp_path, parser):
+        want = _touch(tmp_path, "legacy.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./legacy.cjs", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_existing_js_file_beats_ts_substitution(self, tmp_path, parser):
+        """`./foo.js` with a real `foo.js` on disk must return the JS file,
+        not substitute `foo.ts` (matches Node runtime behavior)."""
+        want = _touch(tmp_path, "foo.js", "module.exports = 1;\n")
+        _touch(tmp_path, "foo.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./foo.js", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dotted_stem_nodenext_specifier_resolves_ts_source(self, tmp_path, parser):
+        """Both features at once: a compiled-NestJS NodeNext specifier
+        `./user.service.js` must resolve the dotted-stem source
+        `user.service.ts` (with_suffix in the fallback replaces only the
+        final `.js`, leaving the dotted stem intact)."""
+        want = _touch(tmp_path, "user.service.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./user.service.js", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dotted_stem_ending_in_js_segment(self, tmp_path, parser):
+        """`./foo.js` where only `foo.js.ts` exists: the append probe runs
+        before the NodeNext substitution, so the literal appended file wins.
+        Documents probe order so a reorder is a conscious decision."""
+        want = _touch(tmp_path, "foo.js.ts")
+        importer = tmp_path / "main.ts"
+        resolved = parser._resolve_module_to_file(
+            "./foo.js", str(importer), "typescript",
+        )
+        assert resolved == str(want.resolve())
+
+
+class TestDartEdges:
+    def test_dart_multi_dot_stem_with_decoys(self, tmp_path, parser):
+        want = _touch(tmp_path, "thing.model.g.dart", "class T {}\n")
+        _touch(tmp_path, "thing.model.dart", "class Decoy1 {}\n")
+        _touch(tmp_path, "thing.dart", "class Decoy2 {}\n")
+        importer = tmp_path / "consumer.dart"
+        resolved = parser._resolve_module_to_file(
+            "./thing.model.g", str(importer), "dart",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dart_exact_extension_still_wins(self, tmp_path, parser):
+        want = _touch(tmp_path, "thing.model.dart", "class T {}\n")
+        importer = tmp_path / "consumer.dart"
+        resolved = parser._resolve_module_to_file(
+            "./thing.model.dart", str(importer), "dart",
+        )
+        assert resolved == str(want.resolve())
+
+    def test_dart_unresolvable_returns_none(self, tmp_path, parser):
+        _touch(tmp_path, "thing.dart", "class Decoy {}\n")
+        importer = tmp_path / "consumer.dart"
+        resolved = parser._resolve_module_to_file(
+            "./thing.model", str(importer), "dart",
+        )
+        assert resolved is None
+
+
+class TestEndToEnd:
+    def test_imports_from_edge_carries_resolved_dotted_target(self, tmp_path, parser):
+        """Full parse: the IMPORTS_FROM edge target must be the resolved
+        dotted-stem file, not the truncated decoy and not the bare module."""
+        _touch(
+            tmp_path, "outlet.entity.ts",
+            "export class Outlet {}\n",
+        )
+        _touch(tmp_path, "outlet.ts", "export const decoy = 1;\n")
+        svc = _touch(
+            tmp_path, "outlet.service.ts",
+            'import { Outlet } from "./outlet.entity";\n'
+            "export class OutletService { o = new Outlet(); }\n",
+        )
+        nodes, edges = parser.parse_file(svc)
+        imports = [e for e in edges if e.kind == "IMPORTS_FROM"]
+        assert imports, "expected an IMPORTS_FROM edge"
+        targets = [e.target for e in imports]
+        assert any(t.endswith("outlet.entity.ts") for t in targets), targets
+        assert not any(t.endswith("/outlet.ts") for t in targets), targets

--- a/tests/test_pr852_edges.py
+++ b/tests/test_pr852_edges.py
@@ -1,0 +1,195 @@
+"""Edge-case tests for the changed_files absolute-path remap in analyze_changes (#848).
+
+Stresses the remap beyond the PR's regression test: absolute passthrough
+(the MCP path), mixed relative/absolute input, backslash separators,
+dot segments, trailing-slash repo_root, unicode file names, the
+no-ranges node fallback, empty input, caller-list immutability, and
+IN-clause batching with >450 changed files.
+"""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.changes import analyze_changes
+from code_review_graph.flows import store_flows, trace_flows
+from code_review_graph.graph import GraphStore
+from code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+def _repo_root() -> str:
+    """A fake absolute repo root valid on the current OS."""
+    return "/repo" if not Path("C:/").exists() else "C:/repo"
+
+
+class TestPR852Edges:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = GraphStore(self.tmp.name)
+        self.root = _repo_root()
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _add_func(self, name: str, path: str, line_start: int = 1, line_end: int = 10) -> int:
+        node = NodeInfo(
+            kind="Function",
+            name=name,
+            file_path=path,
+            line_start=line_start,
+            line_end=line_end,
+            language="python",
+        )
+        nid = self.store.upsert_node(node, file_hash="abc")
+        self.store.commit()
+        return nid
+
+    def _add_call(self, source_qn: str, target_qn: str, path: str) -> None:
+        edge = EdgeInfo(
+            kind="CALLS", source=source_qn, target=target_qn, file_path=path, line=5,
+        )
+        self.store.upsert_edge(edge)
+        self.store.commit()
+
+    def _build_flow(self, sub: str = "services.py") -> str:
+        """One handler -> service flow stored under absolute paths."""
+        routes = f"{self.root}/routes.py"
+        service = f"{self.root}/{sub}"
+        self._add_func("handler", routes)
+        self._add_func("service", service)
+        self._add_call(f"{routes}::handler", f"{service}::service", routes)
+        store_flows(self.store, trace_flows(self.store))
+        return service
+
+    # -- absolute passthrough (the MCP path) --
+
+    def test_absolute_changed_files_pass_through_unchanged(self):
+        service = self._build_flow()
+        result = analyze_changes(
+            self.store,
+            changed_files=[service],
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert len(result["affected_flows"]) >= 1
+        assert "1 changed file(s)" in result["summary"]
+
+    def test_mixed_relative_and_absolute_inputs(self):
+        service = self._build_flow()
+        routes = f"{self.root}/routes.py"
+        result = analyze_changes(
+            self.store,
+            changed_files=["services.py", routes],
+            changed_ranges={service: [(1, 10)], routes: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert result["affected_flows"]
+        assert "2 changed file(s)" in result["summary"]
+
+    # -- separator and segment forms --
+
+    def test_backslash_relative_path_matches(self):
+        """A Windows-style relative path still hits the POSIX graph identity."""
+        service = self._build_flow(sub="pkg/services.py")
+        result = analyze_changes(
+            self.store,
+            changed_files=["pkg\\services.py"],
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert result["affected_flows"]
+
+    def test_leading_dot_segment_is_collapsed(self):
+        service = self._build_flow()
+        result = analyze_changes(
+            self.store,
+            changed_files=["./services.py"],
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert result["affected_flows"]
+
+    def test_trailing_slash_repo_root(self):
+        service = self._build_flow()
+        result = analyze_changes(
+            self.store,
+            changed_files=["services.py"],
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root + "/",
+        )
+        assert result["affected_flows"]
+
+    def test_unicode_file_names(self):
+        service = self._build_flow(sub="ünïcode/файл.py")
+        result = analyze_changes(
+            self.store,
+            changed_files=["ünïcode/файл.py"],
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert result["affected_flows"]
+
+    # -- the no-ranges node fallback (covered by #852, not #837) --
+
+    def test_no_ranges_fallback_finds_nodes_with_relative_paths(self):
+        """With empty changed_ranges the per-file node fallback must also remap."""
+        self._build_flow()
+        result = analyze_changes(
+            self.store,
+            changed_files=["services.py"],
+            changed_ranges={},
+            repo_root=self.root,
+        )
+        assert len(result["changed_functions"]) == 1
+        assert result["changed_functions"][0]["name"] == "service"
+        assert result["affected_flows"]
+
+    # -- degenerate and hostile input --
+
+    def test_empty_changed_files(self):
+        self._build_flow()
+        result = analyze_changes(
+            self.store, changed_files=[], changed_ranges={}, repo_root=self.root,
+        )
+        assert result["affected_flows"] == []
+        assert result["changed_functions"] == []
+
+    def test_caller_list_is_not_mutated(self):
+        """CLI reuses its relative list after the call (estimate_file_tokens)."""
+        service = self._build_flow()
+        changed = ["services.py"]
+        analyze_changes(
+            self.store,
+            changed_files=changed,
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert changed == ["services.py"]
+
+    def test_missing_files_do_not_crash_or_match(self):
+        self._build_flow()
+        result = analyze_changes(
+            self.store,
+            changed_files=["nonexistent.py", "also/missing.py"],
+            changed_ranges={},
+            repo_root=self.root,
+        )
+        assert result["changed_functions"] == []
+        assert result["affected_flows"] == []
+
+    # -- scale: exercise the 450-item IN-clause batching --
+
+    def test_flow_found_when_match_lands_in_second_batch(self):
+        service = self._build_flow()
+        filler = [f"filler/mod_{i:04d}.py" for i in range(500)]
+        # The only real file sorts after the filler so it lands in batch 2.
+        changed = filler + ["services.py"]
+        result = analyze_changes(
+            self.store,
+            changed_files=changed,
+            changed_ranges={service: [(1, 10)]},
+            repo_root=self.root,
+        )
+        assert result["affected_flows"]
+        assert "501 changed file(s)" in result["summary"]

--- a/tests/test_pr853_edges.py
+++ b/tests/test_pr853_edges.py
@@ -1,0 +1,197 @@
+"""Edge-case tests for get_affected_flows detail_level / max_flows (#849, PR #853).
+
+Covers boundaries and scale beyond the PR's own tests: exact-boundary
+truncation, the default max_flows=50 cap on a 60-flow graph, negative and
+huge max_flows values, minimal projection combined with truncation,
+criticality ordering after projection, unknown detail_level fallback, and
+unicode changed-file paths.
+"""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.graph import EdgeInfo, GraphStore, NodeInfo
+from code_review_graph.tools.review import get_affected_flows_func
+
+MINIMAL_KEYS = {"id", "name", "criticality", "depth", "node_count", "file_count"}
+
+
+class _FlowFixture:
+    """Seed a repo-shaped temp dir with N entry points flowing through shared.py."""
+
+    def setup_flows(self, n_flows: int):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.root = Path(self.tmp_dir).resolve()
+        (self.root / ".git").mkdir()
+        (self.root / ".code-review-graph").mkdir()
+
+        db_path = str(self.root / ".code-review-graph" / "graph.db")
+        self.store = GraphStore(db_path)
+
+        shared_py = (self.root / "shared.py").as_posix()
+        self.store.upsert_node(NodeInfo(
+            kind="File", name="shared.py", file_path=shared_py,
+            line_start=1, line_end=50, language="python",
+        ))
+        self.store.upsert_node(NodeInfo(
+            kind="Function", name="shared_helper", file_path=shared_py,
+            line_start=5, line_end=20, language="python",
+        ))
+
+        for i in range(n_flows):
+            entry_file = (self.root / f"entry_{i}.py").as_posix()
+            self.store.upsert_node(NodeInfo(
+                kind="File", name=f"entry_{i}.py", file_path=entry_file,
+                line_start=1, line_end=30, language="python",
+            ))
+            self.store.upsert_node(NodeInfo(
+                kind="Function", name=f"entry_point_{i}", file_path=entry_file,
+                line_start=3, line_end=15, language="python",
+            ))
+            self.store.upsert_edge(EdgeInfo(
+                kind="CALLS",
+                source=f"{entry_file}::entry_point_{i}",
+                target=f"{shared_py}::shared_helper",
+                file_path=entry_file, line=7,
+            ))
+        self.store.commit()
+
+        from code_review_graph.flows import store_flows, trace_flows
+        store_flows(self.store, trace_flows(self.store))
+
+    def teardown_method(self):
+        self.store.close()
+        import shutil
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def affected(self, **kwargs):
+        return get_affected_flows_func(
+            changed_files=["shared.py"], repo_root=str(self.root), **kwargs
+        )
+
+
+class TestMaxFlowsBoundaries(_FlowFixture):
+    """Exact boundary behavior of max_flows on a 5-flow graph."""
+
+    def setup_method(self):
+        self.setup_flows(5)
+
+    def test_max_flows_equal_to_total_is_not_truncated(self):
+        result = self.affected(max_flows=5)
+        assert result["status"] == "ok"
+        assert result["total"] == 5
+        assert len(result["affected_flows"]) == 5
+        assert result["truncated"] is False
+        assert "showing" not in result["summary"]
+
+    def test_max_flows_one_below_total_truncates(self):
+        result = self.affected(max_flows=4)
+        assert result["total"] == 5
+        assert len(result["affected_flows"]) == 4
+        assert result["truncated"] is True
+        assert "showing 4" in result["summary"]
+
+    def test_max_flows_one_returns_single_highest_criticality(self):
+        full = self.affected(max_flows=0)
+        result = self.affected(max_flows=1)
+        assert len(result["affected_flows"]) == 1
+        assert result["truncated"] is True
+        # Truncation keeps the head of the criticality-sorted list.
+        assert result["affected_flows"][0]["id"] == full["affected_flows"][0]["id"]
+
+    def test_negative_max_flows_disables_limit(self):
+        # Documented contract is 0 disables; negatives currently behave the
+        # same way (no truncation) rather than raising or returning nothing.
+        result = self.affected(max_flows=-1)
+        assert result["status"] == "ok"
+        assert result["truncated"] is False
+        assert len(result["affected_flows"]) == result["total"] == 5
+
+    def test_huge_max_flows_returns_everything(self):
+        result = self.affected(max_flows=10**9)
+        assert result["truncated"] is False
+        assert len(result["affected_flows"]) == 5
+
+    def test_truncated_key_present_when_nothing_matches(self):
+        result = get_affected_flows_func(
+            changed_files=["unrelated.py"], repo_root=str(self.root)
+        )
+        assert result["status"] == "ok"
+        assert result["total"] == 0
+        assert result["truncated"] is False
+
+
+class TestDefaultCapAtScale(_FlowFixture):
+    """The default max_flows=50 must bound a 60-flow response (#849)."""
+
+    def setup_method(self):
+        self.setup_flows(60)
+
+    def test_default_truncates_sixty_flows_to_fifty(self):
+        result = self.affected()
+        assert result["status"] == "ok"
+        assert result["total"] == 60
+        assert len(result["affected_flows"]) == 50
+        assert result["truncated"] is True
+        assert "showing 50" in result["summary"]
+
+    def test_zero_disables_limit_at_scale(self):
+        result = self.affected(max_flows=0)
+        assert result["truncated"] is False
+        assert len(result["affected_flows"]) == result["total"] == 60
+
+    def test_minimal_with_default_cap_stays_projected(self):
+        result = self.affected(detail_level="minimal")
+        assert len(result["affected_flows"]) == 50
+        assert result["truncated"] is True
+        for flow in result["affected_flows"]:
+            assert set(flow.keys()) == MINIMAL_KEYS
+
+
+class TestMinimalProjection(_FlowFixture):
+    def setup_method(self):
+        self.setup_flows(5)
+
+    def test_minimal_has_exactly_the_documented_keys(self):
+        result = self.affected(detail_level="minimal")
+        assert result["total"] == 5
+        for flow in result["affected_flows"]:
+            assert set(flow.keys()) == MINIMAL_KEYS
+            assert flow["id"] is not None
+            assert flow["name"]
+            assert flow["node_count"] >= 1
+
+    def test_minimal_matches_standard_order_and_identity(self):
+        standard = self.affected(max_flows=0)
+        minimal = self.affected(detail_level="minimal", max_flows=0)
+        assert [f["id"] for f in minimal["affected_flows"]] == [
+            f["id"] for f in standard["affected_flows"]
+        ]
+        crits = [f["criticality"] for f in minimal["affected_flows"]]
+        assert crits == sorted(crits, reverse=True)
+
+    def test_minimal_truncation_applies_before_projection(self):
+        standard = self.affected(max_flows=0)
+        result = self.affected(detail_level="minimal", max_flows=2)
+        assert len(result["affected_flows"]) == 2
+        assert result["total"] == 5
+        assert [f["id"] for f in result["affected_flows"]] == [
+            f["id"] for f in standard["affected_flows"][:2]
+        ]
+
+    def test_unknown_detail_level_falls_back_to_standard(self):
+        # Sibling tools treat anything except "minimal" as standard; the new
+        # parameter follows the same convention rather than raising.
+        for level in ("full", "MINIMAL", "", "detailed"):
+            result = self.affected(detail_level=level)
+            assert result["status"] == "ok"
+            assert all("steps" in f for f in result["affected_flows"])
+
+    def test_unicode_changed_file_is_handled(self):
+        result = get_affected_flows_func(
+            changed_files=["mödulé/日本語.py"],
+            repo_root=str(self.root),
+        )
+        assert result["status"] == "ok"
+        assert result["total"] == 0
+        assert result["truncated"] is False

--- a/tests/test_pr854_edges.py
+++ b/tests/test_pr854_edges.py
@@ -1,0 +1,153 @@
+"""Edge-case tests for the test-gap exemption list (#850, PR #854).
+
+Stresses _TEST_GAP_EXEMPT_NAMES beyond the PR's own coverage: that the
+exemption cannot fully hide an untested class (the enclosing Class node
+still surfaces), that it is exact-match only (no substring or case
+leakage), that summary counts stay consistent with the filtered list,
+and that risk scoring still sees the exempt nodes.
+"""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.changes import _TEST_GAP_EXEMPT_NAMES, analyze_changes
+from code_review_graph.graph import GraphStore
+from code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+class TestExemptListEdges:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = GraphStore(self.tmp.name)
+
+    def teardown_method(self):
+        self.store.close()
+        Path(self.tmp.name).unlink(missing_ok=True)
+
+    def _add_node(
+        self,
+        name: str,
+        kind: str = "Function",
+        path: str = "app.py",
+        parent: str | None = None,
+        line_start: int = 1,
+        line_end: int = 10,
+    ) -> None:
+        node = NodeInfo(
+            kind=kind,
+            name=name,
+            file_path=path,
+            line_start=line_start,
+            line_end=line_end,
+            language="python",
+            parent_name=parent,
+            is_test=False,
+            extra={},
+        )
+        self.store.upsert_node(node, file_hash="abc")
+        self.store.commit()
+
+    def _analyze(self, path: str, start: int, end: int) -> dict:
+        return analyze_changes(
+            self.store,
+            changed_files=[path],
+            changed_ranges={path: [(start, end)]},
+        )
+
+    def test_untested_class_still_surfaces_when_only_init_changes(self):
+        """Exempting __init__ must not hide a completely untested class.
+
+        A diff touching only the constructor also overlaps the enclosing
+        Class node, which is not exempt, so the class-level gap remains.
+        """
+        self._add_node("Foo", kind="Class", path="foo.py",
+                       line_start=1, line_end=20)
+        self._add_node("__init__", parent="Foo", path="foo.py",
+                       line_start=2, line_end=5)
+
+        result = self._analyze("foo.py", 3, 4)
+        gap_names = {g["name"] for g in result["test_gaps"]}
+        assert "__init__" not in gap_names
+        assert "Foo" in gap_names
+
+    def test_exemption_is_exact_match_no_substring_or_case_leakage(self):
+        """Only the exact names are exempt; near-misses stay flagged."""
+        for i, name in enumerate(
+            ["setUpX", "mysetUp", "__CONSTRUCT", "Setup_Method",
+             "__init__x", "teardown"]
+        ):
+            self._add_node(name, path="near.py",
+                           line_start=i * 10 + 1, line_end=i * 10 + 5)
+
+        result = self._analyze("near.py", 1, 60)
+        gap_names = {g["name"] for g in result["test_gaps"]}
+        assert gap_names == {
+            "setUpX", "mysetUp", "__CONSTRUCT", "Setup_Method",
+            "__init__x", "teardown",
+        }
+
+    def test_summary_count_matches_filtered_gap_list(self):
+        """The 'N test gap(s)' line counts the post-exemption list."""
+        exempt = ["setUp", "tearDown", "__construct"]
+        real = ["alpha", "beta"]
+        for i, name in enumerate(exempt + real):
+            self._add_node(name, path="mix.php",
+                           line_start=i * 10 + 1, line_end=i * 10 + 5)
+
+        result = self._analyze("mix.php", 1, 50)
+        assert len(result["test_gaps"]) == 2
+        assert "  - 2 test gap(s)" in result["summary"]
+        assert "Untested: " in result["summary"]
+        untested_line = next(
+            line for line in result["summary"].splitlines()
+            if "Untested:" in line
+        )
+        for name in exempt:
+            assert name not in untested_line
+        for name in real:
+            assert name in untested_line
+
+    def test_all_gaps_exempt_gives_zero_and_no_untested_line(self):
+        """A diff of only lifecycle methods reports zero gaps cleanly."""
+        for i, name in enumerate(sorted(_TEST_GAP_EXEMPT_NAMES)):
+            self._add_node(name, path="life.py",
+                           line_start=i * 10 + 1, line_end=i * 10 + 5)
+
+        result = self._analyze("life.py", 1, len(_TEST_GAP_EXEMPT_NAMES) * 10)
+        assert result["test_gaps"] == []
+        assert "  - 0 test gap(s)" in result["summary"]
+        assert "Untested:" not in result["summary"]
+
+    def test_exempt_nodes_still_counted_as_changed_and_risk_scored(self):
+        """Exemption only affects the gap list, not changed_functions."""
+        self._add_node("setUp", path="only.py", line_start=1, line_end=5)
+
+        result = self._analyze("only.py", 1, 5)
+        changed_names = {n["name"] for n in result["changed_functions"]}
+        assert "setUp" in changed_names
+        assert result["risk_score"] > 0.0
+        assert "  - 1 changed function(s)/class(es)" in result["summary"]
+
+    def test_exempt_name_with_existing_coverage_stays_out(self):
+        """A covered constructor is not double-reported either way."""
+        self._add_node("__construct", path="cov.php", line_start=1, line_end=5)
+        # TESTED_BY: source=production, target=test (see #515).
+        qn = self.store.get_nodes_by_file("cov.php")[0].qualified_name
+        self.store.upsert_edge(EdgeInfo(
+            kind="TESTED_BY", source=qn, target="tests::t_construct",
+            file_path="cov.php", line=1,
+        ))
+        self.store.commit()
+
+        result = self._analyze("cov.php", 1, 5)
+        assert result["test_gaps"] == []
+
+    def test_unicode_and_whitespace_names_not_exempt(self):
+        """Odd names never match the frozenset accidentally."""
+        for i, name in enumerate(["初始化", " setUp", "setUp "]):
+            self._add_node(name, path="uni.py",
+                           line_start=i * 10 + 1, line_end=i * 10 + 5)
+
+        result = self._analyze("uni.py", 1, 30)
+        assert len(result["test_gaps"]) == 3

--- a/tests/test_pr855_edges.py
+++ b/tests/test_pr855_edges.py
@@ -1,0 +1,217 @@
+"""Edge-case tests for keyword-argument callback references (#840, PR #855).
+
+Stresses the ``keyword_argument`` branch of ``_ref_from_arguments`` beyond the
+PR's own coverage: nested calls, lambdas, method references, stdlib names,
+keyword-name/value confusion, unicode, splats, scale, and the dead-code
+interplay (no over-suppression of genuinely dead functions).
+"""
+
+import tempfile
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def _parse_source(tmp_path: Path, source: str, name: str = "mod.py"):
+    p = tmp_path / name
+    p.write_text(source, encoding="utf-8")
+    parser = CodeParser()
+    return parser.parse_file(p)
+
+
+def _ref_targets(edges) -> set:
+    return {
+        e.target.rsplit("::", 1)[-1] for e in edges if e.kind == "REFERENCES"
+    }
+
+
+class TestKeywordCallbackEdges:
+    def test_keyword_name_never_treated_as_reference(self, tmp_path):
+        """f(handler=42): the keyword NAME collides with a defined function
+        but the VALUE is a literal — no REFERENCES edge may be emitted."""
+        src = (
+            "def handler(x):\n"
+            "    return x\n"
+            "\n"
+            "def wire(reg):\n"
+            "    reg.configure(handler=42)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        assert "handler" not in _ref_targets(edges)
+
+    def test_keyword_value_matching_keyword_name_emits_single_edge(self, tmp_path):
+        """f(handler=handler): exactly one REFERENCES edge, from the value."""
+        src = (
+            "def handler(x):\n"
+            "    return x\n"
+            "\n"
+            "def wire(reg):\n"
+            "    reg.configure(handler=handler)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        refs = [
+            e for e in edges
+            if e.kind == "REFERENCES" and e.target.endswith("handler")
+        ]
+        assert len(refs) == 1, [(e.source, e.target, e.line) for e in refs]
+        assert refs[0].line == 5
+
+    def test_no_reference_edges_to_stdlib_builtins(self, tmp_path):
+        """key=len, cb=print, factory=str: builtins are neither defined
+        locally nor imported, so no REFERENCES edges may appear."""
+        src = (
+            "def use(items, reg):\n"
+            "    ordered = sorted(items, key=len)\n"
+            "    reg.configure(cb=print, factory=str, cls=dict)\n"
+            "    return ordered\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        targets = _ref_targets(edges)
+        for builtin in ("len", "print", "str", "dict"):
+            assert builtin not in targets, targets
+
+    def test_nested_call_and_lambda_values_do_not_crash_or_emit(self, tmp_path):
+        """cb=make() and cb=lambda: non-identifier values are skipped, while a
+        keyword deeper inside the nested call still emits via recursion."""
+        src = (
+            "def make_handler():\n"
+            "    return None\n"
+            "\n"
+            "def inner_cb(x):\n"
+            "    return x\n"
+            "\n"
+            "def wire(reg):\n"
+            "    reg.configure(cb=make_handler())\n"
+            "    reg.configure(cb=lambda x: x + 1)\n"
+            "    reg.configure(cb=outer_wrap(inner=inner_cb))\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        targets = _ref_targets(edges)
+        # The nested keyword `inner=inner_cb` must still be found by recursion.
+        assert "inner_cb" in targets, targets
+        # `make_handler()` is a call, not a bare identifier: no REFERENCES
+        # from the keyword path (it gets a CALLS edge instead).
+        call_targets = {
+            e.target.rsplit("::", 1)[-1] for e in edges if e.kind == "CALLS"
+        }
+        assert "make_handler" in call_targets
+
+    def test_method_reference_value_is_skipped_without_crash(self, tmp_path):
+        """cb=self.on_event / cb=obj.on_event are attribute nodes: the PR's
+        scope skips them, and parsing must not crash."""
+        src = (
+            "class Widget:\n"
+            "    def on_event(self, e):\n"
+            "        return e\n"
+            "\n"
+            "    def wire(self, reg):\n"
+            "        reg.configure(cb=self.on_event)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        # No exception is the main assertion; also no bogus 'self' ref.
+        assert "self" not in _ref_targets(edges)
+
+    def test_splat_and_conditional_values_do_not_crash(self, tmp_path):
+        src = (
+            "def primary(x):\n"
+            "    return x\n"
+            "\n"
+            "def wire(reg, cbs, opts, flag):\n"
+            "    reg.configure(*cbs, **opts)\n"
+            "    reg.configure(cb=primary if flag else None)\n"
+            "    reg.configure(cb=(primary))\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        # Conditional/parenthesized values are out of scope: skipped, no crash.
+        assert isinstance(edges, list)
+
+    def test_imported_name_as_keyword_value_emits_reference(self, tmp_path):
+        src = (
+            "from mypkg.handlers import telemetry_handler\n"
+            "\n"
+            "def wire(sp):\n"
+            "    sp.set_defaults(func=telemetry_handler)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        assert "telemetry_handler" in _ref_targets(edges)
+
+    def test_unicode_function_name_as_keyword_value(self, tmp_path):
+        src = (
+            "def обработчик(args):\n"
+            "    return args\n"
+            "\n"
+            "def wire(sp):\n"
+            "    sp.set_defaults(func=обработчик)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        assert "обработчик" in _ref_targets(edges)
+
+    def test_uppercase_and_single_char_values_skipped_by_heuristic(self, tmp_path):
+        src = (
+            "def HANDLER(x):\n"
+            "    return x\n"
+            "\n"
+            "def h(x):\n"
+            "    return x\n"
+            "\n"
+            "def wire(reg):\n"
+            "    reg.configure(cb=HANDLER, other=h)\n"
+        )
+        _, edges = _parse_source(tmp_path, src)
+        targets = _ref_targets(edges)
+        assert "HANDLER" not in targets
+        assert "h" not in targets
+
+    def test_many_keyword_callbacks_scale(self, tmp_path):
+        """300 keyword-referenced handlers: every one gets an edge."""
+        n = 300
+        defs = "\n".join(
+            f"def handler_{i:03d}(args):\n    return args\n" for i in range(n)
+        )
+        wires = "\n".join(
+            f"    sp.set_defaults(func_{i:03d}=handler_{i:03d})" for i in range(n)
+        )
+        src = f"{defs}\n\ndef wire(sp):\n{wires}\n"
+        _, edges = _parse_source(tmp_path, src)
+        targets = _ref_targets(edges)
+        missing = {f"handler_{i:03d}" for i in range(n)} - targets
+        assert not missing, sorted(missing)[:5]
+
+    def test_dead_code_not_over_suppressed(self, tmp_path):
+        """A keyword-referenced handler is alive; an unreferenced sibling
+        must still be reported dead."""
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.refactor import find_dead_code
+
+        src = (
+            "def live_handler(args):\n"
+            "    return args\n"
+            "\n"
+            "def truly_dead(args):\n"
+            "    return args\n"
+            "\n"
+            "def wire(sp):\n"
+            "    sp.set_defaults(func=live_handler)\n"
+        )
+        p = tmp_path / "deadmod.py"
+        p.write_text(src, encoding="utf-8")
+        parser = CodeParser()
+        nodes, edges = parser.parse_file(p)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            store = GraphStore(Path(tmp_dir) / "graph.db")
+            try:
+                store.store_file_nodes_edges(str(p), nodes, edges, "")
+                dead_names = {d["name"] for d in find_dead_code(store)}
+                assert "live_handler" not in dead_names, dead_names
+                assert "truly_dead" in dead_names, dead_names
+            finally:
+                store.close()
+
+    def test_javascript_arguments_behavior_unchanged(self, tmp_path):
+        """The python-only guard must not alter JS bare-identifier callbacks."""
+        src = (
+            "function clickHandler(e) { return e; }\n"
+            "function wire(el) { el.addEventListener('click', clickHandler); }\n"
+        )
+        _, edges = _parse_source(tmp_path, src, name="mod.js")
+        assert "clickHandler" in _ref_targets(edges)

--- a/tests/test_pr856_edges.py
+++ b/tests/test_pr856_edges.py
@@ -1,0 +1,154 @@
+"""Edge-case guards for the google-genai packaging switch (PR #856 / issue #534).
+
+All tests are offline and deterministic: they inspect packaging metadata
+(pyproject.toml, uv.lock) and force the ImportError path without needing
+google-genai installed or absent.
+"""
+
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _pyproject() -> dict:
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)
+
+
+def _lock() -> dict:
+    with (ROOT / "uv.lock").open("rb") as f:
+        return tomllib.load(f)
+
+
+def test_all_extra_covers_every_optional_group():
+    """[all] must reference every optional group except dev, per README's
+    "All optional dependencies" claim (issue #534)."""
+    optional = _pyproject()["project"]["optional-dependencies"]
+    referenced = {
+        req.split("[", 1)[1].rstrip("]")
+        for req in optional["all"]
+        if req.startswith("code-review-graph[")
+    }
+    expected = set(optional) - {"all", "dev"}
+    assert referenced == expected
+
+
+def test_all_extra_contains_only_self_referential_extras():
+    """Every entry in [all] must be a self-referential extra so pip/uv
+    resolve it against this same distribution."""
+    optional = _pyproject()["project"]["optional-dependencies"]
+    for req in optional["all"]:
+        assert req.startswith("code-review-graph["), req
+        assert req.endswith("]"), req
+
+
+def test_old_google_sdk_fully_evicted_from_lock():
+    """The deprecated SDK and its exclusive transitive tree must be gone."""
+    names = {pkg["name"] for pkg in _lock()["package"]}
+    for stale in (
+        "google-generativeai",
+        "google-ai-generativelanguage",
+        "google-api-python-client",
+        "google-api-core",
+        "grpcio",
+        "grpcio-status",
+        "proto-plus",
+    ):
+        assert stale not in names, f"{stale} should no longer be locked"
+    assert "google-genai" in names
+
+
+def test_lock_pins_google_genai_within_pyproject_bounds():
+    lock_pkgs = {pkg["name"]: pkg for pkg in _lock()["package"]}
+    version = lock_pkgs["google-genai"]["version"]
+    major = int(version.split(".", 1)[0])
+    assert 1 <= major < 3, version
+
+
+def test_lock_registry_sources_are_pypi_only():
+    """Supply-chain guard: every locked package must come from pypi.org."""
+    for pkg in _lock()["package"]:
+        source = pkg.get("source", {})
+        registry = source.get("registry")
+        if registry is not None:
+            assert registry == "https://pypi.org/simple", (
+                pkg["name"],
+                registry,
+            )
+
+
+def test_lock_requires_dist_matches_pyproject():
+    """The lock's recorded requires-dist must agree with pyproject on both
+    the SDK swap and the [all] extra addition."""
+    lock = _lock()
+    crg = next(
+        pkg
+        for pkg in lock["package"]
+        if pkg["name"] == "code-review-graph"
+    )
+    requires = crg["metadata"]["requires-dist"]
+    google = [r for r in requires if r["name"] == "google-genai"]
+    assert len(google) == 1
+    assert google[0]["marker"] == "extra == 'google-embeddings'"
+    assert google[0]["specifier"] == ">=1.0.0,<3"
+    assert not any(r["name"] == "google-generativeai" for r in requires)
+    all_extras = [
+        r["extras"]
+        for r in requires
+        if r["name"] == "code-review-graph" and r.get("marker") == "extra == 'all'"
+    ]
+    assert ["google-embeddings"] in all_extras
+
+
+def test_import_error_names_current_sdk_and_quotes_extra(monkeypatch):
+    """When google-genai is missing, the guidance must name the current SDK
+    and quote the extra so zsh-style shells do not glob the brackets."""
+    from code_review_graph.embeddings import GoogleEmbeddingProvider
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "google" or name.startswith("google."):
+            raise ImportError(f"blocked: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "google", raising=False)
+    monkeypatch.delitem(sys.modules, "google.genai", raising=False)
+    monkeypatch.setattr(builtins, "__import__", blocked)
+
+    with pytest.raises(ImportError) as excinfo:
+        GoogleEmbeddingProvider(api_key="k")
+
+    message = str(excinfo.value)
+    assert "google-genai" in message
+    assert "google-generativeai" not in message.replace("google-genai", "")
+    assert '"code-review-graph[google-embeddings]"' in message
+
+
+def test_no_stale_sdk_references_outside_lock():
+    """No source, docs, or config file may still name the deprecated SDK."""
+    stale_hits = []
+    for pattern in ("*.py", "*.toml", "*.md", "*.yml", "*.yaml"):
+        for path in ROOT.rglob(pattern):
+            parts = path.relative_to(ROOT).parts
+            if parts[0] in {".git", ".venv", "node_modules", ".claude"}:
+                continue
+            if " 2." in path.name or path.name == "test_pr856_edges.py":
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            if "google-generativeai" in text or "google_generativeai" in text:
+                stale_hits.append(str(path.relative_to(ROOT)))
+    assert stale_hits == []

--- a/tests/test_pr861_edges.py
+++ b/tests/test_pr861_edges.py
@@ -1,0 +1,298 @@
+"""Edge-case tests for the orphan-row purge in reconciliation (PR #861 / issue #812).
+
+Covers boundaries beyond the PR's own regression test: virtual-node exclusion
+during reconciliation itself, edge-only orphans in both reconciliation modes,
+paths outside the repository root, unicode paths, same-path rows in both
+tables counting once, NULL ``extra`` rows, ordering/dedup guarantees of
+``get_all_files``, and purge behavior at scale.
+"""
+
+import time
+from unittest.mock import patch
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import _reconcile_stale_files, full_build
+from code_review_graph.parser import EdgeInfo, NodeInfo
+
+
+def _add_orphan_function(store, path, name="orphan_fn"):
+    store.upsert_node(
+        NodeInfo(
+            kind="Function",
+            name=name,
+            file_path=path,
+            line_start=1,
+            line_end=2,
+            language="javascript",
+        )
+    )
+
+
+def _add_orphan_edge(store, path):
+    store.upsert_edge(
+        EdgeInfo(
+            kind="CALLS",
+            source=f"{path}::caller",
+            target=f"{path}::callee",
+            file_path=path,
+        )
+    )
+
+
+def _add_virtual_event_node(store, name="OrderCreated"):
+    store.upsert_node(
+        NodeInfo(
+            kind="Event",
+            name=name,
+            file_path="event",
+            line_start=0,
+            line_end=0,
+            language="java",
+            extra={"event_type": name, "virtual": True},
+        )
+    )
+
+
+def _count_edges(store, path):
+    return store._conn.execute(
+        "SELECT COUNT(*) FROM edges WHERE file_path = ?", (path,)
+    ).fetchone()[0]
+
+
+class TestReconcileVirtualExclusion:
+    def test_virtual_event_node_survives_reconcile_while_orphans_purge(self, tmp_path):
+        real = tmp_path / "real.py"
+        real.write_text("def live():\n    pass\n")
+        orphan_node_path = str(tmp_path / "gone" / "a.js")
+        orphan_edge_path = str(tmp_path / "gone" / "b.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            _add_virtual_event_node(store)
+            _add_orphan_function(store, orphan_node_path)
+            _add_orphan_edge(store, orphan_edge_path)
+            store.commit()
+
+            stale = _reconcile_stale_files(tmp_path, store, ["real.py"])
+
+            assert sorted(stale) == sorted([orphan_node_path, orphan_edge_path])
+            events = store._conn.execute(
+                "SELECT COUNT(*) FROM nodes WHERE kind = 'Event' AND file_path = 'event'"
+            ).fetchone()[0]
+            assert events == 1
+            assert store.get_nodes_by_file(orphan_node_path) == []
+            assert _count_edges(store, orphan_edge_path) == 0
+        finally:
+            store.close()
+
+    def test_virtual_event_node_survives_probe_mode_reconcile(self, tmp_path):
+        # current_files=None branch: the relative sentinel path "event" raises
+        # ValueError in relative_to() and would be purged if not excluded.
+        real = tmp_path / "real.py"
+        real.write_text("def live():\n    pass\n")
+        orphan = str(tmp_path / "missing.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store.store_file_nodes_edges(
+                str(real),
+                [
+                    NodeInfo(
+                        kind="File",
+                        name="real.py",
+                        file_path=str(real),
+                        line_start=1,
+                        line_end=2,
+                        language="python",
+                    )
+                ],
+                [],
+                "hash",
+            )
+            _add_virtual_event_node(store)
+            _add_orphan_function(store, orphan)
+            store.commit()
+
+            stale = _reconcile_stale_files(tmp_path, store)
+
+            assert stale == [orphan]
+            events = store._conn.execute(
+                "SELECT COUNT(*) FROM nodes WHERE kind = 'Event'"
+            ).fetchone()[0]
+            assert events == 1
+            assert store.get_nodes_by_file(str(real)) != []
+        finally:
+            store.close()
+
+
+class TestOrphanPurgeBoundaries:
+    def test_same_path_in_nodes_and_edges_counts_once(self, tmp_path):
+        current = tmp_path / "sample.py"
+        current.write_text("def hello():\n    pass\n")
+        orphan = str(tmp_path / "generated" / "both.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            _add_orphan_function(store, orphan)
+            _add_orphan_edge(store, orphan)
+            store.commit()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["sample.py"],
+            ):
+                result = full_build(tmp_path, store)
+
+            assert result["stale_files_removed"] == 1
+            assert store.get_nodes_by_file(orphan) == []
+            assert _count_edges(store, orphan) == 0
+        finally:
+            store.close()
+
+    def test_orphan_outside_repo_root_is_purged_in_both_modes(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "sample.py").write_text("def hello():\n    pass\n")
+        outside = str(tmp_path / "elsewhere" / "x.js")
+
+        store = GraphStore(tmp_path / "full.db")
+        try:
+            _add_orphan_edge(store, outside)
+            store.commit()
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["sample.py"],
+            ):
+                result = full_build(repo, store)
+            assert result["stale_files_removed"] == 1
+            assert _count_edges(store, outside) == 0
+        finally:
+            store.close()
+
+        store = GraphStore(tmp_path / "probe.db")
+        try:
+            _add_orphan_function(store, outside)
+            store.commit()
+            stale = _reconcile_stale_files(repo, store)
+            assert stale == [outside]
+            assert store.get_nodes_by_file(outside) == []
+        finally:
+            store.close()
+
+    def test_unicode_orphan_path_is_purged(self, tmp_path):
+        (tmp_path / "sample.py").write_text("def hello():\n    pass\n")
+        orphan = str(tmp_path / "généré" / "文件.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            _add_orphan_function(store, orphan, name="加载")
+            store.commit()
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["sample.py"],
+            ):
+                result = full_build(tmp_path, store)
+            assert result["stale_files_removed"] == 1
+            assert store.get_nodes_by_file(orphan) == []
+        finally:
+            store.close()
+
+    def test_orphan_purge_leaves_unrelated_live_rows_intact(self, tmp_path):
+        live = tmp_path / "live.py"
+        live.write_text("def keep():\n    pass\n")
+        orphan = str(tmp_path / "generated" / "dead.js")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            _add_orphan_function(store, orphan)
+            _add_orphan_edge(store, orphan)
+            store.commit()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["live.py"],
+            ):
+                full_build(tmp_path, store)
+
+            live_nodes = store.get_nodes_by_file(str(live))
+            assert any(n.kind == "File" for n in live_nodes)
+            assert any(n.name == "keep" for n in live_nodes)
+            assert store.get_nodes_by_file(orphan) == []
+        finally:
+            store.close()
+
+    def test_many_orphan_edge_paths_purge_completely(self, tmp_path):
+        (tmp_path / "sample.py").write_text("def hello():\n    pass\n")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            now = time.time()
+            rows = []
+            for i in range(300):
+                path = str(tmp_path / "gen" / f"chunk{i}.js")
+                for j in range(5):
+                    rows.append(
+                        (
+                            "CALLS",
+                            f"{path}::caller{j}",
+                            f"{path}::callee{j}",
+                            path,
+                            j,
+                            "{}",
+                            now,
+                        )
+                    )
+            store._conn.executemany(
+                "INSERT INTO edges (kind, source_qualified, target_qualified,"
+                " file_path, line, extra, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+            store.commit()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["sample.py"],
+            ):
+                result = full_build(tmp_path, store)
+
+            assert result["stale_files_removed"] == 300
+            remaining = store._conn.execute(
+                "SELECT COUNT(*) FROM edges WHERE file_path LIKE ?",
+                (str(tmp_path / "gen") + "/%",),
+            ).fetchone()[0]
+            assert remaining == 0
+        finally:
+            store.close()
+
+
+class TestGetAllFilesContract:
+    def test_dedupes_across_tables_and_sorts(self, tmp_path):
+        a = str(tmp_path / "a.py")
+        b = str(tmp_path / "b.py")
+        c = str(tmp_path / "c.py")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            _add_orphan_function(store, b, name="fb")
+            _add_orphan_edge(store, b)
+            _add_orphan_edge(store, c)
+            _add_orphan_function(store, a, name="fa")
+            store.commit()
+            assert store.get_all_files() == sorted([a, b, c])
+        finally:
+            store.close()
+
+    def test_null_extra_row_is_included_without_error(self, tmp_path):
+        path = str(tmp_path / "legacy.py")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store._conn.execute(
+                "INSERT INTO nodes (kind, name, qualified_name, file_path,"
+                " line_start, line_end, extra, updated_at)"
+                " VALUES ('Function', 'old', ?, ?, 1, 2, NULL, ?)",
+                (f"{path}::old", path, time.time()),
+            )
+            store.commit()
+            assert store.get_all_files() == [path]
+        finally:
+            store.close()
+
+    def test_empty_graph_returns_empty_list(self, tmp_path):
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            assert store.get_all_files() == []
+        finally:
+            store.close()


### PR DESCRIPTION
Adds one test file per PR merged in the August sweep (test_pr<N>_edges.py for 778, 779, 808, 809, 824, 826, 830, 831, 833, 838, 844, 845, 852, 853, 854, 855, 856, 861), written during review to stress each change beyond its own regression tests: boundary inputs, malformed input, unicode names, Windows and POSIX path spellings, scale, and idempotency. 234 new tests, all deterministic and network-free.

Full suite with these files: 2709 passed, 5 skipped, 2 xpassed. The test_pr831 file covers the dotted-stem import fix that landed via #845.