### PR TITLE
fix(graph): survive malformed extra JSON in get_all_files

### DIFF
--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1190,9 +1190,16 @@ class GraphStore:
         # every represented path so those orphans can be purged, while explicit
         # virtual nodes (such as Spring Event markers) remain outside the file
         # inventory and are managed by their owning resolver.
+        # A killed writer can leave extra='' (or truncated text), which makes
+        # json_extract raise SQLite 'malformed JSON' and crash every caller of
+        # get_all_files. json_valid gates the extraction, and the truthiness
+        # comparison keeps extra='{"virtual": false}' visible instead of
+        # making the node immortal to reconciliation (#864).
         rows = self._conn.execute(
             "SELECT file_path FROM nodes "
-            "WHERE json_extract(extra, '$.virtual') IS NULL "
+            "WHERE extra IS NULL "
+            "OR json_valid(extra) = 0 "
+            "OR COALESCE(json_extract(extra, '$.virtual'), 0) != 1 "
             "UNION "
             "SELECT file_path FROM edges "
             "ORDER BY file_path"

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1813,3 +1813,38 @@ class TestRenamePurgeParity:
             assert store.get_nodes_by_file(str(tmp_path / "b.py"))
         finally:
             store.close()
+
+    def test_get_all_files_survives_malformed_extra_and_false_virtual(self, tmp_path):
+        """#864: a killed writer can leave extra='' and crash every
+        get_all_files caller with SQLite 'malformed JSON'; extra with
+        virtual=false must stay visible so reconciliation can purge it."""
+        good = tmp_path / "good.py"
+        good.write_text("def ok():\n    pass\n")
+        store = GraphStore(tmp_path / "test.db")
+        try:
+            store._conn.execute(
+                "INSERT INTO nodes (kind, name, qualified_name, file_path, "
+                "extra, updated_at) "
+                "VALUES ('Function', 'dead', 'dead', ?, '', 1.0)",
+                (str(tmp_path / "killed.py"),),
+            )
+            store._conn.execute(
+                "INSERT INTO nodes (kind, name, qualified_name, file_path, "
+                "extra, updated_at) "
+                "VALUES ('Class', 'Concrete', 'Concrete', ?, ?, 1.0)",
+                (str(tmp_path / "flagged.py"), '{"virtual": false}'),
+            )
+            store._conn.execute(
+                "INSERT INTO nodes (kind, name, qualified_name, file_path, "
+                "extra, updated_at) "
+                "VALUES ('Event', 'SpringEvent', 'SpringEvent', ?, ?, 1.0)",
+                (str(tmp_path / "virtual.py"), '{"virtual": true}'),
+            )
+            store.commit()
+
+            files = set(store.get_all_files())
+            assert str(tmp_path / "killed.py") in files, "malformed extra must not crash"
+            assert str(tmp_path / "flagged.py") in files, "virtual=false must remain purgeable"
+            assert str(tmp_path / "virtual.py") not in files, "virtual=true stays resolver-managed"
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

Follow-up to #861 (noted while merging it, #864): a killed writer can leave `extra=''` in a node row. `get_all_files` ran `json_extract(extra, '$.virtual')` over every non-File row, so SQLite raised `malformed JSON` and crashed **every** caller — build, status, visualize, watch.

Two changes in the WHERE clause:

1. **Malformed rows survive**: `extra IS NULL OR json_valid(extra) = 0` keeps a row with empty/truncated `extra` in the file inventory instead of aborting the query.
2. **Truthiness, not key presence**: `COALESCE(json_extract(extra, '$.virtual'), 0) != 1`. Previously the presence of the key alone hid a row, so `extra='{"virtual": false}'` was invisible to reconciliation and immortal; now only `virtual: true` (resolver-managed, e.g. Spring Event markers) stays out of the inventory.

## Testing

- New regression `test_get_all_files_survives_malformed_extra_and_false_virtual`: inserts rows with `extra=''`, `{"virtual": false}`, and `{"virtual": true}`, then asserts the split — malformed and false-virtual paths are returned, true-virtual stays excluded. **Fails against the previous query** (verified by checkout mutation: `OperationalError: malformed JSON`), passes with the fix.
- `pytest tests/test_graph.py tests/test_incremental.py` — **176 passed** (2 symlink-privilege tests deselected, a pre-existing Windows-environment limitation, same as #860/#861).
- `ruff check code_review_graph/graph.py tests/test_incremental.py` — all checks passed.

Fixes #864