### PR TITLE
Apply lifecycle test-gap exemptions to review guidance

### DIFF
--- a/code_review_graph/changes.py
+++ b/code_review_graph/changes.py
@@ -31,6 +31,11 @@ _TEST_GAP_EXEMPT_NAMES = frozenset({
     "__construct", "__init__", "__destruct",
 })
 
+
+def is_test_gap_exempt(node: GraphNode) -> bool:
+    """Return whether a lifecycle node is exempt from test-gap reporting."""
+    return node.kind == "Function" and node.name in _TEST_GAP_EXEMPT_NAMES
+
 _GIT_TIMEOUT = int(os.environ.get("CRG_GIT_TIMEOUT", "30"))  # seconds, configurable
 
 _SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9_.~^/@{}\-]+$")
@@ -363,9 +368,10 @@ def compute_risk_score(
     score += min(cross_community * 0.05, 0.15)
 
     # --- Test coverage (direct + transitive) ---
-    transitive_tests = store.get_transitive_tests(node.qualified_name)
-    test_count = len(transitive_tests)
-    score += 0.30 - (min(test_count / 5.0, 1.0) * 0.25)
+    if not is_test_gap_exempt(node):
+        transitive_tests = store.get_transitive_tests(node.qualified_name)
+        test_count = len(transitive_tests)
+        score += 0.30 - (min(test_count / 5.0, 1.0) * 0.25)
 
     # --- Security sensitivity ---
     name_lower = node.name.lower()
@@ -495,7 +501,7 @@ def analyze_changes(
     for node in changed_funcs:
         if node.is_test:
             continue
-        if node.name in _TEST_GAP_EXEMPT_NAMES:
+        if is_test_gap_exempt(node):
             continue
         # TESTED_BY edges are stored as source=production, target=test by the
         # parser, so a changed production function finds its tests by source.

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -6,7 +6,12 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from ..changes import analyze_changes, parse_diff_ranges, parse_git_diff_ranges  # noqa: F401
+from ..changes import (  # noqa: F401
+    analyze_changes,
+    is_test_gap_exempt,
+    parse_diff_ranges,
+    parse_git_diff_ranges,
+)
 from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..flows import get_affected_flows as _get_affected_flows
 from ..graph import edge_to_dict, node_to_dict
@@ -95,7 +100,10 @@ def get_review_context(
             tested_qualified = {e.source_qualified for e in test_edges}
             test_gap_count = sum(
                 1 for f in changed_funcs
-                if f.qualified_name not in tested_qualified
+                if (
+                    f.qualified_name not in tested_qualified
+                    and not is_test_gap_exempt(f)
+                )
             )
 
             summary_parts = [
@@ -240,7 +248,11 @@ def _generate_review_guidance(
 
     untested = [
         f for f in changed_funcs
-        if f.qualified_name not in tested_funcs and not f.is_test
+        if (
+            f.qualified_name not in tested_funcs
+            and not f.is_test
+            and not is_test_gap_exempt(f)
+        )
     ]
     if untested:
         guidance_parts.append(

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -245,6 +245,14 @@ class TestChanges:
         # Untested gets 0.30, tested gets 0.05 for test coverage component.
         assert untested_score > tested_score
 
+    def test_risk_score_lifecycle_method_has_no_untested_penalty(self):
+        """Lifecycle methods do not retain the untested risk penalty (#865)."""
+        self._add_func("setUp", path="a.py", line_start=1, line_end=10)
+        node = self.store.get_node("a.py::setUp")
+        assert node is not None
+
+        assert compute_risk_score(self.store, node) == 0.0
+
     def test_risk_score_security_keywords_boost(self):
         """Functions with security keywords score higher."""
         self._add_func("process_data", path="a.py")

--- a/tests/test_pr854_edges.py
+++ b/tests/test_pr854_edges.py
@@ -119,14 +119,14 @@ class TestExemptListEdges:
         assert "  - 0 test gap(s)" in result["summary"]
         assert "Untested:" not in result["summary"]
 
-    def test_exempt_nodes_still_counted_as_changed_and_risk_scored(self):
-        """Exemption only affects the gap list, not changed_functions."""
+    def test_exempt_nodes_still_counted_as_changed_without_gap_risk(self):
+        """Exemption affects gaps and their risk penalty, not changed_functions."""
         self._add_node("setUp", path="only.py", line_start=1, line_end=5)
 
         result = self._analyze("only.py", 1, 5)
         changed_names = {n["name"] for n in result["changed_functions"]}
         assert "setUp" in changed_names
-        assert result["risk_score"] > 0.0
+        assert result["risk_score"] == 0.0
         assert "  - 1 changed function(s)/class(es)" in result["summary"]
 
     def test_exempt_name_with_existing_coverage_stays_out(self):

--- a/tests/test_pr865_review_guidance.py
+++ b/tests/test_pr865_review_guidance.py
@@ -1,0 +1,31 @@
+"""Review-guidance consistency with lifecycle test-gap exemptions (#865)."""
+
+from types import SimpleNamespace
+
+from code_review_graph.tools.review import _generate_review_guidance
+
+
+def _function(name: str, qualified_name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        qualified_name=qualified_name,
+        kind="Function",
+        is_test=False,
+    )
+
+
+def test_review_guidance_exempts_lifecycle_methods():
+    impact = {
+        "changed_nodes": [
+            _function("setUp", "tests::setUp"),
+            _function("refresh_token", "auth::refresh_token"),
+        ],
+        "edges": [],
+        "impacted_nodes": [],
+        "impacted_files": [],
+    }
+
+    guidance = _generate_review_guidance(impact, ["auth.py"])
+
+    assert "setUp" not in guidance
+    assert "1 changed function(s) lack test coverage: refresh_token" in guidance


### PR DESCRIPTION
## Summary

`detect_changes` exempts lifecycle and construction methods from test-gap reporting, but the review surfaces still computed their own untested lists. This could report `setUp`, `tearDown`, `__construct`, and similar methods as coverage gaps even when change analysis correctly reported zero gaps.

This change centralizes the lifecycle predicate and applies it consistently to:

- minimal review-context test-gap counts;
- generated review guidance;
- risk scoring, so exempt lifecycle methods no longer retain the 0.30 untested penalty.

Fixes #865.

## Testing

- `pytest tests/test_changes.py tests/test_pr854_edges.py tests/test_pr865_review_guidance.py -q` — 47 passed
- Added regressions for:
  - review guidance omitting exempt lifecycle methods while retaining real gaps;
  - lifecycle risk having no untested penalty.
- `ruff check` on all changed files — passes
- `git diff --check` — passes

A full Windows test run was also executed: 2,625 tests passed and 75 failed. The failures are in pre-existing Windows/path/encoding-sensitive areas unrelated to these files; the targeted change-related suites pass.
