### PR TITLE
Handle comments in Go receiver types

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -14796,9 +14796,15 @@ class CodeParser:
         )
         receiver_type = parameter.child_by_field_name("type") if parameter else None
         while receiver_type is not None and receiver_type.type in {
-            "generic_type", "pointer_type",
+            "generic_type", "pointer_type", "parenthesized_type",
         }:
-            receiver_type = next(iter(receiver_type.named_children), None)
+            receiver_type = next(
+                (
+                    child for child in receiver_type.named_children
+                    if child.type != "comment"
+                ),
+                None,
+            )
         if receiver_type is None or receiver_type.type != "type_identifier":
             return None
         return receiver_type.text.decode("utf-8", errors="replace")

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -255,6 +255,26 @@ func (b *Box[T]) Pointer() {}
             if edge.kind == "CONTAINS" and edge.source.endswith("::Box")
         } == {"Box.Value", "Box.Pointer"}
 
+    def test_receiver_type_unwrap_skips_comments_and_parentheses(self):
+        nodes, _ = self.parser.parse_bytes(
+            Path("receiver_shapes.go"),
+            b"""package sample
+type Box[T any] struct{}
+func (b * /*receiver comment */ Box[T]) Commented() {}
+func (b (Box[T])) Parenthesized() {}
+""",
+        )
+
+        parents = {
+            node.name: node.parent_name
+            for node in nodes
+            if node.kind == "Function"
+        }
+        assert parents == {
+            "Commented": "Box",
+            "Parenthesized": "Box",
+        }
+
 
 class TestRustParsing:
     def setup_method(self):


### PR DESCRIPTION
## Summary

Go receiver type unwrapping previously took the first named child of `generic_type` and `pointer_type`. Tree-sitter comments are named extras, so a receiver such as:

```go
func (b * /*receiver comment*/ Box[T]) Commented() {}
```

landed on the comment node and lost method ownership. Parenthesized receiver types were also outside the unwrap set.

The unwrap loop now skips comment nodes and includes `parenthesized_type`.

Fixes #863.

## Testing

- Added a regression with a comment inside a generic pointer receiver and a parenthesized generic receiver.
- The regression fails on clean `main` with both methods losing their `Box` parent and passes with the fix.
- `pytest tests/test_multilang.py::TestGoParsing -q` — 28 passed
- `ruff check code_review_graph/parser.py tests/test_multilang.py` — passes
- `git diff --check` — passes
