### PR TITLE
Read Kotlin import names from AST children

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -13488,7 +13488,29 @@ class CodeParser:
                         if module_name and real_name and alias:
                             import_map[alias] = f"{module_name}.{real_name}"
 
-        elif language in ("java", "kotlin"):
+        elif language == "kotlin":
+            module = None
+            alias = None
+            wildcard = False
+            for child in node.children:
+                if child.type == "identifier":
+                    module = child.text.decode("utf-8", errors="replace")
+                elif child.type == "wildcard_import":
+                    wildcard = True
+                elif child.type == "import_alias":
+                    alias = next(
+                        (
+                            part.text.decode("utf-8", errors="replace")
+                            for part in child.children
+                            if part.type == "type_identifier"
+                        ),
+                        None,
+                    )
+            if module and not wildcard:
+                local_name = alias or module.rsplit(".", 1)[-1]
+                import_map[local_name] = module
+
+        elif language == "java":
             text = node.text.decode("utf-8", errors="replace").strip()
             if not text.startswith("import "):
                 return

--- a/tests/test_pr862_edges.py
+++ b/tests/test_pr862_edges.py
@@ -1,0 +1,30 @@
+"""Per-name Kotlin import attribution after folded trailing comments (#862)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def test_import_name_with_trailing_kdoc_still_attributes_calls(tmp_path: Path) -> None:
+    dep = tmp_path / "dep"
+    dep.mkdir()
+    (dep / "Helper.kt").write_text(
+        "package dep\n\nfun helper(): Int = 42\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "Main.kt"
+    source.write_text(
+        "package app\n\n"
+        "import dep.helper\n\n"
+        "/** document the consumer below the import */\n"
+        "class Main {\n"
+        "    fun run(): Int = helper()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(tmp_path).parse_file(source)
+    calls = [edge for edge in edges if edge.kind == "CALLS"]
+
+    assert len(calls) == 1
+    assert calls[0].target.endswith("Helper.kt::helper")


### PR DESCRIPTION
## Summary

`_extract_import` was fixed to read a Kotlin `import_header` identifier child instead of folded node text, but `_collect_import_names` still parsed raw text. When tree-sitter folded a trailing KDoc into the final import, the per-name import map stored a key containing the comment, so calls to that imported function remained unresolved.

The Kotlin branch now builds import bindings from AST children:

- identifier → module;
- `import_alias` → local alias;
- wildcard imports remain excluded from per-name bindings.

Java import handling remains unchanged.

Fixes #862.

## Testing

- Added an end-to-end regression with `import dep.helper`, a trailing KDoc, and a `helper()` call.
- On clean `main`, the call target stayed unresolved as `helper`; with the fix it resolves to `dep/Helper.kt::helper`.
- `pytest tests/test_pr862_edges.py tests/test_kotlin_imports.py tests/test_pr824_edges.py -q` — 23 passed
- `ruff check` on changed files — passes
- `git diff --check` — passes
