### PR TITLE
Address August sweep follow-ups

### DIFF
--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -1658,7 +1658,10 @@ def main() -> None:
             # materialize graph state when neither database exists.
             db_path = get_db_path(repo_root)
     else:
-        db_path = get_db_path(repo_root)
+        db_path = get_db_path(
+            repo_root,
+            read_only=args.command in ("dead-code", "forget"),
+        )
     if (
         args.command in ("dead-code", "forget", *_read_only_db_cmds)
         and not db_path.exists()

--- a/code_review_graph/daemon_cli.py
+++ b/code_review_graph/daemon_cli.py
@@ -23,6 +23,21 @@ import time
 logger = logging.getLogger(__name__)
 
 
+def _configure_utf8_stdio() -> None:
+    """Allow Unicode daemon output on streams using a legacy encoding."""
+    for stream in (sys.stdout, sys.stderr):
+        encoding = getattr(stream, "encoding", None)
+        if not encoding or encoding.lower().replace("-", "") == "utf8":
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Subcommand handlers
 # ---------------------------------------------------------------------------
@@ -78,6 +93,12 @@ def _handle_stop(_args: argparse.Namespace) -> None:
     except PermissionError:
         print(f"Error: Permission denied sending signal to PID {pid}.")
         sys.exit(1)
+    except OSError:
+        # Windows can report WinError 87 when a PID vanishes during the
+        # terminate syscall. Treat that narrow race like ProcessLookupError.
+        clear_pid()
+        print("Daemon stopped (process already gone).")
+        return
 
     try:
         # Wait up to 5 seconds for process to die.
@@ -90,7 +111,7 @@ def _handle_stop(_args: argparse.Namespace) -> None:
             force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
             try:
                 os.kill(pid, force_signal)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 pass
     finally:
         clear_pid()
@@ -236,6 +257,7 @@ def _handle_remove(args: argparse.Namespace) -> None:
 
 def main() -> None:
     """Entry point for the crg-daemon CLI."""
+    _configure_utf8_stdio()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     ap = argparse.ArgumentParser(

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -13654,7 +13654,9 @@ class CodeParser:
             if module.startswith("."):
                 # Relative import — resolve from caller's directory
                 base = caller_dir / module
-                extensions = [".ts", ".tsx", ".js", ".jsx", ".vue"]
+                extensions = [
+                    ".ts", ".tsx", ".js", ".jsx", ".vue", ".mts", ".cts",
+                ]
                 # Try exact path first (might already have extension)
                 if base.is_file():
                     return str(base.resolve())
@@ -13672,8 +13674,14 @@ class CodeParser:
                         return str(target.resolve())
                 # ESM/NodeNext writes `./foo.js` for a file that is `foo.ts` on
                 # disk; only here does replacing the suffix become correct.
-                if base.suffix in (".js", ".jsx", ".mjs", ".cjs"):
-                    for ext in (".ts", ".tsx"):
+                suffix_substitutions = {
+                    ".js": (".ts", ".tsx", ".jsx"),
+                    ".jsx": (".ts", ".tsx"),
+                    ".mjs": (".mts",),
+                    ".cjs": (".cts",),
+                }
+                if base.suffix in suffix_substitutions:
+                    for ext in suffix_substitutions[base.suffix]:
                         target = base.with_suffix(ext)
                         if target.is_file():
                             return str(target.resolve())

--- a/code_review_graph/tools/review.py
+++ b/code_review_graph/tools/review.py
@@ -331,6 +331,7 @@ def get_affected_flows_func(
                 "summary": "No changed files detected.",
                 "affected_flows": [],
                 "total": 0,
+                "truncated": False,
             }
 
         # Convert to absolute paths for graph lookup. Graph identity uses

--- a/tests/test_cli_reconciliation.py
+++ b/tests/test_cli_reconciliation.py
@@ -483,7 +483,8 @@ def test_dead_code_missing_graph_exits_nonzero(tmp_path, monkeypatch, capsys):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
-    monkeypatch.setenv("CRG_DATA_DIR", str(tmp_path / "missing-data"))
+    data_dir = tmp_path / "missing-data"
+    monkeypatch.setenv("CRG_DATA_DIR", str(data_dir))
     argv = ["code-review-graph", "dead-code", "--repo", str(repo)]
 
     with patch.object(sys, "argv", argv):
@@ -492,3 +493,4 @@ def test_dead_code_missing_graph_exits_nonzero(tmp_path, monkeypatch, capsys):
 
     assert exc_info.value.code == 1
     assert "No graph found" in capsys.readouterr().err
+    assert not data_dir.exists()

--- a/tests/test_pr866_followups.py
+++ b/tests/test_pr866_followups.py
@@ -1,0 +1,93 @@
+"""Focused regressions for the August PR-sweep follow-ups (#866)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from code_review_graph.daemon_cli import _configure_utf8_stdio, _handle_stop
+from code_review_graph.parser import CodeParser
+from code_review_graph.tools.review import get_affected_flows_func
+
+
+def test_affected_flows_empty_result_includes_truncated(monkeypatch, tmp_path):
+    store = MagicMock()
+    monkeypatch.setattr(
+        "code_review_graph.tools.review._get_store",
+        lambda _root: (store, tmp_path),
+    )
+
+    result = get_affected_flows_func(changed_files=[], repo_root=str(tmp_path))
+
+    assert result["truncated"] is False
+
+
+def test_js_specifier_resolves_jsx_source(tmp_path: Path) -> None:
+    caller = tmp_path / "app.mts"
+    caller.write_text('import "./foo.js"\n', encoding="utf-8")
+    (tmp_path / "foo.jsx").write_text("export {}\n", encoding="utf-8")
+
+    resolved = CodeParser()._resolve_module_to_file(
+        "./foo.js", str(caller), "typescript"
+    )
+
+    assert resolved == (tmp_path / "foo.jsx").as_posix()
+
+
+def test_mjs_specifier_resolves_mts_source(tmp_path: Path) -> None:
+    caller = tmp_path / "app.mts"
+    caller.write_text('import "./foo.mjs"\n', encoding="utf-8")
+    (tmp_path / "foo.mts").write_text("export {}\n", encoding="utf-8")
+
+    resolved = CodeParser()._resolve_module_to_file(
+        "./foo.mjs", str(caller), "typescript"
+    )
+
+    assert resolved == (tmp_path / "foo.mts").as_posix()
+
+
+def test_cjs_specifier_resolves_cts_source(tmp_path: Path) -> None:
+    caller = tmp_path / "app.cts"
+    caller.write_text('import "./foo.cjs"\n', encoding="utf-8")
+    (tmp_path / "foo.cts").write_text("export {}\n", encoding="utf-8")
+
+    resolved = CodeParser()._resolve_module_to_file(
+        "./foo.cjs", str(caller), "typescript"
+    )
+
+    assert resolved == (tmp_path / "foo.cts").as_posix()
+
+
+def test_daemon_stop_treats_windows_race_oserror(monkeypatch, capsys):
+    monkeypatch.setattr("code_review_graph.daemon.is_daemon_running", lambda: True)
+    monkeypatch.setattr("code_review_graph.daemon.read_pid", lambda: 123)
+    monkeypatch.setattr(
+        "code_review_graph.daemon_cli.os.kill",
+        lambda *_args: (_ for _ in ()).throw(OSError(87, "The parameter is incorrect.")),
+    )
+    cleared = []
+    monkeypatch.setattr("code_review_graph.daemon.clear_pid", lambda: cleared.append(True))
+
+    _handle_stop(MagicMock())
+
+    assert cleared == [True]
+    assert "already gone" in capsys.readouterr().out
+
+
+def test_daemon_utf8_stdio_reconfigures_legacy_streams(monkeypatch):
+    calls = []
+
+    class Stream:
+        encoding = "cp1252"
+
+        def reconfigure(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "sys.stdout", Stream(), raising=False
+    )
+    monkeypatch.setattr(
+        "sys.stderr", Stream(), raising=False
+    )
+
+    _configure_utf8_stdio()
+
+    assert calls == [{"encoding": "utf-8"}, {"encoding": "utf-8"}]


### PR DESCRIPTION
## Summary

Addresses the small follow-ups collected in #866:

- `get_affected_flows` now includes `truncated: false` on its no-changed-files early return.
- JS/TS module suffix substitution now supports:
  - `./foo.js` → `foo.jsx`;
  - `./foo.mjs` → `foo.mts`;
  - `./foo.cjs` → `foo.cts`;
  - direct `.mts` / `.cts` source resolution.
- `dead-code` and `forget` resolve their graph path in read-only mode so a missing graph no longer creates an empty `.code-review-graph/` directory.
- `crg-daemon` configures UTF-8 stdio like the main CLI.
- Daemon forced-stop handles the Windows race where a vanished PID raises `OSError`/WinError 87.

Fixes #866.

## Testing

- Added focused regressions for each code-level follow-up.
- Extended the missing-graph CLI test to assert that no data directory is materialized.
- `pytest tests/test_pr866_followups.py tests/test_cli_reconciliation.py::test_dead_code_missing_graph_exits_nonzero -q` — 7 passed
- `ruff check` on all changed files — passes
- `git diff --check` — passes
