### PR TITLE
Import PHP include and require targets

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -1086,7 +1086,13 @@ _IMPORT_TYPES: dict[str, list[str]] = {
     "perl": ["use_statement", "require_expression"],
     "kotlin": ["import_header"],
     "swift": ["import_declaration"],
-    "php": ["namespace_use_declaration"],
+    "php": [
+        "namespace_use_declaration",
+        "include_expression",
+        "include_once_expression",
+        "require_expression",
+        "require_once_expression",
+    ],
     "scala": ["import_declaration"],
     "solidity": ["import_directive"],
     # Dart: import_or_export wraps library_import > import_specification > configurable_uri
@@ -13788,7 +13794,12 @@ class CodeParser:
             # ``.../App/Foo``) resolve; vendor/global classes (``\Exception``)
             # and ``use function`` / ``use const`` targets with no matching
             # file stay unresolved and keep the bare FQN, like JDK imports.
-            rel_path = module.replace("\\", "/").lstrip("/") + ".php"
+            normalized_module = module.replace("\\", "/").lstrip("/")
+            rel_path = (
+                normalized_module
+                if normalized_module.endswith(".php")
+                else normalized_module + ".php"
+            )
             try:
                 boundary = self._php_repository_boundary(caller_dir)
                 current = caller_dir.resolve()
@@ -15708,6 +15719,22 @@ class CodeParser:
                     if txt and txt != "extends":
                         imports.append(txt)
         elif language == "php":
+            include_types = {
+                "include_expression",
+                "include_once_expression",
+                "require_expression",
+                "require_once_expression",
+            }
+            if node.type in include_types:
+                for child in node.children:
+                    if child.type == "string":
+                        value = child.text.decode(
+                            "utf-8", errors="replace",
+                        ).strip("'\"")
+                        if value:
+                            imports.append(value)
+                return imports
+
             # ``namespace_use_declaration`` covers several shapes:
             #   use A\B\C;            use A\B\C as D;
             #   use function A\b;     use const A\B;

--- a/tests/test_pr819_php_includes.py
+++ b/tests/test_pr819_php_includes.py
@@ -1,0 +1,39 @@
+"""PHP include/require import edge regressions (#819)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def test_require_once_resolves_relative_php_file(tmp_path: Path) -> None:
+    includes = tmp_path / "includes"
+    includes.mkdir()
+    dependency = includes / "conexao.php"
+    dependency.write_text("<?php\nfunction connect() {}\n", encoding="utf-8")
+    source = tmp_path / "index.php"
+    source.write_text(
+        "<?php\nrequire_once 'includes/conexao.php';\nconnect();\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(tmp_path).parse_file(source)
+    imports = [edge for edge in edges if edge.kind == "IMPORTS_FROM"]
+
+    assert len(imports) == 1
+    assert imports[0].target == dependency.resolve().as_posix()
+
+
+def test_include_once_resolves_relative_php_file(tmp_path: Path) -> None:
+    dependency = tmp_path / "helper.php"
+    dependency.write_text("<?php\nfunction helper() {}\n", encoding="utf-8")
+    source = tmp_path / "index.php"
+    source.write_text(
+        "<?php\ninclude_once 'helper.php';\nhelper();\n",
+        encoding="utf-8",
+    )
+
+    _, edges = CodeParser(tmp_path).parse_file(source)
+    imports = [edge for edge in edges if edge.kind == "IMPORTS_FROM"]
+
+    assert len(imports) == 1
+    assert imports[0].target == dependency.resolve().as_posix()


### PR DESCRIPTION
## Summary

PHP `use` declarations produced import edges, but procedural PHP files wired together with `include`, `include_once`, `require`, and `require_once` had no `IMPORTS_FROM` edges. Impact radius and importer queries therefore saw no cross-file structure for non-Composer codebases.

The parser now treats all four include/require expression forms as import nodes, extracts their string argument, and resolves relative paths ending in `.php` without appending a second extension.

Fixes #819.

## Testing

- Added end-to-end regressions for:
  - `require_once 'includes/conexao.php'`;
  - `include_once 'helper.php'`.
- Both tests fail on clean `main` with zero import edges and pass with the fix.
- `pytest tests/test_pr819_php_includes.py -q` — 2 passed
- `pytest tests/test_php_scoped_calls.py tests/test_php_laravel.py tests/test_pr819_php_includes.py -q` — 56 passed, 2 skipped, plus one pre-existing Windows path-separator assertion unchanged by this patch
- `ruff check` on changed files — passes
- `git diff --check` — passes
