### PR TITLE
Prefilter plain C headers before C++ parsing

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2614,15 +2614,16 @@ class CodeParser:
         tree = None
         parse_source = source
         if language == "c" and path.suffix.lower() == ".h":
-            cpp_parser = self._get_parser("cpp")
-            if cpp_parser is not None:
-                cpp_source = self._mask_cpp_qt_macros(source)
-                cpp_tree = cpp_parser.parse(cpp_source)
-                if self._has_cpp_header_evidence(cpp_tree.root_node):
-                    language = "cpp"
-                    parser = cpp_parser
-                    tree = cpp_tree
-                    parse_source = cpp_source
+            if self._has_cpp_header_text_evidence(source):
+                cpp_parser = self._get_parser("cpp")
+                if cpp_parser is not None:
+                    cpp_source = self._mask_cpp_qt_macros(source)
+                    cpp_tree = cpp_parser.parse(cpp_source)
+                    if self._has_cpp_header_evidence(cpp_tree.root_node):
+                        language = "cpp"
+                        parser = cpp_parser
+                        tree = cpp_tree
+                        parse_source = cpp_source
         elif language == "cpp":
             parse_source = self._mask_cpp_qt_macros(source)
 
@@ -2824,8 +2825,21 @@ class CodeParser:
         return False
 
     @staticmethod
+    def _has_cpp_header_text_evidence(source: bytes) -> bool:
+        """Cheaply decide whether a C header merits a speculative C++ parse."""
+        return any(
+            token in source
+            for token in (
+                b"class", b"namespace", b"template", b"::",
+                b"constexpr", b"noexcept", b"->",
+            )
+        )
+
+    @staticmethod
     def _mask_cpp_qt_macros(source: bytes) -> bytes:
         """Shield structural Qt macros without changing byte or line offsets."""
+        if b"Q_" not in source and b"QT_" not in source:
+            return source
         masked = bytearray(source)
         length = len(source)
         index = 0

--- a/tests/test_pr802_cpp_prefilter.py
+++ b/tests/test_pr802_cpp_prefilter.py
@@ -1,0 +1,36 @@
+"""C/C++ parse-throughput prefilters (#802)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def test_plain_c_header_skips_speculative_cpp_parser(monkeypatch):
+    source = b"struct point { int x; int y; };\nint distance(struct point p);\n"
+
+    original_parser = CodeParser._get_parser
+
+    def guarded_parser(parser_self, language):
+        if language == "cpp":
+            raise AssertionError("plain C header must not probe the C++ parser")
+        return original_parser(parser_self, language)
+
+    monkeypatch.setattr(CodeParser, "_get_parser", guarded_parser)
+
+    nodes, _ = CodeParser().parse_bytes(Path("point.h"), source)
+
+    assert "point" in {node.name for node in nodes}
+
+
+def test_cpp_header_still_uses_speculative_parser():
+    source = b"namespace sample { struct Wrapper { class Inner {}; }; }\n"
+
+    nodes, _ = CodeParser().parse_bytes(Path("wrapper.h"), source)
+
+    assert {node.name for node in nodes} >= {"Wrapper", "Inner"}
+
+
+def test_qt_mask_skips_sources_without_structural_macros():
+    source = b"int ordinary_function(int value) { return value + 1; }\n"
+
+    assert CodeParser._mask_cpp_qt_macros(source) is source


### PR DESCRIPTION
## Summary

Header promotion introduced two throughput costs for plain C repositories:

- every `.h` file paid a speculative tree-sitter-cpp parse;
- every C++ file paid the per-byte Qt macro masking walk even when no Qt macros existed.

This change adds cheap source-level prefilters:

- `.h` files are only speculatively parsed as C++ when they contain textual evidence such as `class`, `namespace`, `template`, `::`, `constexpr`, `noexcept`, or a trailing return arrow;
- Qt macro masking returns immediately when the source contains neither `Q_` nor `QT_`.

Qt/C++ behavior is unchanged when those signals are present.

Fixes #802.

## Testing

- Added a plain C header regression that fails if the C++ parser is probed.
- Added a C++ header regression confirming speculative promotion still happens.
- Added a direct Qt-mask fast-path regression.
- Existing Qt header behavior remains covered.
- `pytest tests/test_pr802_cpp_prefilter.py tests/test_cpp_qt_headers.py -q` — 17 passed
- `ruff check` on changed files — passes
- `git diff --check` — passes
