### PR TITLE
Add Windows overrides for Codex hooks

### DIFF
--- a/code_review_graph/skills.py
+++ b/code_review_graph/skills.py
@@ -1094,6 +1094,12 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 " && code-review-graph update --skip-flows"
                                 " || true"
                             ),
+                            "commandWindows": (
+                                'powershell.exe -NoProfile -NonInteractive -Command "'
+                                "[Console]::In.ReadToEnd() | Out-Null; "
+                                "if ((git rev-parse --git-dir) -eq $null) { exit 0 }; "
+                                'code-review-graph update --skip-flows; exit 0"'
+                            ),
                             "timeout": 30,
                             "statusMessage": "Updating code-review-graph",
                         },
@@ -1111,6 +1117,13 @@ def generate_codex_hooks_config(repo_root: Path) -> dict[str, Any]:
                                 "git rev-parse --git-dir >/dev/null 2>&1"
                                 " && code-review-graph status"
                                 " || echo 'Not a git repo, skipping'"
+                            ),
+                            "commandWindows": (
+                                'powershell.exe -NoProfile -NonInteractive -Command "'
+                                "[Console]::In.ReadToEnd() | Out-Null; "
+                                "if ((git rev-parse --git-dir) -eq $null) { "
+                                "'Not a git repo, skipping'; exit 0 }; "
+                                'code-review-graph status; exit 0"'
                             ),
                             "timeout": 10,
                             "statusMessage": "Checking code-review-graph status",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -584,6 +584,23 @@ class TestGenerateCodexHooksConfig:
         assert "code-review-graph update --skip-flows" in post_cmd
         assert "code-review-graph status" in session_cmd
 
+    def test_windows_commands_drain_stdin_and_exit_successfully(self, tmp_path):
+        config = generate_codex_hooks_config(tmp_path)
+        post = config["hooks"]["PostToolUse"][0]["hooks"][0]
+        session = config["hooks"]["SessionStart"][0]["hooks"][0]
+
+        for command in (post["commandWindows"], session["commandWindows"]):
+            assert command.startswith(
+                'powershell.exe -NoProfile -NonInteractive -Command "'
+            )
+            assert "[Console]::In.ReadToEnd() | Out-Null" in command
+            assert "git rev-parse --git-dir" in command
+            assert command.endswith('exit 0"')
+
+        assert "code-review-graph update --skip-flows" in post["commandWindows"]
+        assert "code-review-graph status" in session["commandWindows"]
+        assert "Not a git repo, skipping" in session["commandWindows"]
+
 
 class TestInstallCodexHooks:
     def test_creates_hooks_file(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The generated Codex hooks previously contained only Unix shell commands. On Windows, Codex attempted to run `cat`, `/dev/null`, and Unix shell chaining, causing PostToolUse hook failures.

Both generated hooks now include `commandWindows` overrides using PowerShell:

- drain stdin with `[Console]::In.ReadToEnd()`;
- check whether the current directory is a Git repository;
- run the graph update or status command;
- always exit successfully, matching the Unix `|| true` behavior;
- print `Not a git repo, skipping` for the startup hook outside Git repositories.

Fixes #620.

## Testing

- Added regressions asserting both Windows overrides drain stdin, perform the Git check, invoke the correct graph command, and end successfully.
- `pytest tests/test_skills.py::TestGenerateCodexHooksConfig tests/test_skills.py::TestInstallCodexHooks -q` — 12 passed
- `ruff check code_review_graph/skills.py tests/test_skills.py` — passes
- `git diff --check` — passes
