### PR TITLE
Index Liquid templates

### DIFF
--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -782,6 +782,7 @@ EXTENSION_TO_LANGUAGE: dict[str, str] = {
     ".properties": "properties",
     ".yml": "yaml",
     ".yaml": "yaml",
+    ".liquid": "liquid",
 }
 
 # ``.h`` is shared by C and C++. Keep C as the extension default, then promote
@@ -2410,6 +2411,21 @@ class CodeParser:
     _BLADE_DIRECTIVE_RE = re.compile(
         r"""(?<!@)@(extends|include|component|livewire)\s*\(\s*(['"])([^'"]+)\2\s*\)""",
     )
+    _LIQUID_COMMENT_RE = re.compile(
+        r"\{%-?\s*comment\s*-?%\}.*?\{%-?\s*endcomment\s*-?%\}",
+        re.DOTALL,
+    )
+    _LIQUID_TAG_RE = re.compile(
+        r"\{%-?\s*([A-Za-z_][A-Za-z0-9_-]*)(.*?)-?%\}",
+        re.DOTALL,
+    )
+    _LIQUID_OUTPUT_RE = re.compile(r"\{\{-?\s*(.*?)\s*-?\}\}", re.DOTALL)
+    _LIQUID_ASSIGN_RE = re.compile(
+        r"(?<![\w-])assign\s+([A-Za-z_][A-Za-z0-9_]*)\s*="
+    )
+    _LIQUID_RENDER_RE = re.compile(
+        r"(?<![\w-])(render|include)\s+(['\"])([^'\"]+)\2"
+    )
     _LARAVEL_ROUTE_FACADE = "Illuminate\\Support\\Facades\\Route"
     _LARAVEL_ELOQUENT_MODEL = "Illuminate\\Database\\Eloquent\\Model"
     _LARAVEL_ROUTE_VERBS = frozenset({
@@ -2628,6 +2644,8 @@ class CodeParser:
 
         if language == "blade":
             return self._parse_blade(path, source)
+        if language == "liquid":
+            return self._parse_liquid(path, source)
 
         # Vue SFCs: parse with vue parser, then delegate script blocks to JS/TS
         if language == "vue":
@@ -2967,6 +2985,87 @@ class CodeParser:
                 line=masked.count("\n", 0, match.start()) + 1,
                 extra={"blade_directive": directive},
             ))
+        return nodes, edges
+
+    @classmethod
+    def _mask_liquid_comments(cls, text: str) -> str:
+        """Mask Liquid comments while preserving offsets and line numbers."""
+        def replace_comment(match: re.Match[str]) -> str:
+            return "".join(
+                character if character in "\r\n" else " "
+                for character in match.group(0)
+            )
+
+        return cls._LIQUID_COMMENT_RE.sub(replace_comment, text)
+
+    def _parse_liquid(
+        self,
+        path: Path,
+        source: bytes,
+    ) -> tuple[list[NodeInfo], list[EdgeInfo]]:
+        """Index Liquid files without requiring a dedicated Tree-sitter grammar."""
+        text = source.decode("utf-8", errors="replace")
+        masked = self._mask_liquid_comments(text)
+        file_path = normalize_file_path(path)
+        nodes = [
+            NodeInfo(
+                kind="File",
+                name=file_path,
+                file_path=file_path,
+                line_start=1,
+                line_end=source.count(b"\n") + 1,
+                language="liquid",
+                is_test=_is_test_file(file_path),
+            ),
+        ]
+        edges: list[EdgeInfo] = []
+
+        def line_at(offset: int) -> int:
+            return masked.count("\n", 0, offset) + 1
+
+        for match in self._LIQUID_OUTPUT_RE.finditer(masked):
+            expression = " ".join(match.group(1).split())
+            if not expression:
+                continue
+            line = line_at(match.start())
+            nodes.append(NodeInfo(
+                kind="Output",
+                name=f"output_{line}:{expression[:120]}",
+                file_path=file_path,
+                line_start=line,
+                line_end=line_at(match.end()),
+                language="liquid",
+            ))
+
+        for tag_match in self._LIQUID_TAG_RE.finditer(masked):
+            tag = tag_match.group(1)
+            body = tag_match.group(2)
+            segments = [body] if tag == "liquid" else []
+            if tag in ("assign", "render", "include"):
+                segments.append(f"{tag}{body}")
+            for segment in segments:
+                for assign in self._LIQUID_ASSIGN_RE.finditer(segment):
+                    line = line_at(tag_match.start(2) + assign.start())
+                    nodes.append(NodeInfo(
+                        kind="Variable",
+                        name=assign.group(1),
+                        file_path=file_path,
+                        line_start=line,
+                        line_end=line,
+                        language="liquid",
+                    ))
+
+                for render in self._LIQUID_RENDER_RE.finditer(segment):
+                    offset = tag_match.start(2) + render.start()
+                    edges.append(EdgeInfo(
+                        kind="REFERENCES",
+                        source=file_path,
+                        target=render.group(3),
+                        file_path=file_path,
+                        line=line_at(offset),
+                        extra={"liquid_directive": render.group(1)},
+                    ))
+
         return nodes, edges
 
     def _parse_vue(

--- a/tests/test_liquid.py
+++ b/tests/test_liquid.py
@@ -1,0 +1,59 @@
+"""Liquid template indexing (#348)."""
+
+from pathlib import Path
+
+from code_review_graph.parser import CodeParser
+
+
+def test_liquid_file_has_file_assignment_and_render_nodes(tmp_path: Path) -> None:
+    template = tmp_path / "snippets" / "product-grid.liquid"
+    template.parent.mkdir()
+    template.write_text(
+        "{% assign product_grid = products %}\n"
+        "{{ product_grid }}\n"
+        "{% render 'product-card', product: product %}\n"
+        "{% comment %}{% render 'commented-out' %}{% endcomment %}\n",
+        encoding="utf-8",
+    )
+
+    parser = CodeParser(tmp_path)
+    nodes, edges = parser.parse_file(template)
+
+    assert parser.detect_language(template) == "liquid"
+    file_nodes = [node for node in nodes if node.kind == "File"]
+    variables = {
+        node.name: (node.line_start, node.line_end)
+        for node in nodes
+        if node.kind == "Variable"
+    }
+    outputs = [node for node in nodes if node.kind == "Output"]
+    rendered = {
+        edge.target
+        for edge in edges
+        if edge.kind == "REFERENCES"
+    }
+
+    assert len(file_nodes) == 1
+    assert file_nodes[0].language == "liquid"
+    assert file_nodes[0].line_end == 5
+    assert variables == {"product_grid": (1, 1)}
+    assert len(outputs) == 1
+    assert rendered == {"product-card"}
+
+
+def test_whitespace_liquid_tag_is_indexed(tmp_path: Path) -> None:
+    template = tmp_path / "collection.liquid"
+    template.write_text(
+        "{% liquid\n"
+        "assign featured = collection.products\n"
+        "render 'featured-card'\n"
+        "%}\n",
+        encoding="utf-8",
+    )
+
+    nodes, edges = CodeParser(tmp_path).parse_file(template)
+
+    assert "featured" in {node.name for node in nodes if node.kind == "Variable"}
+    assert "featured-card" in {
+        edge.target for edge in edges if edge.kind == "REFERENCES"
+    }


### PR DESCRIPTION
## Summary

`.liquid` files were not recognized by `detect_language`, so full builds excluded them and file summaries returned zero nodes.

This adds a structural, regex-based Liquid parser that indexes:

- a `File` node for every template;
- `Variable` nodes for `assign` declarations, including whitespace `liquid` blocks;
- `Output` nodes for non-empty `{{ ... }}` expressions;
- `REFERENCES` edges for static `render` and `include` targets.

Liquid comments are masked while preserving byte offsets and line numbers, so directives inside comments are not indexed.

Fixes #348.

## Testing

- Added regressions for:
  - ordinary `assign`, output, `render`, and comment masking;
  - whitespace `{% liquid ... %}` blocks.
- `pytest tests/test_liquid.py -q` — 2 passed
- `ruff check code_review_graph/parser.py tests/test_liquid.py` — passes
- `git diff --check` — passes
