### PR TITLE
fix(watch): exit when the observer emitter thread dies silently

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -17,7 +17,7 @@ import sys
 import threading
 import time
 from pathlib import Path, PurePosixPath
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from .graph import GraphStore
 from .parser import CodeParser, normalize_file_path
@@ -1537,6 +1537,21 @@ def _create_watch_handler(
     return GraphUpdateHandler()
 
 
+def _observer_threads_alive(observer: "Any") -> bool:
+    """Whether the watchdog observer AND every emitter thread are still alive.
+
+    The watchdog observer thread itself can stay alive after an internal
+    emitter reader thread has crashed (the inotify ``_wd_for_path`` KeyError
+    under heavy create/delete churn, or the Windows
+    ``ReadDirectoryChangesW`` equivalent). A dead emitter silently stops
+    delivering events while ``daemon status`` keeps reporting the child
+    process as alive, so watch() must treat emitter death as fatal (#811).
+    """
+    if not observer.is_alive():
+        return False
+    return all(emitter.is_alive() for emitter in observer.emitters)
+
+
 def watch(
     repo_root: Path,
     store: GraphStore,
@@ -1574,6 +1589,15 @@ def watch(
         while True:
             _time.sleep(1)
             handler.raise_if_failed()
+            if not _observer_threads_alive(observer):
+                # Emitter-thread death is silent for the process: poll-based
+                # daemon health checks cannot see it. Exit the child so the
+                # daemon restarts watch instead of serving a frozen graph (#811).
+                logger.critical(
+                    "watch observer thread died; exiting so the daemon can "
+                    "restart watch (see issue #811)"
+                )
+                raise SystemExit(1)
     except KeyboardInterrupt:
         observer.stop()
     finally:

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1813,3 +1813,37 @@ class TestRenamePurgeParity:
             assert store.get_nodes_by_file(str(tmp_path / "b.py"))
         finally:
             store.close()
+
+
+class TestWatchObserverLiveness:
+    """#811: an emitter-thread death must exit watch(), not freeze silently."""
+
+    @staticmethod
+    def _fake_observer(observer_alive: bool, emitter_alive: bool):
+        class _Emitter:
+            def __init__(self, alive: bool) -> None:
+                self._alive = alive
+
+            def is_alive(self) -> bool:
+                return self._alive
+
+        class _Shim:
+            is_alive = staticmethod(lambda: observer_alive)
+            emitters = [_Emitter(emitter_alive)]
+
+        return _Shim()
+
+    def test_alive_observer_with_alive_emitter_is_healthy(self):
+        from code_review_graph.incremental import _observer_threads_alive
+
+        assert _observer_threads_alive(self._fake_observer(True, True))
+
+    def test_dead_observer_is_not_healthy(self):
+        from code_review_graph.incremental import _observer_threads_alive
+
+        assert not _observer_threads_alive(self._fake_observer(False, True))
+
+    def test_dead_emitter_is_not_healthy_even_if_observer_lives(self):
+        from code_review_graph.incremental import _observer_threads_alive
+
+        assert not _observer_threads_alive(self._fake_observer(True, False))


### PR DESCRIPTION
## Summary

A watchdog **emitter reader thread** can crash under heavy create/delete churn — the inotify `_wd_for_path` `KeyError` when Maven Surefire forks churn `target/surefire/`, or the Windows `ReadDirectoryChangesW` variant (both documented in #811) — while the observer thread itself stays alive. The child process keeps passing the daemon's `proc.poll()`-based health check while delivering **no** filesystem events: `daemon status` stays green, `built_at_sha` freezes, and every subsequent edit/`git pull` is missed until a manual restart.

The watch loop now checks `_observer_threads_alive(observer)` — the observer thread **and every emitter thread** — once per second. On the first dead thread it logs `critical` and raises `SystemExit(1)`, exiting the child so the daemon's existing restart path recovers watch instead of silently serving a stale graph forever.

This deliberately implements the issue's fix option 2 (exit so poll-based health checks catch it) rather than option 1 (per-subdirectory scheduling): it covers both the Linux and Windows thread variants, and the reproducer requires churn that a Windows-CI test cannot drive. A follow-up can layer schedule-time ignore filtering on top without conflicting.

## Testing

- New `TestWatchObserverLiveness` (3 cases): alive observer + alive emitter → healthy; dead observer → not healthy; **dead emitter with alive observer → not healthy** (the exact silent-death shape from #811).
- `pytest tests/test_graph.py tests/test_incremental.py` — **178 passed** (2 symlink-privilege tests deselected, the same pre-existing Windows-environment limitation noted in #860/#861/#870).
- `ruff check code_review_graph/incremental.py tests/test_incremental.py` — all checks passed.

Verification boundary: the end-to-end kill (driving a real inotify race under Maven churn) requires the Linux/WSL environment from the report; the unit tests pin the liveness predicate and the exit decision it feeds.

Fixes #811