### PR TITLE
fix(typescript): resolve npm aliases to workspace packages

### DIFF
--- a/code_review_graph/npm_alias_resolver.py
+++ b/code_review_graph/npm_alias_resolver.py
@@ -1,0 +1,258 @@
+"""Resolve npm dependency aliases to local workspace packages."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+_PROBE_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx", ".vue")
+_TYPESCRIPT_SOURCE_EXTENSIONS = {
+    ".js": (".ts", ".tsx"),
+    ".jsx": (".tsx",),
+    ".mjs": (".ts",),
+    ".cjs": (".ts",),
+}
+_DEPENDENCY_SECTIONS = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
+# Generated dependency trees can contain thousands of manifests and duplicate
+# package names. npm aliases are useful to the graph only when they point at
+# source that is intentionally part of the repository.
+_SKIPPED_DIRECTORIES = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "node_modules",
+}
+
+
+class NpmAliasResolver:
+    """Resolve ``alias/subpath`` imports declared with npm aliases.
+
+    npm allows a dependency key to differ from its real package name:
+    ``"sharedLib": "npm:@scope/shared@^1.0.0"``. Source imports then use
+    ``sharedLib/...``. When the real package is also present as workspace
+    source, resolve the import to that source instead of storing an external,
+    unqueryable package string.
+    """
+
+    def __init__(self, repo_root: Optional[Path] = None) -> None:
+        self._repo_root = Path(repo_root).resolve() if repo_root is not None else None
+        self._manifest_cache: dict[Path, Optional[dict]] = {}
+        self._alias_cache: dict[Path, dict[str, str]] = {}
+        self._package_roots: Optional[dict[str, list[Path]]] = None
+
+    def resolve_alias(self, import_str: str, file_path: str) -> Optional[str]:
+        """Return a local source file for an npm-aliased import, or ``None``."""
+        if not import_str or import_str.startswith("."):
+            return None
+
+        aliases = self._aliases_for_file(file_path)
+        matching_alias = self._longest_matching_alias(import_str, aliases)
+        if matching_alias is None:
+            return None
+
+        real_name = _real_package_name(aliases[matching_alias])
+        if real_name is None:
+            return None
+
+        package_roots = self._local_package_roots()
+        candidates = package_roots.get(real_name, [])
+        if len(candidates) != 1:
+            # Absent and ambiguous packages must remain external rather than
+            # producing a confidently wrong edge to another local package.
+            return None
+
+        package_root = candidates[0]
+        subpath = import_str[len(matching_alias):].lstrip("/")
+        if not _safe_subpath(subpath):
+            return None
+
+        found = self._probe_package_path(package_root, subpath)
+        if found is None:
+            return None
+
+        try:
+            package_root_resolved = package_root.resolve()
+            found_resolved = found.resolve()
+            if package_root_resolved not in found_resolved.parents:
+                return None
+        except (OSError, ValueError, RuntimeError):
+            return None
+        return found_resolved.as_posix()
+
+    def _aliases_for_file(self, file_path: str) -> dict[str, str]:
+        """Collect npm aliases from the nearest package manifests."""
+        try:
+            start = Path(file_path).parent.resolve()
+        except (OSError, ValueError, RuntimeError):
+            return {}
+
+        cache_key = start
+        if cache_key in self._alias_cache:
+            return self._alias_cache[cache_key]
+
+        aliases: dict[str, str] = {}
+        current = start
+        while True:
+            manifest = self._read_manifest(current / "package.json")
+            if manifest is not None:
+                for section_name in _DEPENDENCY_SECTIONS:
+                    section = manifest.get(section_name)
+                    if not isinstance(section, dict):
+                        continue
+                    for alias, specification in section.items():
+                        if not isinstance(alias, str) or not isinstance(specification, str):
+                            continue
+                        specification = specification.strip()
+                        if specification.startswith("npm:"):
+                            aliases.setdefault(alias, specification)
+
+            if self._repo_root is not None and current == self._repo_root:
+                break
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+        self._alias_cache[cache_key] = aliases
+        return aliases
+
+    def _local_package_roots(self) -> dict[str, list[Path]]:
+        """Index local package names without following generated/symlinked trees."""
+        if self._package_roots is not None:
+            return self._package_roots
+
+        roots: dict[str, list[Path]] = {}
+        scan_root = self._repo_root
+        if scan_root is None:
+            self._package_roots = roots
+            return roots
+
+        for directory, directory_names, file_names in os.walk(
+            scan_root, topdown=True, followlinks=False,
+        ):
+            directory_names[:] = [
+                name for name in directory_names
+                if name not in _SKIPPED_DIRECTORIES and not name.startswith(".")
+            ]
+            if "package.json" not in file_names:
+                continue
+            current = Path(directory)
+            manifest = self._read_manifest(current / "package.json")
+            name = manifest.get("name") if manifest is not None else None
+            if not isinstance(name, str) or not name:
+                continue
+            package_names = roots.setdefault(name, [])
+            if current not in package_names:
+                package_names.append(current)
+
+        self._package_roots = roots
+        return roots
+
+    def _read_manifest(self, path: Path) -> Optional[dict]:
+        try:
+            canonical = path.resolve()
+        except (OSError, ValueError, RuntimeError):
+            return None
+        if canonical in self._manifest_cache:
+            return self._manifest_cache[canonical]
+
+        manifest: Optional[dict] = None
+        try:
+            if path.is_file() and path.stat().st_size <= 1_048_576:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    manifest = data
+        except (OSError, UnicodeError, json.JSONDecodeError, RuntimeError):
+            manifest = None
+
+        self._manifest_cache[canonical] = manifest
+        return manifest
+
+    @staticmethod
+    def _longest_matching_alias(
+        import_str: str, aliases: dict[str, str],
+    ) -> Optional[str]:
+        matches = [
+            alias for alias in aliases
+            if import_str == alias or import_str.startswith(alias + "/")
+        ]
+        if not matches:
+            return None
+        return max(matches, key=len)
+
+    @staticmethod
+    def _probe_package_path(package_root: Path, subpath: str) -> Optional[Path]:
+        if not subpath:
+            return _probe_package_entry(package_root)
+        return _probe_import_path(package_root / subpath)
+
+
+def _real_package_name(specification: str) -> Optional[str]:
+    """Extract the package name from an npm alias specification."""
+    value = specification[4:]
+    version_separator = value.find("@", 1) if value.startswith("@") else value.find("@")
+    name = value if version_separator < 0 else value[:version_separator]
+    if not name or name in ("@", "@/"):
+        return None
+    return name
+
+
+def _safe_subpath(subpath: str) -> bool:
+    if not subpath:
+        return True
+    if "\\" in subpath or any(ord(char) < 32 for char in subpath):
+        return False
+    parts = Path(subpath).parts
+    return bool(parts) and all(part not in ("", ".", "..") for part in parts)
+
+
+def _probe_package_entry(package_root: Path) -> Optional[Path]:
+    try:
+        manifest_path = package_root / "package.json"
+        if manifest_path.stat().st_size > 1_048_576:
+            return None
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError, RuntimeError):
+        return None
+    if not isinstance(manifest, dict):
+        return None
+
+    for field in ("module", "main"):
+        entry = manifest.get(field)
+        if not isinstance(entry, str) or not _safe_subpath(entry):
+            continue
+        found = _probe_import_path(package_root / entry)
+        if found is not None:
+            return found
+    return _probe_import_path(package_root)
+
+
+def _probe_import_path(base: Path) -> Optional[Path]:
+    try:
+        if base.is_file():
+            return base
+        for extension in _PROBE_EXTENSIONS:
+            candidate = Path(str(base) + extension)
+            if candidate.is_file():
+                return candidate
+        if base.suffix in _TYPESCRIPT_SOURCE_EXTENSIONS:
+            for extension in _TYPESCRIPT_SOURCE_EXTENSIONS[base.suffix]:
+                candidate = base.with_suffix(extension)
+                if candidate.is_file():
+                    return candidate
+        if base.is_dir():
+            for extension in _PROBE_EXTENSIONS:
+                candidate = base / f"index{extension}"
+                if candidate.is_file():
+                    return candidate
+    except (OSError, ValueError, RuntimeError):
+        return None
+    return None

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -31,6 +31,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 from .config_keys import is_spring_config_path, normalize_spring_config_key
 from .custom_languages import CustomLanguage, load_custom_languages
+from .npm_alias_resolver import NpmAliasResolver
 
 try:
     import yaml as _yaml  # type: ignore[import-untyped]
@@ -2434,6 +2435,7 @@ class CodeParser:
         self._excluded_files: set[str] = set()
         self._export_symbol_cache: dict[str, Optional[str]] = {}
         self._tsconfig_resolver = TsconfigResolver()
+        self._npm_alias_resolver = NpmAliasResolver(self._repo_root)
         # Per-parse cache of Dart pubspec root lookups; see #87
         self._dart_pubspec_cache: dict[tuple[str, str], Optional[Path]] = {}
         # Cargo discovery is shared by every Rust import/call in a source file.
@@ -13686,6 +13688,12 @@ class CodeParser:
             else:
                 # Non-relative import — try tsconfig path alias resolution
                 resolved = self._tsconfig_resolver.resolve_alias(module, file_path)
+                if resolved:
+                    return resolved
+                # npm dependency aliases can point at workspace source present
+                # in the scanned repository. Explicit tsconfig paths remain the
+                # stronger, user-provided resolution and are tried first.
+                resolved = self._npm_alias_resolver.resolve_alias(module, file_path)
                 if resolved:
                     return resolved
 

--- a/tests/test_npm_alias_resolver.py
+++ b/tests/test_npm_alias_resolver.py
@@ -1,0 +1,198 @@
+"""npm dependency aliases resolved to local workspace packages."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build, get_db_path
+from code_review_graph.parser import CodeParser
+from code_review_graph.tools.query import query_graph
+
+
+def _write_monorepo(root: Path) -> tuple[Path, Path]:
+    """Build the locally-vendored npm-alias shape from issue #343."""
+    shared_root = root / "packages" / "shared"
+    shared_root.mkdir(parents=True)
+    (shared_root / "package.json").write_text(
+        json.dumps({"name": "@scope/shared", "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    module = shared_root / "some" / "module.ts"
+    module.parent.mkdir(parents=True)
+    module.write_text("export function shared() {}\n", encoding="utf-8")
+
+    app_root = root / "apps" / "consumer"
+    (app_root / "src").mkdir(parents=True)
+    (app_root / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@scope/consumer",
+                "dependencies": {"sharedLib": "npm:@scope/shared@^1.0.0"},
+            },
+        ),
+        encoding="utf-8",
+    )
+    importer = app_root / "src" / "entry.ts"
+    importer.write_text(
+        "import { shared } from 'sharedLib/some/module';\n"
+        "export function entry() { return shared(); }\n",
+        encoding="utf-8",
+    )
+    return importer, module
+
+
+def test_npm_alias_import_resolves_to_local_workspace_module(tmp_path: Path) -> None:
+    importer, module = _write_monorepo(tmp_path)
+
+    parser = CodeParser(repo_root=tmp_path)
+    _nodes, edges = parser.parse_file(importer)
+    imports = [edge for edge in edges if edge.kind == "IMPORTS_FROM"]
+
+    assert imports, "expected the aliased import to be indexed"
+    assert imports[0].target == module.resolve().as_posix()
+
+
+def test_npm_alias_importers_survive_a_full_build_and_query(tmp_path: Path) -> None:
+    importer, module = _write_monorepo(tmp_path)
+    (tmp_path / ".code-review-graph").mkdir()
+    db_path = get_db_path(tmp_path)
+
+    with GraphStore(db_path) as store:
+        built = full_build(tmp_path, store)
+        assert built["errors"] == []
+
+    result = query_graph(
+        "importers_of",
+        "packages/shared/some/module.ts",
+        repo_root=str(tmp_path),
+    )
+
+    assert result["result_count"] == 1
+    assert result["results"][0]["importer"] == importer.resolve().as_posix()
+    assert result["results"][0]["file"] == importer.resolve().as_posix()
+    assert module.is_file()
+
+
+def test_root_npm_alias_resolves_package_entrypoint(tmp_path: Path) -> None:
+    package_root = tmp_path / "packages" / "shared"
+    package_root.mkdir(parents=True)
+    (package_root / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@scope/shared",
+                "main": "./source/public.js",
+            },
+        ),
+        encoding="utf-8",
+    )
+    source = package_root / "source" / "public.ts"
+    source.parent.mkdir()
+    source.write_text("export const value = 1;\n", encoding="utf-8")
+    app_root = tmp_path / "app"
+    app_root.mkdir()
+    (app_root / "package.json").write_text(
+        json.dumps(
+            {"devDependencies": {"sharedLib": "npm:@scope/shared@2.0.0"}},
+        ),
+        encoding="utf-8",
+    )
+    importer = app_root / "entry.ts"
+    importer.write_text("import 'sharedLib';\n", encoding="utf-8")
+
+    _nodes, edges = CodeParser(repo_root=tmp_path).parse_file(importer)
+
+    imports = [edge for edge in edges if edge.kind == "IMPORTS_FROM"]
+    assert imports[0].target == source.resolve().as_posix()
+
+
+def test_missing_and_ambiguous_local_packages_remain_external(tmp_path: Path) -> None:
+    for directory, name in (("first", "@scope/shared"), ("second", "@scope/shared")):
+        package_root = tmp_path / directory
+        package_root.mkdir()
+        (package_root / "package.json").write_text(
+            json.dumps({"name": name}), encoding="utf-8",
+        )
+    app_root = tmp_path / "apps" / "missing"
+    app_root.mkdir(parents=True)
+    (app_root / "package.json").write_text(
+        json.dumps({"dependencies": {"missingLib": "npm:@scope/missing@1.0.0"}}),
+        encoding="utf-8",
+    )
+    missing_importer = app_root / "missing.ts"
+    missing_importer.write_text("import 'missingLib';\n", encoding="utf-8")
+    ambiguous_importer = tmp_path / "ambiguous.ts"
+    ambiguous_importer.write_text("import 'sharedLib';\n", encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        json.dumps({"dependencies": {"sharedLib": "npm:@scope/shared@1.0.0"}}),
+        encoding="utf-8",
+    )
+
+    parser = CodeParser(repo_root=tmp_path)
+    missing_edges = parser.parse_file(missing_importer)[1]
+    ambiguous_edges = parser.parse_file(ambiguous_importer)[1]
+
+    assert [edge.target for edge in missing_edges if edge.kind == "IMPORTS_FROM"] == [
+        "missingLib",
+    ]
+    assert [
+        edge.target for edge in ambiguous_edges if edge.kind == "IMPORTS_FROM"
+    ] == ["sharedLib"]
+
+
+def test_npm_alias_cannot_escape_its_local_package(tmp_path: Path) -> None:
+    package_root = tmp_path / "package"
+    package_root.mkdir()
+    (package_root / "package.json").write_text(
+        json.dumps({"name": "shared"}), encoding="utf-8",
+    )
+    secret = tmp_path / "secret.ts"
+    secret.write_text("export const secret = 1;\n", encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        json.dumps({"dependencies": {"sharedLib": "npm:shared@1.0.0"}}),
+        encoding="utf-8",
+    )
+    importer = tmp_path / "entry.ts"
+    importer.write_text("import 'sharedLib/../secret';\n", encoding="utf-8")
+
+    _nodes, edges = CodeParser(repo_root=tmp_path).parse_file(importer)
+
+    assert [edge.target for edge in edges if edge.kind == "IMPORTS_FROM"] == [
+        "sharedLib/../secret",
+    ]
+
+
+def test_explicit_tsconfig_alias_takes_precedence_over_npm_alias(tmp_path: Path) -> None:
+    package_root = tmp_path / "packages" / "shared"
+    package_root.mkdir(parents=True)
+    (package_root / "package.json").write_text(
+        json.dumps({"name": "@scope/shared"}), encoding="utf-8",
+    )
+    npm_target = package_root / "npm.ts"
+    npm_target.write_text("export const a = 1;\n", encoding="utf-8")
+    tsconfig_target = tmp_path / "explicit.ts"
+    tsconfig_target.write_text("export const b = 2;\n", encoding="utf-8")
+    (tmp_path / "tsconfig.json").write_text(
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {"sharedLib": ["./explicit.ts"]},
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        json.dumps({"dependencies": {"sharedLib": "npm:@scope/shared@1.0.0"}}),
+        encoding="utf-8",
+    )
+    importer = tmp_path / "entry.ts"
+    importer.write_text("import 'sharedLib';\n", encoding="utf-8")
+
+    _nodes, edges = CodeParser(repo_root=tmp_path).parse_file(importer)
+
+    assert [edge.target for edge in edges if edge.kind == "IMPORTS_FROM"] == [
+        tsconfig_target.resolve().as_posix(),
+    ]


### PR DESCRIPTION
## Summary
- Add a dedicated npm dependency-alias resolver for JavaScript and TypeScript imports.
- Read `npm:` aliases from dependency and dev-dependency manifests, then index uniquely named local packages in the repository.
- Resolve `alias/subpath`, root entry points, NodeNext `.js`-to-`.ts` spellings, and package index files to real workspace files.
- Keep absent and ambiguous packages external, prefer explicit tsconfig paths, reject traversal outside the selected package, and skip generated `node_modules` trees.

This makes `IMPORTS_FROM`, `importers_of`, and impact-radius queries cross the alias boundary when the real package source is present locally.

Fixes #343.

## Tests
- Added six regressions covering:
  - the monorepo subpath case from the issue;
  - a real full-build plus `importers_of` query;
  - root entry-point resolution through package metadata;
  - absent and ambiguous local packages remaining external;
  - rejection of traversal outside the package;
  - explicit tsconfig aliases taking precedence.

Validation:
- `pytest tests/test_npm_alias_resolver.py tests/test_tsconfig_resolver.py tests/test_commonjs_imports.py -q` — 23 passed
- `ruff check code_review_graph/npm_alias_resolver.py code_review_graph/parser.py tests/test_npm_alias_resolver.py` — passed
- `git diff --check` — passed