### PR TITLE
fix(build): recover partial graphs before incremental updates

### DIFF
--- a/code_review_graph/forget.py
+++ b/code_review_graph/forget.py
@@ -116,6 +116,7 @@ def forget_files(
     # 2. Drop the forgotten files' own nodes and edges.
     for file_path in targets:
         store.remove_file_data(file_path)
+    store.set_metadata("intentionally_incomplete", "1")
     # Persist deletions before store_file_nodes_edges() opens its own
     # explicit transaction (BEGIN IMMEDIATE) during the re-parse below.
     store.commit()

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1129,6 +1129,7 @@ def full_build(
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
+    store.set_metadata("intentionally_incomplete", "0")
     if not cpp_errors:
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
     _store_vcs_metadata(repo_root, store)

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -5,16 +5,67 @@ from __future__ import annotations
 import logging
 import sqlite3
 import time
+from pathlib import Path
 from typing import Any
 
 from ..incremental import (
+    collect_all_files,
     full_build,
+    get_all_tracked_files,
     incremental_update,
     resolve_incremental_base,
 )
+from ..parser import normalize_file_path
 from ._common import _get_store
 
 logger = logging.getLogger(__name__)
+
+_PARTIAL_GRAPH_MIN_FILES = 8
+_PARTIAL_GRAPH_MAX_COVERAGE = 0.25
+_PARTIAL_GRAPH_SUSPECT_TRACKED_COVERAGE = 0.50
+
+
+def _should_rebuild_partial_graph(
+    repo_root: Path,
+    store: Any,
+    recurse_submodules: bool | None = None,
+) -> bool:
+    """Detect a non-empty graph that represents only a small slice of a repo."""
+    if store.get_metadata("intentionally_incomplete") == "1":
+        return False
+    if (
+        store.get_metadata("last_build_type") == "full"
+        and store.get_metadata("intentionally_incomplete") == "0"
+    ):
+        return False
+
+    represented_paths = {
+        normalize_file_path(path) for path in store.get_all_files()
+    }
+    tracked_files = get_all_tracked_files(repo_root, recurse_submodules)
+    if tracked_files:
+        # Keep the common path cheap: a graph already representing at least
+        # half of all tracked files cannot be severely partial. Below that,
+        # documentation- or asset-heavy repositories still need the precise
+        # parseable inventory below before forcing an expensive rebuild.
+        if (
+            len(represented_paths) >= len(tracked_files)
+            * _PARTIAL_GRAPH_SUSPECT_TRACKED_COVERAGE
+        ):
+            return False
+        if len(tracked_files) < _PARTIAL_GRAPH_MIN_FILES:
+            return False
+
+    expected_files = collect_all_files(repo_root, recurse_submodules)
+    if len(expected_files) < _PARTIAL_GRAPH_MIN_FILES:
+        return False
+
+    expected_paths = {
+        normalize_file_path(repo_root / relative)
+        for relative in expected_files
+    }
+    represented_count = len(expected_paths & represented_paths)
+    return represented_count <= len(expected_paths) * _PARTIAL_GRAPH_MAX_COVERAGE
 
 
 def _run_embedding_refresh(
@@ -502,6 +553,7 @@ def build_or_update_graph(
     """
     store, root = _get_store(repo_root)
     try:
+        recovery_reason: str | None = None
         if not full_rebuild and not store.has_nodes():
             full_rebuild = True
 
@@ -514,6 +566,13 @@ def build_or_update_graph(
             base_resolved = resolve_incremental_base(root, store)
             if base_resolved is None:
                 full_rebuild = True
+
+        if (
+            not full_rebuild
+            and _should_rebuild_partial_graph(root, store, recurse_submodules)
+        ):
+            full_rebuild = True
+            recovery_reason = "partial_graph"
 
         if full_rebuild:
             result = full_build(root, store, recurse_submodules)
@@ -528,6 +587,8 @@ def build_or_update_graph(
                     f"{result['total_edges']} edges."
                 ),
             }
+            if recovery_reason is not None:
+                build_result["recovery_reason"] = recovery_reason
         else:
             result = incremental_update(root, store, base=base_resolved)
             if result["files_updated"] == 0:

--- a/tests/test_pr803_poisoned_graph_recovery.py
+++ b/tests/test_pr803_poisoned_graph_recovery.py
@@ -1,0 +1,136 @@
+"""Recovery for non-empty graphs produced by partial diff-only builds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import get_db_path
+from code_review_graph.parser import CodeParser
+from code_review_graph.tools.build import build_or_update_graph
+
+
+def _make_repo(root: Path, source_count: int = 8) -> None:
+    (root / ".git").mkdir()
+    (root / ".code-review-graph").mkdir()
+    for index in range(source_count):
+        (root / f"module{index}.py").write_text(
+            f"def value{index}() -> int:\n    return {index}\n",
+            encoding="utf-8",
+        )
+
+
+def _seed_partial_graph(root: Path, represented_count: int = 1) -> None:
+    with GraphStore(get_db_path(root)) as store:
+        parser = CodeParser(root)
+        for relative in [f"module{index}.py" for index in range(represented_count)]:
+            source_path = root / relative
+            nodes, edges = parser.parse_file(source_path)
+            store.store_file_nodes_edges(
+                str(source_path), nodes, edges,
+                f"seed-{relative}",
+            )
+        store.set_metadata("last_build_type", "incremental")
+        store.set_metadata("git_head_sha", "0" * 40)
+
+
+def test_severely_partial_synced_graph_gets_full_rebuild(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    _make_repo(tmp_path)
+    _seed_partial_graph(tmp_path)
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    monkeypatch.setattr(
+        "code_review_graph.tools.build.resolve_incremental_base",
+        lambda *_args, **_kwargs: "HEAD~1",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.get_changed_files",
+        lambda *_args, **_kwargs: [],
+    )
+
+    result = build_or_update_graph(
+        repo_root=str(tmp_path),
+        full_rebuild=False,
+        postprocess="none",
+    )
+
+    assert result["build_type"] == "full"
+    assert result["files_parsed"] == 8
+    assert result["recovery_reason"] == "partial_graph"
+    with GraphStore(get_db_path(tmp_path)) as store:
+        assert len(store.get_all_files()) == 8
+        assert store.get_metadata("last_build_type") == "full"
+        assert store.get_metadata("intentionally_incomplete") == "0"
+
+
+def test_complete_incremental_graph_is_not_rebuilt(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+    first = build_or_update_graph(
+        repo_root=str(tmp_path),
+        full_rebuild=True,
+        postprocess="none",
+    )
+    assert first["files_parsed"] == 8
+    with GraphStore(get_db_path(tmp_path)) as store:
+        store.set_metadata("last_build_type", "incremental")
+
+    monkeypatch.setattr(
+        "code_review_graph.tools.build.resolve_incremental_base",
+        lambda *_args, **_kwargs: "HEAD~1",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.get_changed_files",
+        lambda *_args, **_kwargs: [],
+    )
+
+    result = build_or_update_graph(
+        repo_root=str(tmp_path),
+        full_rebuild=False,
+        postprocess="none",
+    )
+
+    assert result["build_type"] == "incremental"
+    assert result["files_updated"] == 0
+    assert "recovery_reason" not in result
+
+
+def test_unknown_tracked_assets_do_not_look_like_a_poisoned_graph(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    _make_repo(tmp_path)
+    for index in range(80):
+        (tmp_path / f"asset{index}.txt").write_text(
+            f"documentation or data {index}\n", encoding="utf-8",
+        )
+    _seed_partial_graph(tmp_path, represented_count=8)
+    monkeypatch.setattr(
+        "code_review_graph.tools.build.resolve_incremental_base",
+        lambda *_args, **_kwargs: "HEAD~1",
+    )
+    monkeypatch.setattr(
+        "code_review_graph.incremental.get_changed_files",
+        lambda *_args, **_kwargs: [],
+    )
+
+    result = build_or_update_graph(
+        repo_root=str(tmp_path),
+        full_rebuild=False,
+        postprocess="none",
+    )
+
+    assert result["build_type"] == "incremental"
+    assert "recovery_reason" not in result
+
+
+def test_intentional_forget_marker_disables_coverage_recovery(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    _seed_partial_graph(tmp_path, represented_count=1)
+    with GraphStore(get_db_path(tmp_path)) as store:
+        store.set_metadata("intentionally_incomplete", "1")
+        from code_review_graph.tools.build import _should_rebuild_partial_graph
+
+        assert _should_rebuild_partial_graph(tmp_path, store) is False


### PR DESCRIPTION
## Summary
- Detect non-empty graphs that represent only a severe slice of the repository even when their stored VCS head makes an incremental base look valid.
- Use a cheap tracked-file ratio first, then confirm suspected graphs against the exact parseable inventory to avoid false positives in documentation- or asset-heavy repositories.
- Force one full rebuild for such graphs and expose `recovery_reason: partial_graph` in the build result.
- Mark `forget` results as intentionally incomplete and clear that marker on full builds, so explicit exclusions are not overridden by coverage recovery.

Fixes #803.

## Tests
- Added four regressions covering:
  - a one-of-eight synced partial graph being rebuilt;
  - a complete incremental graph remaining incremental;
  - many unknown tracked assets not being mistaken for poison;
  - the intentional `forget` marker disabling recovery.

Validation:
- `pytest tests/test_pr803_poisoned_graph_recovery.py -q` — 4 passed
- `pytest tests/test_tools.py::TestBuildPostprocess tests/test_cli_reconciliation.py tests/test_pr809_edges.py -q` — 51 passed
- `ruff check code_review_graph/tools/build.py code_review_graph/incremental.py code_review_graph/forget.py tests/test_pr803_poisoned_graph_recovery.py` — passed
- `git diff --check` — passed