### PR TITLE
fix(watch): accept resolved paths for symlinked roots

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -1407,7 +1407,17 @@ def _create_watch_handler(
             try:
                 relative = candidate.relative_to(lexical_root)
             except ValueError:
-                return None
+                if lexical_root == resolved_root:
+                    return None
+                # Some backends—notably FSEvents on macOS—report the resolved
+                # path even when the watcher was scheduled through a symlinked
+                # repository root. Retry against the resolved root so both
+                # spellings refer to the same watched tree.
+                candidate = Path(os.path.realpath(path))
+                try:
+                    relative = candidate.relative_to(resolved_root)
+                except ValueError:
+                    return None
             existing = candidate
             while not existing.exists() and existing != lexical_root:
                 existing = existing.parent

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1564,6 +1564,39 @@ class TestWatchReconciliation:
         finally:
             store.close()
 
+    def test_watch_accepts_resolved_event_paths_for_symlinked_repo_root(self, tmp_path):
+        import os
+        import sys
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        source = repo / "source.py"
+        source.write_text("def source():\n    pass\n")
+        linked_repo = tmp_path / "repo-link"
+        if sys.platform == "win32":
+            import _winapi
+
+            _winapi.CreateJunction(str(repo), str(linked_repo))
+        else:
+            linked_repo.symlink_to(repo, target_is_directory=True)
+
+        store = GraphStore(repo / "graph.db")
+        handler = _create_watch_handler(linked_repo, store, None)
+        try:
+            from watchdog.events import FileModifiedEvent
+
+            with patch(
+                "code_review_graph.incremental.collect_all_files",
+                side_effect=AssertionError("resolved root event inventoried repository"),
+            ):
+                handler.process([FileModifiedEvent(str(source))])
+
+            assert store.get_nodes_by_file(str(linked_repo / "source.py"))
+        finally:
+            store.close()
+            if sys.platform == "win32" and linked_repo.exists():
+                os.rmdir(linked_repo)
+
     def test_watch_rejects_file_below_symlinked_ancestor_outside_repo(self, tmp_path):
         outside = tmp_path.parent / f"{tmp_path.name}-outside"
         outside.mkdir()


### PR DESCRIPTION
## Summary
- Match resolved backend event paths against the resolved repository root when watching through a symlinked root.
- Keep lexical-root handling and the existing in-repository symlink and escape checks.
- Add a regression that uses a directory symlink (or junction on Windows) and verifies a resolved event updates the graph.

Fixes #892.

## Testing
- Pristine main: the new regression failed before the fix (the resolved event was dropped and no node was stored).
- ```text
  uv run pytest tests/test_incremental.py -q --deselect tests/test_incremental.py::TestWatchReconciliation::test_watch_symlink_events_are_rejected --deselect tests/test_incremental.py::TestWatchReconciliation::test_watch_rejects_file_below_symlinked_ancestor_outside_repo
  106 passed, 2 deselected
  ```
- The two deselected pre-existing tests require unprivileged symlink creation on this Windows host; the new junction-based regression ran in the selected suite.
- ```text
  uv run ruff check code_review_graph/incremental.py tests/test_incremental.py
  git diff --check origin/main..HEAD
  ```
