### PR TITLE
fix(deps): test declared minimum versions

### DIFF
--- a/.github/requirements-minimum.txt
+++ b/.github/requirements-minimum.txt
@@ -1,0 +1,11 @@
+# Exact direct-dependency floors declared by pyproject.toml. CI installs this
+# set with the package and dev tools to prove that the declared lower bounds
+# remain compatible instead of merely hoping older releases still work.
+mcp==1.29.0
+fastmcp==3.2.4
+tree-sitter==0.26.0
+tree-sitter-language-pack==0.13.0
+pyyaml==6.0
+networkx==3.2
+watchdog==4.0.0
+tomli==2.0.0; python_version < "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,26 @@ jobs:
       - name: Run tests with coverage
         run: pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65
 
+  minimum-dependencies:
+    name: Minimum declared dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+      - name: Install every direct dependency at its declared floor
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]" -r .github/requirements-minimum.txt
+      - name: Check dependency resolution
+        run: python -m pip check
+      - name: Print resolved direct versions
+        run: python scripts/print_minimum_dependencies.py
+      - name: Run tests at dependency floors
+        run: pytest --tb=short -q
+
   google-embeddings:
     name: Google embeddings (${{ matrix.extra }})
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,15 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "mcp>=1.0.0,<3",
+    # The floors are the oldest direct versions exercised by CI; see
+    # .github/workflows/ci.yml and .github/requirements-minimum.txt.
+    "mcp>=1.29.0,<3",
     # fastmcp >=3.2.4 is required for Message-based prompts and includes the
     # CVE-2025-62800/62801/66416 fixes; <4 prevents the next major release
     # from breaking the server the way fastmcp 3.0 did. See: #488
     "fastmcp>=3.2.4,<4",
-    "tree-sitter>=0.23.0,<1",
-    "tree-sitter-language-pack>=0.3.0,<1",
+    "tree-sitter>=0.26.0,<1",
+    "tree-sitter-language-pack>=0.13.0,<1",
     "pyyaml>=6.0,<7",
     "networkx>=3.2,<4",
     "watchdog>=4.0.0,<7",

--- a/scripts/print_minimum_dependencies.py
+++ b/scripts/print_minimum_dependencies.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+
+PACKAGES = (
+    "mcp",
+    "fastmcp",
+    "tree-sitter",
+    "tree-sitter-language-pack",
+    "pyyaml",
+    "networkx",
+    "watchdog",
+)
+
+
+def main() -> None:
+    for package in PACKAGES:
+        print(f"{package}=={version(package)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -1,0 +1,57 @@
+"""Keep declared dependency floors synchronized with minimum-version CI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+
+EXPECTED_FLOORS = {
+    "mcp": "1.29.0",
+    "fastmcp": "3.2.4",
+    "tree-sitter": "0.26.0",
+    "tree-sitter-language-pack": "0.13.0",
+    "pyyaml": "6.0",
+    "networkx": "3.2",
+    "watchdog": "4.0.0",
+}
+
+
+def test_project_declares_tested_dependency_floors() -> None:
+    with Path("pyproject.toml").open("rb") as source:
+        project = tomllib.load(source)
+
+    declared = {
+        dependency.split(">=", 1)[0]: dependency.split(">=", 1)[1].split(",", 1)[0]
+        for dependency in project["project"]["dependencies"]
+        if ">=" in dependency
+    }
+
+    for package, floor in EXPECTED_FLOORS.items():
+        assert declared[package] == floor
+
+
+def test_minimum_ci_pins_match_declared_floors() -> None:
+    requirements = {
+        line.split("==", 1)[0]: line.split("==", 1)[1].split(";", 1)[0]
+        for line in Path(".github/requirements-minimum.txt").read_text().splitlines()
+        if line and not line.startswith("#")
+    }
+
+    expected = dict(EXPECTED_FLOORS)
+    if sys.version_info < (3, 11):
+        expected["tomli"] = "2.0.0"
+
+    assert requirements == expected
+
+
+def test_minimum_ci_checks_dependency_resolution() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text()
+
+    assert "minimum-dependencies:" in workflow
+    assert "python -m pip check" in workflow

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'communities'", specifier = ">=0.11.0" },
     { name = "jedi", marker = "extra == 'enrichment'", specifier = ">=0.19.2" },
     { name = "matplotlib", marker = "extra == 'eval'", specifier = ">=3.7.0" },
-    { name = "mcp", specifier = ">=1.0.0,<3" },
+    { name = "mcp", specifier = ">=1.29.0,<3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "networkx", specifier = ">=3.2,<4" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.26,<3" },
@@ -529,8 +529,8 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=3.0.0,<6" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0,<3" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0" },
-    { name = "tree-sitter", specifier = ">=0.23.0,<1" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.3.0,<1" },
+    { name = "tree-sitter", specifier = ">=0.26.0,<1" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.13.0,<1" },
     { name = "watchdog", specifier = ">=4.0.0,<7" },
 ]
 provides-extras = ["embeddings", "google-embeddings", "communities", "eval", "wiki", "all", "enrichment", "dev"]


### PR DESCRIPTION
## Summary
- Raise the reusable-library lower bounds to the documented, currently tested baseline:
  - `mcp>=1.29.0`
  - `tree-sitter>=0.26.0`
  - `tree-sitter-language-pack>=0.13.0`
- Keep bounded upper ranges and the existing security-driven `fastmcp>=3.2.4` floor rather than pinning end users to exact releases.
- Add an exact direct-dependency floor file covering every runtime dependency (including Python 3.10's conditional `tomli`).
- Add a Python 3.10 CI job that installs the package and dev tools together with those exact floors, runs `pip check`, prints resolved versions, and executes the test suite.
- Add regressions that keep `pyproject.toml`, the floor file, and the minimum-version CI contract synchronized.
- Refresh lockfile provenance without changing resolved locked versions.

Fixes #265.

## Tests
Validation at the exact declared floors in a Python 3.10 environment:

- Dependency resolution: 93 packages checked, all compatible
- Focused contract tests: 3 passed
- Parser/probe/MCP/tool suites: 176 passed
- Full exploratory suite: 2,810 passed, 20 skipped, 2 xpassed; the remaining Windows failures are the repository's existing path/encoding host issues and were not introduced by the dependency floors
- `mypy code_review_graph/ --ignore-missing-imports --no-strict-optional` — passed
- Changed-file Ruff and format checks — passed
- `uv build` — source distribution and wheel built successfully
- `git diff --check` — passed