### PR TITLE
fix: preserve graphs across repository root spellings (integrates #894)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ uv run code-review-graph eval               # Run evaluation benchmarks
 - `tests/test_migrations.py` — Database migrations
 - `tests/test_eval.py` — Evaluation framework
 - `tests/test_tsconfig_resolver.py` — TypeScript path resolution
+- `tests/test_repo_root_identity.py` — One graph identity per repository root spelling
 - `tests/test_integration_v2.py` — v2 pipeline integration test
 - `tests/test_action_render.py` — GitHub Action PR comment renderer (`scripts/render_pr_comment.py`)
 - `tests/fixtures/` — Sample files for each supported language

--- a/code_review_graph/cli.py
+++ b/code_review_graph/cli.py
@@ -541,6 +541,40 @@ _GRAPH_TOOL_COMMANDS = {
 }
 
 
+_PATH_REPO_COMMANDS = frozenset({
+    "install",
+    "init",
+    "uninstall",
+    "build",
+    "update",
+    "postprocess",
+    "embed",
+    "watch",
+    "status",
+    "forget",
+    "visualize",
+    "wiki",
+    "detect-changes",
+    "dead-code",
+    "serve",
+    "mcp",
+    *_GRAPH_TOOL_COMMANDS,
+})
+
+
+def _canonicalize_repo_argument(args: argparse.Namespace) -> None:
+    """Canonicalize path-valued ``--repo`` arguments in place.
+
+    Commands whose ``--repo`` value is a repository *name* rather than a path
+    (eval configs and daemon log aliases) are deliberately excluded. Every
+    path consumer receives the same absolute, symlink-resolved spelling before
+    it opens a database or compares stored paths.
+    """
+    repo = getattr(args, "repo", None)
+    if args.command in _PATH_REPO_COMMANDS and repo:
+        args.repo = str(Path(repo).expanduser().resolve())
+
+
 def _find_explicit_repo_root(start: Path) -> "Path | None":
     """Resolve an explicit --repo for graph-tool commands.
 
@@ -1327,6 +1361,8 @@ def main() -> None:
         _print_banner()
         return
 
+    _canonicalize_repo_argument(args)
+
     if (
         args.command == "refactor"
         and args.mode == "rename"
@@ -1765,6 +1801,9 @@ def main() -> None:
                     postprocess=pp,
                     **embedding_refresh_kwargs,
                 )
+            except RuntimeError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                sys.exit(1)
             finally:
                 logging.disable(previous_disable)
             nodes = result.get("total_nodes", 0)

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -1199,6 +1199,17 @@ class GraphStore:
         ).fetchall()
         return [r["file_path"] for r in rows]
 
+    def get_file_marker_paths(self) -> list[str]:
+        """Return paths that have authoritative File nodes.
+
+        Reconciliation uses this to distinguish a graph anchored to another
+        repository from orphan Function/Edge rows left by a failed update.
+        """
+        rows = self._conn.execute(
+            "SELECT file_path FROM nodes WHERE kind = 'File' ORDER BY file_path"
+        ).fetchall()
+        return [row["file_path"] for row in rows]
+
     def search_nodes(self, query: str, limit: int = 20) -> list[GraphNode]:
         """Keyword search across node names.
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -941,6 +941,30 @@ def _reconcile_stale_files(
     return stale_files
 
 
+def _assert_graph_matches_root(repo_root: Path, store: GraphStore) -> None:
+    """Refuse an incremental reconciliation anchored to a different root.
+
+    Authoritative File nodes identify the root a graph was built with. If none
+    of them are under the requested root, treating every row as stale is more
+    likely to destroy a usable graph than to clean up orphan rows. Orphan-only
+    databases have no File markers and retain the purge behavior from #861.
+    """
+    file_paths = store.get_file_marker_paths()
+    if not file_paths:
+        return
+    prefix = normalize_file_path(repo_root)
+    prefix = prefix if prefix.endswith("/") else prefix + "/"
+    if any(normalize_file_path(path).startswith(prefix) for path in file_paths):
+        return
+    sample = normalize_file_path(sorted(file_paths)[0])
+    raise RuntimeError(
+        f"the graph holds {len(file_paths)} file(s) such as {sample!r}, none of "
+        f"them under {str(repo_root)!r}; it was built with a different "
+        "repository root. Rebuild it, or retry with the root it was built "
+        "with, instead of reconciling every file away."
+    )
+
+
 _MAX_DEPENDENT_HOPS = int(os.environ.get("CRG_DEPENDENT_HOPS", "2"))
 _MAX_DEPENDENT_FILES = 500
 
@@ -1050,6 +1074,16 @@ def _parse_single_file(
         return (rel_path, [], [], str(e), "")
 
 
+def _canonical_repo_root(repo_root: Path) -> Path:
+    """Return one stable identity for a repository root.
+
+    Graph paths are anchored to the root supplied by the caller. Resolving the
+    root once prevents equivalent spellings (notably ``.`` and an absolute
+    path) from looking like two different repositories during reconciliation.
+    """
+    return Path(repo_root).expanduser().resolve()
+
+
 def full_build(
     repo_root: Path,
     store: GraphStore,
@@ -1063,6 +1097,7 @@ def full_build(
         recurse_submodules: If True, include files from git submodules.
             When *None*, falls back to ``CRG_RECURSE_SUBMODULES`` env var.
     """
+    repo_root = _canonical_repo_root(repo_root)
     parser = CodeParser(repo_root)
     files = collect_all_files(repo_root, recurse_submodules)
     stale_files = _reconcile_stale_files(repo_root, store, files)
@@ -1166,6 +1201,9 @@ def incremental_update(
     reconcile_stale: bool = True,
 ) -> dict:
     """Incremental update: re-parse changed + dependent files only."""
+    repo_root = _canonical_repo_root(repo_root)
+    if reconcile_stale:
+        _assert_graph_matches_root(repo_root, store)
     parser = CodeParser(repo_root)
     ignore_patterns = _load_ignore_patterns(repo_root)
 
@@ -1556,6 +1594,7 @@ def watch(
     """
     from watchdog.observers import Observer
 
+    repo_root = _canonical_repo_root(repo_root)
     initial = incremental_update(repo_root, store, changed_files=[])
     _raise_watch_update_errors(initial, "initial watch reconciliation")
     if initial["files_updated"] > 0 and on_files_updated is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import json
 import logging
 import sys
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from code_review_graph import cli
@@ -84,7 +85,7 @@ class TestServeCommand:
                 cli.main()
 
         mock_serve.assert_called_once_with(
-            repo_root="repo-root",
+            repo_root=str(Path("repo-root").resolve()),
             auto_watch=True,
             tools=None,
         )
@@ -101,7 +102,7 @@ class TestServeCommand:
                 cli.main()
 
         mock_serve.assert_called_once_with(
-            repo_root="repo-root",
+            repo_root=str(Path("repo-root").resolve()),
             auto_watch=False,
         )
 
@@ -192,7 +193,7 @@ class TestBuildUpdateCommands:
 
         mock_build.assert_called_once_with(
             full_rebuild=True,
-            repo_root="repo-root",
+            repo_root=str(Path("repo-root").resolve()),
             postprocess="none",
         )
         mock_postprocess.assert_not_called()
@@ -230,7 +231,7 @@ class TestBuildUpdateCommands:
         # can resolve the base to the last-synced commit.
         mock_build.assert_called_once_with(
             full_rebuild=False,
-            repo_root="repo-root",
+            repo_root=str(Path("repo-root").resolve()),
             base=None,
             postprocess="minimal",
         )

--- a/tests/test_embedding_refresh.py
+++ b/tests/test_embedding_refresh.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -435,7 +436,7 @@ class TestRefreshWiring:
 
         build.assert_called_once_with(
             full_rebuild=True,
-            repo_root="repo-root",
+            repo_root=str(Path("repo-root").resolve()),
             postprocess="full",
             embedding_provider="local",
             embedding_model="test-model",

--- a/tests/test_pr856_edges.py
+++ b/tests/test_pr856_edges.py
@@ -141,7 +141,7 @@ def test_no_stale_sdk_references_outside_lock():
     for pattern in ("*.py", "*.toml", "*.md", "*.yml", "*.yaml"):
         for path in ROOT.rglob(pattern):
             parts = path.relative_to(ROOT).parts
-            if parts[0] in {".git", ".venv", "node_modules", ".claude"}:
+            if parts[0] in {".git", ".venv", "node_modules", ".claude", "evaluate"}:
                 continue
             if " 2." in path.name or path.name == "test_pr856_edges.py":
                 continue

--- a/tests/test_repo_root_identity.py
+++ b/tests/test_repo_root_identity.py
@@ -1,0 +1,133 @@
+"""Repository-root identity regressions for graph reconciliation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from code_review_graph import cli
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build, incremental_update
+
+
+def test_incremental_update_survives_mixed_repo_root_spellings(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "app.py").write_text("def main() -> None:\n    pass\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    store = GraphStore(repo / ".code-review-graph" / "graph.db")
+    try:
+        full_build(repo.resolve(), store)
+        before = store.get_all_files()
+
+        result = incremental_update(Path("."), store, changed_files=[])
+
+        assert result["stale_files_removed"] == 0
+        assert store.get_all_files() == before
+    finally:
+        store.close()
+
+
+def test_incremental_update_refuses_total_root_mismatch_without_purging(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "app.py").write_text("def main() -> None:\n    pass\n", encoding="utf-8")
+    wrong_root = tmp_path / "wrong-root"
+    wrong_root.mkdir()
+    store = GraphStore(repo / ".code-review-graph" / "graph.db")
+    try:
+        full_build(repo, store)
+        before = store.get_all_files()
+
+        with pytest.raises(RuntimeError, match="different repository root"):
+            incremental_update(wrong_root, store, changed_files=[])
+
+        assert store.get_all_files() == before
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "command",
+    sorted(cli._PATH_REPO_COMMANDS),
+)
+def test_path_repo_commands_use_one_absolute_root_spelling(
+    command: str, tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    args = SimpleNamespace(command=command, repo=".")
+
+    cli._canonicalize_repo_argument(args)
+
+    assert args.repo == str(repo.resolve())
+
+
+@pytest.mark.parametrize("command", ["eval", "daemon"])
+def test_name_valued_repo_arguments_are_not_treated_as_paths(
+    command: str,
+) -> None:
+    args = SimpleNamespace(command=command, repo="repo-config-name")
+
+    cli._canonicalize_repo_argument(args)
+
+    assert args.repo == "repo-config-name"
+
+
+@pytest.mark.parametrize("command", ["build", "update"])
+def test_build_and_update_cli_pass_a_canonical_root(
+    command: str, tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.chdir(repo)
+    result = {
+        "files_parsed": 1,
+        "files_updated": 0,
+        "total_nodes": 2,
+        "total_edges": 1,
+        "errors": [],
+    }
+
+    with patch.object(cli.sys, "argv", ["code-review-graph", command, "--repo", ".", "--quiet"]):
+        with patch("code_review_graph.graph.GraphStore", return_value=MagicMock()):
+            with patch(
+                "code_review_graph.incremental.get_db_path",
+                return_value=MagicMock(),
+            ):
+                with patch(
+                    "code_review_graph.tools.build.build_or_update_graph",
+                    return_value=result,
+                ) as build_or_update:
+                    cli.main()
+
+    assert build_or_update.call_args.kwargs["repo_root"] == str(repo.resolve())
+
+
+def test_watch_cli_passes_a_canonical_root(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.chdir(repo)
+    store = MagicMock()
+
+    with patch.object(cli.sys, "argv", ["code-review-graph", "watch", "--repo", "."]):
+        with patch("code_review_graph.graph.GraphStore", return_value=store):
+            with patch(
+                "code_review_graph.incremental.get_db_path",
+                return_value=MagicMock(),
+            ):
+                with patch("code_review_graph.incremental.watch") as watch:
+                    cli.main()
+
+    watch.assert_called_once_with(repo.resolve(), store, on_files_updated=ANY)


### PR DESCRIPTION
Integrates #894 by @yzxcj797, which could not merge on its own: #890 landed while it was in review and both branches added a guard named `_assert_graph_matches_root` with the parameters in opposite order. The later definition silently shadowed the earlier one, so after resolving the textual conflict the tree failed with 47 test errors and 3 mypy errors.

Resolution, verified locally:

- `watch()` keeps the `_WatchSupervisor` block from #890 but normalizes its root with `_canonical_repo_root` instead of `os.path.abspath`.
- #890's watch-only `_assert_graph_matches_root(store, repo_root)` is dropped; #894's `(repo_root, store)` version sits at the `incremental_update` choke point, which `watch()` reconciles through, so it subsumes the removed one.

Side effect worth noting: this also fixes both halves of #892. A repository reached through a symlinked path is now watched and indexed rather than refused, through the CLI and through `serve --auto-watch`, without touching the event-path logic that #893 proposed.

Also in this branch: `tests/test_repo_root_identity.py` added to the Test Structure list in CLAUDE.md, and the stale-SDK sweep now skips `evaluate/`, whose gitignored benchmark clones vendor an old copy of this project and failed the test on any machine that has run the benchmarks.

Local gates: `2985 passed, 9 skipped, 2 xpassed`, ruff and mypy clean.

Closes #889.