### PR TITLE
release: v2.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.3.8] - 2026-08-21
+
 ### Added
 
 - Empty results from `query_graph`, `get_impact_radius`, and
@@ -35,6 +37,25 @@
 
 ### Fixed
 
+- Every MCP tool response is now bounded. #849 found `get_affected_flows`
+  returning roughly 247k tokens inside a workflow documented as "5 tool calls,
+  800 tokens total"; measuring all 30 registered tools against a real
+  5.6k-node graph found the same shape in ten more places, several of them on
+  the default path. Each list now carries a hard ceiling, keeps its
+  untruncated total, and reports "showing N of M" in the summary, so a caller
+  can tell a short answer from a truncated one. Four query tools are still
+  unbounded and tracked in #888 (#849, #853, #887).
+- A repository is now one graph however its root is spelled. Every
+  path-valued `--repo` is canonicalized at the CLI boundary, and the full
+  build, incremental update and watch entry points each resolve their root, so
+  `.`, a relative path, a trailing slash, a symlinked path and an absolute
+  path no longer split the graph or reconcile each other away. An incremental
+  run whose stored `File` nodes all belong to a different root is refused with
+  a clear error instead of emptying the graph file by file, while orphan-only
+  cleanup from #861 is unchanged (#889).
+- A repository reached through a symlinked path is watched and indexed instead
+  of silently dropping every filesystem event, both through
+  `code-review-graph watch --repo` and through `serve --auto-watch` (#892).
 - Watch mode no longer registers OS watches inside ignored trees, and no longer
   keeps running after its filesystem observer dies. Watches are now planned per
   directory (ignored trees are skipped, the repo root is watched

--- a/code_review_graph/__init__.py
+++ b/code_review_graph/__init__.py
@@ -8,7 +8,7 @@ from .context_savings import (
     format_context_savings,
 )
 
-__version__ = "2.3.7"
+__version__ = "2.3.8"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-review-graph"
-version = "2.3.7"
+version = "2.3.8"
 description = "Local-first knowledge graph for token-efficient code review through MCP and CLI"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"


### PR DESCRIPTION
Patch release cutting the accumulated `[Unreleased]` section, 108 merges since v2.3.7.

**Version**: `2.3.7` → `2.3.8` in `pyproject.toml` and `code_review_graph/__init__.py`.

**Changelog**: `[Unreleased]` becomes `[2.3.8] - 2026-08-21`, plus three entries for work that landed without one — bounded MCP tool responses (#849, #853, #887), one graph identity per repository root spelling (#889), and symlinked roots being watched rather than silently dropped (#892).

**Verification before cutting**

- `2985 passed, 9 skipped, 2 xpassed`; ruff and mypy clean.
- VS Code extension: `npm run compile` and `tsc --noEmit` both clean.
- `python -m build` produces `code_review_graph-2.3.8` sdist and wheel.
- End-to-end CLI run on a scratch repository, 19/19: build, status, incremental update, `query callers_of`, detect-changes, wiki, visualize, forget, register/repos, `update --repo .`, MCP stdio handshake (initialize → tools/list → 30 tools → tools/call), install and uninstall.
- Symlinked-root watch verified separately on merged main: build through `/var/folders/...` then `watch` on the same spelling picks up a later edit.

Merging this tags v2.3.8 and publishes to PyPI via the release workflow.