### PR TITLE
chore(lock): record 2.3.8 for the local package

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "code-review-graph"
-version = "2.3.7"
+version = "2.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
The v2.3.8 bump updated `pyproject.toml` and `code_review_graph/__init__.py` but not the lockfile's own entry for this package, which still said 2.3.7. Regenerated with `uv lock`; one line changes and no dependency versions move. Tagging waits on this so the tag points at a self-consistent tree.