### PR TITLE
fix(python): resolve imports whose package name is not the on-disk layout

### DIFF
--- a/code_review_graph/python_resolver.py
+++ b/code_review_graph/python_resolver.py
@@ -4,16 +4,109 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .graph import GraphStore
 
 logger = logging.getLogger(__name__)
 
+# A one-segment suffix ("exceptions") matches far too many unrelated files to
+# be evidence of anything. Two is the shortest suffix that still carries the
+# defining directory, and uniqueness is enforced on top of it.
+_MIN_SUFFIX_SEGMENTS = 2
+
+# Floor for the attestation count, so a two-file repository can still establish
+# a prefix while a single coincidence cannot.
+_MIN_PREFIX_EVIDENCE = 2
+
+
+def learn_synthetic_prefixes(
+    modules: dict[str, set[str]], raw_modules: Iterable[str],
+) -> set[str]:
+    """Infer which leading segments name a package the repository never spells.
+
+    ``modules`` is keyed by every path suffix of every indexed file, so an
+    import is found when the package name matches the repository layout. It is
+    not when a framework assembles the package at runtime: Odoo serves
+    ``odoo.addons.foo.bar`` from ``addons/<any>/foo/bar.py``, and no directory
+    named ``odoo`` exists in the repository at all.
+
+    Stripping whatever prefix happens to make a suffix match is not safe -- an
+    import of a module that simply is not indexed will find some unrelated file
+    that shares its last two segments. So the prefix has to earn it: count how
+    many distinct imports each candidate prefix would resolve uniquely, and keep
+    only those attested well enough to be a real namespace rather than a
+    coincidence. A genuine one is shared by everything the framework loads,
+    which puts it orders of magnitude above the noise.
+    """
+    votes: Counter[str] = Counter()
+    for raw_module in raw_modules:
+        segments = raw_module.split(".")
+        for cut in range(1, len(segments) - _MIN_SUFFIX_SEGMENTS + 1):
+            if len(modules.get(".".join(segments[cut:]), ())) == 1:
+                votes[".".join(segments[:cut])] += 1
+    if not votes:
+        return set()
+    strongest = max(votes.values())
+    threshold = max(_MIN_PREFIX_EVIDENCE, strongest // 4)
+    return {prefix for prefix, count in votes.items() if count >= threshold}
+
+
+def _candidates_behind_prefix(
+    modules: dict[str, set[str]], raw_module: str, prefixes: set[str],
+) -> set[str]:
+    """Look the import up with an attested synthetic prefix removed.
+
+    Only the shortest attested prefix is tried, and its result is returned as
+    is: if the remainder names nothing indexed, the import stays unresolved
+    rather than falling through to a shorter, less specific suffix.
+    """
+    segments = raw_module.split(".")
+    for cut in range(1, len(segments) - _MIN_SUFFIX_SEGMENTS + 1):
+        if ".".join(segments[:cut]) in prefixes:
+            return modules.get(".".join(segments[cut:]), set())
+    return set()
+
+
+def _module_of(edge, python_file_set: set[str]) -> tuple[dict, str | None]:
+    """Return the edge's metadata and the module name still to be resolved.
+
+    ``None`` for the module means there is nothing to resolve: the target is
+    already a path, or a relative import the parser handles on its own.
+    """
+    try:
+        extra = json.loads(edge["extra"] or "{}")
+    except (TypeError, json.JSONDecodeError):
+        extra = {}
+    if not isinstance(extra, dict):
+        extra = {}
+
+    raw_module = extra.get("python_module")
+    if isinstance(raw_module, str):
+        return extra, raw_module
+
+    raw_module = edge["target_qualified"]
+    if (
+        raw_module in python_file_set
+        or raw_module.startswith(".")
+        or "/" in raw_module
+        or "\\" in raw_module
+    ):
+        return extra, None
+    return extra, raw_module
+
 
 def resolve_python_imports(store: GraphStore) -> dict[str, int]:
-    """Resolve raw Python modules by unique repository-wide path suffix."""
+    """Resolve raw Python modules by unique repository-wide path suffix.
+
+    Suffixes are taken on both sides: of the indexed file paths, and -- when the
+    full module name is absent from the index -- of the import itself. See
+    ``_candidates_by_module_suffix``.
+    """
     conn = store._conn  # intentional: bounded post-build maintenance pass
     python_files = [
         row["file_path"]
@@ -51,31 +144,35 @@ def resolve_python_imports(store: GraphStore) -> dict[str, int]:
     resolved = 0
     ambiguous = 0
     python_file_set = set(python_files)
-    for edge in conn.execute(
+    edge_rows = conn.execute(
         "SELECT DISTINCT e.id, e.target_qualified, e.extra "
         "FROM edges e JOIN nodes f "
         "ON f.kind = 'File' AND f.file_path = e.file_path "
         "WHERE e.kind = 'IMPORTS_FROM' AND f.language = 'python'"
-    ).fetchall():
-        try:
-            extra = json.loads(edge["extra"] or "{}")
-        except (TypeError, json.JSONDecodeError):
-            extra = {}
-        if not isinstance(extra, dict):
-            extra = {}
+    ).fetchall()
 
-        raw_module = extra.get("python_module")
-        if not isinstance(raw_module, str):
-            raw_module = edge["target_qualified"]
-            if (
-                raw_module in python_file_set
-                or raw_module.startswith(".")
-                or "/" in raw_module
-                or "\\" in raw_module
-            ):
-                continue
+    # Which prefixes are synthetic is a property of the repository, not of any
+    # one import, so it is settled once -- over the imports the layout cannot
+    # explain -- before any of them is resolved.
+    parsed_edges = []
+    for edge in edge_rows:
+        extra, raw_module = _module_of(edge, python_file_set)
+        if raw_module is not None:
+            parsed_edges.append((edge, extra, raw_module))
+    synthetic_prefixes = learn_synthetic_prefixes(
+        modules,
+        {
+            raw_module
+            for _edge, _extra, raw_module in parsed_edges
+            if raw_module not in modules
+        },
+    )
 
-        candidates = sorted(modules.get(raw_module, ()))
+    for edge, extra, raw_module in parsed_edges:
+        candidates = sorted(
+            modules.get(raw_module)
+            or _candidates_behind_prefix(modules, raw_module, synthetic_prefixes)
+        )
         desired_extra = dict(extra)
         desired_extra["python_module"] = raw_module
         if len(candidates) == 1:

--- a/tests/test_python_namespace_imports.py
+++ b/tests/test_python_namespace_imports.py
@@ -1,0 +1,195 @@
+"""Imports whose package name is not the on-disk layout.
+
+``src`` layouts already resolve because ``mypkg.runner`` is a literal suffix of
+``src/mypkg/runner.py``. Frameworks that assemble a package at runtime are the
+gap: the import carries a prefix that exists in no directory. Odoo is the
+clearest case -- ``odoo.addons.foo.bar`` is served from ``addons/<any>/foo/bar.py``
+and nothing on disk is named ``odoo`` -- but Django app registries and plugin
+namespaces land in the same place.
+"""
+
+from unittest.mock import patch
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import full_build
+from code_review_graph.postprocessing import run_post_processing
+from code_review_graph.python_resolver import (
+    _MIN_PREFIX_EVIDENCE,
+    _candidates_behind_prefix,
+    learn_synthetic_prefixes,
+)
+
+
+def _odoo_like_repo(tmp_path):
+    """Two addons and their tests, addressed through a synthetic package.
+
+    Two, not one: a prefix has to be attested by more than a single import
+    before it is treated as a namespace, and a framework that assembles one
+    always loads more than a single module through it.
+    """
+    module = tmp_path / "addons" / "partner" / "billing" / "wizard" / "invoice.py"
+    test_file = tmp_path / "addons" / "partner" / "billing" / "tests" / "test_invoice.py"
+    sibling = tmp_path / "addons" / "partner" / "shipping" / "wizard" / "label.py"
+    sibling_test = tmp_path / "addons" / "partner" / "shipping" / "tests" / "test_label.py"
+    for path in (module, test_file, sibling, sibling_test):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        (path.parent / "__init__.py").write_text("")
+    module.write_text(
+        "def prepare_totals(amount):\n"
+        "    return amount * 2\n"
+    )
+    test_file.write_text(
+        "from odoo.addons.billing.wizard.invoice import prepare_totals\n\n"
+        "def test_prepare_totals_doubles():\n"
+        "    assert prepare_totals(2) == 4\n"
+    )
+    sibling.write_text(
+        "def build_label(code):\n"
+        "    return code.upper()\n"
+    )
+    sibling_test.write_text(
+        "from odoo.addons.shipping.wizard.label import build_label\n\n"
+        "def test_build_label_uppercases():\n"
+        "    assert build_label('a') == 'A'\n"
+    )
+    (tmp_path / ".git").mkdir()
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    tracked = [
+        "addons/partner/billing/wizard/__init__.py",
+        "addons/partner/billing/wizard/invoice.py",
+        "addons/partner/billing/tests/__init__.py",
+        "addons/partner/billing/tests/test_invoice.py",
+        "addons/partner/shipping/wizard/__init__.py",
+        "addons/partner/shipping/wizard/label.py",
+        "addons/partner/shipping/tests/__init__.py",
+        "addons/partner/shipping/tests/test_label.py",
+    ]
+    return module, test_file, graph_dir, tracked
+
+
+def test_synthetic_package_import_resolves_to_the_indexed_file(tmp_path):
+    module, test_file, graph_dir, tracked = _odoo_like_repo(tmp_path)
+    store = GraphStore(graph_dir / "graph.db")
+    try:
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=tracked,
+        ):
+            result = full_build(tmp_path, store)
+
+        assert result["python_resolution"]["imports_resolved"] == 2
+        assert {
+            row["target_qualified"]
+            for row in store._conn.execute(
+                "SELECT target_qualified FROM edges "
+                "WHERE kind = 'IMPORTS_FROM' AND file_path = ?",
+                (test_file.as_posix(),),
+            ).fetchall()
+        } == {module.as_posix()}
+    finally:
+        store.close()
+
+
+def test_coverage_is_visible_through_a_synthetic_package_import(tmp_path):
+    """The user-visible symptom: tests_for reporting covered code as uncovered."""
+    module, _test_file, graph_dir, tracked = _odoo_like_repo(tmp_path)
+    store = GraphStore(graph_dir / "graph.db")
+    try:
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=tracked,
+        ):
+            full_build(tmp_path, store)
+        run_post_processing(store)
+
+        production = f"{module.as_posix()}::prepare_totals"
+        covering = store.get_transitive_tests(production, max_depth=0)
+
+        assert {test["name"] for test in covering} == {"test_prepare_totals_doubles"}
+    finally:
+        store.close()
+
+
+def _attested(*raw_modules):
+    """A prefix only counts once several imports agree on it."""
+    return list(raw_modules) * _MIN_PREFIX_EVIDENCE
+
+
+def test_attested_prefix_is_learned():
+    modules = {
+        "billing.wizard.invoice": {"/repo/addons/partner/billing/wizard/invoice.py"},
+        "shipping.wizard.label": {"/repo/addons/partner/shipping/wizard/label.py"},
+    }
+
+    prefixes = learn_synthetic_prefixes(
+        modules,
+        _attested(
+            "odoo.addons.billing.wizard.invoice",
+            "odoo.addons.shipping.wizard.label",
+        ),
+    )
+
+    assert "odoo.addons" in prefixes
+
+
+def test_import_of_an_unindexed_module_stays_unresolved():
+    """The regression that made the first cut of this fix wrong.
+
+    ``web`` is not in the repository -- it ships with the framework. Stripping
+    one segment further finds an unrelated ``controllers/utils.py`` that happens
+    to be the only one, and a confidently wrong edge is worse than none.
+    """
+    modules = {
+        "billing.wizard.invoice": {"/repo/addons/partner/billing/wizard/invoice.py"},
+        "controllers.utils": {"/repo/addons/other/renting/controllers/utils.py"},
+    }
+    prefixes = learn_synthetic_prefixes(
+        modules, _attested("odoo.addons.billing.wizard.invoice"),
+    )
+
+    assert prefixes == {"odoo.addons"}
+    assert _candidates_behind_prefix(
+        modules, "odoo.addons.web.controllers.utils", prefixes,
+    ) == set()
+
+
+def test_ambiguous_module_is_reported_rather_than_picked():
+    """Two files behind the same module must stay ambiguous.
+
+    The caller resolves only when exactly one candidate comes back, so handing
+    it both is what keeps a wrong edge from being invented.
+    """
+    both = {
+        "/repo/addons/partner/billing/wizard/invoice.py",
+        "/repo/addons/other/billing/wizard/invoice.py",
+    }
+    modules = {"billing.wizard.invoice": both}
+
+    assert _candidates_behind_prefix(
+        modules, "odoo.addons.billing.wizard.invoice", {"odoo.addons"},
+    ) == both
+
+
+def test_a_single_coincidence_does_not_establish_a_prefix():
+    modules = {"controllers.utils": {"/repo/addons/other/renting/controllers/utils.py"}}
+
+    prefixes = learn_synthetic_prefixes(modules, ["odoo.addons.web.controllers.utils"])
+
+    assert prefixes == set()
+
+
+def test_unattested_prefix_resolves_nothing():
+    modules = {"billing.wizard.invoice": {"/repo/addons/partner/billing/wizard/invoice.py"}}
+
+    assert _candidates_behind_prefix(
+        modules, "odoo.addons.billing.wizard.invoice", set(),
+    ) == set()
+
+
+def test_single_segment_remainder_is_not_evidence():
+    """``exceptions`` matches half the world; it must never resolve on its own."""
+    modules = {"exceptions": {"/repo/addons/partner/billing/exceptions.py"}}
+
+    assert learn_synthetic_prefixes(modules, _attested("odoo.exceptions")) == set()
+    assert _candidates_behind_prefix(modules, "odoo.exceptions", {"odoo"}) == set()


### PR DESCRIPTION
Fixes #903.

## The gap

`resolve_python_imports` indexes every path suffix of every indexed Python file,
then looks each import up by its **full** module name:

```python
candidates = sorted(modules.get(raw_module, ()))
```

That works whenever the package name matches the repository layout — `src`
layouts resolve because `mypkg.runner` is a literal suffix of
`src/mypkg/runner.py`, which is what `test_src_layout_imports_resolve_before_test_coverage`
covers.

It does not work when a framework assembles the package at runtime. Odoo serves
`odoo.addons.foo.bar` from `addons/<any>/foo/bar.py`, and no directory named
`odoo` exists in the repository at all, so the key is never present and the
import is recorded `unresolved`.

Everything downstream inherits that. `_resolve_bare_endpoints` has no import
evidence to match bare `TESTED_BY` sources against, so
`_select_evidence_backed_candidate` returns `None` and the edge is dropped —
which surfaces to the user as `tests_for` reporting covered code as uncovered,
silently. Django app registries and plugin namespaces land in the same place.

## Why not just strip segments until something matches

That was my first cut, and it was wrong. An import of a module that is simply
not indexed keeps shortening until it finds *some* file sharing its last two
segments:

```
odoo.addons.web.controllers.utils  ->  addons/enterprise/sale_renting/controllers/utils.py
odoo.addons.base.models.ir_qweb    ->  addons/enterprise/web_studio/models/ir_qweb.py
```

`web` and `base` ship with the framework and are not in the repository. On the
same corpus that produced the numbers below, 20 of 326 resolutions were
fabricated this way. A confidently wrong edge is worse than a missing one, so
that approach is not in this PR — but it is in the tests, as a regression.

## The change

The prefix has to be attested. Count how many distinct imports each candidate
prefix would resolve uniquely, and accept only those supported well enough to be
a namespace rather than a coincidence. A real one is shared by everything the
framework loads, which puts it far above the noise — on the corpus below,
`odoo.addons` scores 305 against 6 for the runner-up, and is the only prefix
accepted.

Once a prefix is established the remainder is looked up as is. No match means
unresolved; it never falls through to a shorter, less specific suffix. Ambiguity
is still the caller's call: more than one candidate is reported ambiguous, as
before.

## Measurements

Odoo 18 repository, 9,891 files, 921 distinct dotted imports:

| | before | after |
|---|---:|---:|
| resolved | 0 | **305** |
| ambiguous | 0 | 87 |
| unresolved | 921 | 529 |

The 529 that remain are genuinely external — `odoo` itself, stdlib,
site-packages — and correctly stay unresolved.

Correctness was checked, not just volume: for every resolution of an
`odoo.addons.X...` import, the destination file must live under a directory
named `X`. All 305 do. The naive version scored 306 coherent and 20 fabricated;
this one trades that single extra resolution for eliminating all 20.

## Tests

`tests/test_python_namespace_imports.py`, eight cases: two end-to-end (imports
resolve; coverage becomes visible through `get_transitive_tests`) and six on the
boundaries — a prefix is learned only when attested, a single coincidence
establishes nothing, an unindexed module stays unresolved, ambiguity is
preserved, an unattested prefix resolves nothing, and a one-segment remainder is
never evidence.

Full suite: **2996 passed, 5 skipped, 1 failed**. The failure is
`test_windows_server_still_prewarms_before_mcp_run`, which fails identically on
`upstream/main` without this change (`NameError: windows_events` — a Windows
path exercised on macOS). `ruff check code_review_graph/` is clean.

## Prior art

#799 fixed the same namespace-versus-path mismatch for C#, by mapping declared
namespaces back to the files declaring them. Python has no declared namespace to
map, since the module name is derived from the path — hence inferring the
prefix from repeated evidence instead of a lookup table.
