### PR TITLE
test(windows): cover incremental and watch suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,14 @@ jobs:
           tests/test_communities.py
           tests/test_flows.py
           tests/test_graph.py
+          tests/test_incremental.py
           tests/test_integration_v2.py
           tests/test_migrations.py
           tests/test_postprocessing.py
           tests/test_refactor.py
           tests/test_search.py
           tests/test_tools.py
+          tests/test_watch_robustness.py
           tests/test_wiki.py
           tests/test_skills.py::TestInstallCodexHooks
           tests/test_skills.py::TestInstallCursorHooks

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -164,7 +164,7 @@ class TestGetDbPath:
         get_db_path(tmp_path)
         gi = tmp_path / ".code-review-graph" / ".gitignore"
         assert gi.exists()
-        assert "*\n" in gi.read_text()
+        assert "*\n" in gi.read_text(encoding="utf-8")
 
     def test_migrates_legacy_db(self, tmp_path):
         legacy = tmp_path / ".code-review-graph.db"

--- a/tests/test_watch_robustness.py
+++ b/tests/test_watch_robustness.py
@@ -1024,6 +1024,10 @@ class TestWatchLoop:
         assert seen[0].get("phase") == "initial-build"
         assert seen[0].get("stalled") is False
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="os.kill(SIGTERM) terminates Windows processes before the handler can run",
+    )
     def test_sigterm_clears_the_health_file(self, tmp_path):
         """`crg-daemon stop` sends SIGTERM; a leftover file reads as stalled."""
         import os


### PR DESCRIPTION
## Linked issue

Closes #898

## What & why

- Run `tests/test_incremental.py` and `tests/test_watch_robustness.py` in the
  existing Windows-native CI job.
- Read the generated UTF-8 `.gitignore` explicitly as UTF-8 so the assertion
  does not depend on the Windows system locale.
- Skip only the in-process SIGTERM cleanup test on Windows, where
  `os.kill(SIGTERM)` terminates the process before the installed Python handler
  can run. The rest of both suites continues to run on Windows.

## How it was tested

- Python 3.12 Windows-native CI selection: 679 passed, 11 skipped.
- Python 3.11 Windows-native CI selection: 679 passed, 11 skipped.
- `uv run ruff check code_review_graph/ tests/test_incremental.py tests/test_watch_robustness.py`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
- Workflow YAML parsing and `git diff --check`

The repository's complete test suite is not currently Windows-clean outside
the selected native job; this change does not modify production code.

## Checklist

- [x] Tests updated for the expanded Windows coverage
- [x] Windows-native test selection passes
- [x] Linting passes
- [x] Type checking passes
- [x] Lines are at most 100 characters
- [x] Documentation is not affected