### PR TITLE
fix(parser): preserve full C# nested type identity

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -77,6 +77,12 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
+CSHARP_IDENTITY_VERSION = "1"
+_CSHARP_IDENTITY_METADATA_KEY = "csharp_identity_version"
+_IDENTITY_FORMATS = (
+    ("cpp", "C++", _CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION),
+    ("csharp", "C#", _CSHARP_IDENTITY_METADATA_KEY, CSHARP_IDENTITY_VERSION),
+)
 
 
 def _run_python_resolver(store: GraphStore) -> Optional[dict]:
@@ -1273,8 +1279,15 @@ def full_build(
     total_nodes = 0
     total_edges = 0
     errors = []
-    cpp_errors: set[str] = set()
+    identity_errors: dict[str, set[str]] = {
+        language: set() for language, _, _, _ in _IDENTITY_FORMATS
+    }
     file_count = len(files)
+
+    def record_identity_error(rel_path: str) -> None:
+        language = parser.detect_language(repo_root / rel_path)
+        if language in identity_errors:
+            identity_errors[language].add(str(rel_path))
 
     use_serial = os.environ.get("CRG_SERIAL_PARSE", "") == "1"
 
@@ -1291,13 +1304,11 @@ def full_build(
                 total_edges += len(edges)
             except (OSError, PermissionError) as e:
                 errors.append({"file": rel_path, "error": str(e)})
-                if parser.detect_language(full_path) == "cpp":
-                    cpp_errors.add(str(rel_path))
+                record_identity_error(rel_path)
             except Exception as e:
                 logger.warning("Error parsing %s: %s", rel_path, e)
                 errors.append({"file": rel_path, "error": str(e)})
-                if parser.detect_language(full_path) == "cpp":
-                    cpp_errors.add(str(rel_path))
+                record_identity_error(rel_path)
             if i % 50 == 0 or i == file_count:
                 logger.info("Progress: %d/%d files parsed", i, file_count)
     else:
@@ -1315,8 +1326,7 @@ def full_build(
                 if error:
                     logger.warning("Error parsing %s: %s", rel_path, error)
                     errors.append({"file": rel_path, "error": error})
-                    if parser.detect_language(repo_root / rel_path) == "cpp":
-                        cpp_errors.add(str(rel_path))
+                    record_identity_error(rel_path)
                     continue
                 full_path = repo_root / rel_path
                 store.store_file_nodes_edges(
@@ -1332,8 +1342,9 @@ def full_build(
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
-    if not cpp_errors:
-        store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+    for language, _, metadata_key, version in _IDENTITY_FORMATS:
+        if not identity_errors[language]:
+            store.set_metadata(metadata_key, version)
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
@@ -1375,12 +1386,16 @@ def incremental_update(
     parser = CodeParser(repo_root)
     ignore_patterns = _load_ignore_patterns(repo_root)
 
-    if (
-        store.get_metadata(_CPP_IDENTITY_METADATA_KEY) != CPP_IDENTITY_VERSION
-        and store.has_nodes_for_language("cpp")
-    ):
+    pending_identity_formats = [
+        (language, label)
+        for language, label, metadata_key, version in _IDENTITY_FORMATS
+        if store.get_metadata(metadata_key) != version
+        and store.has_nodes_for_language(language)
+    ]
+    if pending_identity_formats:
         logger.info(
-            "C++ identity format changed; rebuilding the graph before incremental update",
+            "%s identity format changed; rebuilding the graph before incremental update",
+            ", ".join(label for _, label in pending_identity_formats),
         )
         rebuilt = full_build(repo_root, store)
         return {
@@ -1397,6 +1412,7 @@ def incremental_update(
             "event_resolution": rebuilt["event_resolution"],
             "temporal_resolution": rebuilt["temporal_resolution"],
             "hcl_resolution": rebuilt["hcl_resolution"],
+            "scoped_resolution": rebuilt["scoped_resolution"],
         }
 
     # Determine changed files
@@ -1507,7 +1523,8 @@ def incremental_update(
     if files_updated:
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
-        store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+        for _, _, metadata_key, version in _IDENTITY_FORMATS:
+            store.set_metadata(metadata_key, version)
         _store_vcs_metadata(repo_root, store)
         store.commit()
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5376,6 +5376,7 @@ class CodeParser:
                     result,
                     child.child_by_field_name("name"),
                     declared_type,
+                    keep_qualifier=True,
                 )
 
         elif language == "csharp" and node.type == "parameter":
@@ -5383,6 +5384,7 @@ class CodeParser:
                 result,
                 node.child_by_field_name("name"),
                 node.child_by_field_name("type"),
+                keep_qualifier=True,
             )
 
         elif language == "php" and node.type == "assignment_expression":
@@ -5426,18 +5428,28 @@ class CodeParser:
         return {name} if name else set()
 
     @classmethod
-    def _store_typed_binding(cls, result: dict[str, str], name_node, type_node) -> None:
+    def _store_typed_binding(
+        cls,
+        result: dict[str, str],
+        name_node,
+        type_node,
+        *,
+        keep_qualifier: bool = False,
+    ) -> None:
         if name_node is None or type_node is None:
             return
         name = name_node.text.decode("utf-8", errors="replace")
         type_name = cls._base_type_name(
             type_node.text.decode("utf-8", errors="replace"),
+            keep_qualifier=keep_qualifier,
         )
         if name and type_name:
             result[name] = type_name
 
     @classmethod
-    def _base_type_name(cls, annotation: str) -> Optional[str]:
+    def _base_type_name(
+        cls, annotation: str, *, keep_qualifier: bool = False,
+    ) -> Optional[str]:
         """Return the receiver class from a generic/nullable annotation."""
         current = annotation.strip()
         for _ in range(4):
@@ -5464,7 +5476,7 @@ class CodeParser:
                 "string", "unknown", "void",
             ):
                 return None
-            return outer
+            return match.group(1) if keep_qualifier else outer
         return None
 
     def _resolve_typed_method_target(
@@ -5490,7 +5502,7 @@ class CodeParser:
             # class receiver cannot be resolved to its defining file during
             # a single-file parse. Emit the receiver class as a scope target
             # for the graph-wide scoped resolver (#612).
-            base_type = self._base_type_name(type_name)
+            base_type = self._base_type_name(type_name, keep_qualifier=True)
             if not base_type:
                 return None
             return f"{base_type}::{method}"
@@ -7425,10 +7437,10 @@ class CodeParser:
         return qualifier, name
 
     @staticmethod
-    def _julia_scope_join(
+    def _scope_join(
         outer: Optional[str], inner: Optional[str],
     ) -> Optional[str]:
-        """Join Julia scope paths without repeating an existing prefix."""
+        """Join dotted scope paths without repeating an existing prefix."""
         if not outer:
             return inner
         if not inner:
@@ -7523,7 +7535,7 @@ class CodeParser:
         import_map: dict[str, str],
     ) -> Optional[str]:
         """Resolve a Julia import alias from the nearest lexical scope."""
-        scope = self._julia_scope_join(enclosing_class, enclosing_func)
+        scope = self._scope_join(enclosing_class, enclosing_func)
         scope_parts = scope.split(".") if scope else []
         for size in range(len(scope_parts), -1, -1):
             prefix = ".".join(scope_parts[:size])
@@ -7672,11 +7684,11 @@ class CodeParser:
                 if name:
                     is_test = _is_test_function(name, file_path, ())
                     kind = "Test" if is_test else "Function"
-                    lexical_parent = self._julia_scope_join(
+                    lexical_parent = self._scope_join(
                         enclosing_class, enclosing_func,
                     )
                     qualifier = self._julia_short_qualifier(lhs)
-                    identity_parent = self._julia_scope_join(
+                    identity_parent = self._scope_join(
                         lexical_parent, qualifier,
                     )
                     qualified = self._qualify(
@@ -7870,7 +7882,7 @@ class CodeParser:
                         vname = variant.text.decode(
                             "utf-8", errors="replace",
                         )
-                        variant_parent = self._julia_scope_join(
+                        variant_parent = self._scope_join(
                             enclosing_class, type_name,
                         )
                         qualified_v = self._qualify(
@@ -7915,7 +7927,7 @@ class CodeParser:
                 line_no = child.start_point[0] + 1
                 synth_base = f"testset:{desc}" if desc else "testset"
                 synth_name = f"{synth_base}@L{line_no}"
-                lexical_parent = self._julia_scope_join(
+                lexical_parent = self._scope_join(
                     enclosing_class, enclosing_func,
                 )
                 qualified = self._qualify(
@@ -10257,7 +10269,7 @@ class CodeParser:
         # CONTAINS edge
         class_container = (
             self._qualify(enclosing_class, file_path, None)
-            if language == "julia" and enclosing_class
+            if language in ("csharp", "julia") and enclosing_class
             else file_path
         )
         edges.append(EdgeInfo(
@@ -10295,8 +10307,8 @@ class CodeParser:
             self._emit_kafka_edges_from_class(child, name, file_path, edges)
 
         # Recurse into class body
-        if language == "julia":
-            recursive_class = self._julia_scope_join(enclosing_class, name)
+        if language in ("csharp", "julia"):
+            recursive_class = self._scope_join(enclosing_class, name)
         else:
             recursive_class = name
         self._extract_from_tree(
@@ -10403,11 +10415,11 @@ class CodeParser:
         container_scope = enclosing_class
         julia_qualifier: Optional[str] = None
         if language == "julia":
-            lexical_parent = self._julia_scope_join(
+            lexical_parent = self._scope_join(
                 enclosing_class, enclosing_func,
             )
             julia_qualifier = self._julia_definition_qualifier(child)
-            parent_name = self._julia_scope_join(
+            parent_name = self._scope_join(
                 lexical_parent, julia_qualifier,
             )
             container_scope = lexical_parent
@@ -13066,7 +13078,7 @@ class CodeParser:
                 module_name = name_node.text.decode(
                     "utf-8", errors="replace",
                 )
-                current_scope = self._julia_scope_join(
+                current_scope = self._scope_join(
                     current_scope, module_name,
                 )
 
@@ -13078,7 +13090,7 @@ class CodeParser:
                     child, "julia", source, local_imports,
                 )
                 for alias, target in local_imports.items():
-                    key = self._julia_scope_join(current_scope, alias)
+                    key = self._scope_join(current_scope, alias)
                     if key:
                         import_map[key] = target
                 continue

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -351,32 +351,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
                     ns for ns in declared if isinstance(ns, str)
                 }
 
-    def _csharp_namespace_visible(candidate: str, caller_file: str) -> bool:
-        """Whether *caller_file* can name *candidate* without qualifying it.
-
-        Namespaces are absent from ``parent_name``, so an exact containing-type
-        match proves nothing about the namespace the candidate actually sits in:
-        a type declared ``namespace Other { class App { class Report { ... } } }``
-        is keyed as ``App.Report.ExportHandler`` and matches a receiver meaning a
-        wholly different ``App.Report.ExportHandler``. When the receiver names no
-        namespace itself, the candidate's namespace therefore has to be reachable
-        from the call site -- same file, the global namespace, a ``using``, or a
-        namespace the caller declares.
-        """
-        candidate_file = file_of.get(candidate, "")
-        if candidate_file == caller_file:
-            return True
-        declared = csharp_namespaces_by_file.get(candidate_file, set())
-        if not declared:
-            return True  # global namespace is visible everywhere
-        visible = {
-            target
-            for target in imports_by_file.get(caller_file, set())
-            if "/" not in target and "\\" not in target
-        }
-        visible |= csharp_namespaces_by_file.get(caller_file, set())
-        return bool(declared & visible)
-
     def csharp_disambiguate(
         candidates: list[str], caller_file: str
     ) -> tuple[Optional[str], Optional[str]]:
@@ -545,16 +519,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             ))
             if not found:
                 continue
-            if dropped_namespace is None and language == "csharp":
-                # The receiver named no namespace, so the candidate's own
-                # namespace must be reachable from the call site.
-                found = [
-                    candidate
-                    for candidate in found
-                    if _csharp_namespace_visible(candidate, row["file_path"])
-                ]
-                if not found:
-                    continue
             if dropped_namespace is not None:
                 # The namespace evidence is per *file*, not per node, and one C#
                 # file may declare several namespaces. Membership alone would

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -351,6 +351,32 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
                     ns for ns in declared if isinstance(ns, str)
                 }
 
+    def _csharp_namespace_visible(candidate: str, caller_file: str) -> bool:
+        """Whether *caller_file* can name *candidate* without qualifying it.
+
+        Namespaces are absent from ``parent_name``, so an exact containing-type
+        match proves nothing about the namespace the candidate actually sits in:
+        a type declared ``namespace Other { class App { class Report { ... } } }``
+        is keyed as ``App.Report.ExportHandler`` and matches a receiver meaning a
+        wholly different ``App.Report.ExportHandler``. When the receiver names no
+        namespace itself, the candidate's namespace therefore has to be reachable
+        from the call site -- same file, the global namespace, a ``using``, or a
+        namespace the caller declares.
+        """
+        candidate_file = file_of.get(candidate, "")
+        if candidate_file == caller_file:
+            return True
+        declared = csharp_namespaces_by_file.get(candidate_file, set())
+        if not declared:
+            return True  # global namespace is visible everywhere
+        visible = {
+            target
+            for target in imports_by_file.get(caller_file, set())
+            if "/" not in target and "\\" not in target
+        }
+        visible |= csharp_namespaces_by_file.get(caller_file, set())
+        return bool(declared & visible)
+
     def csharp_disambiguate(
         candidates: list[str], caller_file: str
     ) -> tuple[Optional[str], Optional[str]]:
@@ -519,6 +545,16 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             ))
             if not found:
                 continue
+            if dropped_namespace is None and language == "csharp":
+                # The receiver named no namespace, so the candidate's own
+                # namespace must be reachable from the call site.
+                found = [
+                    candidate
+                    for candidate in found
+                    if _csharp_namespace_visible(candidate, row["file_path"])
+                ]
+                if not found:
+                    continue
             if dropped_namespace is not None:
                 # The namespace evidence is per *file*, not per node, and one C#
                 # file may declare several namespaces. Membership alone would

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -105,6 +105,29 @@ def _fold(name: str, language: str) -> str:
     return name.casefold() if language == "php" else name
 
 
+def _csharp_scope_suffixes(name: str) -> list[str]:
+    """Return a C# type path from most to least qualified."""
+    parts = name.split(".")
+    return [".".join(parts[index:]) for index in range(len(parts))]
+
+
+def _csharp_lexical_scopes(enclosing: Optional[str], receiver: str) -> list[str]:
+    """Return the receiver resolved against each enclosing scope, innermost first.
+
+    C# name lookup starts in the innermost enclosing type and walks outward
+    before it ever considers a global type, so inside ``Outer.Consumer`` the
+    receiver ``D.E`` means ``Outer.D.E`` even when a top-level ``D.E`` exists.
+    ``("Outer.Consumer", "D.E")`` → ``["Outer.Consumer.D.E", "Outer.D.E"]``.
+    """
+    if not enclosing:
+        return []
+    parts = enclosing.split(".")
+    return [
+        ".".join(parts[: index + 1]) + f".{receiver}"
+        for index in reversed(range(len(parts)))
+    ]
+
+
 def _path_tokens(file_path: str) -> list[str]:
     """Path split into segments, with the file extension stripped off the last.
 
@@ -237,11 +260,7 @@ def _scope_and_method(
         scope, _, method = target.partition("::")
         if not scope or not method or "::" in method:
             return None
-        # Strip any namespace qualifier: ``Acme.Services.Service`` → ``Service``.
-        class_name = scope.rsplit(".", 1)[-1]
-        if not class_name:
-            return None
-        return class_name, method, False
+        return scope, method, False
 
     return None
 
@@ -275,6 +294,7 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
     # keys are case-folded for PHP only (Rust identifiers are case-sensitive).
     # ------------------------------------------------------------------
     method_map: dict[tuple[str, str, str], list[str]] = {}
+    csharp_suffix_method_map: dict[tuple[str, str, str], list[str]] = {}
     file_of: dict[str, str] = {}
     kind_placeholders = ",".join("?" for _ in _METHOD_KINDS)
     for row in conn.execute(
@@ -285,8 +305,18 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         (*_METHOD_KINDS, *_SCOPED_LANGUAGES),
     ).fetchall():
         lang = row["language"]
-        key = (lang, _fold(row["parent_name"], lang), _fold(row["name"], lang))
+        key = (
+            lang,
+            _fold(row["parent_name"], lang),
+            _fold(row["name"], lang),
+        )
         method_map.setdefault(key, []).append(row["qualified_name"])
+        if lang == "csharp":
+            for parent_name in _csharp_scope_suffixes(row["parent_name"])[1:]:
+                suffix_key = (lang, parent_name, row["name"])
+                csharp_suffix_method_map.setdefault(suffix_key, []).append(
+                    row["qualified_name"]
+                )
         file_of[row["qualified_name"]] = row["file_path"]
 
     if not method_map:
@@ -450,9 +480,47 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             class_name = enclosing
         assert class_name is not None  # non-enclosing parse always sets a class
 
-        candidates = method_map.get(
-            (language, _fold(class_name, language), _fold(method, language))
-        )
+        # C# resolves a receiver by binding its leading identifier lexically,
+        # then binding each following component against that entity. Approximate
+        # that with three ordered phases, every exact phase exhausted before any
+        # heuristic runs:
+        #   1. lexical  - the receiver under each enclosing type, innermost first
+        #   2. exact    - the receiver itself, then progressively shorter paths
+        #   3. suffix   - the suffix map, which matches a *containing-type tail*
+        # Phase 2 must finish before phase 3 starts. Namespaces are deliberately
+        # absent from ``parent_name`` (they live in ``csharp_namespaces_by_file``),
+        # so a namespace-qualified receiver such as ``App.Details.QueryHandler``
+        # only matches exactly once shortened to ``Details.QueryHandler``.
+        # Interleaving the phases would let an unrelated nested type whose
+        # containing path merely ends in ``App.Details.QueryHandler`` win first,
+        # and a unique-but-wrong suffix hit then bypasses the namespace
+        # disambiguator entirely. ``needs_enclosing`` targets already name the
+        # caller's own type, so they never take the lexical phase.
+        lexical_scopes: list[str] = []
+        class_names = [class_name]
+        if language == "csharp":
+            if not needs_enclosing:
+                lexical_scopes = _csharp_lexical_scopes(
+                    _enclosing_class(row["source_qualified"]), class_name,
+                )
+            class_names = _csharp_scope_suffixes(class_name)
+
+        candidates = None
+        for candidate_class in [*lexical_scopes, *class_names]:
+            candidates = method_map.get((
+                language,
+                _fold(candidate_class, language),
+                _fold(method, language),
+            ))
+            if candidates:
+                break
+        if not candidates and language == "csharp":
+            for candidate_class in class_names:
+                candidates = csharp_suffix_method_map.get((
+                    language, candidate_class, method,
+                ))
+                if candidates:
+                    break
         if not candidates:
             continue
 

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -294,7 +294,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
     # keys are case-folded for PHP only (Rust identifiers are case-sensitive).
     # ------------------------------------------------------------------
     method_map: dict[tuple[str, str, str], list[str]] = {}
-    csharp_suffix_method_map: dict[tuple[str, str, str], list[str]] = {}
     file_of: dict[str, str] = {}
     kind_placeholders = ",".join("?" for _ in _METHOD_KINDS)
     for row in conn.execute(
@@ -311,12 +310,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             _fold(row["name"], lang),
         )
         method_map.setdefault(key, []).append(row["qualified_name"])
-        if lang == "csharp":
-            for parent_name in _csharp_scope_suffixes(row["parent_name"])[1:]:
-                suffix_key = (lang, parent_name, row["name"])
-                csharp_suffix_method_map.setdefault(suffix_key, []).append(
-                    row["qualified_name"]
-                )
         file_of[row["qualified_name"]] = row["file_path"]
 
     if not method_map:
@@ -481,21 +474,23 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         assert class_name is not None  # non-enclosing parse always sets a class
 
         # C# resolves a receiver by binding its leading identifier lexically,
-        # then binding each following component against that entity. Approximate
-        # that with three ordered phases, every exact phase exhausted before any
-        # heuristic runs:
-        #   1. lexical  - the receiver under each enclosing type, innermost first
-        #   2. exact    - the receiver itself, then progressively shorter paths
-        #   3. suffix   - the suffix map, which matches a *containing-type tail*
-        # Phase 2 must finish before phase 3 starts. Namespaces are deliberately
-        # absent from ``parent_name`` (they live in ``csharp_namespaces_by_file``),
-        # so a namespace-qualified receiver such as ``App.Details.QueryHandler``
-        # only matches exactly once shortened to ``Details.QueryHandler``.
-        # Interleaving the phases would let an unrelated nested type whose
-        # containing path merely ends in ``App.Details.QueryHandler`` win first,
-        # and a unique-but-wrong suffix hit then bypasses the namespace
-        # disambiguator entirely. ``needs_enclosing`` targets already name the
-        # caller's own type, so they never take the lexical phase.
+        # then binding each following component against that entity. Two ordered
+        # phases approximate that, and both match a containing-type path exactly:
+        #   1. lexical - the receiver under each enclosing type, innermost first
+        #   2. exact   - the receiver itself, then progressively shorter paths
+        # Phase 2 exists because namespaces are deliberately absent from
+        # ``parent_name`` (they live in ``csharp_namespaces_by_file``), so a
+        # namespace-qualified receiver such as ``App.Details.QueryHandler`` only
+        # matches once shortened to ``Details.QueryHandler``.
+        #
+        # There is deliberately no containing-type *suffix* fallback. Selecting a
+        # nested type from a bare receiver would bind names C# cannot bind: a bare
+        # ``QueryHandler`` does not name ``Details.QueryHandler``, which has to be
+        # qualified, so a lone indexed candidate would otherwise be rewritten as a
+        # single match with no visibility check at all. Leaving such a receiver
+        # unresolved is correct; the type may well live in a dependency that was
+        # never indexed. ``needs_enclosing`` targets already name the caller's own
+        # type, so they never take the lexical phase.
         lexical_scopes: list[str] = []
         class_names = [class_name]
         if language == "csharp":
@@ -514,13 +509,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             ))
             if candidates:
                 break
-        if not candidates and language == "csharp":
-            for candidate_class in class_names:
-                candidates = csharp_suffix_method_map.get((
-                    language, candidate_class, method,
-                ))
-                if candidates:
-                    break
         if not candidates:
             continue
 

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -473,42 +473,64 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             class_name = enclosing
         assert class_name is not None  # non-enclosing parse always sets a class
 
-        # C# resolves a receiver by binding its leading identifier lexically,
-        # then binding each following component against that entity. Two ordered
-        # phases approximate that, and both match a containing-type path exactly:
-        #   1. lexical - the receiver under each enclosing type, innermost first
-        #   2. exact   - the receiver itself, then progressively shorter paths
-        # Phase 2 exists because namespaces are deliberately absent from
-        # ``parent_name`` (they live in ``csharp_namespaces_by_file``), so a
-        # namespace-qualified receiver such as ``App.Details.QueryHandler`` only
-        # matches once shortened to ``Details.QueryHandler``.
+        # C# resolves a receiver by binding its leading identifier to a
+        # namespace or type, then binding each later component relative to what
+        # preceded it. It never discards a leading component and restarts.
         #
-        # There is deliberately no containing-type *suffix* fallback. Selecting a
-        # nested type from a bare receiver would bind names C# cannot bind: a bare
-        # ``QueryHandler`` does not name ``Details.QueryHandler``, which has to be
-        # qualified, so a lone indexed candidate would otherwise be rewritten as a
-        # single match with no visibility check at all. Leaving such a receiver
-        # unresolved is correct; the type may well live in a dependency that was
-        # never indexed. ``needs_enclosing`` targets already name the caller's own
-        # type, so they never take the lexical phase.
-        lexical_scopes: list[str] = []
-        class_names = [class_name]
+        # Two ordered phases approximate that. Both match a containing-type path
+        # exactly; there is no suffix fallback, because selecting a nested type
+        # from a bare receiver would bind names C# cannot bind.
+        #   1. lexical - the receiver under each enclosing type, innermost first
+        #   2. exact   - the receiver, then forms with a leading namespace removed
+        #
+        # Phase 2 exists only because namespaces are absent from ``parent_name``
+        # (they live in ``csharp_namespaces_by_file``), so a namespace-qualified
+        # receiver such as ``App.Report.ExportHandler`` is stored as
+        # ``Report.ExportHandler``. Every shortened form therefore has to prove
+        # the part it dropped really is a namespace of the candidate's defining
+        # file. Without that check the resolver would happily strip ``App`` and
+        # bind a ``Report.ExportHandler`` sitting in namespace ``Other`` -- a
+        # single candidate takes the single_match path, so nothing downstream
+        # would catch it. ``needs_enclosing`` targets already name the caller's
+        # own type, so they never take the lexical phase.
+        lookups: list[tuple[str, Optional[str]]] = []
         if language == "csharp":
             if not needs_enclosing:
-                lexical_scopes = _csharp_lexical_scopes(
-                    _enclosing_class(row["source_qualified"]), class_name,
+                lookups.extend(
+                    (scope, None)
+                    for scope in _csharp_lexical_scopes(
+                        _enclosing_class(row["source_qualified"]), class_name,
+                    )
                 )
-            class_names = _csharp_scope_suffixes(class_name)
+            parts = class_name.split(".")
+            lookups.extend(
+                (".".join(parts[index:]), ".".join(parts[:index]) or None)
+                for index in range(len(parts))
+            )
+        else:
+            lookups.append((class_name, None))
 
         candidates = None
-        for candidate_class in [*lexical_scopes, *class_names]:
-            candidates = method_map.get((
+        for candidate_class, dropped_namespace in lookups:
+            found = method_map.get((
                 language,
                 _fold(candidate_class, language),
                 _fold(method, language),
             ))
-            if candidates:
-                break
+            if not found:
+                continue
+            if dropped_namespace is not None:
+                found = [
+                    candidate
+                    for candidate in found
+                    if dropped_namespace in csharp_namespaces_by_file.get(
+                        file_of.get(candidate, ""), set(),
+                    )
+                ]
+                if not found:
+                    continue
+            candidates = found
+            break
         if not candidates:
             continue
 

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -520,12 +520,22 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
             if not found:
                 continue
             if dropped_namespace is not None:
+                # The namespace evidence is per *file*, not per node, and one C#
+                # file may declare several namespaces. Membership alone would
+                # only prove the dropped name appears somewhere in the candidate's
+                # file, not that it encloses the candidate: a file declaring both
+                # ``App`` and ``Other`` would let ``App.Ledger.AuditHandler`` bind
+                # an ``Other.Ledger.AuditHandler``. Require the file to declare
+                # exactly the dropped namespace, so the evidence is unambiguous.
+                # This leaves genuine matches in multi-namespace files unresolved,
+                # which is the right trade for a resolver that must not fabricate
+                # edges; per-node namespaces would resolve them properly.
                 found = [
                     candidate
                     for candidate in found
-                    if dropped_namespace in csharp_namespaces_by_file.get(
+                    if csharp_namespaces_by_file.get(
                         file_of.get(candidate, ""), set(),
-                    )
+                    ) == {dropped_namespace}
                 ]
                 if not found:
                     continue

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1153,6 +1153,20 @@ class TestCSharpReceiverCallResolution:
         "}\n"
         "public class E { public void M() { } }\n"
     )
+    LONE_NESTED = (
+        "public class Wrapper\n"
+        "{\n"
+        "    public class LoneHandler { public void Handle() { } }\n"
+        "}\n"
+    )
+    LONE_BARE_CONSUMER = (
+        "using External;\n"
+        "public class LoneBareConsumer\n"
+        "{\n"
+        "    LoneHandler handler;\n"
+        "    public void Call() { handler.Handle(); }\n"
+        "}\n"
+    )
     EXACT_PREFIX_TARGET = (
         "public class B\n"
         "{\n"
@@ -1226,6 +1240,8 @@ class TestCSharpReceiverCallResolution:
             "PrefixCollision.cs": self.PREFIX_COLLISION,
             "ExactPrefixTarget.cs": self.EXACT_PREFIX_TARGET,
             "LexicalShadow.cs": self.LEXICAL_SHADOW,
+            "LoneNested.cs": self.LONE_NESTED,
+            "LoneBareConsumer.cs": self.LONE_BARE_CONSUMER,
             "Namespaced.cs": self.NAMESPACED,
             "NamespaceSuffixDecoy.cs": self.NAMESPACE_SUFFIX_DECOY,
             "NamespacedConsumer.cs": self.NAMESPACED_CONSUMER,
@@ -1310,12 +1326,25 @@ class TestCSharpReceiverCallResolution:
             tmp_path, "ExactPathConsumer.Call",
         ) == {f"{target.as_posix()}::B.C.M"}
 
-    def test_longer_suffix_match_beats_shorter_exact_type(self, tmp_path):
+    def test_enclosing_scope_resolves_receiver_over_shorter_global_type(
+        self, tmp_path,
+    ):
+        """``D.E`` inside ``LexicalOuter`` binds to ``LexicalOuter.D.E`` through
+        the lexical phase, not to the shorter top-level ``E``."""
         self._build(tmp_path)
         target = tmp_path / "PrefixCollision.cs"
         assert self._call_targets_of(
             tmp_path, "LexicalOuter.SuffixPathConsumer.Call",
         ) == {f"{target.as_posix()}::LexicalOuter.D.E.M"}
+
+    def test_bare_receiver_never_selects_a_nested_type(self, tmp_path):
+        """A bare ``QueryHandler`` cannot name ``Details.QueryHandler`` in C#;
+        it has to be qualified. Even as the only indexed candidate it must stay
+        unresolved -- the real type may be in an unindexed dependency.
+        """
+        self._build(tmp_path)
+        targets = self._call_targets_of(tmp_path, "LoneBareConsumer.Call")
+        assert targets == {"Handle"}, targets
 
     def test_enclosing_type_shadows_global_type_of_the_same_path(self, tmp_path):
         """C# lookup starts at the innermost enclosing type, so inside

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1153,6 +1153,20 @@ class TestCSharpReceiverCallResolution:
         "}\n"
         "public class E { public void M() { } }\n"
     )
+    WRONG_NAMESPACE = (
+        "namespace Other;\n"
+        "public class Ledger\n"
+        "{\n"
+        "    public class AuditHandler { public void Run() { } }\n"
+        "}\n"
+    )
+    WRONG_NAMESPACE_CONSUMER = (
+        "public class WrongNamespaceConsumer\n"
+        "{\n"
+        "    App.Ledger.AuditHandler handler;\n"
+        "    public void Call() { handler.Run(); }\n"
+        "}\n"
+    )
     LONE_NESTED = (
         "public class Wrapper\n"
         "{\n"
@@ -1241,6 +1255,8 @@ class TestCSharpReceiverCallResolution:
             "ExactPrefixTarget.cs": self.EXACT_PREFIX_TARGET,
             "LexicalShadow.cs": self.LEXICAL_SHADOW,
             "LoneNested.cs": self.LONE_NESTED,
+            "WrongNamespace.cs": self.WRONG_NAMESPACE,
+            "WrongNamespaceConsumer.cs": self.WRONG_NAMESPACE_CONSUMER,
             "LoneBareConsumer.cs": self.LONE_BARE_CONSUMER,
             "Namespaced.cs": self.NAMESPACED,
             "NamespaceSuffixDecoy.cs": self.NAMESPACE_SUFFIX_DECOY,
@@ -1336,6 +1352,19 @@ class TestCSharpReceiverCallResolution:
         assert self._call_targets_of(
             tmp_path, "LexicalOuter.SuffixPathConsumer.Call",
         ) == {f"{target.as_posix()}::LexicalOuter.D.E.M"}
+
+    def test_shortened_receiver_requires_the_dropped_part_to_be_a_namespace(
+        self, tmp_path,
+    ):
+        """``App.Ledger.AuditHandler`` is stored as ``Ledger.AuditHandler``
+        only when ``App`` is the defining file's namespace. The one indexed
+        candidate here sits in namespace ``Other``, so dropping ``App`` to reach
+        it would bind a type the source never asked for; C# resolves the leading
+        identifier first and never restarts at a later component.
+        """
+        self._build(tmp_path)
+        targets = self._call_targets_of(tmp_path, "WrongNamespaceConsumer.Call")
+        assert targets == {"Run"}, targets
 
     def test_bare_receiver_never_selects_a_nested_type(self, tmp_path):
         """A bare ``QueryHandler`` cannot name ``Details.QueryHandler`` in C#;

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1153,6 +1153,23 @@ class TestCSharpReceiverCallResolution:
         "}\n"
         "public class E { public void M() { } }\n"
     )
+    WRONG_NAMESPACE_EXACT_PATH = (
+        "namespace Other;\n"
+        "public class Vault\n"
+        "{\n"
+        "    public class Archive\n"
+        "    {\n"
+        "        public class StoreHandler { public void Store() { } }\n"
+        "    }\n"
+        "}\n"
+    )
+    WRONG_NAMESPACE_EXACT_CONSUMER = (
+        "public class ExactPathNamespaceConsumer\n"
+        "{\n"
+        "    Vault.Archive.StoreHandler handler;\n"
+        "    public void Call() { handler.Store(); }\n"
+        "}\n"
+    )
     MULTI_NAMESPACE = (
         "namespace App\n"
         "{\n"
@@ -1277,6 +1294,8 @@ class TestCSharpReceiverCallResolution:
             "LoneNested.cs": self.LONE_NESTED,
             "WrongNamespace.cs": self.WRONG_NAMESPACE,
             "MultiNamespace.cs": self.MULTI_NAMESPACE,
+            "WrongNamespaceExactPath.cs": self.WRONG_NAMESPACE_EXACT_PATH,
+            "WrongNamespaceExactConsumer.cs": self.WRONG_NAMESPACE_EXACT_CONSUMER,
             "MultiNamespaceConsumer.cs": self.MULTI_NAMESPACE_CONSUMER,
             "WrongNamespaceConsumer.cs": self.WRONG_NAMESPACE_CONSUMER,
             "LoneBareConsumer.cs": self.LONE_BARE_CONSUMER,
@@ -1398,6 +1417,21 @@ class TestCSharpReceiverCallResolution:
         self._build(tmp_path)
         targets = self._call_targets_of(tmp_path, "MultiNamespaceConsumer.Call")
         assert targets == {"Post"}, targets
+
+    def test_exact_path_match_still_checks_the_candidate_namespace(
+        self, tmp_path,
+    ):
+        """An exact containing-type match is not an exact *type* match, because
+        namespaces are absent from ``parent_name``. ``Vault.Archive.StoreHandler``
+        declared inside ``namespace Other`` is keyed exactly as the receiver
+        spells it, yet the caller means a different type entirely and cannot see
+        ``Other``. Matching the path alone would fabricate the edge.
+        """
+        self._build(tmp_path)
+        targets = self._call_targets_of(
+            tmp_path, "ExactPathNamespaceConsumer.Call",
+        )
+        assert targets == {"Store"}, targets
 
     def test_bare_receiver_never_selects_a_nested_type(self, tmp_path):
         """A bare ``QueryHandler`` cannot name ``Details.QueryHandler`` in C#;

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1170,6 +1170,21 @@ class TestCSharpReceiverCallResolution:
         "    public void Call() { handler.Store(); }\n"
         "}\n"
     )
+    GLOBAL_USING = "global using Depot;\n"
+    GLOBAL_USING_TARGET = (
+        "namespace Depot;\n"
+        "public class Crate\n"
+        "{\n"
+        "    public class PackHandler { public void Pack() { } }\n"
+        "}\n"
+    )
+    GLOBAL_USING_CONSUMER = (
+        "public class GlobalUsingConsumer\n"
+        "{\n"
+        "    Crate.PackHandler handler;\n"
+        "    public void Call() { handler.Pack(); }\n"
+        "}\n"
+    )
     MULTI_NAMESPACE = (
         "namespace App\n"
         "{\n"
@@ -1296,6 +1311,9 @@ class TestCSharpReceiverCallResolution:
             "MultiNamespace.cs": self.MULTI_NAMESPACE,
             "WrongNamespaceExactPath.cs": self.WRONG_NAMESPACE_EXACT_PATH,
             "WrongNamespaceExactConsumer.cs": self.WRONG_NAMESPACE_EXACT_CONSUMER,
+            "GlobalUsings.cs": self.GLOBAL_USING,
+            "GlobalUsingTarget.cs": self.GLOBAL_USING_TARGET,
+            "GlobalUsingConsumer.cs": self.GLOBAL_USING_CONSUMER,
             "MultiNamespaceConsumer.cs": self.MULTI_NAMESPACE_CONSUMER,
             "WrongNamespaceConsumer.cs": self.WRONG_NAMESPACE_CONSUMER,
             "LoneBareConsumer.cs": self.LONE_BARE_CONSUMER,
@@ -1418,20 +1436,38 @@ class TestCSharpReceiverCallResolution:
         targets = self._call_targets_of(tmp_path, "MultiNamespaceConsumer.Call")
         assert targets == {"Post"}, targets
 
-    def test_exact_path_match_still_checks_the_candidate_namespace(
+    @pytest.mark.xfail(
+        reason=(
+            "Known limitation: namespaces are absent from parent_name, so an "
+            "exact containing-type match cannot prove the candidate is the type "
+            "the receiver names. Deciding this needs per-node namespaces; "
+            "file-level evidence cannot. main mislinks this too, on the bare "
+            "name, so the branch narrows rather than introduces it."
+        ),
+    )
+    def test_exact_path_match_should_check_the_candidate_namespace(
         self, tmp_path,
     ):
-        """An exact containing-type match is not an exact *type* match, because
-        namespaces are absent from ``parent_name``. ``Vault.Archive.StoreHandler``
-        declared inside ``namespace Other`` is keyed exactly as the receiver
-        spells it, yet the caller means a different type entirely and cannot see
-        ``Other``. Matching the path alone would fabricate the edge.
-        """
+        """``Vault.Archive.StoreHandler`` declared inside ``namespace Other`` is
+        keyed exactly as the receiver spells it, but the caller means a
+        different type and cannot see ``Other``."""
         self._build(tmp_path)
         targets = self._call_targets_of(
             tmp_path, "ExactPathNamespaceConsumer.Call",
         )
         assert targets == {"Store"}, targets
+
+    def test_global_using_target_still_resolves(self, tmp_path):
+        """A ``global using`` applies project-wide, from a different file than
+        the call site. Any future namespace-visibility check must not treat the
+        caller's own file as the only source of visibility evidence, or valid
+        calls like this one regress to unresolved.
+        """
+        self._build(tmp_path)
+        target = tmp_path / "GlobalUsingTarget.cs"
+        assert self._call_targets_of(tmp_path, "GlobalUsingConsumer.Call") == {
+            f"{target.as_posix()}::Crate.PackHandler.Pack"
+        }
 
     def test_bare_receiver_never_selects_a_nested_type(self, tmp_path):
         """A bare ``QueryHandler`` cannot name ``Details.QueryHandler`` in C#;

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1153,6 +1153,26 @@ class TestCSharpReceiverCallResolution:
         "}\n"
         "public class E { public void M() { } }\n"
     )
+    MULTI_NAMESPACE = (
+        "namespace App\n"
+        "{\n"
+        "    public class SomethingElse { }\n"
+        "}\n"
+        "namespace Other\n"
+        "{\n"
+        "    public class Journal\n"
+        "    {\n"
+        "        public class PostHandler { public void Post() { } }\n"
+        "    }\n"
+        "}\n"
+    )
+    MULTI_NAMESPACE_CONSUMER = (
+        "public class MultiNamespaceConsumer\n"
+        "{\n"
+        "    App.Journal.PostHandler handler;\n"
+        "    public void Call() { handler.Post(); }\n"
+        "}\n"
+    )
     WRONG_NAMESPACE = (
         "namespace Other;\n"
         "public class Ledger\n"
@@ -1256,6 +1276,8 @@ class TestCSharpReceiverCallResolution:
             "LexicalShadow.cs": self.LEXICAL_SHADOW,
             "LoneNested.cs": self.LONE_NESTED,
             "WrongNamespace.cs": self.WRONG_NAMESPACE,
+            "MultiNamespace.cs": self.MULTI_NAMESPACE,
+            "MultiNamespaceConsumer.cs": self.MULTI_NAMESPACE_CONSUMER,
             "WrongNamespaceConsumer.cs": self.WRONG_NAMESPACE_CONSUMER,
             "LoneBareConsumer.cs": self.LONE_BARE_CONSUMER,
             "Namespaced.cs": self.NAMESPACED,
@@ -1365,6 +1387,17 @@ class TestCSharpReceiverCallResolution:
         self._build(tmp_path)
         targets = self._call_targets_of(tmp_path, "WrongNamespaceConsumer.Call")
         assert targets == {"Run"}, targets
+
+    def test_dropped_namespace_must_be_the_files_only_namespace(self, tmp_path):
+        """The namespace evidence is per file, and one C# file may declare
+        several namespaces. ``Definitions.cs`` declaring both ``App`` and
+        ``Other`` proves only that ``App`` appears somewhere in the file, not
+        that it encloses ``Journal.PostHandler`` -- which actually sits in
+        ``Other``. Ambiguous evidence must not resolve the call.
+        """
+        self._build(tmp_path)
+        targets = self._call_targets_of(tmp_path, "MultiNamespaceConsumer.Call")
+        assert targets == {"Post"}, targets
 
     def test_bare_receiver_never_selects_a_nested_type(self, tmp_path):
         """A bare ``QueryHandler`` cannot name ``Details.QueryHandler`` in C#;

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -628,6 +628,134 @@ class TestCSharpParsing:
         assert "Status" not in by_source
         assert "byte" not in {edge.target for edge in inherits}
 
+    def test_nested_types_keep_complete_identity_and_containment(self, tmp_path):
+        path = tmp_path / "Nested.cs"
+        path.write_text(
+            "public class Details {\n"
+            "    public class QueryHandler { public void Handle() {} }\n"
+            "}\n"
+            "public class Edit {\n"
+            "    public class QueryHandler { public void Handle() {} }\n"
+            "}\n"
+            "public class A {\n"
+            "    public class B {\n"
+            "        public class C { public void M() {} }\n"
+            "    }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        nodes, edges = self.parser.parse_file(path)
+        prefix = path.as_posix()
+        qualified = {
+            self.parser._node_qualified(node)
+            for node in nodes
+            if node.kind != "File"
+        }
+        assert {
+            f"{prefix}::Details.QueryHandler.Handle",
+            f"{prefix}::Edit.QueryHandler.Handle",
+            f"{prefix}::A.B.C",
+            f"{prefix}::A.B.C.M",
+        } <= qualified
+
+        contains = {
+            (edge.source, edge.target)
+            for edge in edges
+            if edge.kind == "CONTAINS"
+        }
+        assert {
+            (f"{prefix}::Details", f"{prefix}::Details.QueryHandler"),
+            (
+                f"{prefix}::Details.QueryHandler",
+                f"{prefix}::Details.QueryHandler.Handle",
+            ),
+            (f"{prefix}::Edit", f"{prefix}::Edit.QueryHandler"),
+            (
+                f"{prefix}::Edit.QueryHandler",
+                f"{prefix}::Edit.QueryHandler.Handle",
+            ),
+            (f"{prefix}::A", f"{prefix}::A.B"),
+            (f"{prefix}::A.B", f"{prefix}::A.B.C"),
+            (f"{prefix}::A.B.C", f"{prefix}::A.B.C.M"),
+        } <= contains
+        assert all(source == prefix or source in qualified for source, _ in contains)
+
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.tools.query import query_graph
+
+        graph_dir = tmp_path / ".code-review-graph"
+        graph_dir.mkdir()
+        store = GraphStore(graph_dir / "graph.db")
+        try:
+            store.store_file_nodes_edges(str(path), nodes, edges)
+        finally:
+            store.close()
+
+        # Addressed by qualified name; short-name lookup of a dotted nested
+        # path is a separate query-resolution change.
+        result = query_graph(
+            "children_of",
+            f"{prefix}::Details.QueryHandler",
+            repo_root=str(tmp_path),
+        )
+        assert result["status"] == "ok"
+        assert {child["name"] for child in result["results"]} == {"Handle"}
+
+    def test_incremental_upgrade_rebuilds_legacy_nested_identities(self, tmp_path):
+        from unittest.mock import patch
+
+        from code_review_graph.graph import GraphStore
+        from code_review_graph.incremental import (
+            CSHARP_IDENTITY_VERSION,
+            incremental_update,
+        )
+        from code_review_graph.parser import NodeInfo
+
+        path = tmp_path / "Nested.cs"
+        path.write_text(
+            "public class Details {\n"
+            "    public class QueryHandler { public void Handle() {} }\n"
+            "}\n"
+            "public class Edit {\n"
+            "    public class QueryHandler { public void Handle() {} }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        store = GraphStore(tmp_path / "graph.db")
+        legacy = f"{path.as_posix()}::QueryHandler.Handle"
+        try:
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="Handle",
+                file_path=str(path),
+                line_start=2,
+                line_end=2,
+                language="csharp",
+                parent_name="QueryHandler",
+            ))
+            store.commit()
+
+            with patch(
+                "code_review_graph.incremental.get_all_tracked_files",
+                return_value=["Nested.cs"],
+            ):
+                result = incremental_update(tmp_path, store, changed_files=[])
+
+            assert result["identity_rebuild"] is True
+            assert store.get_metadata("csharp_identity_version") == (
+                CSHARP_IDENTITY_VERSION
+            )
+            assert store.get_node(legacy) is None
+            assert store.get_node(
+                f"{path.as_posix()}::Details.QueryHandler.Handle"
+            ) is not None
+            assert store.get_node(
+                f"{path.as_posix()}::Edit.QueryHandler.Handle"
+            ) is not None
+        finally:
+            store.close()
+
     @pytest.mark.parametrize(
         ("statement", "expected_targets"),
         [
@@ -971,6 +1099,112 @@ class TestCSharpReceiverCallResolution:
         "    }\n"
         "}\n"
     )
+    NESTED = (
+        "public class Details\n"
+        "{\n"
+        "    public class QueryHandler { public void Handle() { } }\n"
+        "}\n"
+        "public class Edit\n"
+        "{\n"
+        "    public class QueryHandler { public void Handle() { } }\n"
+        "}\n"
+    )
+    NESTED_CONSUMERS = (
+        "public class DetailsConsumer\n"
+        "{\n"
+        "    Details.QueryHandler handler;\n"
+        "    public void CallDetails() { handler.Handle(); }\n"
+        "}\n"
+        "public class EditConsumer\n"
+        "{\n"
+        "    Edit.QueryHandler handler;\n"
+        "    public void CallEdit() { handler.Handle(); }\n"
+        "}\n"
+        "public class AmbiguousConsumer\n"
+        "{\n"
+        "    QueryHandler handler;\n"
+        "    public void CallAmbiguous() { handler.Handle(); }\n"
+        "}\n"
+    )
+    PREFIX_COLLISION = (
+        "public class A\n"
+        "{\n"
+        "    public class B\n"
+        "    {\n"
+        "        public class C { public void M() { } }\n"
+        "    }\n"
+        "}\n"
+        "public class ExactPathConsumer\n"
+        "{\n"
+        "    B.C value;\n"
+        "    public void Call() { value.M(); }\n"
+        "}\n"
+        "public class LexicalOuter\n"
+        "{\n"
+        "    public class D\n"
+        "    {\n"
+        "        public class E { public void M() { } }\n"
+        "    }\n"
+        "    public class SuffixPathConsumer\n"
+        "    {\n"
+        "        D.E value;\n"
+        "        public void Call() { value.M(); }\n"
+        "    }\n"
+        "}\n"
+        "public class E { public void M() { } }\n"
+    )
+    EXACT_PREFIX_TARGET = (
+        "public class B\n"
+        "{\n"
+        "    public class C { public void M() { } }\n"
+        "}\n"
+    )
+    NAMESPACED = (
+        "namespace App\n"
+        "{\n"
+        "    public class Report\n"
+        "    {\n"
+        "        public class ExportHandler { public void Run() { } }\n"
+        "    }\n"
+        "}\n"
+    )
+    NAMESPACE_SUFFIX_DECOY = (
+        "public class X\n"
+        "{\n"
+        "    public class App\n"
+        "    {\n"
+        "        public class Report\n"
+        "        {\n"
+        "            public class ExportHandler { public void Run() { } }\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+    NAMESPACED_CONSUMER = (
+        "public class NamespacedConsumer\n"
+        "{\n"
+        "    App.Report.ExportHandler handler;\n"
+        "    public void Call() { handler.Run(); }\n"
+        "}\n"
+    )
+    LEXICAL_SHADOW = (
+        "public class D\n"
+        "{\n"
+        "    public class E { public void M() { } }\n"
+        "}\n"
+        "public class Shadower\n"
+        "{\n"
+        "    public class D\n"
+        "    {\n"
+        "        public class E { public void M() { } }\n"
+        "    }\n"
+        "    public class Consumer\n"
+        "    {\n"
+        "        D.E value;\n"
+        "        public void Call() { value.M(); }\n"
+        "    }\n"
+        "}\n"
+    )
 
     def _build(self, tmp_path):
         from unittest.mock import patch
@@ -987,6 +1221,14 @@ class TestCSharpReceiverCallResolution:
             "Single.cs": self.SINGLE,
             "Decoy.cs": self.DECOY,
             "ServiceTests.cs": self.TESTS,
+            "Nested.cs": self.NESTED,
+            "NestedConsumers.cs": self.NESTED_CONSUMERS,
+            "PrefixCollision.cs": self.PREFIX_COLLISION,
+            "ExactPrefixTarget.cs": self.EXACT_PREFIX_TARGET,
+            "LexicalShadow.cs": self.LEXICAL_SHADOW,
+            "Namespaced.cs": self.NAMESPACED,
+            "NamespaceSuffixDecoy.cs": self.NAMESPACE_SUFFIX_DECOY,
+            "NamespacedConsumer.cs": self.NAMESPACED_CONSUMER,
         }
         for name, content in files.items():
             (tmp_path / name).write_text(content, encoding="utf-8")
@@ -1030,6 +1272,75 @@ class TestCSharpReceiverCallResolution:
         single = str(tmp_path / "Single.cs")
         targets = self._call_targets_of(tmp_path, "Runner.Go")
         assert f"{single}::Widget.Spin" in targets
+
+    def test_nested_receiver_calls_resolve_to_distinct_methods(self, tmp_path):
+        from code_review_graph.tools.query import query_graph
+
+        self._build(tmp_path)
+        nested = str(tmp_path / "Nested.cs")
+        expected = {
+            "DetailsConsumer.CallDetails": (
+                "CallDetails", f"{nested}::Details.QueryHandler.Handle"
+            ),
+            "EditConsumer.CallEdit": (
+                "CallEdit", f"{nested}::Edit.QueryHandler.Handle"
+            ),
+        }
+        for caller, (caller_name, target) in expected.items():
+            assert self._call_targets_of(tmp_path, caller) == {target}
+            result = query_graph("callers_of", target, repo_root=str(tmp_path))
+            assert result["status"] == "ok"
+            resolved = {
+                node["name"]
+                for node in result["results"]
+                if node.get("target_resolution") != "unresolved"
+            }
+            assert resolved == {caller_name}
+
+    def test_bare_nested_receiver_stays_unresolved_when_ambiguous(self, tmp_path):
+        self._build(tmp_path)
+        assert self._call_targets_of(
+            tmp_path, "AmbiguousConsumer.CallAmbiguous",
+        ) == {"Handle"}
+
+    def test_exact_nested_receiver_beats_suffix_match(self, tmp_path):
+        self._build(tmp_path)
+        target = tmp_path / "ExactPrefixTarget.cs"
+        assert self._call_targets_of(
+            tmp_path, "ExactPathConsumer.Call",
+        ) == {f"{target.as_posix()}::B.C.M"}
+
+    def test_longer_suffix_match_beats_shorter_exact_type(self, tmp_path):
+        self._build(tmp_path)
+        target = tmp_path / "PrefixCollision.cs"
+        assert self._call_targets_of(
+            tmp_path, "LexicalOuter.SuffixPathConsumer.Call",
+        ) == {f"{target.as_posix()}::LexicalOuter.D.E.M"}
+
+    def test_enclosing_type_shadows_global_type_of_the_same_path(self, tmp_path):
+        """C# lookup starts at the innermost enclosing type, so inside
+        ``Shadower.Consumer`` the receiver ``D.E`` is ``Shadower.D.E`` even
+        though a top-level ``D.E`` also exists."""
+        self._build(tmp_path)
+        target = tmp_path / "LexicalShadow.cs"
+        assert self._call_targets_of(
+            tmp_path, "Shadower.Consumer.Call",
+        ) == {f"{target.as_posix()}::Shadower.D.E.M"}
+
+    def test_namespaced_receiver_beats_conflicting_containing_type_suffix(
+        self, tmp_path,
+    ):
+        """C# namespaces are not part of ``parent_name``, so the receiver
+        ``App.Report.ExportHandler`` only matches exactly once shortened to
+        ``Report.ExportHandler``. An unrelated nested type whose containing
+        path merely ends in ``App.Report.ExportHandler`` must not win first via
+        the suffix map -- every exact candidate is tried before any heuristic.
+        """
+        self._build(tmp_path)
+        target = tmp_path / "Namespaced.cs"
+        assert self._call_targets_of(
+            tmp_path, "NamespacedConsumer.Call",
+        ) == {f"{target.as_posix()}::Report.ExportHandler.Run"}
 
     def test_callers_of_returns_resolved_caller_after_full_build(self, tmp_path):
         from code_review_graph.tools.query import query_graph


### PR DESCRIPTION
## Summary

Method nodes inside a nested class were qualified with only the immediate enclosing
class, so two nested classes sharing a name collapsed their methods into a single
node — `Details.QueryHandler.Handle` and `Edit.QueryHandler.Handle` both became
`QueryHandler.Handle`, silently losing one method with no uncertainty caveat. Only
one level of nesting was ever retained.

- accumulate the containing-type path when recursing into a class body, as Julia already did
- emit `CONTAINS` edges against the full path
- resolve C# receivers against the new dotted parent names
- rebuild persistent graphs once through the existing version gate shared with C++

Fixes #934

## Why the resolver moves with the parser

These are one change, not two. `parent_name` is now a dotted path, and the old
receiver lookup reduced a scope to its last segment (`scope.rsplit(".", 1)[-1]`).
Shipping the parser fix alone would miss every nested type and stop resolving C#
receiver calls entirely.

## Resolution model

A receiver is matched against a containing-type path **exactly**, in two phases:

1. **lexical** — the receiver under each enclosing type, innermost first
   (`Outer.Consumer.D.E`, then `Outer.D.E`)
2. **exact** — the receiver itself, then forms with a leading *namespace* removed

There is deliberately **no suffix fallback**. Selecting a nested type from a bare
receiver would bind names C# cannot bind: a bare `QueryHandler` does not name
`Details.QueryHandler`, which has to be qualified. A lone indexed candidate would
otherwise be rewritten as a single match with no visibility check at all, and the
real type is often in a dependency that was never indexed.

Phase 1 matters because inside `Outer.Consumer` a receiver `D.E` denotes `Outer.D.E`
even when a top-level `D.E` exists.

Phase 2 exists only because namespaces are absent from `parent_name` — they live in
`csharp_namespaces_by_file` — so `App.Report.ExportHandler` is stored as
`Report.ExportHandler`. **The only thing a receiver may drop is a verified namespace
prefix.** A shortened form must prove the part it dropped is the namespace declared
by the candidate's defining file:

- file declares exactly `App` → resolves
- file declares `Other` → unresolved
- file declares both `App` and `Other` → unresolved, because file-level evidence
  cannot show which namespace encloses the candidate
- dropping a *type* name (`Details.QueryHandler` → `QueryHandler`) → unresolved,
  since `Details` is not a namespace

The multi-namespace case is conservative on purpose: it leaves genuine matches
unresolved rather than fabricating an edge. Resolving them properly needs per-node
namespace information rather than per-file, which is a follow-up.

Gated to C#. `_SCOPED_LANGUAGES` is `php`, `rust`, `csharp`; PHP and Rust are untouched.

## Scope

This PR is the identity fix and nothing else. Short-name addressing of a dotted
nested path (`children_of Details.QueryHandler`) was split out to #942 — it carried a
schema migration, an index, and Java-FQN precedence questions unrelated to this bug.
Nested types are addressable here by qualified name, which is what demonstrates the fix.

## Safety

- receivers only ever match a containing-type path exactly
- the sole permitted reduction is dropping an unambiguously verified namespace
- ambiguous or unverifiable receivers stay unresolved instead of being guessed
- PHP and Rust scoped resolution is unchanged
- no schema change

## Testing

- `uv run pytest tests/ --tb=short -q` (2996 passed, 9 skipped, 2 xpassed)
- distinct identities and `CONTAINS` parents for `Details.QueryHandler` vs `Edit.QueryHandler`
- three-level nesting (`A.B.C.M`)
- lexical shadowing: nested `Shadower.D.E` beats top-level `D.E`
- namespaced receiver resolves when the file declares exactly that namespace
- receiver stays unresolved when the dropped name is the wrong namespace,
  one of several namespaces in the file, or a type rather than a namespace
- bare receiver never selects a nested type, unique candidate or not
- legacy identity rebuild through the version gate
- `uv run ruff check code_review_graph/`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
