### PR TITLE
fix(parser): resolve generic inheritance targets

### DIFF
--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -78,6 +78,13 @@ logger = logging.getLogger(__name__)
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
 
+# Bumped when the parser changes how a Java/C# INHERITS target is spelled, so
+# graphs built by an older version are rebuilt instead of keeping targets that
+# no longer match any node. See #935.
+INHERITS_IDENTITY_VERSION = "1"
+_INHERITS_IDENTITY_METADATA_KEY = "inherits_identity_version"
+_INHERITS_IDENTITY_LANGUAGES = ("java", "csharp")
+
 
 def _run_python_resolver(store: GraphStore) -> Optional[dict]:
     """Run repository-wide Python import resolution without failing a build."""
@@ -1273,7 +1280,7 @@ def full_build(
     total_nodes = 0
     total_edges = 0
     errors = []
-    cpp_errors: set[str] = set()
+    failed_languages: set[str] = set()
     file_count = len(files)
 
     use_serial = os.environ.get("CRG_SERIAL_PARSE", "") == "1"
@@ -1291,13 +1298,11 @@ def full_build(
                 total_edges += len(edges)
             except (OSError, PermissionError) as e:
                 errors.append({"file": rel_path, "error": str(e)})
-                if parser.detect_language(full_path) == "cpp":
-                    cpp_errors.add(str(rel_path))
+                failed_languages.add(parser.detect_language(full_path) or "")
             except Exception as e:
                 logger.warning("Error parsing %s: %s", rel_path, e)
                 errors.append({"file": rel_path, "error": str(e)})
-                if parser.detect_language(full_path) == "cpp":
-                    cpp_errors.add(str(rel_path))
+                failed_languages.add(parser.detect_language(full_path) or "")
             if i % 50 == 0 or i == file_count:
                 logger.info("Progress: %d/%d files parsed", i, file_count)
     else:
@@ -1315,8 +1320,9 @@ def full_build(
                 if error:
                     logger.warning("Error parsing %s: %s", rel_path, error)
                     errors.append({"file": rel_path, "error": error})
-                    if parser.detect_language(repo_root / rel_path) == "cpp":
-                        cpp_errors.add(str(rel_path))
+                    failed_languages.add(
+                        parser.detect_language(repo_root / rel_path) or "",
+                    )
                     continue
                 full_path = repo_root / rel_path
                 store.store_file_nodes_edges(
@@ -1332,8 +1338,10 @@ def full_build(
 
     store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
     store.set_metadata("last_build_type", "full")
-    if not cpp_errors:
+    if "cpp" not in failed_languages:
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+    if failed_languages.isdisjoint(_INHERITS_IDENTITY_LANGUAGES):
+        store.set_metadata(_INHERITS_IDENTITY_METADATA_KEY, INHERITS_IDENTITY_VERSION)
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
@@ -1375,12 +1383,24 @@ def incremental_update(
     parser = CodeParser(repo_root)
     ignore_patterns = _load_ignore_patterns(repo_root)
 
+    stale_identity = None
     if (
         store.get_metadata(_CPP_IDENTITY_METADATA_KEY) != CPP_IDENTITY_VERSION
         and store.has_nodes_for_language("cpp")
     ):
+        stale_identity = "C++"
+    elif (
+        store.get_metadata(_INHERITS_IDENTITY_METADATA_KEY) != INHERITS_IDENTITY_VERSION
+        and any(
+            store.has_nodes_for_language(language)
+            for language in _INHERITS_IDENTITY_LANGUAGES
+        )
+    ):
+        stale_identity = "Java/C# inheritance"
+    if stale_identity:
         logger.info(
-            "C++ identity format changed; rebuilding the graph before incremental update",
+            "%s identity format changed; rebuilding the graph before incremental update",
+            stale_identity,
         )
         rebuilt = full_build(repo_root, store)
         return {
@@ -1508,6 +1528,7 @@ def incremental_update(
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+        store.set_metadata(_INHERITS_IDENTITY_METADATA_KEY, INHERITS_IDENTITY_VERSION)
         _store_vcs_metadata(repo_root, store)
         store.commit()
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2402,6 +2402,93 @@ def _ansible_is_play_item(item: object) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _erase_type_arguments(type_name: str) -> str:
+    """Strip type arguments to the name spelling inheritance lookup matches on.
+
+    This is deliberately *not* a language-level declaration identity. It drops
+    C#/Java generic arity, so ``G<T>`` and ``G<T, U>`` both yield ``G``, and it
+    does not resolve namespace or package qualification. Both limits match how
+    ``inheritors_of`` already resolves non-generic bases: nodes are keyed by
+    bare class name, and the bare-name fallback is arity- and namespace-blind
+    for every base, generic or not. The goal here is parity with the
+    non-generic path, not a full type identity.
+
+    Malformed type text (unbalanced angle brackets) is returned unchanged, so
+    an error-tolerant parse of a half-edited file never rewrites a target into
+    a bogus name.
+    """
+    depth = 0
+    identity = []
+    for char in type_name:
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            if depth == 0:
+                return type_name
+            depth -= 1
+        elif depth == 0:
+            identity.append(char)
+    return "".join(identity).strip() if depth == 0 else type_name
+
+
+#: Grammar nodes holding a type argument list: ``<...>`` in C# and Java.
+_TYPE_ARGUMENT_NODES = ("type_argument_list", "type_arguments")
+
+
+def _declaration_name(node) -> str:
+    """Rebuild a base type's spelling from the syntax tree, minus type arguments.
+
+    Angle brackets cannot be located reliably by scanning characters, because
+    ``<`` and ``>`` also occur inside trivia that the grammar treats as
+    insignificant -- ``class C : I</* < */ string> {}`` is legal C# that a
+    bracket counter reads as unbalanced. Collecting leaf tokens and skipping the
+    type-argument subtrees lets the grammar decide what is a delimiter.
+
+    Returns an empty string when the node carries no usable tokens, which lets
+    callers fall back rather than store a truncated name.
+    """
+    tokens: list[str] = []
+
+    def collect(current) -> None:
+        if current.type in _TYPE_ARGUMENT_NODES or current.type == "comment":
+            return
+        if current.child_count == 0:
+            tokens.append(current.text.decode("utf-8", errors="replace"))
+            return
+        for child in current.children:
+            collect(child)
+
+    collect(node)
+    return "".join(tokens).strip()
+
+
+def _group_bases_by_target(entries: list[tuple[str, str]]) -> dict[str, list[str]]:
+    """Group ``(spelling, target)`` base entries by target, in source order.
+
+    C# permits one class to implement several closed constructions of the same
+    generic interface (``class C : I<int>, I<string> {}``). Those collapse to a
+    single target, and every collapsed base shares the class declaration line,
+    so emitting one edge each would produce rows that ``upsert_edge`` treats as
+    the same edge -- the last one silently overwriting the rest. Grouping first
+    keeps the relationship as one edge that records every construction.
+    """
+    grouped: dict[str, list[str]] = {}
+    for spelling, target in entries:
+        grouped.setdefault(target, []).append(spelling)
+    return grouped
+
+
+def _constructed_type_extra(target: str, constructions: list[str]) -> dict:
+    """Build the ``extra`` payload recording how *target* was constructed.
+
+    ``constructed_types`` is always a list, including for the single-construction
+    case, so consumers get one shape rather than one that changes when somebody
+    adds another interface to a class.
+    """
+    constructed = [c for c in dict.fromkeys(constructions) if c != target]
+    return {"constructed_types": constructed} if constructed else {}
+
+
 class CodeParser:
     """Parses source files using Tree-sitter and extracts structural information."""
 
@@ -10269,16 +10356,17 @@ class CodeParser:
         ))
 
         # Inheritance edges
-        bases = self._get_bases(child, language, source)
-        for base in bases:
+        base_entries = self._get_base_entries(child, language, source)
+        for target, constructions in _group_bases_by_target(base_entries).items():
             edges.append(EdgeInfo(
                 kind="INHERITS",
                 source=self._qualify(
                     name, file_path, class_parent,
                 ),
-                target=base,
+                target=target,
                 file_path=file_path,
                 line=child.start_point[0] + 1,
+                extra=_constructed_type_extra(target, constructions),
             ))
 
         # Spring DI: emit INJECTS edges for injected dependencies
@@ -15279,16 +15367,15 @@ class CodeParser:
                     return node.children[i + 1].text.decode("utf-8", errors="replace")
         return None
 
-    def _get_bases(self, node, language: str, source: bytes) -> list[str]:
-        """Extract base classes / implemented interfaces."""
+    def _get_base_type_nodes(self, node, language: str) -> list:
+        """Return the syntax nodes naming each base type, for Java and C#.
+
+        Kept separate from :meth:`_get_bases` so the raw spelling and the
+        tree-derived declaration name are read from one traversal instead of
+        being recovered from text afterwards.
+        """
         bases = []
-        if language == "python":
-            for child in node.children:
-                if child.type == "argument_list":
-                    for arg in child.children:
-                        if arg.type in ("identifier", "attribute"):
-                            bases.append(arg.text.decode("utf-8", errors="replace"))
-        elif language == "java":
+        if language == "java":
             # Java: superclass and super_interfaces wrap the keyword
             # (extends/implements) around type_identifier children.
             # Taking .text would include the keyword (e.g. "implements Foo").
@@ -15297,13 +15384,13 @@ class CodeParser:
                 if child.type == "superclass":
                     for sub in child.children:
                         if sub.type in ("type_identifier", "generic_type"):
-                            bases.append(sub.text.decode("utf-8", errors="replace"))
+                            bases.append(sub)
                 elif child.type == "super_interfaces":
                     for sub in child.children:
                         if sub.type == "type_list":
                             for ident in sub.children:
                                 if ident.type in ("type_identifier", "generic_type"):
-                                    bases.append(ident.text.decode("utf-8", errors="replace"))
+                                    bases.append(ident)
         elif language == "csharp":
             # C# wraps ``: Base, IFace`` in a base_list. Iterate named type
             # entries so punctuation is excluded while qualified/generic names
@@ -15321,18 +15408,48 @@ class CodeParser:
                         # Positional records contain Base(args); retain only Base.
                         type_node = sub.child_by_field_name("type")
                         if type_node is not None:
-                            bases.append(
-                                type_node.text.decode("utf-8", errors="replace")
-                            )
+                            bases.append(type_node)
                         else:
                             for nested in sub.children:
                                 if nested.is_named and nested.type != "argument_list":
-                                    bases.append(
-                                        nested.text.decode("utf-8", errors="replace")
-                                    )
+                                    bases.append(nested)
                                     break
                         continue
-                    bases.append(sub.text.decode("utf-8", errors="replace"))
+                    bases.append(sub)
+        return bases
+
+    def _get_base_entries(
+        self, node, language: str, source: bytes,
+    ) -> list[tuple[str, str]]:
+        """Return ``(source spelling, edge target)`` for each base type.
+
+        For Java and C# the target is the declaration name with type arguments
+        removed, derived from the syntax tree so that comments and other trivia
+        inside a type argument list cannot be mistaken for generic delimiters.
+        Every other language targets the spelling unchanged.
+        """
+        if language not in ("java", "csharp"):
+            return [(base, base) for base in self._get_bases(node, language, source)]
+        entries = []
+        for base in self._get_base_type_nodes(node, language):
+            raw = base.text.decode("utf-8", errors="replace")
+            entries.append((raw, _declaration_name(base) or _erase_type_arguments(raw)))
+        return entries
+
+    def _get_bases(self, node, language: str, source: bytes) -> list[str]:
+        """Extract base classes / implemented interfaces."""
+        bases = []
+        if language == "python":
+            for child in node.children:
+                if child.type == "argument_list":
+                    for arg in child.children:
+                        if arg.type in ("identifier", "attribute"):
+                            bases.append(arg.text.decode("utf-8", errors="replace"))
+        elif language in ("java", "csharp"):
+            bases.extend(
+                base.text.decode("utf-8", errors="replace")
+                for base in self._get_base_type_nodes(node, language)
+            )
         elif language == "kotlin":
             # Look for superclass/interfaces in extends/implements clauses
             for child in node.children:

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -384,6 +384,124 @@ class TestJavaParsing:
         assert len(calls) >= 3
 
 
+@pytest.mark.parametrize(
+    ("file_name", "source", "constructed_type"),
+    [
+        (
+            "Generic.java",
+            "abstract class GenericBase<T> {}\n"
+            "class FromGeneric extends "
+            "GenericBase<java.util.Map<String, java.util.List<Integer>>> {}\n",
+            "GenericBase<java.util.Map<String, java.util.List<Integer>>>",
+        ),
+        (
+            "Generic.cs",
+            "abstract class GenericBase<T> {}\n"
+            "class FromGeneric : "
+            "GenericBase<System.Collections.Generic.Dictionary<string, "
+            "System.Collections.Generic.List<int>>> {}\n",
+            "GenericBase<System.Collections.Generic.Dictionary<string, "
+            "System.Collections.Generic.List<int>>>",
+        ),
+    ],
+)
+def test_generic_inheritance_targets_declaration(
+    tmp_path, file_name, source, constructed_type,
+):
+    from code_review_graph.graph import GraphStore
+    from code_review_graph.tools.query import query_graph
+
+    path = tmp_path / file_name
+    nodes, edges = CodeParser().parse_bytes(path, source.encode())
+    inheritance = next(
+        edge for edge in edges
+        if edge.kind == "INHERITS" and edge.source.endswith("::FromGeneric")
+    )
+    assert inheritance.target == "GenericBase"
+    assert inheritance.extra["constructed_types"] == [constructed_type]
+
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    with GraphStore(graph_dir / "graph.db") as store:
+        store.store_file_nodes_edges(str(path), nodes, edges)
+
+    result = query_graph("inheritors_of", "GenericBase", repo_root=str(tmp_path))
+    assert result["status"] == "ok"
+    assert {node["name"] for node in result["results"]} == {"FromGeneric"}
+
+
+@pytest.mark.parametrize(
+    ("file_name", "source", "constructed"),
+    [
+        (
+            "Trivia.cs",
+            "interface I<T> {}\nclass C : I</* < */ string> {}\n",
+            "I</* < */ string>",
+        ),
+        (
+            "Trivia.java",
+            "interface I<T> {}\nclass C implements I</* < */ String> {}\n",
+            "I</* < */ String>",
+        ),
+    ],
+)
+def test_generic_target_ignores_angle_brackets_inside_trivia(
+    tmp_path, file_name, source, constructed,
+):
+    """A '<' inside a comment is trivia, not a generic delimiter.
+
+    Counting characters reads this legal source as unbalanced and leaves the
+    constructed spelling as the target, so the base stays unresolvable.
+    """
+    path = tmp_path / file_name
+    _, edges = CodeParser().parse_bytes(path, source.encode())
+    inheritance = next(
+        edge for edge in edges
+        if edge.kind == "INHERITS" and edge.source.endswith("::C")
+    )
+    assert inheritance.target == "I"
+    assert inheritance.extra["constructed_types"] == [constructed]
+
+
+@pytest.mark.parametrize("type_name", ["Foo<T", "Foo<T>>"])
+def test_generic_identity_preserves_unbalanced_type_arguments(type_name):
+    from code_review_graph.parser import _erase_type_arguments
+
+    assert _erase_type_arguments(type_name) == type_name
+
+
+def test_multiple_closed_constructions_keep_every_type_argument(tmp_path):
+    """C# may implement one generic interface at several closed constructions.
+
+    They erase to a single target and share the class declaration line, so
+    upsert_edge would treat one-edge-per-base as the same edge and keep only the
+    last construction.
+    """
+    from code_review_graph.graph import GraphStore
+
+    path = tmp_path / "Multi.cs"
+    source = "interface I<T> {}\nclass C : I<int>, I<string> {}\n"
+    nodes, edges = CodeParser().parse_bytes(path, source.encode())
+    inheritance = [
+        edge for edge in edges
+        if edge.kind == "INHERITS" and edge.source.endswith("::C")
+    ]
+    assert len(inheritance) == 1
+    assert inheritance[0].target == "I"
+    assert inheritance[0].extra["constructed_types"] == ["I<int>", "I<string>"]
+
+    graph_dir = tmp_path / ".code-review-graph"
+    graph_dir.mkdir()
+    with GraphStore(graph_dir / "graph.db") as store:
+        store.store_file_nodes_edges(str(path), nodes, edges)
+        stored = [
+            edge for edge in store.get_edges_by_source(f"{path}::C")
+            if edge.kind == "INHERITS"
+        ]
+    assert len(stored) == 1
+    assert stored[0].extra["constructed_types"] == ["I<int>", "I<string>"]
+
+
 class TestJavaMethodNames:
     """Regression tests for #804: Java method/constructor names come from the
     grammar ``name`` field (same approach as C# after #794), not the first
@@ -604,7 +722,10 @@ class TestCSharpParsing:
         assert "IRepository" in targets
         assert "InMemoryRepo" in targets
         assert "System.IDisposable" in targets
-        assert "List<User>" in targets
+        assert "List" in targets
+        assert next(e for e in inherits if e.target == "List").extra == {
+            "constructed_types": ["List<User>"],
+        }
         assert all(not e.target.startswith(":") for e in inherits)
         assert all("," not in e.target for e in inherits)
 
@@ -619,8 +740,12 @@ class TestCSharpParsing:
         assert by_source.get("AuditedUser") == {"User", "IRepository"}
         assert by_source.get("TaggedUser") == {"User"}
         assert "IRepository" in by_source.get("Token", set())
-        assert "System.Collections.Generic.List<User>" in {
-            edge.target for edge in inherits
+        scoped_list = next(
+            edge for edge in inherits
+            if edge.target == "System.Collections.Generic.List"
+        )
+        assert scoped_list.extra == {
+            "constructed_types": ["System.Collections.Generic.List<User>"],
         }
         assert "ConstrainedHolder" not in by_source
         assert by_source.get("SeededRepo") == {"InMemoryRepo"}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -4676,3 +4676,64 @@ class TestAnsibleMetaParsing:
     def test_depends_on_name_key_collections(self):
         dep_targets = {e.target for e in self.edges if e.kind == "DEPENDS_ON"}
         assert "security.hardening" in dep_targets
+
+
+def test_incremental_upgrade_rebuilds_legacy_generic_inheritance(tmp_path):
+    """A graph built before this change still spells the target GenericBase<string>.
+
+    Nothing reparses an unchanged file, so without an identity version the
+    stale target would survive the upgrade and #935 would persist.
+    """
+    from unittest.mock import patch
+
+    from code_review_graph.graph import GraphStore
+    from code_review_graph.incremental import (
+        INHERITS_IDENTITY_VERSION,
+        incremental_update,
+    )
+    from code_review_graph.parser import EdgeInfo, NodeInfo
+
+    source_path = tmp_path / "Bases.cs"
+    source_path.write_text(
+        "public abstract class GenericBase<T> { }\n"
+        "public class FromGeneric : GenericBase<string> { }\n",
+        encoding="utf-8",
+    )
+    store = GraphStore(tmp_path / "graph.db")
+    try:
+        for name in ("GenericBase", "FromGeneric"):
+            store.upsert_node(NodeInfo(
+                kind="Class",
+                name=name,
+                file_path=str(source_path),
+                line_start=1,
+                line_end=1,
+                language="csharp",
+            ))
+        store.upsert_edge(EdgeInfo(
+            kind="INHERITS",
+            source=f"{source_path.as_posix()}::FromGeneric",
+            target="GenericBase<string>",
+            file_path=str(source_path),
+            line=2,
+        ))
+        store.commit()
+
+        with patch(
+            "code_review_graph.incremental.get_all_tracked_files",
+            return_value=["Bases.cs"],
+        ):
+            result = incremental_update(tmp_path, store, changed_files=[])
+
+        assert result["identity_rebuild"] is True
+        assert store.get_metadata("inherits_identity_version") == INHERITS_IDENTITY_VERSION
+        targets = [
+            edge.target_qualified
+            for edge in store.get_edges_by_source(
+                f"{source_path.as_posix()}::FromGeneric"
+            )
+            if edge.kind == "INHERITS"
+        ]
+        assert targets == ["GenericBase"]
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Resolve Java and C# generic inheritance against the base type's declaration name instead
of the constructed spelling, so `class Child : GenericBase<string>` links to
`GenericBase`. Every type argument is retained on the edge in `extra.constructed_types`.

Fixes #935. Closes #941.

## How the target is derived

The declaration name comes from the syntax tree, skipping the type-argument and comment
subtrees. It is deliberately not derived by scanning for `<` and `>`: those characters
also occur in trivia the grammar ignores, so `class C : I</* < */ string> {}` — legal C#
— reads as unbalanced to a character counter and would keep the constructed spelling as
its target, leaving the original bug in place.

`_get_base_type_nodes` is split out of `_get_bases` so the source spelling and the target
come from a single traversal.

## Repeated generic bases

C# permits one class to implement several closed constructions of the same generic
interface (`class C : I<int>, I<string> {}`). These erase to one target and share the
class declaration line, so `upsert_edge`'s identity — `(kind, source, target, file_path,
line)`, which excludes `extra` — would treat one-edge-per-base as the same edge and keep
only the last. Bases are grouped by target and emitted as one edge recording every
construction.

## Existing graphs

Changing a persisted spelling leaves old graphs stale, since nothing reparses an
unchanged file. This uses the mechanism already in the project for that situation,
`CPP_IDENTITY_VERSION` in `incremental.py`: an `INHERITS_IDENTITY_VERSION` records the
spelling a graph was built with, and `incremental_update` rebuilds once when it is
missing or stale and the graph holds Java or C# nodes.

The rebuild runs the real parser, so there is no second implementation of the
normalization to keep in step. An earlier revision of this PR carried a v10 SQL migration
that rewrote rows from stored text; it was dropped because it duplicated the parser's
logic — including comment handling — and both review findings against it landed on that
seam.

`cpp_errors` becomes `failed_languages`, since only its emptiness was ever used and the
same guard is needed per language: a file that failed to parse keeps its old edges, so
the version must not be marked current for that language. C++ behaviour is unchanged.

Verified on a graph built with pre-PR code, then updated with no file changes: the
rebuild triggers, `inheritors_of GenericBase` returns `FromGeneric`, and a second update
does not rebuild again.

## What the target is (and is not)

The target is a **lookup name**, not a language-level declaration identity. It drops
generic arity (`G<T>` and `G<T, U>` both yield `G`) and carries no namespace or package.

`inheritors_of` already resolves non-generic bases the same way: class nodes are keyed by
bare name, so `G<T>` and `G<T, U>` collapse to one node regardless of this PR, and the
bare-name fallback already unions same-named classes. This brings generic bases to parity
with that path rather than introducing a new resolution model. The constructed spelling is
preserved losslessly in `extra.constructed_types`, so a namespace-aware resolver later has
the evidence it needs — tracked in #940, deliberately not attempted here since it
reproduces on `main` for non-generic bases.

## Safety

- only Java/C# `INHERITS` targets containing type arguments change
- malformed or unreadable type text is left unchanged
- no schema change and no SQL data migration
- the identity rebuild runs once, then records the version

## Testing

- `uv run pytest --tb=short -q --cov=code_review_graph --cov-report=term-missing --cov-fail-under=65` (2993 passed, 9 skipped, 2 xpassed; 85.07% coverage)
- `uv run ruff check code_review_graph/ tests/test_multilang.py`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`

Regression tests cover nested generic arguments (Java and C#), angle brackets inside
trivia, repeated closed constructions, unbalanced type text, and the upgrade rebuild.
