### PR TITLE
feat(query): address dotted symbol targets through an indexed tail lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ When using code-review-graph MCP tools, follow these rules:
   - `wiki.py` — Markdown wiki generation from community structure
   - `skills.py` — Multi-platform install/config generation and shipped skill metadata
   - `registry.py` — Multi-repo registry helpers
-  - `migrations.py` — Database schema migrations (v1-v9)
+  - `migrations.py` — Database schema migrations (v1-v10)
   - `tsconfig_resolver.py` — TypeScript path alias resolution
 
 - **VS Code Extension**: `code-review-graph-vscode/` (TypeScript)

--- a/code-review-graph-vscode/src/backend/sqlite.ts
+++ b/code-review-graph-vscode/src/backend/sqlite.ts
@@ -212,7 +212,7 @@ export class SqliteReader {
         if (row) {
           const version = parseInt(row.value, 10);
           // Must match LATEST_VERSION in code_review_graph/migrations.py
-          const SUPPORTED_SCHEMA_VERSION = 9;
+          const SUPPORTED_SCHEMA_VERSION = 10;
           if (!isNaN(version) && version > SUPPORTED_SCHEMA_VERSION) {
             return `Database was created with a newer version (schema v${version}). Update the extension.`;
           }

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -54,6 +54,16 @@ def _compatible_edge_languages(language: str) -> tuple[str, ...]:
     return (language,)
 
 
+def _symbol_of(qualified_name: str) -> str:
+    """Return the symbol portion of a qualified name (after the first "::").
+
+    ``src/app.py::Handler.process`` → ``Handler.process``. A qualified name
+    without a path component is already a bare symbol.
+    """
+    _, sep, symbol = qualified_name.partition("::")
+    return symbol if sep else qualified_name
+
+
 def _bridge_qualified_name(qualified_name: str) -> str:
     """Return *qualified_name* with its file-path component POSIX-normalized.
 
@@ -88,6 +98,13 @@ CREATE TABLE IF NOT EXISTS nodes (
     is_test INTEGER DEFAULT 0,
     file_hash TEXT,
     extra TEXT DEFAULT '{}',
+    -- Symbol portion of qualified_name (everything after the first "::").
+    -- Stored so a dotted-tail lookup is an indexed equality test instead of a
+    -- substr() scan over every node; see search_nodes_by_qualified_tail.
+    -- idx_nodes_symbol is created by migration v10, not here: _init_schema runs
+    -- before run_migrations, so indexing a column this CREATE TABLE cannot add
+    -- to an existing table would break every pre-existing database on open.
+    symbol TEXT,
     updated_at REAL NOT NULL
 );
 
@@ -238,8 +255,8 @@ class GraphStore:
             """INSERT INTO nodes
                (kind, name, qualified_name, file_path, line_start, line_end,
                 language, parent_name, params, return_type, modifiers, is_test,
-                file_hash, extra, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                file_hash, extra, symbol, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(qualified_name) DO UPDATE SET
                  kind=excluded.kind, name=excluded.name,
                  file_path=excluded.file_path, line_start=excluded.line_start,
@@ -247,14 +264,15 @@ class GraphStore:
                  parent_name=excluded.parent_name, params=excluded.params,
                  return_type=excluded.return_type, modifiers=excluded.modifiers,
                  is_test=excluded.is_test, file_hash=excluded.file_hash,
-                 extra=excluded.extra, updated_at=excluded.updated_at
+                 extra=excluded.extra, symbol=excluded.symbol,
+                 updated_at=excluded.updated_at
             """,
             (
                 node.kind, node.name, qualified, node.file_path,
                 node.line_start, node.line_end, node.language,
                 node.parent_name, node.params, node.return_type,
                 node.modifiers, int(node.is_test), file_hash,
-                extra, now,
+                extra, _symbol_of(qualified), now,
             ),
         )
         row = self._conn.execute(
@@ -1209,6 +1227,30 @@ class GraphStore:
             "SELECT file_path FROM nodes WHERE kind = 'File' ORDER BY file_path"
         ).fetchall()
         return [row["file_path"] for row in rows]
+
+    def search_nodes_by_qualified_tail(
+        self, tail: str, limit: int = 20,
+    ) -> list[GraphNode]:
+        """Return nodes whose qualified symbol portion exactly matches *tail*.
+
+        Both predicates are indexed equality tests (``idx_nodes_symbol`` and the
+        ``qualified_name`` unique index), so this stays a bounded lookup rather
+        than a scan of every node on large graphs.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM nodes WHERE symbol = ? OR qualified_name = ? LIMIT ?",
+            (tail, tail, limit),
+        ).fetchall()
+        return [self._row_to_node(row) for row in rows]
+
+    def count_nodes_by_qualified_tail(self, tail: str) -> int:
+        """Count nodes whose qualified symbol portion exactly matches *tail*."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) AS count FROM nodes "
+            "WHERE symbol = ? OR qualified_name = ?",
+            (tail, tail),
+        ).fetchone()
+        return int(row["count"])
 
     def search_nodes(self, query: str, limit: int = 20) -> list[GraphNode]:
         """Keyword search across node names.

--- a/code_review_graph/migrations.py
+++ b/code_review_graph/migrations.py
@@ -238,6 +238,30 @@ def _migrate_v9(conn: sqlite3.Connection) -> None:
     logger.info("Migration v9: added edge confidence columns")
 
 
+def _migrate_v10(conn: sqlite3.Connection) -> None:
+    """v10: Add the indexed ``nodes.symbol`` column used by tail lookups.
+
+    ``symbol`` holds the portion of ``qualified_name`` after the first ``::``.
+    Storing it lets a dotted-target lookup be an indexed equality test; the
+    previous ``substr(qualified_name, -n)`` predicate could not use any index
+    and scanned the whole table on every dotted symbol query.
+    """
+    if not _has_column(conn, "nodes", "symbol"):
+        conn.execute("ALTER TABLE nodes ADD COLUMN symbol TEXT")
+    # instr() returns 0 when "::" is absent, in which case the qualified name
+    # is already a bare symbol. Mirrors graph._symbol_of.
+    conn.execute(
+        "UPDATE nodes SET symbol = CASE "
+        "WHEN instr(qualified_name, '::') > 0 "
+        "THEN substr(qualified_name, instr(qualified_name, '::') + 2) "
+        "ELSE qualified_name END"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_nodes_symbol ON nodes(symbol)"
+    )
+    logger.info("Migration v10: added indexed nodes.symbol column")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -251,6 +275,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     7: _migrate_v7,
     8: _migrate_v8,
     9: _migrate_v9,
+    10: _migrate_v10,
 }
 
 LATEST_VERSION = max(MIGRATIONS.keys())

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -48,7 +48,7 @@ _QUERY_PATTERNS = {
 }
 
 _JAVA_FQN_PART = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
-_MAX_FQN_CANDIDATES = 100
+_MAX_DOTTED_TARGET_CANDIDATES = 100
 
 
 def _looks_like_java_method_fqn(target: str) -> bool:
@@ -76,7 +76,9 @@ def _java_fqn_candidates(store: GraphStore, target: str) -> list[GraphNode] | No
     parts = target.split(".")
     class_name, method_name = parts[-2:]
     matches: list[GraphNode] = []
-    for candidate in store.search_nodes(method_name, limit=_MAX_FQN_CANDIDATES):
+    for candidate in store.search_nodes(
+        method_name, limit=_MAX_DOTTED_TARGET_CANDIDATES,
+    ):
         if candidate.language.lower() != "java" or candidate.name != method_name:
             continue
         parent_name = candidate.parent_name or ""
@@ -328,12 +330,35 @@ def query_graph(
                 abs_target = normalize_file_path(root / target)
                 node = store.get_node(abs_target)
             if not node:
+                qualified_tail_candidates = []
+                if "." in target:
+                    # Nested type paths are exact indexed tails but also look
+                    # Java-shaped; recognize the exact node before the Java
+                    # FQN guard, without changing bare-name disambiguation.
+                    qualified_tail_candidates = (
+                        store.search_nodes_by_qualified_tail(
+                            target, limit=_MAX_DOTTED_TARGET_CANDIDATES,
+                        )
+                    )
                 java_candidates = _java_fqn_candidates(store, target)
-                candidates = (
-                    java_candidates
-                    if java_candidates is not None
-                    else store.search_nodes(target, limit=20)
-                )
+                if java_candidates:
+                    # Established behavior: a Java-shaped target that has real
+                    # Java matches resolves against Java, and the unfiltered
+                    # tail lookup never gets to displace it.
+                    candidates = java_candidates
+                elif qualified_tail_candidates:
+                    # No Java match. An exact qualified-tail hit is a structural
+                    # match on the whole symbol path, not the fuzzy global-name
+                    # fallback the Java guard exists to block, so it is safe to
+                    # use here. This is what makes C# nested paths such as
+                    # ``Details.QueryHandler.Handle`` addressable (#934); they
+                    # are Java-FQN-shaped and have no Java candidates.
+                    candidates = qualified_tail_candidates
+                elif java_candidates is not None:
+                    # Java-shaped with no safe match: do not fall back.
+                    candidates = []
+                else:
+                    candidates = store.search_nodes(target, limit=20)
                 if pattern == "inheritors_of" and "::" not in target:
                     exact_type_candidates = [
                         candidate
@@ -348,11 +373,17 @@ def query_graph(
                     node = candidates[0]
                     target = node.qualified_name
                 elif len(candidates) > 1:
-                    candidate_count = (
-                        len(candidates)
-                        if java_candidates is not None
-                        else store.count_search_nodes(target)
-                    )
+                    # Count the population the candidates were drawn from, not
+                    # the truncated slice, so candidates_truncated stays honest
+                    # when more than _MAX_DOTTED_TARGET_CANDIDATES nodes match.
+                    if java_candidates:
+                        candidate_count = len(candidates)
+                    elif qualified_tail_candidates:
+                        candidate_count = store.count_nodes_by_qualified_tail(target)
+                    elif java_candidates is not None:
+                        candidate_count = len(candidates)
+                    else:
+                        candidate_count = store.count_search_nodes(target)
                     ranked = _rank_disambiguation_candidates(candidates, target)
                     return {
                         "status": "ambiguous",

--- a/tests/test_agent_transparency.py
+++ b/tests/test_agent_transparency.py
@@ -258,6 +258,51 @@ class TestSymbolDisambiguation:
             for candidate in result["disambiguation"]
         )
 
+    def test_qualified_tail_filter_runs_before_candidate_limit(self, tmp_path):
+        root, store = _make_repo(tmp_path)
+        target_path = root / "Target.cs"
+        target = f"{target_path}::Details.QueryHandler"
+        try:
+            for index in range(100):
+                store.upsert_node(NodeInfo(
+                    kind="Class",
+                    name="QueryHandler",
+                    parent_name=f"Outer{index}",
+                    file_path=str(root / f"Decoy{index}.cs"),
+                    line_start=1,
+                    line_end=1,
+                    language="csharp",
+                ))
+            store.upsert_node(NodeInfo(
+                kind="Class",
+                name="QueryHandler",
+                parent_name="Details",
+                file_path=str(target_path),
+                line_start=1,
+                line_end=5,
+                language="csharp",
+            ))
+            store.commit()
+            assert [
+                node.qualified_name
+                for node in store.search_nodes_by_qualified_tail(
+                    "Details.QueryHandler", limit=100,
+                )
+            ] == [target]
+            assert store.count_nodes_by_qualified_tail(
+                "Details.QueryHandler",
+            ) == 1
+        finally:
+            store.close()
+
+        result = query_graph(
+            "children_of", "Details.QueryHandler", str(root),
+        )
+
+        assert result["status"] == "ok"
+        assert result["target"] == target
+        assert result["results"] == []
+
     def test_java_fqn_requires_matching_language_and_class(self, tmp_path):
         root, store = _make_repo(tmp_path)
         try:
@@ -330,6 +375,116 @@ class TestSymbolDisambiguation:
             str(root),
         )
         assert result["status"] == "not_found"
+
+    @pytest.mark.parametrize(
+        ("language", "parent_name", "file_name", "method", "target"),
+        [
+            ("go", "Handler", "handler.go", "Process", "Handler.Process"),
+            ("go", "pkg.Handler", "handler.go", "Process", "pkg.Handler.Process"),
+            ("python", "Handler", "service.py", "process", "Handler.process"),
+            ("kotlin", "Handler", "Handler.kt", "process", "Handler.process"),
+            ("typescript", "Handler", "handler.ts", "process", "Handler.process"),
+            (
+                "csharp", "Details.QueryHandler", "Details.cs", "Handle",
+                "Details.QueryHandler.Handle",
+            ),
+        ],
+    )
+    def test_dotted_target_resolves_for_every_language(
+        self, tmp_path, language, parent_name, file_name, method, target,
+    ):
+        """A dotted target is Java-FQN-shaped in every language, so the Java
+        guard must not withhold an exact qualified-tail match from Go, Python,
+        Kotlin, TypeScript or C# when no Java node competes for it."""
+        root, store = _make_repo(tmp_path)
+        try:
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name=method,
+                parent_name=parent_name,
+                file_path=str(root / file_name),
+                line_start=1,
+                line_end=5,
+                language=language,
+            ))
+            store.commit()
+        finally:
+            store.close()
+
+        result = query_graph("callers_of", target, str(root))
+
+        assert result["status"] == "ok"
+        assert result["target"] == f"{root / file_name}::{parent_name}.{method}"
+
+    def test_java_fqn_not_displaced_by_same_tail_in_another_language(
+        self, tmp_path,
+    ):
+        """The dotted-tail lookup is not language-filtered, so a non-Java node
+        whose qualified tail happens to equal a Java FQN must not silently win
+        over a genuine Java match."""
+        root, store = _make_repo(tmp_path)
+        try:
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="process",
+                parent_name="OrderHandler",
+                file_path=str(root / "com" / "example" / "OrderHandler.java"),
+                line_start=10,
+                line_end=20,
+                language="java",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Function",
+                name="process",
+                parent_name="com.example.OrderHandler",
+                file_path=str(root / "Impostor.cs"),
+                line_start=1,
+                line_end=5,
+                language="csharp",
+            ))
+            store.commit()
+        finally:
+            store.close()
+
+        result = query_graph(
+            "callers_of",
+            "com.example.OrderHandler.process",
+            str(root),
+        )
+
+        # The Java match wins outright: the unfiltered tail lookup must not
+        # displace it, exactly as before the dotted-tail lookup existed.
+        assert result["status"] == "ok"
+        assert result["target"] == (
+            f"{root / 'com' / 'example' / 'OrderHandler.java'}"
+            "::OrderHandler.process"
+        )
+
+    def test_dotted_ambiguity_count_survives_the_candidate_cap(self, tmp_path):
+        """``candidate_count`` must describe the whole matching population, not
+        the capped slice, or ``candidates_truncated`` silently under-reports."""
+        root, store = _make_repo(tmp_path)
+        over_cap = query_module._MAX_DOTTED_TARGET_CANDIDATES + 1
+        try:
+            for index in range(over_cap):
+                store.upsert_node(NodeInfo(
+                    kind="Function",
+                    name="Process",
+                    parent_name="Handler",
+                    file_path=str(root / f"pkg{index}" / "handler.go"),
+                    line_start=1,
+                    line_end=5,
+                    language="go",
+                ))
+            store.commit()
+        finally:
+            store.close()
+
+        result = query_graph("callers_of", "Handler.Process", str(root))
+
+        assert result["status"] == "ambiguous"
+        assert f"matches {over_cap} node(s)" in result["summary"]
+        assert result["candidates_truncated"] is True
 
     def test_duplicate_java_class_method_stays_ambiguous(self, tmp_path):
         root, store = _make_repo(tmp_path)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,6 +23,68 @@ class TestMigrations:
         self.store.close()
         Path(self.tmp.name).unlink(missing_ok=True)
 
+    def test_v10_upgrades_a_database_created_before_the_symbol_column(self):
+        """A real pre-v10 database has no ``symbol`` column at all.
+
+        ``_init_schema`` runs before ``run_migrations`` and ``CREATE TABLE IF
+        NOT EXISTS`` cannot add a column to an existing table, so if the schema
+        script indexed ``symbol`` directly every pre-existing graph would fail
+        to open. Reopening a stripped database must migrate it cleanly.
+        """
+        path = self.tmp.name
+        conn = self.store._conn
+        conn.execute("DROP INDEX IF EXISTS idx_nodes_symbol")
+        conn.execute("ALTER TABLE nodes DROP COLUMN symbol")
+        conn.execute(
+            "INSERT INTO nodes "
+            "(kind, name, qualified_name, file_path, language, updated_at) "
+            "VALUES ('Function', 'process', ?, 'src/app.py', 'python', 0)",
+            ("src/app.py::Handler.process",),
+        )
+        conn.execute("UPDATE metadata SET value = '9' WHERE key = 'schema_version'")
+        self.store.commit()
+        self.store.close()
+
+        # Reopening runs _init_schema and then the migrations.
+        self.store = GraphStore(path)
+
+        assert get_schema_version(self.store._conn) == LATEST_VERSION
+        assert [
+            node.qualified_name
+            for node in self.store.search_nodes_by_qualified_tail("Handler.process")
+        ] == ["src/app.py::Handler.process"]
+
+    def test_v10_backfills_and_indexes_the_symbol_column(self):
+        """v10 must populate ``symbol`` for pre-existing rows and index it, so
+        dotted-tail lookups are indexed rather than scanning every node."""
+        conn = self.store._conn
+        conn.execute("DROP INDEX IF EXISTS idx_nodes_symbol")
+        conn.execute(
+            "INSERT INTO nodes "
+            "(kind, name, qualified_name, file_path, language, symbol, updated_at) "
+            "VALUES ('Function', 'process', ?, 'src/app.py', 'python', NULL, 0)",
+            ("src/app.py::Handler.process",),
+        )
+        # A bare qualified name with no path component stays its own symbol.
+        conn.execute(
+            "INSERT INTO nodes "
+            "(kind, name, qualified_name, file_path, language, symbol, updated_at) "
+            "VALUES ('File', 'loose', 'loose', 'loose', 'python', NULL, 0)"
+        )
+        conn.execute("UPDATE metadata SET value = '9' WHERE key = 'schema_version'")
+        self.store.commit()
+
+        run_migrations(conn)
+
+        rows = dict(conn.execute("SELECT qualified_name, symbol FROM nodes").fetchall())
+        assert rows["src/app.py::Handler.process"] == "Handler.process"
+        assert rows["loose"] == "loose"
+
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM nodes WHERE symbol = ?", ("x",)
+        ).fetchall()
+        assert any("idx_nodes_symbol" in str(step[-1]) for step in plan)
+
     def test_fresh_db_gets_latest_version(self):
         """A newly created DB should be at the latest schema version."""
         version = get_schema_version(self.store._conn)


### PR DESCRIPTION
## Summary

A dotted symbol target could not be addressed by short name. `Details.QueryHandler.Handle`,
`Handler.Process` and `pkg.Handler.Process` all returned `not_found`.

The cause is that `_looks_like_java_method_fqn()` is a purely lexical test, so **every**
dotted target looks Java-FQN-shaped regardless of which language defines it.
`_java_fqn_candidates()` then withheld the match from Go, Python, Kotlin, TypeScript and
C# alike. That guard exists to stop a globally unique method name in another language
being selected for a Java FQN, but it was over-blocking far beyond Java.

- resolve dotted targets against an exact qualified-tail match
- back that lookup with an indexed `nodes.symbol` column instead of a table scan
- keep Java FQN precedence exactly as it is today
- report honest ambiguity counts past the candidate cap

Split out of #937, which is the C# nested-type identity fix (#934). This is the
query-resolution half; the two are independent and this branch is cut from `main`.

## Java precedence is unchanged

The tail lookup is consulted **only when no Java candidate exists**. A Java-shaped target
with real Java matches still resolves against Java:

| case | `main` | this PR |
| --- | --- | --- |
| Java `com.example.Handler.process` | ok → Java | ok → Java |
| Java + unrelated Python `process` | ok → Java | ok → Java |
| Java + same-tail Go node | ok → Java | ok → Java |
| Java + same-tail C# node | ok → Java | ok → Java |
| two Java `Handler.process` | ambiguous | ambiguous |
| Go `Handler.Process` / `pkg.Handler.Process` | not_found | **ok** |
| Python / Kotlin / TypeScript `Handler.process` | not_found | **ok** |
| C# `Details.QueryHandler.Handle` | not_found | **ok** |

Every Java row is identical to `main`. The only behavior change is that a dotted target
with an exact qualified-path match now resolves where `main` returned `not_found`. An
exact match on the entire symbol path is different in kind from the fuzzy
globally-unique-name fallback the guard was written to block, and cannot mislink.

## Indexed lookup

Matching with `substr(qualified_name, -n) = ?` cannot use any B-tree index; SQLite planned
it as `SCAN nodes` on every dotted lookup, plus a second scan for the ambiguity count.

Nodes now carry an indexed `symbol` column holding the portion of `qualified_name` after
the first `::`. `symbol` is stored rather than reconstructed from `parent_name || '.' || name`
because `qualified_name` is built from `identity_name or name`, so the reconstruction would
miss C++ overload identities.

```
before:  SCAN nodes
after:   SEARCH nodes USING INDEX idx_nodes_symbol (symbol=?)
         SEARCH nodes USING INDEX sqlite_autoindex_nodes_1 (qualified_name=?)
```

Migration v10 backfills and indexes the column. The index is created **in the migration,
not the schema script**: `_init_schema` runs before `run_migrations`, and
`CREATE TABLE IF NOT EXISTS` cannot add a column to an existing table, so indexing `symbol`
from the script raised `no such column: symbol` and every pre-v10 database failed to open.
`SUPPORTED_SCHEMA_VERSION` in the VS Code backend moves to 10 to match.

> **Merge note:** #939 also defines a `_migrate_v10`. Whichever lands second must renumber
> to v11; `run_migrations()` iterates `sorted(MIGRATIONS)` and tolerates the gap.

## Bounded-result honesty

`candidate_count` used `len(candidates)` for Java-shaped targets, so 101 exact matches
reported `matches 100 node(s)` with `candidates_truncated: false` — both wrong, on fields
that exist for agent-facing transparency. It now counts the population candidates were
drawn from.

## Testing

- `uv run pytest tests/ --tb=short -q` (2996 passed, 9 skipped, 2 xpassed)
- cross-language dotted-target matrix (Go, Python, Kotlin, TypeScript, C#)
- Java precedence: a same-tail C# node does not displace a real Java match
- truncation count at `_MAX_DOTTED_TARGET_CANDIDATES + 1`
- v10 upgrade of a database with the `symbol` column stripped, reproducing a genuine pre-v10 graph
- `EXPLAIN QUERY PLAN` asserts indexed `SEARCH` for both lookups
- `uv run ruff check code_review_graph/`
- `uv run mypy code_review_graph/ --ignore-missing-imports --no-strict-optional`
