### PR TITLE
fix(csharp): preserve namespace identity and lexical call binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- C# declarations no longer collapse across namespaces, and calls no longer
+  bind to a type the caller cannot name. Qualified names now carry the
+  namespace and the complete containing-type path
+  (`/repo/Handlers.cs::App.Report.ExportHandler.Run`), and a dedicated
+  namespace-aware pass binds each call from its own lexical scope: `using`
+  directives are read at the byte offset of the namespace body that declares
+  them, so a reopened or file-scoped body cannot leak its imports elsewhere;
+  `global::` and namespace aliases keep their meaning; `Alias::Type` searches
+  only namespace aliases; and an unqualified call reaches a static method in
+  an enclosing type without crossing a nearer method group. File co-location
+  and short-name uniqueness are no longer treated as visibility evidence, so
+  an ambiguous or unsupported reference stays unresolved instead of pointing
+  at the wrong declaration. Overload selection, generic binding (#943),
+  inherited members and `using static` remain outside this change (#946, with
+  the nested-type identity needed by #934 and #937).
+- C# bindings are now re-evaluated on every update rather than fixed at first
+  parse. Each call keeps its raw reference, so a binding is revoked when the
+  usings or declarations behind it change, `TESTED_BY` mirrors move with their
+  call, and deleting a callee returns incoming calls to raw references so
+  recreating the declaration binds them again. A binding change marks flows
+  dirty and the next full postprocess retraces them, which keeps callers and
+  entry points outside the parsed files correct (#946).
+- Existing C# graphs reparse once on the next incremental update to adopt the
+  new identities; a file that fails to parse is retried on its own instead of
+  holding the version gate open and repeating a full rebuild (#944). Graphs
+  that carry embeddings should re-run `code-review-graph embed` afterwards:
+  the renamed C# nodes leave their previous vectors orphaned until a refresh
+  purges them.
+
 ## [2.3.8] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
   recreating the declaration binds them again. A binding change marks flows
   dirty and the next full postprocess retraces them, which keeps callers and
   entry points outside the parsed files correct (#946).
+- C# generic declarations are keyed by arity, so a constructed receiver reaches
+  the declaration it names — `I<int>` binds to `I<T>`, `I` binds to the separate
+  `I`, and `Pair<int>` binds to neither when only `Pair<K, V>` is declared. The
+  receiver's spelling is retained on the call and the arity is read from the
+  syntax, so nested arguments and tuples count correctly. Type argument
+  substitution, constraints and overload selection remain out of scope (#946).
 - Existing C# graphs reparse once on the next incremental update to adopt the
   new identities; a file that fails to parse is retried on its own instead of
   holding the version gate open and repeating a full rebuild (#944). Graphs

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -36,6 +36,69 @@ def _join(parent: str, name: str) -> str:
     return f"{parent}.{name}" if parent else name
 
 
+_CLOSING = {"<": ">", "(": ")", "[": "]"}
+
+
+def _split(text: str, separator: str) -> list[str] | None:
+    """Split on *separator* at nesting depth zero, or ``None`` if unbalanced."""
+    parts: list[str] = []
+    depth: list[str] = []
+    current = ""
+    for character in text:
+        if character in _CLOSING:
+            depth.append(_CLOSING[character])
+        elif depth and character == depth[-1]:
+            depth.pop()
+        elif character == separator and not depth:
+            parts.append(current)
+            current = ""
+            continue
+        current += character
+    if depth:
+        return None
+    parts.append(current)
+    return parts
+
+
+def _arity(arguments: str) -> int | None:
+    """Return how many type arguments *arguments* supplies, ``<`` excluded."""
+    if not arguments.endswith(">"):
+        return None
+    supplied = _split(arguments[:-1], ",")
+    if supplied is None or not all(argument.strip() for argument in supplied):
+        return None
+    return len(supplied)
+
+
+def _type_key(reference: str) -> str | None:
+    """Return the declaration key a type reference names, or ``None``.
+
+    Generic declarations are keyed by arity — ``App.Box`1`` — because that is
+    what distinguishes ``Box`` from ``Box<T>``. Erasing the arguments instead
+    would let a reference select a declaration it does not name.
+    """
+    segments = _split(reference, ".")
+    if segments is None:
+        return None
+    keys = []
+    for index, segment in enumerate(segments):
+        name, separator, arguments = segment.partition("<")
+        if not separator:
+            if not segment.isidentifier():
+                return None
+            keys.append(segment)
+            continue
+        # A constructed containing type carries its own arity, which one key
+        # cannot describe; ``Outer<T>.Inner`` stays unresolved.
+        if index != len(segments) - 1 or not name.isidentifier():
+            return None
+        arity = _arity(arguments)
+        if arity is None:
+            return None
+        keys.append(f"{name}`{arity}")
+    return ".".join(keys)
+
+
 def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> dict:
     conn = store._conn
     nodes = conn.execute("SELECT * FROM nodes WHERE language = 'csharp'").fetchall()
@@ -79,8 +142,12 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         qualified = node["qualified_name"]
         parent = node["parent_name"] or ""
         parents[qualified] = parent
-        if node["kind"] == "Class" and not extra.get("csharp_generic"):
-            types.setdefault(_join(parent, node["name"]), []).append(qualified)
+        if node["kind"] == "Class":
+            arity = extra.get("csharp_arity")
+            name = node["name"]
+            if isinstance(arity, int) and arity > 0:
+                name = f"{name}`{arity}"
+            types.setdefault(_join(parent, name), []).append(qualified)
             type_files[qualified] = node["file_path"]
             if extra.get("csharp_partial"):
                 partial_types.add(qualified)
@@ -136,7 +203,8 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         raw = raw.removeprefix("global::").removesuffix("?")
         alias, separator, reference = raw.partition("::")
         if separator:
-            if not alias.isidentifier() or not all(p.isidentifier() for p in reference.split(".")):
+            reference_key = _type_key(reference)
+            if not alias.isidentifier() or reference_key is None:
                 return []
             # Unlike '.', '::' searches only namespace aliases, even when a
             # local, type, or namespace has the same name as the qualifier.
@@ -147,12 +215,14 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
                 if len(aliases) != 1:
                     return []
                 target = import_target(*aliases[0])
-                return types.get(_join(target, reference), []) if target in namespaces else []
+                return types.get(_join(target, reference_key), []) if target in namespaces else []
             return []
-        # Keep generic arguments lossless; erasure could select a different
-        # declaration (I vs I<T>). Generic binding belongs to #943.
-        if not all(part.isidentifier() for part in raw.split(".")):
+        # Generic arguments are kept, not erased: the reference resolves by
+        # arity, so ``I<int>`` reaches ``I<T>`` and never the separate ``I``.
+        key = _type_key(raw)
+        if key is None:
             return []
+        raw = key
         first, _, tail = raw.partition(".")
         if absolute:
             return types.get(raw, [])

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -1,0 +1,284 @@
+"""Bind C# calls using declaration identity and lexical namespace evidence.
+
+Raw references survive binding: every pass can revoke a previously inferred
+edge when declarations or usings change. This is a structural binder, not a
+C# compiler; unsupported type expressions and ambiguous declarations stay raw.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .graph import GraphStore
+
+
+def _extra(raw: str | None) -> dict:
+    try:
+        value = json.loads(raw or "{}")
+    except (ValueError, TypeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _parents(name: str):
+    while name:
+        yield name
+        name = name.rpartition(".")[0]
+    yield ""
+
+
+def _join(parent: str, name: str) -> str:
+    return f"{parent}.{name}" if parent else name
+
+
+def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> dict:
+    conn = store._conn
+    nodes = conn.execute("SELECT * FROM nodes WHERE language = 'csharp'").fetchall()
+    files = {n["file_path"] for n in nodes}
+    if not files:
+        return {"files_indexed": 0, "calls_resolved": 0}
+    root = repo_root or Path(os.path.commonpath([str(Path(f).parent) for f in files]))
+
+    @lru_cache(maxsize=None)
+    def project(directory: Path) -> str | None:
+        try:
+            projects = list(directory.glob("*.csproj"))
+        except OSError:
+            return None
+        if projects:
+            return str(projects[0]) if len(projects) == 1 else None
+        if directory == root or directory.parent == directory:
+            # ponytail: loose .cs files share the review root; MSBuild compile
+            # item evaluation is needed for linked/conditional source ownership.
+            return str(root)
+        return project(directory.parent)
+
+    projects = {f: project(Path(f).parent) for f in files}
+    types: dict[str, list[str]] = {}
+    methods: dict[tuple[str, str], list[str]] = {}
+    parents: dict[str, str] = {}
+    partial_types: set[str] = set()
+    type_files: dict[str, str] = {}
+    namespaces = {""}
+    for node in nodes:
+        extra = _extra(node["extra"])
+        namespace = extra.get("csharp_namespace")
+        if node["kind"] == "File":
+            for name in extra.get("csharp_namespaces", []):
+                namespaces.update(_parents(name))
+        if not isinstance(namespace, str):
+            continue  # Legacy nodes do not establish namespace identity.
+        namespaces.update(_parents(namespace))
+        qualified = node["qualified_name"]
+        parent = node["parent_name"] or ""
+        parents[qualified] = parent
+        if node["kind"] == "Class" and not extra.get("csharp_generic"):
+            types.setdefault(_join(parent, node["name"]), []).append(qualified)
+            type_files[qualified] = node["file_path"]
+            if extra.get("csharp_partial"):
+                partial_types.add(qualified)
+        elif node["kind"] in ("Function", "Method", "Test"):
+            method_key = (f"{node['file_path']}::{parent}", node["name"])
+            methods.setdefault(method_key, []).append(qualified)
+
+    imports: dict[tuple[str, int], list[tuple[str, dict]]] = {}
+    global_imports: dict[str, list[tuple[str, dict]]] = {}
+    csharp_files_sql = "SELECT file_path FROM nodes WHERE kind = 'File' AND language = 'csharp'"
+    for row in conn.execute(
+        f"SELECT * FROM edges WHERE kind = 'IMPORTS_FROM' AND file_path IN ({csharp_files_sql})",
+    ):
+        extra = _extra(row["extra"])
+        scopes = extra.get("csharp_scopes")
+        if row["file_path"] not in files or not scopes:
+            continue
+        directive = (row["target_qualified"], extra)
+        scope = scopes[0][1]
+        if extra.get("csharp_global") and scope == -1:
+            # Ambiguous project ownership never exports a using to other files.
+            key = projects[row["file_path"]] or row["file_path"]
+            global_imports.setdefault(key, []).append(directive)
+        else:
+            imports.setdefault((row["file_path"], scope), []).append(directive)
+
+    def import_target(raw: str, extra: dict) -> str | None:
+        absolute = raw.startswith("global::")
+        raw = raw.removeprefix("global::")
+        if not all(part.isidentifier() for part in raw.split(".")):
+            return None
+        first = raw.split(".", 1)[0]
+        namespace = extra["csharp_scopes"][0][0]
+        for parent in ([""] if absolute else _parents(namespace)):
+            prefix = _join(parent, first)
+            if prefix in namespaces or prefix in types:
+                target = _join(parent, raw)
+                return target if target in namespaces or target in types else None
+        return None
+
+    def directives(file: str, scope: int) -> list[tuple[str, dict]]:
+        local = imports.get((file, scope), [])
+        if scope == -1:
+            return local + global_imports.get(projects[file] or file, [])
+        return local
+
+    def type_targets(raw: str, owner: str, scopes: list, file: str) -> list[str]:
+        absolute = raw.startswith("global::")
+        raw = raw.removeprefix("global::")
+        # Keep generic arguments lossless; erasure could select a different
+        # declaration (I vs I<T>). Generic binding belongs to #943.
+        if not all(part.isidentifier() for part in raw.split(".")):
+            return []
+        first, _, tail = raw.partition(".")
+        if absolute:
+            return types.get(raw, [])
+        namespace = scopes[0][0]
+        for enclosing in _parents(owner):
+            if enclosing == namespace:
+                break
+            if _join(enclosing, first) in types:
+                return types.get(_join(enclosing, raw), [])
+        scope_by_namespace = {name: scope for name, scope in scopes}
+        for enclosing in _parents(namespace):
+            visible = (
+                directives(file, scope_by_namespace[enclosing])
+                if enclosing in scope_by_namespace else []
+            )
+            aliases = [
+                (target, extra) for target, extra in visible
+                if extra.get("csharp_alias") == first
+            ]
+            prefix = _join(enclosing, first)
+            if prefix in namespaces or prefix in types:
+                return [] if aliases else types.get(_join(enclosing, raw), [])
+            if aliases:
+                if len(aliases) != 1:
+                    return []
+                alias = import_target(*aliases[0])
+                return types.get(_join(alias, tail) if tail else alias, []) if alias else []
+            imported = set()
+            for target, extra in visible:
+                kind = extra.get("csharp_using_kind")
+                if kind not in ("namespace", "static"):
+                    continue
+                imported_scope = import_target(target, extra)
+                if imported_scope is None:
+                    continue
+                # Using a namespace imports its types, never child namespaces.
+                if kind == "namespace" and imported_scope not in namespaces:
+                    continue
+                if kind == "static" and imported_scope not in types:
+                    continue
+                candidate = _join(imported_scope, first)
+                if candidate in types:
+                    imported.add(candidate)
+            if imported:
+                if len(imported) != 1:
+                    return []
+                prefix = next(iter(imported))
+                return types.get(_join(prefix, tail) if tail else prefix, [])
+        return []
+
+    def targets(row, extra: dict) -> list[str]:
+        scopes = extra.get("csharp_scopes")
+        if not scopes:
+            return []
+        owner = parents.get(row["source_qualified"], "")
+        kind = extra.get("csharp_call_kind")
+        method = extra["csharp_raw_target"].rsplit("::", 1)[-1]
+        receiver = extra.get("receiver_scope", "")
+        if extra.get("receiver") == "this" or kind == "unqualified":
+            own_type = f"{row['file_path']}::{owner}"
+            candidates = [own_type] if own_type in parents else []
+            if own_type in partial_types:
+                candidates = [
+                    c for c in types.get(owner, []) if c in partial_types
+                    and projects[type_files[c]] == projects[row["file_path"]]
+                ]
+        else:
+            candidates = type_targets(receiver, owner, scopes, row["file_path"])
+        if not candidates:
+            return []
+        if len(candidates) > 1:
+            owners = {projects[type_files[c]] for c in candidates}
+            if (
+                not all(c in partial_types for c in candidates)
+                or len(owners) != 1 or None in owners
+            ):
+                return []
+        if kind == "constructor":
+            return candidates
+        return [method_qn for c in candidates for method_qn in methods.get((c, method), [])]
+
+    resolved = 0
+    changed = False
+    for row in conn.execute(
+        f"SELECT * FROM edges WHERE kind = 'CALLS' AND file_path IN ({csharp_files_sql})",
+    ).fetchall():
+        extra = _extra(row["extra"])
+        raw = extra.get("csharp_raw_target")
+        if row["file_path"] not in files or not isinstance(raw, str):
+            continue
+        candidates = targets(row, extra)
+        target = candidates[0] if len(candidates) == 1 else raw
+        for key in ("unresolved_targets", "scoped_resolved", "scoped_via"):
+            extra.pop(key, None)
+        if len(candidates) == 1:
+            extra.update(scoped_resolved=True, scoped_via="csharp_namespace")
+        else:
+            extra["unresolved_targets"] = []
+        if _set_call(store, row, target, extra):
+            resolved += len(candidates) == 1
+            changed = True
+    if changed:
+        conn.commit()
+        store._invalidate_cache()
+    return {"files_indexed": len(files), "calls_resolved": resolved}
+
+
+def _set_call(store: GraphStore, row, target: str, extra: dict) -> bool:
+    if target == row["target_qualified"] and extra == _extra(row["extra"]):
+        return False
+    serialized = json.dumps(extra, sort_keys=True)
+    tier = "INFERRED" if extra.get("scoped_resolved") else "EXTRACTED"
+    store._conn.execute(
+        "UPDATE edges SET target_qualified = ?, extra = ?, confidence_tier = ? WHERE id = ?",
+        (target, serialized, tier, row["id"]),
+    )
+    # Match old endpoint and evidence: two calls on one line can have mirrors.
+    store._conn.execute(
+        "UPDATE edges SET source_qualified = ?, extra = ?, confidence_tier = ? "
+        "WHERE kind = 'TESTED_BY' AND source_qualified = ? AND target_qualified = ? "
+        "AND file_path = ? AND line = ? AND extra = ?",
+        (target, serialized, tier, row["target_qualified"], row["source_qualified"],
+         row["file_path"], row["line"], row["extra"]),
+    )
+    return True
+
+
+def restore_csharp_references(store: GraphStore, deleted_files: list[str]) -> None:
+    """Restore raw incoming calls before permanent deletion removes their targets."""
+    if not deleted_files:
+        return
+    deleted = set(deleted_files)
+    rows = store._conn.execute(
+        "SELECT e.*, n.file_path AS target_file FROM edges e "
+        "JOIN nodes n ON e.target_qualified = n.qualified_name "
+        "WHERE e.kind = 'CALLS' AND n.language = 'csharp'",
+    ).fetchall()
+    changed = False
+    for row in rows:
+        extra = _extra(row["extra"])
+        raw = extra.get("csharp_raw_target")
+        if row["target_file"] not in deleted or not isinstance(raw, str):
+            continue
+        extra.pop("scoped_resolved", None)
+        extra.pop("scoped_via", None)
+        extra["unresolved_targets"] = []
+        changed = _set_call(store, row, raw, extra) or changed
+    if changed:
+        store.commit()
+        store._invalidate_cache()

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -61,6 +61,7 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
     projects = {f: project(Path(f).parent) for f in files}
     types: dict[str, list[str]] = {}
     methods: dict[tuple[str, str], list[str]] = {}
+    static_methods: set[str] = set()
     parents: dict[str, str] = {}
     partial_types: set[str] = set()
     type_files: dict[str, str] = {}
@@ -85,6 +86,8 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         elif node["kind"] in ("Function", "Method", "Test"):
             method_key = (f"{node['file_path']}::{parent}", node["name"])
             methods.setdefault(method_key, []).append(qualified)
+            if extra.get("csharp_static"):
+                static_methods.add(qualified)
 
     imports: dict[tuple[str, int], list[tuple[str, dict]]] = {}
     global_imports: dict[str, list[tuple[str, dict]]] = {}
@@ -130,6 +133,21 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         # Nullable receivers use the underlying declaration for member lookup;
         # the original annotation remains in the call's stored evidence.
         raw = raw.removeprefix("global::").removesuffix("?")
+        alias, separator, reference = raw.partition("::")
+        if separator:
+            if not alias.isidentifier() or not all(p.isidentifier() for p in reference.split(".")):
+                return []
+            # Unlike '.', '::' searches only namespace aliases, even when a
+            # local, type, or namespace has the same name as the qualifier.
+            for _, scope in scopes:
+                aliases = [d for d in directives(file, scope) if d[1].get("csharp_alias") == alias]
+                if not aliases:
+                    continue
+                if len(aliases) != 1:
+                    return []
+                target = import_target(*aliases[0])
+                return types.get(_join(target, reference), []) if target in namespaces else []
+            return []
         # Keep generic arguments lossless; erasure could select a different
         # declaration (I vs I<T>). Generic binding belongs to #943.
         if not all(part.isidentifier() for part in raw.split(".")):
@@ -186,7 +204,7 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
 
     def targets(row, extra: dict) -> list[str]:
         scopes = extra.get("csharp_scopes")
-        if not scopes:
+        if not scopes or extra.get("receiver_resolution") == "shadowed_callable":
             return []
         # Initializers have a File caller but still belong to a lexical type.
         owner = extra.get("csharp_containing_type") or parents.get(
@@ -195,28 +213,34 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         kind = extra.get("csharp_call_kind")
         method = extra["csharp_raw_target"].rsplit("::", 1)[-1]
         receiver = extra.get("receiver_scope", "")
-        if extra.get("receiver") == "this" or kind == "unqualified":
-            own_type = f"{row['file_path']}::{owner}"
-            candidates = [own_type] if own_type in parents else []
-            if own_type in partial_types:
-                candidates = [
-                    c for c in types.get(owner, []) if c in partial_types
-                    and projects[type_files[c]] == projects[row["file_path"]]
-                ]
-        else:
-            candidates = type_targets(receiver, owner, scopes, row["file_path"])
-        if not candidates:
-            return []
-        if len(candidates) > 1:
-            owners = {projects[type_files[c]] for c in candidates}
-            if (
-                not all(c in partial_types for c in candidates)
-                or len(owners) != 1 or None in owners
-            ):
-                return []
-        if kind == "constructor":
-            return candidates
-        return [method_qn for c in candidates for method_qn in methods.get((c, method), [])]
+        for enclosing in (_parents(owner) if kind == "unqualified" else (owner,)):
+            if kind == "unqualified" and enclosing == scopes[0][0]:
+                break  # Only containing types, never namespaces or imported static members.
+            if extra.get("receiver") == "this" or kind == "unqualified":
+                own_type = f"{row['file_path']}::{enclosing}"
+                candidates = [own_type] if own_type in parents else []
+                if own_type in partial_types:
+                    candidates = [
+                        c for c in types.get(enclosing, []) if c in partial_types
+                        and projects[type_files[c]] == projects[row["file_path"]]
+                    ]
+            else:
+                candidates = type_targets(receiver, owner, scopes, row["file_path"])
+            if len(candidates) > 1:
+                owners = {projects[type_files[c]] for c in candidates}
+                if (
+                    not all(c in partial_types for c in candidates)
+                    or len(owners) != 1 or None in owners
+                ):
+                    return []
+            if kind == "constructor":
+                return candidates
+            found = [qn for c in candidates for qn in methods.get((c, method), [])]
+            if found:
+                if enclosing != owner and (len(found) != 1 or found[0] not in static_methods):
+                    return []
+                return found
+        return []
 
     resolved = 0
     changed = False
@@ -261,6 +285,12 @@ def _set_call(store: GraphStore, row, target: str, extra: dict) -> bool:
         (target, serialized, tier, row["target_qualified"], row["source_qualified"],
          row["file_path"], row["line"], row["extra"]),
     )
+    if target != row["target_qualified"]:
+        # Persist alongside the edge: callers and entry points outside the
+        # parsed files may change, including when restoring a deleted target.
+        store._conn.execute(
+            "INSERT OR IGNORE INTO metadata (key, value) VALUES ('csharp_flows_dirty', '1')",
+        )
     return True
 
 

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -53,8 +53,9 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         if projects:
             return str(projects[0]) if len(projects) == 1 else None
         if directory == root or directory.parent == directory:
-            # ponytail: loose .cs files share the review root; MSBuild compile
-            # item evaluation is needed for linked/conditional source ownership.
+            # Loose .cs files share the review root. Resolving linked or
+            # conditional source ownership properly needs MSBuild compile-item
+            # evaluation, which is outside this pass.
             return str(root)
         return project(directory.parent)
 

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -127,7 +127,9 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
 
     def type_targets(raw: str, owner: str, scopes: list, file: str) -> list[str]:
         absolute = raw.startswith("global::")
-        raw = raw.removeprefix("global::")
+        # Nullable receivers use the underlying declaration for member lookup;
+        # the original annotation remains in the call's stored evidence.
+        raw = raw.removeprefix("global::").removesuffix("?")
         # Keep generic arguments lossless; erasure could select a different
         # declaration (I vs I<T>). Generic binding belongs to #943.
         if not all(part.isidentifier() for part in raw.split(".")):
@@ -186,7 +188,10 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
         scopes = extra.get("csharp_scopes")
         if not scopes:
             return []
-        owner = parents.get(row["source_qualified"], "")
+        # Initializers have a File caller but still belong to a lexical type.
+        owner = extra.get("csharp_containing_type") or parents.get(
+            row["source_qualified"], scopes[0][0],
+        )
         kind = extra.get("csharp_call_kind")
         method = extra["csharp_raw_target"].rsplit("::", 1)[-1]
         receiver = extra.get("receiver_scope", "")

--- a/code_review_graph/csharp_resolver.py
+++ b/code_review_graph/csharp_resolver.py
@@ -127,7 +127,7 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
     methods: dict[tuple[str, str], list[str]] = {}
     static_methods: set[str] = set()
     parents: dict[str, str] = {}
-    partial_types: set[str] = set()
+    partial_types: dict[str, str] = {}
     type_files: dict[str, str] = {}
     namespaces = {""}
     for node in nodes:
@@ -147,10 +147,11 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
             name = node["name"]
             if isinstance(arity, int) and arity > 0:
                 name = f"{name}`{arity}"
-            types.setdefault(_join(parent, name), []).append(qualified)
+            type_key = _join(parent, name)
+            types.setdefault(type_key, []).append(qualified)
             type_files[qualified] = node["file_path"]
             if extra.get("csharp_partial"):
-                partial_types.add(qualified)
+                partial_types[qualified] = type_key
         elif node["kind"] in ("Function", "Method", "Test"):
             method_key = (f"{node['file_path']}::{parent}", node["name"])
             methods.setdefault(method_key, []).append(qualified)
@@ -291,8 +292,9 @@ def resolve_csharp_calls(store: GraphStore, repo_root: Path | None = None) -> di
                 own_type = f"{row['file_path']}::{enclosing}"
                 candidates = [own_type] if own_type in parents else []
                 if own_type in partial_types:
+                    # Preserve declaration arity when joining partial definitions.
                     candidates = [
-                        c for c in types.get(enclosing, []) if c in partial_types
+                        c for c in types.get(partial_types[own_type], []) if c in partial_types
                         and projects[type_files[c]] == projects[row["file_path"]]
                     ]
             else:

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -449,6 +449,7 @@ def store_flows(store: GraphStore, flows: list[dict]) -> int:
                 )
             count += 1
 
+        conn.execute("DELETE FROM metadata WHERE key = 'csharp_flows_dirty'")
         conn.commit()
     except BaseException:
         conn.rollback()
@@ -473,6 +474,10 @@ def incremental_trace_flows(
 
     Returns the number of re-traced flows that were stored.
     """
+    if store.get_metadata("csharp_flows_dirty") == "1":
+        # ponytail: C# rebinding can change unchanged callers and entry points;
+        # use a full retrace until the binder supplies a complete affected set.
+        return store_flows(store, trace_flows(store, max_depth=max_depth))
     if not changed_files:
         return 0
 

--- a/code_review_graph/flows.py
+++ b/code_review_graph/flows.py
@@ -475,8 +475,9 @@ def incremental_trace_flows(
     Returns the number of re-traced flows that were stored.
     """
     if store.get_metadata("csharp_flows_dirty") == "1":
-        # ponytail: C# rebinding can change unchanged callers and entry points;
-        # use a full retrace until the binder supplies a complete affected set.
+        # C# rebinding can change callers and entry points in files that were
+        # never reparsed, so a changed-file set cannot bound the work. Retrace
+        # in full until the binder reports a complete affected set.
         return store_flows(store, trace_flows(store, max_depth=max_depth))
     if not changed_files:
         return 0

--- a/code_review_graph/graph.py
+++ b/code_review_graph/graph.py
@@ -270,12 +270,15 @@ class GraphStore:
         confidence_tier = str(extra_dict.get("confidence_tier", "EXTRACTED"))
         extra = json.dumps(extra_dict)
 
-        # Check for existing edge (include line so multiple call sites are preserved)
+        # A parser can supply a byte offset when distinct scopes/calls share a
+        # line. Without it, two C# namespace bodies can overwrite a using edge.
         existing = self._conn.execute(
             """SELECT id FROM edges
                WHERE kind=? AND source_qualified=? AND target_qualified=?
-                     AND file_path=? AND line=?""",
-            (edge.kind, edge.source, edge.target, edge.file_path, edge.line),
+                     AND file_path=? AND line=?
+                     AND json_extract(extra, '$.source_offset') IS ?""",
+            (edge.kind, edge.source, edge.target, edge.file_path, edge.line,
+             extra_dict.get("source_offset")),
         ).fetchone()
 
         if existing:

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -78,7 +78,7 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
-CSHARP_IDENTITY_VERSION = "4"  # Namespace/call context + static member evidence (#946).
+CSHARP_IDENTITY_VERSION = "5"  # Namespace/call context, static and generic-arity evidence.
 _CSHARP_IDENTITY_METADATA_KEY = "csharp_identity_version"
 _CSHARP_PENDING_METADATA_KEY = "csharp_identity_pending_files"
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -22,6 +22,7 @@ import uuid
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, NamedTuple, Optional
 
+from .csharp_resolver import restore_csharp_references
 from .graph import GraphStore
 from .parser import CodeParser, normalize_file_path
 
@@ -77,6 +78,9 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
+CSHARP_IDENTITY_VERSION = "2"  # Namespace + complete containing-type path (#946).
+_CSHARP_IDENTITY_METADATA_KEY = "csharp_identity_version"
+_CSHARP_PENDING_METADATA_KEY = "csharp_identity_pending_files"
 
 
 def _run_python_resolver(store: GraphStore) -> Optional[dict]:
@@ -145,11 +149,11 @@ def _run_hcl_resolver(store: GraphStore) -> Optional[dict]:
         return None
 
 
-def _run_scoped_resolver(store: GraphStore) -> Optional[dict]:
+def _run_scoped_resolver(store: GraphStore, repo_root: Path) -> Optional[dict]:
     """Resolve static/scoped ``Class::method`` calls without failing a build."""
     try:
         from .scoped_resolver import resolve_scoped_calls
-        return resolve_scoped_calls(store)
+        return resolve_scoped_calls(store, repo_root)
     except Exception as exc:  # noqa: BLE001 - best-effort post-pass
         logger.warning("Scoped call resolver failed: %s", exc)
         return None
@@ -1105,6 +1109,7 @@ def _reconcile_stale_files(
                 current_paths.add(stored_file)
     stale_files = sorted(stored_files - current_paths)
     if stale_files:
+        restore_csharp_references(store, stale_files)
         store.remove_files_permanently(stale_files)
     return stale_files
 
@@ -1334,6 +1339,12 @@ def full_build(
     store.set_metadata("last_build_type", "full")
     if not cpp_errors:
         store.set_metadata(_CPP_IDENTITY_METADATA_KEY, CPP_IDENTITY_VERSION)
+    # Record the attempted C# format and retry only failed files. Holding the
+    # entire version gate open for one bad file repeats a full build (#944).
+    store.set_metadata(_CSHARP_IDENTITY_METADATA_KEY, CSHARP_IDENTITY_VERSION)
+    store.set_metadata(_CSHARP_PENDING_METADATA_KEY, json.dumps(sorted(
+        error["file"] for error in errors if error["file"].endswith(".cs")
+    )))
     _store_vcs_metadata(repo_root, store)
     store.commit()
 
@@ -1343,7 +1354,7 @@ def full_build(
     spring_event_stats = _run_spring_event_resolver(store)
     temporal_stats = _run_temporal_resolver(store)
     hcl_stats = _run_hcl_resolver(store)
-    scoped_stats = _run_scoped_resolver(store)
+    scoped_stats = _run_scoped_resolver(store, repo_root)
 
     return {
         "files_parsed": len(files),
@@ -1402,6 +1413,20 @@ def incremental_update(
     # Determine changed files
     if changed_files is None:
         changed_files = get_changed_files(repo_root, base)
+    csharp_upgrade = (
+        store.get_metadata(_CSHARP_IDENTITY_METADATA_KEY) != CSHARP_IDENTITY_VERSION
+        and store.has_nodes_for_language("csharp")
+    )
+    pending_csharp = set(json.loads(store.get_metadata(_CSHARP_PENDING_METADATA_KEY) or "[]"))
+    if csharp_upgrade:
+        pending_csharp.update(
+            str(Path(row[0]).relative_to(repo_root))
+            for row in store._conn.execute(
+                "SELECT DISTINCT file_path FROM nodes WHERE language = 'csharp'",
+            )
+            if Path(row[0]).is_relative_to(repo_root)
+        )
+    changed_files = sorted(set(changed_files) | pending_csharp)
     stale_files = _reconcile_stale_files(repo_root, store) if reconcile_stale else []
 
     if not changed_files and not stale_files:
@@ -1452,7 +1477,10 @@ def incremental_update(
             raw = abs_path.read_bytes()
             fhash = hashlib.sha256(raw).hexdigest()
             existing_nodes = store.get_nodes_by_file(str(abs_path))
-            if existing_nodes and existing_nodes[0].file_hash == fhash:
+            if (
+                rel_path not in pending_csharp
+                and existing_nodes and existing_nodes[0].file_hash == fhash
+            ):
                 continue
         except (OSError, PermissionError):
             pass
@@ -1502,8 +1530,14 @@ def incremental_update(
                 total_nodes += len(nodes)
                 total_edges += len(edges)
 
+    restore_csharp_references(store, sorted(missing_paths))
     removed_files = store.remove_files_permanently(sorted(missing_paths)) if missing_paths else 0
     files_updated = parsed_files + len(stale_files) + removed_files
+    if csharp_upgrade or pending_csharp or any(p.endswith(".cs") for p in all_files):
+        store.set_metadata(_CSHARP_IDENTITY_METADATA_KEY, CSHARP_IDENTITY_VERSION)
+        store.set_metadata(_CSHARP_PENDING_METADATA_KEY, json.dumps(sorted(
+            error["file"] for error in errors if error["file"].endswith(".cs")
+        )))
     if files_updated:
         store.set_metadata("last_updated", time.strftime("%Y-%m-%dT%H:%M:%S"))
         store.set_metadata("last_build_type", "incremental")
@@ -1539,8 +1573,11 @@ def incremental_update(
     temporal_stats = _run_temporal_resolver(store) if spring_changed else None
     hcl_changed = any(rp.endswith((".tf", ".hcl")) for rp in all_files)
     hcl_stats = _run_hcl_resolver(store) if hcl_changed else None
-    scoped_changed = any(rp.endswith((".php", ".rs", ".cs")) for rp in all_files)
-    scoped_stats = _run_scoped_resolver(store) if scoped_changed else None
+    scoped_changed = any(
+        rp.endswith((".php", ".rs", ".cs", ".csproj"))
+        for rp in set(all_files) | set(stale_files) | missing_paths
+    )
+    scoped_stats = _run_scoped_resolver(store, repo_root) if scoped_changed else None
 
     return {
         "files_updated": files_updated,
@@ -1557,6 +1594,7 @@ def incremental_update(
         "temporal_resolution": temporal_stats,
         "hcl_resolution": hcl_stats,
         "scoped_resolution": scoped_stats,
+        **({"identity_rebuild": True} if csharp_upgrade else {}),
     }
 
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -78,7 +78,7 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
-CSHARP_IDENTITY_VERSION = "3"  # Namespace identity + per-call lexical context (#946).
+CSHARP_IDENTITY_VERSION = "4"  # Namespace/call context + static member evidence (#946).
 _CSHARP_IDENTITY_METADATA_KEY = "csharp_identity_version"
 _CSHARP_PENDING_METADATA_KEY = "csharp_identity_pending_files"
 

--- a/code_review_graph/incremental.py
+++ b/code_review_graph/incremental.py
@@ -78,7 +78,7 @@ logger = logging.getLogger(__name__)
 
 CPP_IDENTITY_VERSION = "1"
 _CPP_IDENTITY_METADATA_KEY = "cpp_identity_version"
-CSHARP_IDENTITY_VERSION = "2"  # Namespace + complete containing-type path (#946).
+CSHARP_IDENTITY_VERSION = "3"  # Namespace identity + per-call lexical context (#946).
 _CSHARP_IDENTITY_METADATA_KEY = "csharp_identity_version"
 _CSHARP_PENDING_METADATA_KEY = "csharp_identity_pending_files"
 

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -2080,6 +2080,52 @@ def _php_docblock_marks_test(node) -> bool:
     )
 
 
+def _csharp_name(node) -> str:
+    """Read a C# name without folding trivia into its identity."""
+    parts = []
+    pending = [node] if node is not None else []
+    while pending:
+        current = pending.pop()
+        if current.type == "comment":
+            continue
+        if current.children:
+            pending.extend(reversed(current.children))
+        else:
+            parts.append(current.text.decode("utf-8", errors="replace").removeprefix("@"))
+    return "".join(parts)
+
+
+def _csharp_namespace_context(node) -> list[tuple[str, int]]:
+    """Innermost namespace body first; byte offsets distinguish reopened bodies.
+
+    Some grammar versions put file-scoped namespace members beside the
+    declaration rather than underneath it. Its scope still extends to EOF.
+    The compilation unit has scope -1, distinct from a namespace at byte 0.
+    """
+    declarations = []
+    current = node.parent
+    while current is not None:
+        if current.type in ("namespace_declaration", "file_scoped_namespace_declaration"):
+            declarations.append(current)
+        if current.parent is None and not declarations:
+            for child in current.named_children:
+                if child.start_byte >= node.start_byte:
+                    break
+                if child.type == "file_scoped_namespace_declaration":
+                    declarations.append(child)
+                    break
+                if child.type in _CLASS_TYPES["csharp"] or child.type == "namespace_declaration":
+                    break
+        current = current.parent
+    scopes = [("", -1)]
+    namespace = ""
+    for declaration in reversed(declarations):
+        name = _csharp_name(declaration.child_by_field_name("name"))
+        namespace = f"{namespace}.{name}" if namespace else name
+        scopes.append((namespace, declaration.start_byte))
+    return list(reversed(scopes))
+
+
 def _csharp_namespaces(root_node) -> list[str]:
     """Return all namespaces declared in a C# compilation unit.
 
@@ -2089,7 +2135,7 @@ def _csharp_namespaces(root_node) -> list[str]:
     See: #310
     """
     namespaces: list[str] = []
-    stack = [(root_node, None)]
+    stack = [(root_node, "")]
 
     while stack:
         node, parent_namespace = stack.pop()
@@ -2099,7 +2145,7 @@ def _csharp_namespaces(root_node) -> list[str]:
         ):
             for c in node.children:
                 if c.type in ("qualified_name", "identifier"):
-                    text = c.text.decode("utf-8", errors="replace").strip()
+                    text = _csharp_name(c)
                     if text:
                         current_namespace = (
                             f"{parent_namespace}.{text}"
@@ -2765,6 +2811,15 @@ class CodeParser:
             )
 
         edges = self._apply_typed_call_targets(edges, typed_call_targets, language)
+        if language == "csharp":
+            for edge in edges:
+                if edge.kind != "CALLS":
+                    continue
+                receiver = edge.extra.get("receiver_scope") or edge.extra.get("receiver")
+                if receiver:
+                    # Distinct receivers on one line must survive edge upsert.
+                    edge.target = f"{receiver}::{edge.target}"
+                edge.extra["csharp_raw_target"] = edge.target
 
         # Resolve bare call targets to qualified names using same-file definitions
         edges = self._resolve_call_targets(nodes, edges, file_path_str)
@@ -4669,6 +4724,11 @@ class CodeParser:
                 nodes, edges, file_path,
             )
 
+        # All C# call binding belongs to the namespace-aware graph pass.
+        # A same-file or bare-name match cannot establish C# visibility.
+        if any(node.language == "csharp" for node in nodes):
+            return edges
+
         is_cpp = any(node.language == "cpp" for node in nodes)
         is_go = any(node.language == "go" for node in nodes)
 
@@ -5150,7 +5210,14 @@ class CodeParser:
                         if language == "php"
                         else "typed_receiver"
                     )
-                    if type_name is None and receiver[:1].isupper():
+                    if (
+                        type_name is None
+                        and (receiver[:1].isupper() or language == "csharp")
+                        and not (
+                            language == "csharp"
+                            and receiver.split(".", 1)[0] in bindings
+                        )
+                    ):
                         # C# receivers keep their class-name evidence even
                         # when the class is not visible in this file: the
                         # graph-wide scoped resolver validates it against
@@ -5376,6 +5443,7 @@ class CodeParser:
                     result,
                     child.child_by_field_name("name"),
                     declared_type,
+                    csharp=True,
                 )
 
         elif language == "csharp" and node.type == "parameter":
@@ -5383,6 +5451,7 @@ class CodeParser:
                 result,
                 node.child_by_field_name("name"),
                 node.child_by_field_name("type"),
+                csharp=True,
             )
 
         elif language == "php" and node.type == "assignment_expression":
@@ -5426,8 +5495,17 @@ class CodeParser:
         return {name} if name else set()
 
     @classmethod
-    def _store_typed_binding(cls, result: dict[str, str], name_node, type_node) -> None:
-        if name_node is None or type_node is None:
+    def _store_typed_binding(
+        cls, result: dict[str, str], name_node, type_node, *, csharp: bool = False,
+    ) -> None:
+        if name_node is None:
+            return
+        if csharp:
+            # Preserve qualification and type arguments. An unknown local still
+            # shadows a type name; it must not become a static receiver guess.
+            result[_csharp_name(name_node)] = _csharp_name(type_node)
+            return
+        if type_node is None:
             return
         name = name_node.text.decode("utf-8", errors="replace")
         type_name = cls._base_type_name(
@@ -5490,10 +5568,7 @@ class CodeParser:
             # class receiver cannot be resolved to its defining file during
             # a single-file parse. Emit the receiver class as a scope target
             # for the graph-wide scoped resolver (#612).
-            base_type = self._base_type_name(type_name)
-            if not base_type:
-                return None
-            return f"{base_type}::{method}"
+            return f"{type_name}::{method}" if type_name else None
 
         base_type = self._base_type_name(type_name)
         if not base_type:
@@ -10171,12 +10246,23 @@ class CodeParser:
             return False
 
         class_parent = enclosing_class
+        csharp_namespace = None
+        if language == "csharp":
+            name = _csharp_name(child.child_by_field_name("name"))
+            csharp_namespace = _csharp_namespace_context(child)[0][0]
+            class_parent = enclosing_class or csharp_namespace or None
 
         # Swift: detect the actual type keyword (class/struct/enum/actor/extension)
         # and store it in extra["swift_kind"] for richer downstream analysis.
         # Tree-sitter maps struct/enum/actor/extension all to class_declaration;
         # protocol uses its own protocol_declaration node type.
         extra: dict = {}
+        if language == "csharp":
+            extra["csharp_namespace"] = csharp_namespace
+            if any(c.type == "type_parameter_list" for c in child.children):
+                extra["csharp_generic"] = True
+            if any(c.type == "modifier" and c.text == b"partial" for c in child.children):
+                extra["csharp_partial"] = True
         if language == "swift":
             if child.type == "class_declaration":
                 _swift_keywords = {"class", "struct", "enum", "actor", "extension"}
@@ -10257,7 +10343,7 @@ class CodeParser:
         # CONTAINS edge
         class_container = (
             self._qualify(enclosing_class, file_path, None)
-            if language == "julia" and enclosing_class
+            if language in ("julia", "csharp") and enclosing_class
             else file_path
         )
         edges.append(EdgeInfo(
@@ -10297,6 +10383,8 @@ class CodeParser:
         # Recurse into class body
         if language == "julia":
             recursive_class = self._julia_scope_join(enclosing_class, name)
+        elif language == "csharp":
+            recursive_class = f"{class_parent}.{name}" if class_parent else name
         else:
             recursive_class = name
         self._extract_from_tree(
@@ -10328,6 +10416,8 @@ class CodeParser:
         name = self._get_name(child, language, "function")
         if not name:
             return False
+        if language == "csharp":
+            name = _csharp_name(child.child_by_field_name("name")) or name
 
         # Go methods: attach to their receiver type as the enclosing class,
         # so `func (s *T) Foo()` becomes a member of T rather than a
@@ -10437,6 +10527,8 @@ class CodeParser:
 
         # Java: detect Temporal method-level annotations and Kafka listeners
         method_extra: dict = {}
+        if language == "csharp":
+            method_extra["csharp_namespace"] = _csharp_namespace_context(child)[0][0]
         go_receiver_bindings = None
         if language == "go" and child.type == "method_declaration":
             receiver_name = self._get_go_receiver_name(child)
@@ -10624,6 +10716,24 @@ class CodeParser:
         extraction instead of silently dropping the call. See: Ruby call graph.
         """
         imports = self._extract_import(child, language, source)
+        extra = {}
+        if language == "csharp":
+            scopes = _csharp_namespace_context(child)
+            alias = next((c for c in child.children if c.type == "="), None)
+            extra = {
+                "source_offset": child.start_byte,
+                "csharp_scopes": scopes,
+                "csharp_global": any(c.type == "global" for c in child.children),
+                "csharp_using_kind": (
+                    "alias" if alias is not None
+                    else "static" if any(c.type == "static" for c in child.children)
+                    else "namespace"
+                ),
+            }
+            if alias is not None:
+                extra["csharp_alias"] = _csharp_name(next(
+                    c for c in child.named_children if c.type != "comment"
+                ))
         for imp_target in imports:
             resolved = self._resolve_module_to_file(
                 imp_target, file_path, language,
@@ -10634,6 +10744,7 @@ class CodeParser:
                 target=resolved if resolved else imp_target,
                 file_path=file_path,
                 line=child.start_point[0] + 1,
+                extra=extra,
             ))
         return bool(imports)
 
@@ -10843,7 +10954,25 @@ class CodeParser:
             # lives on the receiver's type, not in the current file's scope.
             # The spring_resolver post-pass will do the correct cross-type lookup.
             receiver_name = call_extra.get("receiver")
-            if receiver_name in ("self", "cls", "this") and enclosing_class:
+            if language == "csharp":
+                target = call_name
+                callee = child.child_by_field_name("function")
+                call_extra.update({
+                    "source_offset": child.start_byte,
+                    "csharp_raw_target": call_name,
+                    "csharp_scopes": _csharp_namespace_context(child),
+                    "csharp_call_kind": (
+                        "constructor" if child.type == "object_creation_expression"
+                        else "unqualified" if callee is not None and callee.type == "identifier"
+                        else "member"
+                    ),
+                    "unresolved_targets": [],
+                })
+                if child.type == "object_creation_expression":
+                    call_extra["receiver_scope"] = _csharp_name(
+                        child.child_by_field_name("type"),
+                    )
+            elif receiver_name in ("self", "cls", "this") and enclosing_class:
                 target = (
                     call_name
                     if language == "cpp"
@@ -11075,13 +11204,13 @@ class CodeParser:
             name_node = callee.child_by_field_name("name")
             if name_node is None:
                 return None, None
-            method = name_node.text.decode("utf-8", errors="replace")
+            method = _csharp_name(name_node)
             receiver_node = callee.child_by_field_name("expression")
             if receiver_node is None:
                 return None, method
             if receiver_node.type in ("identifier", "this", "this_expression"):
                 return (
-                    receiver_node.text.decode("utf-8", errors="replace"),
+                    _csharp_name(receiver_node),
                     method,
                 )
             # ``this.field.Save()``: the class field is the receiver.
@@ -11094,9 +11223,22 @@ class CodeParser:
                     and root.type in ("this", "this_expression")
                 ):
                     return (
-                        field_node.text.decode("utf-8", errors="replace"),
+                        _csharp_name(field_node),
                         method,
                     )
+            # Namespace/type paths retain every segment, including global::.
+            # Calls or computed expressions in the receiver are not type names.
+            pending = [receiver_node]
+            while pending:
+                part = pending.pop()
+                if part.type not in (
+                    "identifier", "member_access_expression", "qualified_name",
+                    "alias_qualified_name", "comment",
+                ):
+                    break
+                pending.extend(part.named_children)
+            else:
+                return _csharp_name(receiver_node), method
             return None, method
 
         if callee.type == "conditional_access_expression":
@@ -11109,7 +11251,7 @@ class CodeParser:
             name_node = bindings[-1].child_by_field_name("name")
             if name_node is None:
                 return None, None
-            method = name_node.text.decode("utf-8", errors="replace")
+            method = _csharp_name(name_node)
             receiver_node = callee.child_by_field_name("condition")
             named_children = [
                 child for child in callee.children if child.is_named
@@ -11120,7 +11262,7 @@ class CodeParser:
                 and len(named_children) == 2
             ):
                 return (
-                    receiver_node.text.decode("utf-8", errors="replace"),
+                    _csharp_name(receiver_node),
                     method,
                 )
             return None, method
@@ -15532,7 +15674,11 @@ class CodeParser:
                 if child.type in ("system_lib_string", "string_literal"):
                     val = child.text.decode("utf-8", errors="replace").strip("<>\"")
                     imports.append(val)
-        elif language in ("java", "csharp"):
+        elif language == "csharp":
+            names = [c for c in node.named_children if c.type != "comment"]
+            if names:
+                imports.append(_csharp_name(names[-1]))
+        elif language == "java":
             # import/using package.Class
             parts = text.split()
             if len(parts) >= 2:

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5140,6 +5140,8 @@ class CodeParser:
 
         class_types = set(self._class_types.get(language, []))
         function_types = set(self._function_types.get(language, []))
+        if language == "csharp":
+            function_types.add("local_function_statement")
         call_types = set(self._call_types.get(language, []))
         block_types = {
             "java": {"block"},
@@ -5180,6 +5182,10 @@ class CodeParser:
 
             if node.type in block_types:
                 scoped = dict(bindings)
+                if language == "csharp":
+                    for child in node.named_children:
+                        if child.type == "local_function_statement":
+                            scoped[_csharp_name(child.child_by_field_name("name"))] = ""
                 for child in node.children:
                     walk(child, scoped, class_fields, depth + 1)
                 return
@@ -5201,6 +5207,13 @@ class CodeParser:
                 return
 
             if node.type in call_types:
+                if language == "csharp":
+                    callee = node.child_by_field_name("function")
+                    if callee is not None and callee.type == "identifier":
+                        name = _csharp_name(callee)
+                        if name in bindings:
+                            # A callable local/member hides containing-type methods.
+                            targets[(node.start_byte, "", name)] = ("", "", "shadowed_callable")
                 receiver, method = self._get_member_call_receiver_method(
                     node, language,
                 )
@@ -5451,7 +5464,7 @@ class CodeParser:
                     csharp=True,
                 )
 
-        elif language == "csharp" and node.type == "parameter":
+        elif language == "csharp" and node.type in ("parameter", "property_declaration"):
             self._store_typed_binding(
                 result,
                 node.child_by_field_name("name"),
@@ -5604,7 +5617,10 @@ class CodeParser:
             receiver = edge.extra.get("receiver")
             method = edge.target.rsplit(".", 1)[-1].rsplit("::", 1)[-1]
             position = edge.extra.get("source_offset", -1) if language == "csharp" else edge.line
-            evidence = targets.get((position, receiver, method)) if receiver else None
+            evidence = (
+                targets.get((position, receiver or "", method))
+                if receiver or language == "csharp" else None
+            )
             if edge.kind == "CALLS" and evidence:
                 target, type_name, evidence_kind = evidence
                 extra = dict(edge.extra)
@@ -10535,6 +10551,9 @@ class CodeParser:
         method_extra: dict = {}
         if language == "csharp":
             method_extra["csharp_namespace"] = _csharp_namespace_context(child)[0][0]
+            method_extra["csharp_static"] = any(
+                c.type == "modifier" and c.text == b"static" for c in child.children
+            )
         go_receiver_bindings = None
         if language == "go" and child.type == "method_declaration":
             receiver_name = self._get_go_receiver_name(child)

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -10281,8 +10281,15 @@ class CodeParser:
         extra: dict = {}
         if language == "csharp":
             extra["csharp_namespace"] = csharp_namespace
-            if any(c.type == "type_parameter_list" for c in child.children):
-                extra["csharp_generic"] = True
+            parameters = next(
+                (c for c in child.children if c.type == "type_parameter_list"), None,
+            )
+            if parameters is not None:
+                # Arity, not a flag: it is what separates the declarations of
+                # ``I``, ``I<T>`` and ``I<T, U>`` from one another.
+                extra["csharp_arity"] = sum(
+                    1 for c in parameters.named_children if c.type == "type_parameter"
+                )
             if any(c.type == "modifier" and c.text == b"partial" for c in child.children):
                 extra["csharp_partial"] = True
         if language == "swift":

--- a/code_review_graph/parser.py
+++ b/code_review_graph/parser.py
@@ -5127,8 +5127,9 @@ class CodeParser:
     ) -> dict[tuple[int, str, str], tuple[str, str, str]]:
         """Collect evidence-backed targets for calls on typed receivers.
 
-        The result is keyed by source line, receiver, and method so the normal
-        call extractor remains the single producer of CALLS edges. Statically
+        The result is keyed by source position, receiver, and method so the normal
+        call extractor remains the single producer of CALLS edges. C# uses byte
+        offsets to distinguish lexical bindings on the same line. Statically
         typed receivers resolve directly when their class is repository-local.
         PHP variables assigned from ``new Type`` retain a bare parse-time target
         plus the constructed class scope for conservative graph-wide resolution.
@@ -5239,7 +5240,11 @@ class CodeParser:
                             defined_names,
                         )
                         if target:
-                            key = (node.start_point[0] + 1, receiver, method)
+                            position = (
+                                node.start_byte if language == "csharp"
+                                else node.start_point[0] + 1
+                            )
+                            key = (position, receiver, method)
                             targets[key] = (target, type_name, evidence)
 
             for child in node.children:
@@ -5598,7 +5603,8 @@ class CodeParser:
         for edge in edges:
             receiver = edge.extra.get("receiver")
             method = edge.target.rsplit(".", 1)[-1].rsplit("::", 1)[-1]
-            evidence = targets.get((edge.line, receiver, method)) if receiver else None
+            position = edge.extra.get("source_offset", -1) if language == "csharp" else edge.line
+            evidence = targets.get((position, receiver, method)) if receiver else None
             if edge.kind == "CALLS" and evidence:
                 target, type_name, evidence_kind = evidence
                 extra = dict(edge.extra)
@@ -10961,6 +10967,7 @@ class CodeParser:
                     "source_offset": child.start_byte,
                     "csharp_raw_target": call_name,
                     "csharp_scopes": _csharp_namespace_context(child),
+                    "csharp_containing_type": enclosing_class,
                     "csharp_call_kind": (
                         "constructor" if child.type == "object_creation_expression"
                         else "unqualified" if callee is not None and callee.type == "identifier"

--- a/code_review_graph/scoped_resolver.py
+++ b/code_review_graph/scoped_resolver.py
@@ -13,16 +13,7 @@ When a local receiver was directly constructed (``$x = new Type(); $x->run()``),
 the parser stores the class as ``extra.receiver_scope`` and this pass uses that
 evidence to resolve the call without changing parse-only output (GitHub #745).
 
-C# receiver calls (``Service.StaticCall()``, ``obj.InstanceCall()``,
-``obj?.ConditionalCall()``) follow the same pattern: ``using`` directives import
-namespaces rather than files, so a single-file parse cannot know which file
-defines the receiver's class. The parser keeps the bare method target and
-records the receiver class in ``extra.receiver_scope`` (from the static class
-receiver itself, or from a declared/constructed local variable type); this pass
-resolves it against Class/method nodes in the graph, disambiguating multiple
-same-named candidates by call-site file and by namespace visibility
-(``using`` directives plus the caller file's own declared namespaces)
-(GitHub #612).
+C# calls use the dedicated namespace-aware pass in ``csharp_resolver``.
 
 This module runs after the graph is built and rewrites the resolvable
 ``Class::method`` targets to the canonical qualified name of the defined
@@ -61,7 +52,10 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+
+from .csharp_resolver import resolve_csharp_calls
 
 if TYPE_CHECKING:
     from .graph import GraphStore
@@ -69,11 +63,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Languages whose scoped/static calls dangle as ``Class::method`` targets.
-_SCOPED_LANGUAGES = ("php", "rust", "csharp")
+_SCOPED_LANGUAGES = ("php", "rust")
 
 # Languages whose parsers keep a bare method target and record the receiver
 # class in ``extra.receiver_scope`` for this pass to resolve.
-_RECEIVER_SCOPE_LANGUAGES = ("php", "csharp")
+_RECEIVER_SCOPE_LANGUAGES = ("php",)
 
 # Node kinds that can be a scoped-call target (methods live under a class).
 _METHOD_KINDS = ("Function", "Test", "Method")
@@ -233,27 +227,18 @@ def _scope_and_method(
             return None
         return scope, method, False
 
-    if language == "csharp":
-        scope, _, method = target.partition("::")
-        if not scope or not method or "::" in method:
-            return None
-        # Strip any namespace qualifier: ``Acme.Services.Service`` → ``Service``.
-        class_name = scope.rsplit(".", 1)[-1]
-        if not class_name:
-            return None
-        return class_name, method, False
-
     return None
 
 
-def resolve_scoped_calls(store: GraphStore) -> dict:
+def resolve_scoped_calls(store: GraphStore, repo_root: Path | None = None) -> dict:
     """Rewrite evidence-backed scoped CALLS targets to node qualified names.
 
-    Safe to call repeatedly — rewritten edges start with a path head (and carry
-    ``extra.scoped_resolved``), so they are no longer treated as candidates.
+    Safe to call repeatedly. PHP/Rust skip resolved edges; C# re-evaluates
+    retained source references and only writes bindings that have changed.
 
     Returns a dict with resolution counts for telemetry.
     """
+    csharp_stats = resolve_csharp_calls(store, repo_root)
     conn = store._conn
 
     lang_placeholders = ",".join("?" for _ in _SCOPED_LANGUAGES)
@@ -267,7 +252,7 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         ).fetchall()
     }
     if not file_language:
-        return {"files_indexed": 0, "calls_resolved": 0}
+        return csharp_stats
 
     # ------------------------------------------------------------------
     # method_map: (language, class_key, method_key) → [qualified, ...]
@@ -290,7 +275,10 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         file_of[row["qualified_name"]] = row["file_path"]
 
     if not method_map:
-        return {"files_indexed": len(file_language), "calls_resolved": 0}
+        return {
+            "files_indexed": len(file_language) + csharp_stats["files_indexed"],
+            "calls_resolved": csharp_stats["calls_resolved"],
+        }
 
     # ------------------------------------------------------------------
     # imports_by_file: caller file → set of imported target strings, used to
@@ -303,63 +291,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         imports_by_file.setdefault(row["file_path"], set()).add(
             row["target_qualified"]
         )
-
-    # ------------------------------------------------------------------
-    # csharp_namespaces_by_file: .cs file → namespaces it declares. C#
-    # ``using`` directives store the raw namespace string as their
-    # IMPORTS_FROM target, so namespace visibility is the disambiguation
-    # evidence between same-named C# classes (see #310, #612).
-    # ------------------------------------------------------------------
-    csharp_namespaces_by_file: dict[str, set[str]] = {}
-    if "csharp" in file_language.values():
-        for row in conn.execute(
-            "SELECT file_path, extra FROM nodes "
-            "WHERE kind = 'File' AND language = 'csharp'"
-        ).fetchall():
-            try:
-                node_extra = json.loads(row["extra"] or "{}")
-            except (json.JSONDecodeError, TypeError):
-                continue
-            if not isinstance(node_extra, dict):
-                continue
-            declared = node_extra.get("csharp_namespaces")
-            if isinstance(declared, list):
-                csharp_namespaces_by_file[row["file_path"]] = {
-                    ns for ns in declared if isinstance(ns, str)
-                }
-
-    def csharp_disambiguate(
-        candidates: list[str], caller_file: str
-    ) -> tuple[Optional[str], Optional[str]]:
-        """Pick the single candidate the C# call site can actually see.
-
-        Same-file definitions win outright; otherwise a candidate must be
-        the only one whose defining file declares a namespace visible to
-        the caller (via a ``using`` directive or the caller's own declared
-        namespaces).
-        """
-        same_file = [
-            candidate
-            for candidate in candidates
-            if file_of.get(candidate) == caller_file
-        ]
-        if len(same_file) == 1:
-            return same_file[0], "same_file"
-        visible_ns = {
-            target
-            for target in imports_by_file.get(caller_file, set())
-            if "/" not in target and "\\" not in target
-        }
-        visible_ns |= csharp_namespaces_by_file.get(caller_file, set())
-        visible = [
-            candidate
-            for candidate in candidates
-            if csharp_namespaces_by_file.get(file_of.get(candidate, ""), set())
-            & visible_ns
-        ]
-        if len(visible) == 1:
-            return visible[0], "namespace"
-        return None, None
 
     def disambiguate(
         candidates: list[str], caller_file: str, class_name: str, language: str
@@ -459,10 +390,6 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         if len(candidates) == 1:
             new_target = candidates[0]
             via = "single_match"
-        elif language == "csharp":
-            new_target, via = csharp_disambiguate(candidates, row["file_path"])
-            if new_target is None:
-                continue
         else:
             new_target = disambiguate(
                 candidates, row["file_path"], class_name, language
@@ -511,4 +438,7 @@ def resolve_scoped_calls(store: GraphStore) -> dict:
         "Scoped resolver: resolved %d CALLS edges across %d files",
         resolved, len(file_language),
     )
-    return {"files_indexed": len(file_language), "calls_resolved": resolved}
+    return {
+        "files_indexed": len(file_language) + csharp_stats["files_indexed"],
+        "calls_resolved": resolved + csharp_stats["calls_resolved"],
+    }

--- a/code_review_graph/tools/build.py
+++ b/code_review_graph/tools/build.py
@@ -530,7 +530,9 @@ def build_or_update_graph(
             }
         else:
             result = incremental_update(root, store, base=base_resolved)
-            if result["files_updated"] == 0:
+            if result["files_updated"] == 0 and not (
+                postprocess == "full" and store.get_metadata("csharp_flows_dirty") == "1"
+            ):
                 return {
                     **result,
                     "status": "ok",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,12 @@ enclosing types, enclosing namespaces, and imports at their actual lexical scope
 it does not use file co-location, short-name uniqueness, or suffix matching as
 visibility evidence. Namespace imports expose types, not child namespaces.
 `global::` qualifications and simple namespace/type aliases retain their meaning.
+`Alias::Type` searches only namespace aliases in the call's lexical scopes; it
+does not select a same-named type, namespace, or local. Unqualified calls can reach
+static methods in enclosing types, using parsed `csharp_static` evidence. Lookup
+stops at a nearer method group; `this.Run()` stays within the immediate type.
+Unqualified calls hidden by recorded local, parameter, field or property bindings
+stay unresolved.
 This follows the lookup order in the C# specification's
 [namespace and type names](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/basic-concepts#78-namespace-and-type-names)
 and [using directives](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/namespaces#146-using-directives).
@@ -135,10 +141,17 @@ graph fallbacks cannot bind them using weaker evidence. Each C# update re-evalua
 these calls, including unchanged callers. `TESTED_BY` mirrors move with their calls.
 Before deleting a callee file, incoming managed calls return to their raw references
 so recreating a declaration can resolve them again.
+Binding changes persist a `csharp_flows_dirty` marker with the edge update.
+The next full postprocess retraces all flows, including unchanged callers and
+old/new entry points. Deferred postprocessing retains the marker even if a later
+update parses no files; successful full flow replacement clears it atomically.
+This reuses the existing full trace until the binder can provide a complete
+affected set for incremental tracing.
 
-`CSHARP_IDENTITY_VERSION = "3"` upgrades the old namespace-free format, the
+`CSHARP_IDENTITY_VERSION = "4"` upgrades the old namespace-free format, the
 nested-type-only format proposed in #937, and graphs lacking per-call lexical
-context. Incremental updates reparse existing C# files despite matching hashes.
+context or static/callable evidence. Incremental updates reparse existing C# files
+despite matching hashes.
 The attempted version is recorded together with
 failed file paths; subsequent updates retry those files alone and preserve their
 last stored data until parsing succeeds. This avoids extending #944's repeated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,60 @@ Nodes are uniquely identified by qualified names:
 - Functions: `file_path::function_name` (e.g., `/repo/src/auth.py::authenticate`)
 - Methods: `file_path::ClassName.method_name` (e.g., `/repo/src/auth.py::AuthService.login`)
 
+### C# namespace identity and binding
+
+C# declarations include their namespace and complete containing-type path:
+`/repo/Handlers.cs::App.Report.ExportHandler.Run`. `parent_name` contains
+`App.Report.ExportHandler`; `extra.csharp_namespace` separately records `App`.
+This distinguishes types in different namespaces even when they occupy the same
+file. Namespace strings remain metadata, not synthetic graph nodes. The existing
+file-level `csharp_namespaces` list remains available for file import/impact queries.
+
+Parsing records facts; `csharp_resolver.py` binds calls after storage. C# calls and
+imports carry `csharp_scopes`, ordered pairs of namespace names and namespace-body
+byte offsets, innermost first. Compilation-unit scope uses offset `-1`. Reopened
+bodies with the same namespace name have different offsets, so an ordinary using
+cannot leak between them. File-scoped namespaces include all following members,
+including grammars that represent those members as siblings. `source_offset`
+distinguishes edges on the same source line without a schema migration.
+
+The resolver selects a receiver type before looking up its method. It checks
+enclosing types, enclosing namespaces, and imports at their actual lexical scopes;
+it does not use file co-location, short-name uniqueness, or suffix matching as
+visibility evidence. Namespace imports expose types, not child namespaces.
+`global::` qualifications and simple namespace/type aliases retain their meaning.
+This follows the lookup order in the C# specification's
+[namespace and type names](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/basic-concepts#78-namespace-and-type-names)
+and [using directives](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/namespaces#146-using-directives).
+
+Explicit global usings are collected across files owned by the nearest single
+`.csproj`, rather than across all projects in the repository. With multiple project
+files in that directory, ownership is unknown and global usings stay local to their
+file. Loose C# files without a project share the review root as one compilation.
+This is a structural approximation: linked/conditional compile items, generated or
+implicit usings, project references and target frameworks require MSBuild evaluation.
+Rebuild after changing project layout when updates are driven only by source watches.
+
+Every C# call keeps `csharp_raw_target` and receiver evidence after binding. Resolved
+edges are marked `INFERRED`; unresolved edges retain `unresolved_targets` so generic
+graph fallbacks cannot bind them using weaker evidence. Each C# update re-evaluates
+these calls, including unchanged callers. `TESTED_BY` mirrors move with their calls.
+Before deleting a callee file, incoming managed calls return to their raw references
+so recreating a declaration can resolve them again.
+
+`CSHARP_IDENTITY_VERSION = "2"` upgrades both the old namespace-free format and the
+nested-type-only format proposed in #937. Incremental updates reparse existing C#
+files despite matching hashes. The attempted version is recorded together with
+failed file paths; subsequent updates retry those files alone and preserve their
+last stored data until parsing succeeds. This avoids extending #944's repeated
+full-rebuild loop. No SQL migration attempts to reconstruct missing source identity.
+
+This remains a structural graph, not a C# compiler. Overload selection, generic
+arity/type substitution (#943), inherited members, assembly accessibility, and
+unqualified calls imported with `using static` are outside this change. Constructed
+receiver spellings are retained rather than erased to another declaration; unsupported
+or ambiguous bindings stay unresolved. Inheritance target spelling is unchanged.
+
 ## Parsing Strategy
 
 Tree-sitter provides language-agnostic AST access. The parser:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,9 @@ byte offsets, innermost first. Compilation-unit scope uses offset `-1`. Reopened
 bodies with the same namespace name have different offsets, so an ordinary using
 cannot leak between them. File-scoped namespaces include all following members,
 including grammars that represent those members as siblings. `source_offset`
-distinguishes edges on the same source line without a schema migration.
+distinguishes both receiver evidence and stored edges on the same source line
+without a schema migration. Calls also retain `csharp_containing_type` so field
+and property initializers keep their lexical context when their graph caller is a File.
 
 The resolver selects a receiver type before looking up its method. It checks
 enclosing types, enclosing namespaces, and imports at their actual lexical scopes;
@@ -134,9 +136,10 @@ these calls, including unchanged callers. `TESTED_BY` mirrors move with their ca
 Before deleting a callee file, incoming managed calls return to their raw references
 so recreating a declaration can resolve them again.
 
-`CSHARP_IDENTITY_VERSION = "2"` upgrades both the old namespace-free format and the
-nested-type-only format proposed in #937. Incremental updates reparse existing C#
-files despite matching hashes. The attempted version is recorded together with
+`CSHARP_IDENTITY_VERSION = "3"` upgrades the old namespace-free format, the
+nested-type-only format proposed in #937, and graphs lacking per-call lexical
+context. Incremental updates reparse existing C# files despite matching hashes.
+The attempted version is recorded together with
 failed file paths; subsequent updates retry those files alone and preserve their
 last stored data until parsing succeeds. This avoids extending #944's repeated
 full-rebuild loop. No SQL migration attempts to reconstruct missing source identity.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,20 +148,29 @@ update parses no files; successful full flow replacement clears it atomically.
 This reuses the existing full trace until the binder can provide a complete
 affected set for incremental tracing.
 
-`CSHARP_IDENTITY_VERSION = "4"` upgrades the old namespace-free format, the
+`CSHARP_IDENTITY_VERSION = "5"` upgrades the old namespace-free format, the
 nested-type-only format proposed in #937, and graphs lacking per-call lexical
-context or static/callable evidence. Incremental updates reparse existing C# files
+context, static/callable evidence, or generic arity. Incremental updates reparse existing C# files
 despite matching hashes.
 The attempted version is recorded together with
 failed file paths; subsequent updates retry those files alone and preserve their
 last stored data until parsing succeeds. This avoids extending #944's repeated
 full-rebuild loop. No SQL migration attempts to reconstruct missing source identity.
 
-This remains a structural graph, not a C# compiler. Overload selection, generic
-arity/type substitution (#943), inherited members, assembly accessibility, and
-unqualified calls imported with `using static` are outside this change. Constructed
-receiver spellings are retained rather than erased to another declaration; unsupported
-or ambiguous bindings stay unresolved. Inheritance target spelling is unchanged.
+A generic declaration is keyed by arity — ``App.Box`1`` — so a constructed
+reference reaches the declaration it names and never a same-named one of another
+arity: `I<int>` binds to `I<T>`, `I` binds to `I`, and `Pair<int>` binds to
+neither when only `Pair<K, V>` exists. The receiver's spelling is retained on the
+call; only the key is derived from it, and the key is built from the syntax rather
+than by scanning for angle brackets, so nested arguments and tuples count
+correctly. A constructed containing type such as `Outer<T>.Inner` carries a second
+arity that one key cannot describe, and stays unresolved.
+
+This remains a structural graph, not a C# compiler. Overload selection, type
+argument substitution and constraints (#943), inherited members, assembly
+accessibility, and unqualified calls imported with `using static` are outside this
+change; unsupported or ambiguous bindings stay unresolved. Inheritance target
+spelling is unchanged.
 
 ## Parsing Strategy
 

--- a/tests/test_csharp_namespaces.py
+++ b/tests/test_csharp_namespaces.py
@@ -123,6 +123,59 @@ def _calls(store: GraphStore, caller: str):
         "class C { void Go() { Alias.Service.Run(); } } }",
         "Consumer.C.Go", "A.B.Service.Run",
     ),
+    (
+        "using Alias = App; namespace App { class Service { public static void Run() {} } } "
+        "class C { void Go() { Alias::Service.Run(); } }",
+        "C.Go", "App.Service.Run",
+    ),
+    (
+        "namespace App { class Outer { static void Run() {} "
+        "class Inner { void Go() { Run(); } } } }",
+        "App.Outer.Inner.Go", "App.Outer.Run",
+    ),
+    (
+        "using Alias = App; class Alias {} "
+        "namespace App { class Service { public static void Run() {} } } "
+        "class C { void Go(int Alias) { Alias::Service.Run(); } }",
+        "C.Go", "App.Service.Run",
+    ),
+    (
+        "using Alias = App.Container; namespace App { class Container { "
+        "public class Service { public static void Run() {} } } } "
+        "class C { void Go() { Alias::Service.Run(); } }",
+        "C.Go", None,
+    ),
+    (
+        "namespace App { class Service { public static void Run() {} } } "
+        "namespace N { using Alias = App; class C {} } "
+        "namespace N { class C { void Go() { Alias::Service.Run(); } } }",
+        "N.C.Go", None,
+    ),
+    (
+        "using Alias = App; namespace App { class Service { public void Run() {} } } "
+        "class C { void Go(Alias::Service value) { value.Run(); } }",
+        "C.Go", "App.Service.Run",
+    ),
+    (
+        "namespace App { class Outer { static void Run() {} "
+        "class Inner { void Go() { this.Run(); } } } }",
+        "App.Outer.Inner.Go", None,
+    ),
+    (
+        "namespace App { class Outer { void Run() {} "
+        "class Inner { void Go() { Run(); } } } }",
+        "App.Outer.Inner.Go", None,
+    ),
+    (
+        "namespace App { class Outer { static void Run() {} "
+        "class Inner { void Run() {} void Go() { Run(); } } } }",
+        "App.Outer.Inner.Go", "App.Outer.Inner.Run",
+    ),
+    (
+        "namespace App { class Outer { static void Run() {} "
+        "class Inner { void Go(System.Action Run) { Run(); } } } }",
+        "App.Outer.Inner.Go", None,
+    ),
 ])
 def test_namespace_binding(source, caller, expected, tmp_path):
     with _build(tmp_path, {"Case.cs": source}) as store:
@@ -135,6 +188,23 @@ def test_namespace_binding(source, caller, expected, tmp_path):
         else:
             assert calls[0]["target_qualified"] == extra["csharp_raw_target"]
             assert "unresolved_targets" in extra
+
+
+@pytest.mark.parametrize("declaration", [
+    "System.Action Run; void Go() { Run(); }",
+    "System.Action Run { get; set; } void Go() { Run(); }",
+    "void Go() { System.Action Run = () => {}; Run(); }",
+    "void Go() { void Run() {} Run(); }",
+    "void Go() { Run(); void Run() {} }",
+])
+def test_enclosing_static_lookup_preserves_callable_shadowing(tmp_path, declaration):
+    with _build(tmp_path, {"Case.cs":
+        "namespace App { class Outer { static void Run() {} class Inner { "
+        + declaration + " } } }"
+    }) as store:
+        call, = _calls(store, "App.Outer.Inner.Go")
+        assert call["target_qualified"] == "Run"
+        assert "unresolved_targets" in json.loads(call["extra"])
 
 
 def test_same_file_identities_and_same_line_calls_survive_storage(tmp_path):
@@ -258,13 +328,17 @@ def test_using_before_and_after_file_scoped_namespace_has_distinct_lookup(tmp_pa
         assert _calls(store, "App.C.Go")[0]["target_qualified"].endswith(f"::{namespace}.S.Run")
 
 
-def test_partial_type_methods_keep_their_declaring_file(tmp_path):
+@pytest.mark.parametrize("nested", [False, True])
+def test_partial_type_methods_keep_their_declaring_file(tmp_path, nested):
+    declaration = "class Inner { void Go() { Run(); } }" if nested else "void Go() { Run(); }"
+    modifier = "static " if nested else ""
     with _build(tmp_path, {
-        "First.cs": "namespace A; partial class C { void Go() { Run(); } }",
-        "Second.cs": "namespace A; partial class C { public void Run() {} }",
-        "Caller.cs": "using A; class Consumer { void Go(C value) { value.Run(); } }",
+        "First.cs": "namespace A; partial class C { " + declaration + " }",
+        "Second.cs": "namespace A; partial class C { public " + modifier + "void Run() {} }",
+        "Caller.cs": "using A; class Consumer { void Go(C value) { "
+                     + ("C" if nested else "value") + ".Run(); } }",
     }) as store:
-        for caller in ("A.C.Go", "Consumer.Go"):
+        for caller in ("A.C.Inner.Go" if nested else "A.C.Go", "Consumer.Go"):
             assert _calls(store, caller)[0]["target_qualified"] == (
                 f"{tmp_path / 'Second.cs'}::A.C.Run"
             )
@@ -332,6 +406,54 @@ def test_global_usings_are_project_scoped_and_rebound_on_update(tmp_path):
         assert _calls(store, "One.C.Go")[0]["target_qualified"].endswith("::Other.Service.Run")
 
 
+@pytest.mark.parametrize("postprocess", ["full", "minimal", "none"])
+def test_rebinding_refreshes_flows_for_unchanged_callers(tmp_path, postprocess):
+    from code_review_graph.flows import get_flows, store_flows, trace_flows
+    from code_review_graph.tools.build import _run_postprocess, build_or_update_graph
+
+    with _build(tmp_path, {
+        "Imports.cs": "global using S = A.Service;",
+        "Caller.cs": "class Caller { void Go() { S.Run(); } }",
+        "A.cs": "namespace A; class Service { public static void Run() { Finish(); } "
+                "static void Finish() {} }",
+        "B.cs": "namespace B; class Service { public static void Run() { Finish(); } "
+                "static void Finish() {} }",
+    }) as store:
+        store_flows(store, trace_flows(store))
+        assert len(get_flows(store)) == 2
+        for directive in (
+            "global using S = B.Service;", "// removed", "global using S = A.Service;",
+        ):
+            (tmp_path / "Imports.cs").write_text(directive, encoding="utf-8")
+            result = incremental_update(tmp_path, store, changed_files=["Imports.cs"])
+            assert result["files_updated"] == 1
+            if postprocess == "full" and directive == "global using S = B.Service;":
+                previous_flows = get_flows(store)
+                with pytest.raises(KeyError):
+                    # Failed replacement must preserve flows and pending invalidation.
+                    store_flows(store, [{}])
+                assert get_flows(store) == previous_flows
+            _run_postprocess(store, result, postprocess, changed_files=result["changed_files"])
+            if postprocess != "full":
+                # A later full postprocess must consume invalidation even with no source changes.
+                with patch("code_review_graph.incremental.get_changed_files", return_value=[]):
+                    build_or_update_graph(repo_root=str(tmp_path), base="HEAD", postprocess="full")
+            assert {
+                flow["entry_point_id"]: flow["path"] for flow in get_flows(store)
+            } == {
+                flow["entry_point_id"]: flow["path"] for flow in trace_flows(store)
+            }
+
+        (tmp_path / "A.cs").unlink()
+        result = incremental_update(tmp_path, store, changed_files=["A.cs"])
+        _run_postprocess(store, result, "full", changed_files=result["changed_files"])
+        assert {
+            flow["entry_point_id"]: flow["path"] for flow in get_flows(store)
+        } == {
+            flow["entry_point_id"]: flow["path"] for flow in trace_flows(store)
+        }
+
+
 def test_global_using_and_tested_by_survive_repeated_passes(tmp_path):
     with _build(tmp_path, {
         "Imports.cs": "global using Other;",
@@ -353,11 +475,16 @@ def test_global_using_and_tested_by_survive_repeated_passes(tmp_path):
 
 
 @pytest.mark.parametrize("ambiguous_project", [False, True])
-def test_global_alias_requires_known_shared_project_ownership(tmp_path, ambiguous_project):
+@pytest.mark.parametrize("qualified", [False, True])
+def test_global_alias_requires_known_shared_project_ownership(
+    tmp_path, ambiguous_project, qualified,
+):
+    alias_target = "Other" if qualified else "Other.Service"
+    receiver = "Alias::Service" if qualified else "Alias"
     files = {
         "One.csproj": "<Project />",
-        "Imports.cs": "global using Alias = Other.Service;",
-        "Caller.cs": "class C { void Go() { Alias.Run(); } }",
+        "Imports.cs": f"global using Alias = {alias_target};",
+        "Caller.cs": "class C { void Go() { " + receiver + ".Run(); } }",
         "Service.cs": "namespace Other; class Service { public static void Run() {} }",
     }
     if ambiguous_project:
@@ -365,12 +492,12 @@ def test_global_alias_requires_known_shared_project_ownership(tmp_path, ambiguou
     with _build(tmp_path, files) as store:
         target = _calls(store, "C.Go")[0]["target_qualified"]
         if ambiguous_project:
-            assert target == "Alias::Run"
+            assert target == f"{receiver}::Run"
         else:
             assert target.endswith("::Other.Service.Run")
 
 
-@pytest.mark.parametrize("stored_version", ["1", "2"])
+@pytest.mark.parametrize("stored_version", ["1", "2", "3"])
 def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path, stored_version):
     with _build(tmp_path, {
         "Good.cs": "namespace Good; class C { static int Run() => 1; static int Value = Run(); }",
@@ -382,6 +509,8 @@ def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path,
         for name in ("Good", "Bad"):
             path = tmp_path / f"{name}.cs"
             nodes, edges = CodeParser().parse_file(path)
+            for node in nodes:
+                node.extra.pop("csharp_static", None)
             if stored_version == "1":
                 for node in nodes:
                     node.parent_name = (
@@ -409,7 +538,8 @@ def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path,
             upgraded = incremental_update(tmp_path, store, changed_files=[])
             assert upgraded["identity_rebuild"]
             assert set(attempts) == {"Good.cs", "Bad.cs"}
-            assert store.get_node(f"{tmp_path / 'Good.cs'}::Good.C.Run") is not None
+            run = store.get_node(f"{tmp_path / 'Good.cs'}::Good.C.Run")
+            assert run is not None and run.extra["csharp_static"]
             assert store.get_node(f"{tmp_path / 'Good.cs'}::C.Run") is None
             call = store._conn.execute("SELECT * FROM edges WHERE kind = 'CALLS'").fetchone()
             assert call["target_qualified"] == f"{tmp_path / 'Good.cs'}::Good.C.Run"

--- a/tests/test_csharp_namespaces.py
+++ b/tests/test_csharp_namespaces.py
@@ -366,6 +366,44 @@ def test_partial_type_methods_keep_their_declaring_file(tmp_path, nested):
             )
 
 
+@pytest.mark.parametrize("parameters", ["<T>", "<T, U>"])
+@pytest.mark.parametrize("split", [False, True])
+def test_generic_partial_lookup_preserves_declaring_arity(tmp_path, parameters, split):
+    method = "public void Run() {}"
+    files = {
+        "First.cs": (
+            f"namespace App; partial class Box{parameters} {{ "
+            "void Go() { Run(); this.Run(); } " + ("" if split else method) + " }"
+        ),
+    }
+    if split:
+        other_parameters = "<T, U>" if parameters == "<T>" else "<T>"
+        files.update({
+            "Second.cs": f"namespace App; partial class Box{parameters} {{ {method} }}",
+            "Plain.cs": f"namespace App; partial class Box {{ {method} }}",
+            "OtherArity.cs": f"namespace App; partial class Box{other_parameters} {{ {method} }}",
+        })
+    with _build(tmp_path, files) as store:
+        calls = _calls(store, "App.Box.Go")
+        expected_file = "Second.cs" if split else "First.cs"
+        assert len(calls) == 2
+        assert all(
+            call["target_qualified"] == f"{tmp_path / expected_file}::App.Box.Run"
+            for call in calls
+        )
+
+
+def test_nested_caller_uses_generic_partial_enclosing_type(tmp_path):
+    with _build(tmp_path, {
+        "First.cs": "namespace App; partial class Box<T> { "
+                    "class Inner { void Go() { Run(); } } }",
+        "Second.cs": "namespace App; partial class Box<T> { public static void Run() {} }",
+        "Plain.cs": "namespace App; partial class Box { public static void Run() {} }",
+    }) as store:
+        call, = _calls(store, "App.Box.Inner.Go")
+        assert call["target_qualified"] == f"{tmp_path / 'Second.cs'}::App.Box.Run"
+
+
 def test_generic_reference_is_not_erased_to_a_non_generic_declaration(tmp_path):
     with _build(tmp_path, {
         "Plain.cs": "namespace A; class I { public void Run() {} }",

--- a/tests/test_csharp_namespaces.py
+++ b/tests/test_csharp_namespaces.py
@@ -157,6 +157,85 @@ class Caller { void Go() { A.Outer.Inner.Run(); B.Outer.Inner.Run(); } }
         ]
 
 
+@pytest.mark.parametrize(("declaration", "expected_file", "expected_name"), [
+    ("class C { static int Value = Service.Run(); }", "App.cs", "App.Service.Run"),
+    ("class C { static int Value { get; } = Service.Run(); }", "App.cs", "App.Service.Run"),
+    (
+        "class Outer { public class Service { public static int Run() => 3; } "
+        "class C { static int Value = Service.Run(); } }",
+        "Caller.cs", "App.Outer.Service.Run",
+    ),
+    (
+        "class C { static int Init() => 3; static int Value = Init(); }",
+        "Caller.cs", "App.C.Init",
+    ),
+])
+def test_initializers_keep_lexical_type_context(
+    tmp_path, declaration, expected_file, expected_name,
+):
+    with _build(tmp_path, {
+        "Global.cs": "public class Service { public static int Run() => 1; }",
+        "App.cs": "namespace App; public class Service { public static int Run() => 2; }",
+        "Caller.cs": "namespace App; " + declaration,
+    }) as store:
+        calls = store._conn.execute(
+            "SELECT * FROM edges WHERE kind = 'CALLS' AND source_qualified = ?",
+            (str(tmp_path / "Caller.cs"),),
+        ).fetchall()
+        assert len(calls) == 1
+        assert calls[0]["target_qualified"] == f"{tmp_path / expected_file}::{expected_name}"
+
+
+@pytest.mark.parametrize("type_name", ["Service?", "global::Other.Service?", "Service<int>?"])
+def test_nullable_receivers_keep_raw_spelling_and_generic_boundaries(tmp_path, type_name):
+    with _build(tmp_path, {
+        "Service.cs": "namespace Other; public class Service { public void Run() {} }",
+        "Generic.cs": "namespace Other; public class Service<T> { public void Run() {} }",
+        "Caller.cs": (
+            "#nullable enable\nusing Other; namespace App; class C { "
+            f"{type_name} field; void Go({type_name} value) {{ {type_name} local = value; "
+            "value?.Run(); field.Run(); local?.Run(); } }"
+        ),
+    }) as store:
+        calls = _calls(store, "App.C.Go")
+        assert len(calls) == 3
+        for call in calls:
+            extra = json.loads(call["extra"])
+            assert extra["receiver_type"] == type_name
+            assert extra["csharp_raw_target"] == f"{type_name}::Run"
+            if "<" in type_name:
+                assert call["target_qualified"] == extra["csharp_raw_target"]
+                assert "unresolved_targets" in extra
+            else:
+                assert call["target_qualified"] == f"{tmp_path / 'Service.cs'}::Other.Service.Run"
+                assert "unresolved_targets" not in extra
+
+
+@pytest.mark.parametrize("separator", [" ", "\n"])
+def test_typed_receiver_evidence_and_test_mirrors_follow_each_call(tmp_path, separator):
+    with _build(tmp_path, {
+        "A.cs": "namespace A; public class Service { public void Run() {} }",
+        "B.cs": "namespace B; public class Service { public void Run() {} }",
+        "CallerTests.cs": (
+            "// π makes byte offsets differ from character offsets.\n"
+            "class CallerTests { void TestRun() { "
+            "{ A.Service s = new A.Service(); s.Run(); }" + separator
+            + "{ B.Service s = new B.Service(); s.Run(); } } }"
+        ),
+    }) as store:
+        calls = [
+            call for call in _calls(store, "CallerTests.TestRun")
+            if json.loads(call["extra"])["csharp_call_kind"] != "constructor"
+        ]
+        expected = [f"{tmp_path / (ns + '.cs')}::{ns}.Service.Run" for ns in ("A", "B")]
+        assert [call["target_qualified"] for call in calls] == expected
+        mirrors = store._conn.execute(
+            "SELECT source_qualified FROM edges WHERE kind = 'TESTED_BY' "
+            "AND source_qualified LIKE '%.Run' ORDER BY id",
+        ).fetchall()
+        assert [row[0] for row in mirrors] == expected
+
+
 def test_repeated_usings_on_one_line_retain_both_namespace_bodies(tmp_path):
     with _build(tmp_path, {"Case.cs":
         "namespace Other { class S { public static void Run() {} } } "
@@ -291,23 +370,29 @@ def test_global_alias_requires_known_shared_project_ownership(tmp_path, ambiguou
             assert target.endswith("::Other.Service.Run")
 
 
-def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path):
+@pytest.mark.parametrize("stored_version", ["1", "2"])
+def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path, stored_version):
     with _build(tmp_path, {
-        "Good.cs": "namespace Good; class C { public void Run() {} }",
+        "Good.cs": "namespace Good; class C { static int Run() => 1; static int Value = Run(); }",
         "Bad.cs": "namespace Bad; class C { public void Run() {} }",
         "untouched.py": "def f(): pass",
     }) as store:
-        store.set_metadata("csharp_identity_version", "1")
-        # Seed the actual legacy format while retaining the current file hash.
+        store.set_metadata("csharp_identity_version", stored_version)
+        # Seed old identities or call context while retaining the current hash.
         for name in ("Good", "Bad"):
             path = tmp_path / f"{name}.cs"
             nodes, edges = CodeParser().parse_file(path)
-            for node in nodes:
-                node.parent_name = (node.parent_name or "").removeprefix(name).lstrip(".") or None
-                node.extra.pop("csharp_namespace", None)
+            if stored_version == "1":
+                for node in nodes:
+                    node.parent_name = (
+                        (node.parent_name or "").removeprefix(name).lstrip(".") or None
+                    )
+                    node.extra.pop("csharp_namespace", None)
             for edge in edges:
-                edge.source = edge.source.replace(f"::{name}.", "::")
-                edge.target = edge.target.replace(f"::{name}.", "::")
+                if stored_version == "1":
+                    edge.source = edge.source.replace(f"::{name}.", "::")
+                    edge.target = edge.target.replace(f"::{name}.", "::")
+                edge.extra.pop("csharp_containing_type", None)
             store.store_file_nodes_edges(
                 str(path), nodes, edges, hashlib.sha256(path.read_bytes()).hexdigest(),
             )
@@ -326,6 +411,9 @@ def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path)
             assert set(attempts) == {"Good.cs", "Bad.cs"}
             assert store.get_node(f"{tmp_path / 'Good.cs'}::Good.C.Run") is not None
             assert store.get_node(f"{tmp_path / 'Good.cs'}::C.Run") is None
+            call = store._conn.execute("SELECT * FROM edges WHERE kind = 'CALLS'").fetchone()
+            assert call["target_qualified"] == f"{tmp_path / 'Good.cs'}::Good.C.Run"
+            assert json.loads(call["extra"])["csharp_containing_type"] == "Good.C"
             attempts.clear()
             retried = incremental_update(tmp_path, store, changed_files=[])
             assert attempts == ["Bad.cs"]

--- a/tests/test_csharp_namespaces.py
+++ b/tests/test_csharp_namespaces.py
@@ -1,0 +1,351 @@
+"""Namespace identity and binding regressions for #946, through persisted graphs."""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from code_review_graph.graph import GraphStore
+from code_review_graph.incremental import CSHARP_IDENTITY_VERSION, incremental_update
+from code_review_graph.parser import CodeParser
+from code_review_graph.scoped_resolver import resolve_scoped_calls
+
+
+def _build(root: Path, files: dict[str, str]) -> GraphStore:
+    store = GraphStore(root / ".code-review-graph" / "graph.db")
+    parser = CodeParser(root)
+    for name, source in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+        if path.suffix == ".cs":
+            nodes, edges = parser.parse_file(path)
+            store.store_file_nodes_edges(
+                str(path), nodes, edges, hashlib.sha256(path.read_bytes()).hexdigest(),
+            )
+    store.set_metadata("csharp_identity_version", CSHARP_IDENTITY_VERSION)
+    resolve_scoped_calls(store, root)
+    store.resolve_bare_call_targets()
+    store.resolve_bare_tested_by_sources()
+    return store
+
+
+def _calls(store: GraphStore, caller: str):
+    return store._conn.execute(
+        "SELECT * FROM edges WHERE kind = 'CALLS' AND source_qualified LIKE ? ORDER BY line, id",
+        (f"%::{caller}",),
+    ).fetchall()
+
+
+@pytest.mark.parametrize(("source", "caller", "expected"), [
+    (
+        "namespace Other { class App { public class Report { public class ExportHandler "
+        "{ public static void Run() {} } } } } "
+        "namespace Consumer { class C { void Go() { App.Report.ExportHandler.Run(); } } }",
+        "Consumer.C.Go", None,
+    ),
+    (
+        "namespace Other { class Service { public static void Run() {} } } "
+        "namespace Consumer { class C { void Go() { Service.Run(); } } }",
+        "Consumer.C.Go", None,
+    ),
+    (
+        "namespace Other { class Service { public static void Run() {} } } "
+        "namespace Consumer { class C { void Go() { Other.Service.Run(); } } }",
+        "Consumer.C.Go", "Other.Service.Run",
+    ),
+    (
+        "namespace Other { class Service { public static void Run() {} } } "
+        "namespace A { using Other; class C { void Go() { Service.Run(); } } } "
+        "namespace B { class C { void Go() { Service.Run(); } } }",
+        "B.C.Go", None,
+    ),
+    (
+        "namespace Other { class Service { public static void Run() {} } } "
+        "namespace A { using Other; class First {} } "
+        "namespace A { class C { void Go() { Service.Run(); } } }",
+        "A.C.Go", None,
+    ),
+    (
+        "namespace Other { class Service { public static void Run() {} } } "
+        "namespace A { using Other; namespace B { class C { void Go() { Service.Run(); } } } }",
+        "A.B.C.Go", "Other.Service.Run",
+    ),
+    (
+        "namespace A { class Service { public static void Run() {} } } "
+        "namespace B { class Service {} } "
+        "namespace Consumer { using A; using B; class C { void Go() { Service.Run(); } } }",
+        "Consumer.C.Go", None,
+    ),
+    (
+        "namespace A.B { class Service { public static void Run() {} } } "
+        "namespace Consumer { using A; class C { void Go() { B.Service.Run(); } } }",
+        "Consumer.C.Go", None,
+    ),
+    (
+        "namespace A { class Service { public static void Run() {} } } "
+        "namespace Consumer { using Alias = global::A; "
+        "class C { void Go() { Alias.Service.Run(); } } }",
+        "Consumer.C.Go", "A.Service.Run",
+    ),
+    (
+        "namespace A { class Service { public static void Run() {} } } "
+        "namespace Consumer { class A {} class C { void Go() { A.Service.Run(); } } }",
+        "Consumer.C.Go", None,
+    ),
+    (
+        "namespace A { class Service { public static void Run() {} } } "
+        "namespace Consumer { class A {} class C { void Go() { global::A.Service.Run(); } } }",
+        "Consumer.C.Go", "A.Service.Run",
+    ),
+    (
+        "namespace A { class Outer { public class Service { public static void Run() {} } "
+        "class C { public class Service {} void Go() { Service.Run(); } } } }",
+        "A.Outer.C.Go", None,
+    ),
+    (
+        "namespace A { class Outer { public class D { public class E { "
+        "public static void Run() {} } } class C { void Go() { D.E.Run(); } } } } "
+        "class D { public class E { public static void Run() {} } }",
+        "A.Outer.C.Go", "A.Outer.D.E.Run",
+    ),
+    (
+        "namespace A { class C { public void Run() {} void Go() { Run(); } } } "
+        "namespace B { class C { public void Run() {} } }",
+        "A.C.Go", "A.C.Run",
+    ),
+    (
+        "namespace @A { namespace /* trivia */ B { "
+        "class @Service { public static void @Run() {} } } } "
+        "namespace Consumer { using /* trivia */ Alias = A.B; "
+        "class C { void Go() { Alias.Service.Run(); } } }",
+        "Consumer.C.Go", "A.B.Service.Run",
+    ),
+])
+def test_namespace_binding(source, caller, expected, tmp_path):
+    with _build(tmp_path, {"Case.cs": source}) as store:
+        calls = _calls(store, caller)
+        assert len(calls) == 1
+        extra = json.loads(calls[0]["extra"])
+        if expected:
+            assert calls[0]["target_qualified"] == f"{tmp_path / 'Case.cs'}::{expected}"
+            assert "unresolved_targets" not in extra
+        else:
+            assert calls[0]["target_qualified"] == extra["csharp_raw_target"]
+            assert "unresolved_targets" in extra
+
+
+def test_same_file_identities_and_same_line_calls_survive_storage(tmp_path):
+    with _build(tmp_path, {"Case.cs": """
+namespace A { class Outer { public class Inner { public static void Run() {} } } }
+namespace B { class Outer { public class Inner { public static void Run() {} } } }
+class Caller { void Go() { A.Outer.Inner.Run(); B.Outer.Inner.Run(); } }
+"""}) as store:
+        calls = _calls(store, "Caller.Go")
+        assert {row["target_qualified"].split("::")[1] for row in calls} == {
+            "A.Outer.Inner.Run", "B.Outer.Inner.Run",
+        }
+        nodes = store.get_nodes_by_file(str(tmp_path / "Case.cs"))
+        assert len([node for node in nodes if node.name == "Run"]) == 2
+        contains = store._conn.execute(
+            "SELECT source_qualified, target_qualified FROM edges WHERE kind = 'CONTAINS'",
+        ).fetchall()
+        assert (f"{tmp_path / 'Case.cs'}::A.Outer", f"{tmp_path / 'Case.cs'}::A.Outer.Inner") in [
+            tuple(row) for row in contains
+        ]
+
+
+def test_repeated_usings_on_one_line_retain_both_namespace_bodies(tmp_path):
+    with _build(tmp_path, {"Case.cs":
+        "namespace Other { class S { public static void Run() {} } } "
+        "namespace A { using Other; class C { void Go() { S.Run(); } } } "
+        "namespace B { using Other; class C { void Go() { S.Run(); } } }"
+    }) as store:
+        for caller in ("A.C.Go", "B.C.Go"):
+            assert _calls(store, caller)[0]["target_qualified"].endswith("::Other.S.Run")
+
+
+@pytest.mark.parametrize("inside", [False, True])
+def test_using_before_and_after_file_scoped_namespace_has_distinct_lookup(tmp_path, inside):
+    caller = "namespace App; using Other;" if inside else "using Other; namespace App;"
+    with _build(tmp_path, {
+        "Caller.cs": caller + " class C { void Go() { S.Run(); } }",
+        "Types.cs": "namespace Other { class S { public static void Run() {} } } "
+                    "namespace App.Other { class S { public static void Run() {} } }",
+    }) as store:
+        namespace = "App.Other" if inside else "Other"
+        assert _calls(store, "App.C.Go")[0]["target_qualified"].endswith(f"::{namespace}.S.Run")
+
+
+def test_partial_type_methods_keep_their_declaring_file(tmp_path):
+    with _build(tmp_path, {
+        "First.cs": "namespace A; partial class C { void Go() { Run(); } }",
+        "Second.cs": "namespace A; partial class C { public void Run() {} }",
+        "Caller.cs": "using A; class Consumer { void Go(C value) { value.Run(); } }",
+    }) as store:
+        for caller in ("A.C.Go", "Consumer.Go"):
+            assert _calls(store, caller)[0]["target_qualified"] == (
+                f"{tmp_path / 'Second.cs'}::A.C.Run"
+            )
+
+
+def test_generic_reference_is_not_erased_to_a_non_generic_declaration(tmp_path):
+    with _build(tmp_path, {
+        "Plain.cs": "namespace A; class I { public void Run() {} }",
+        "Generic.cs": "namespace A; class I<T> { public void Run() {} }",
+        "Caller.cs": "using A; class C { void Go(I<int> value) { value.Run(); } }",
+    }) as store:
+        call = _calls(store, "C.Go")[0]
+        assert call["target_qualified"] == "I<int>::Run"
+        assert json.loads(call["extra"])["receiver_scope"] == "I<int>"
+
+
+def test_bare_type_receiver_does_not_select_generic_declaration(tmp_path):
+    with _build(tmp_path, {
+        "Generic.cs": "namespace A; class I<T> { public static void Run() {} }",
+        "Caller.cs": "using A; class C { void Go() { I.Run(); } }",
+    }) as store:
+        assert _calls(store, "C.Go")[0]["target_qualified"] == "I::Run"
+
+
+def test_this_does_not_bind_an_enclosing_types_instance_method(tmp_path):
+    with _build(tmp_path, {"Case.cs":
+        "namespace A { class Outer { public void Run() {} "
+        "class Inner { void Go() { this.Run(); } } } }"
+    }) as store:
+        assert _calls(store, "A.Outer.Inner.Go")[0]["target_qualified"] == "this::Run"
+
+
+@pytest.mark.parametrize("using", ["using Other;", "global using Other;"])
+def test_file_scoped_namespace_and_typed_receiver(tmp_path, using):
+    with _build(tmp_path, {
+        "Imports.cs": "global using Other;" if using.startswith("global") else "",
+        "Caller.cs": (
+            (using if not using.startswith("global") else "")
+            + "namespace Consumer; class C { "
+            "void Go(global::Other.Service value) { value.Run(); } }"
+        ),
+        "Other.cs": "namespace Other; class Service { public void Run() {} }",
+    }) as store:
+        assert _calls(store, "Consumer.C.Go")[0]["target_qualified"] == (
+            f"{tmp_path / 'Other.cs'}::Other.Service.Run"
+        )
+
+
+def test_global_usings_are_project_scoped_and_rebound_on_update(tmp_path):
+    with _build(tmp_path, {
+        "One/One.csproj": "<Project />",
+        "Two/Two.csproj": "<Project />",
+        "One/Imports.cs": "global using Other;",
+        "One/Caller.cs": "namespace One; class C { void Go() { Service.Run(); } }",
+        "Two/Caller.cs": "namespace Two; class C { void Go() { Service.Run(); } }",
+        "One/Other.cs": "namespace Other; class Service { public static void Run() {} }",
+    }) as store:
+        assert _calls(store, "One.C.Go")[0]["target_qualified"].endswith("::Other.Service.Run")
+        assert _calls(store, "Two.C.Go")[0]["target_qualified"] == "Service::Run"
+        (tmp_path / "One/Imports.cs").write_text("// removed", encoding="utf-8")
+        incremental_update(tmp_path, store, changed_files=["One/Imports.cs"])
+        assert _calls(store, "One.C.Go")[0]["target_qualified"] == "Service::Run"
+        (tmp_path / "One/Imports.cs").write_text("global using Other;", encoding="utf-8")
+        incremental_update(tmp_path, store, changed_files=["One/Imports.cs"])
+        assert _calls(store, "One.C.Go")[0]["target_qualified"].endswith("::Other.Service.Run")
+
+
+def test_global_using_and_tested_by_survive_repeated_passes(tmp_path):
+    with _build(tmp_path, {
+        "Imports.cs": "global using Other;",
+        "CaseTests.cs": "class CaseTests { void TestRun() { Service.Run(); } }",
+        "Other.cs": "namespace Other; class Service { public static void Run() {} }",
+    }) as store:
+        first = [tuple(r) for r in store._conn.execute("SELECT * FROM edges ORDER BY id")]
+        assert resolve_scoped_calls(store, tmp_path)["calls_resolved"] == 0
+        assert first == [tuple(r) for r in store._conn.execute("SELECT * FROM edges ORDER BY id")]
+        mirror = store._conn.execute("SELECT * FROM edges WHERE kind = 'TESTED_BY'").fetchone()
+        assert mirror["source_qualified"].endswith("::Other.Service.Run")
+        (tmp_path / "Imports.cs").write_text("// removed", encoding="utf-8")
+        incremental_update(tmp_path, store, changed_files=["Imports.cs"])
+        store.resolve_bare_call_targets()
+        store.resolve_bare_tested_by_sources()
+        mirror = store._conn.execute("SELECT * FROM edges WHERE kind = 'TESTED_BY'").fetchone()
+        assert mirror["source_qualified"] == "Service::Run"
+        assert "unresolved_targets" in json.loads(mirror["extra"])
+
+
+@pytest.mark.parametrize("ambiguous_project", [False, True])
+def test_global_alias_requires_known_shared_project_ownership(tmp_path, ambiguous_project):
+    files = {
+        "One.csproj": "<Project />",
+        "Imports.cs": "global using Alias = Other.Service;",
+        "Caller.cs": "class C { void Go() { Alias.Run(); } }",
+        "Service.cs": "namespace Other; class Service { public static void Run() {} }",
+    }
+    if ambiguous_project:
+        files["Two.csproj"] = "<Project />"
+    with _build(tmp_path, files) as store:
+        target = _calls(store, "C.Go")[0]["target_qualified"]
+        if ambiguous_project:
+            assert target == "Alias::Run"
+        else:
+            assert target.endswith("::Other.Service.Run")
+
+
+def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path):
+    with _build(tmp_path, {
+        "Good.cs": "namespace Good; class C { public void Run() {} }",
+        "Bad.cs": "namespace Bad; class C { public void Run() {} }",
+        "untouched.py": "def f(): pass",
+    }) as store:
+        store.set_metadata("csharp_identity_version", "1")
+        # Seed the actual legacy format while retaining the current file hash.
+        for name in ("Good", "Bad"):
+            path = tmp_path / f"{name}.cs"
+            nodes, edges = CodeParser().parse_file(path)
+            for node in nodes:
+                node.parent_name = (node.parent_name or "").removeprefix(name).lstrip(".") or None
+                node.extra.pop("csharp_namespace", None)
+            for edge in edges:
+                edge.source = edge.source.replace(f"::{name}.", "::")
+                edge.target = edge.target.replace(f"::{name}.", "::")
+            store.store_file_nodes_edges(
+                str(path), nodes, edges, hashlib.sha256(path.read_bytes()).hexdigest(),
+            )
+        parser = CodeParser.parse_bytes
+        attempts = []
+
+        def fail_bad(self, path, source):
+            attempts.append(path.name)
+            if path.name == "Bad.cs":
+                raise ValueError("persistent parser failure")
+            return parser(self, path, source)
+
+        with patch.object(CodeParser, "parse_bytes", fail_bad):
+            upgraded = incremental_update(tmp_path, store, changed_files=[])
+            assert upgraded["identity_rebuild"]
+            assert set(attempts) == {"Good.cs", "Bad.cs"}
+            assert store.get_node(f"{tmp_path / 'Good.cs'}::Good.C.Run") is not None
+            assert store.get_node(f"{tmp_path / 'Good.cs'}::C.Run") is None
+            attempts.clear()
+            retried = incremental_update(tmp_path, store, changed_files=[])
+            assert attempts == ["Bad.cs"]
+            assert len(retried["errors"]) == 1
+        recovered = incremental_update(tmp_path, store, changed_files=[])
+        assert recovered["files_updated"] == 1
+        assert store.get_metadata("csharp_identity_pending_files") == "[]"
+        assert store.get_node(f"{tmp_path / 'Bad.cs'}::Bad.C.Run") is not None
+        assert store.get_node(f"{tmp_path / 'Bad.cs'}::C.Run") is None
+
+
+def test_deleted_callee_keeps_raw_reference_for_recreation(tmp_path):
+    with _build(tmp_path, {
+        "Caller.cs": "using Other; class C { void Go() { Service.Run(); } }",
+        "Other.cs": "namespace Other; class Service { public static void Run() {} }",
+    }) as store:
+        source = (tmp_path / "Other.cs").read_text()
+        (tmp_path / "Other.cs").unlink()
+        incremental_update(tmp_path, store, changed_files=["Other.cs"])
+        assert _calls(store, "C.Go")[0]["target_qualified"] == "Service::Run"
+        (tmp_path / "Other.cs").write_text(source, encoding="utf-8")
+        incremental_update(tmp_path, store, changed_files=["Other.cs"])
+        assert _calls(store, "C.Go")[0]["target_qualified"].endswith("::Other.Service.Run")

--- a/tests/test_csharp_namespaces.py
+++ b/tests/test_csharp_namespaces.py
@@ -176,6 +176,31 @@ def _calls(store: GraphStore, caller: str):
         "class Inner { void Go(System.Action Run) { Run(); } } } }",
         "App.Outer.Inner.Go", None,
     ),
+    (
+        "namespace A { class Box<T> { public void Run() {} } "
+        "class C { void Go(Box<int> value) { value.Run(); } } }",
+        "A.C.Go", "A.Box.Run",
+    ),
+    (
+        "namespace A { class Pair<K, V> { public void Run() {} } "
+        "class C { void Go(Pair<string, int> value) { value.Run(); } } }",
+        "A.C.Go", "A.Pair.Run",
+    ),
+    (
+        "namespace A { class Box<T> { public void Run() {} } class C { "
+        "void Go(Box<System.Collections.Generic.List<int>> value) { value.Run(); } } }",
+        "A.C.Go", "A.Box.Run",
+    ),
+    (
+        "namespace A { class Pair<K, V> { public void Run() {} } "
+        "class C { void Go(Pair<int> value) { value.Run(); } } }",
+        "A.C.Go", None,
+    ),
+    (
+        "namespace A { class Outer<T> { public class Inner { public void Run() {} } } "
+        "class C { void Go(Outer<int>.Inner value) { value.Run(); } } }",
+        "A.C.Go", None,
+    ),
 ])
 def test_namespace_binding(source, caller, expected, tmp_path):
     with _build(tmp_path, {"Case.cs": source}) as store:
@@ -273,12 +298,9 @@ def test_nullable_receivers_keep_raw_spelling_and_generic_boundaries(tmp_path, t
             extra = json.loads(call["extra"])
             assert extra["receiver_type"] == type_name
             assert extra["csharp_raw_target"] == f"{type_name}::Run"
-            if "<" in type_name:
-                assert call["target_qualified"] == extra["csharp_raw_target"]
-                assert "unresolved_targets" in extra
-            else:
-                assert call["target_qualified"] == f"{tmp_path / 'Service.cs'}::Other.Service.Run"
-                assert "unresolved_targets" not in extra
+            expected = "Generic.cs" if "<" in type_name else "Service.cs"
+            assert call["target_qualified"] == f"{tmp_path / expected}::Other.Service.Run"
+            assert "unresolved_targets" not in extra
 
 
 @pytest.mark.parametrize("separator", [" ", "\n"])
@@ -351,7 +373,9 @@ def test_generic_reference_is_not_erased_to_a_non_generic_declaration(tmp_path):
         "Caller.cs": "using A; class C { void Go(I<int> value) { value.Run(); } }",
     }) as store:
         call = _calls(store, "C.Go")[0]
-        assert call["target_qualified"] == "I<int>::Run"
+        # Arity selects the declaration the reference names; the separate
+        # non-generic ``I`` stays out of reach, and the spelling is retained.
+        assert call["target_qualified"] == f"{tmp_path / 'Generic.cs'}::A.I.Run"
         assert json.loads(call["extra"])["receiver_scope"] == "I<int>"
 
 
@@ -497,7 +521,7 @@ def test_global_alias_requires_known_shared_project_ownership(
             assert target.endswith("::Other.Service.Run")
 
 
-@pytest.mark.parametrize("stored_version", ["1", "2", "3"])
+@pytest.mark.parametrize("stored_version", ["1", "2", "3", "4"])
 def test_upgrade_retries_only_failed_files_and_bypasses_unchanged_hash(tmp_path, stored_version):
     with _build(tmp_path, {
         "Good.cs": "namespace Good; class C { static int Run() => 1; static int Value = Run(); }",

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -612,7 +612,7 @@ class TestCSharpParsing:
         inherits = [e for e in self.edges if e.kind == "INHERITS"]
         by_source = {}
         for edge in inherits:
-            by_source.setdefault(edge.source.rsplit("::", 1)[-1], set()).add(
+            by_source.setdefault(edge.source.rsplit("::", 1)[-1].removeprefix("SampleApp."), set()).add(
                 edge.target
             )
 
@@ -1018,18 +1018,18 @@ class TestCSharpReceiverCallResolution:
     ):
         self._build(tmp_path)
         service = str(tmp_path / "Service.cs")
-        targets = self._call_targets_of(tmp_path, "Consumer.Run")
-        assert f"{service}::Service.StaticCall" in targets
-        assert f"{service}::Service.InstanceCall" in targets
-        assert f"{service}::Service.ConditionalCall" in targets
+        targets = self._call_targets_of(tmp_path, "Acme.App.Consumer.Run")
+        assert f"{service}::Acme.Services.Service.StaticCall" in targets
+        assert f"{service}::Acme.Services.Service.InstanceCall" in targets
+        assert f"{service}::Acme.Services.Service.ConditionalCall" in targets
         decoy = str(tmp_path / "Decoy.cs")
         assert not any(t.startswith(f"{decoy}::") for t in targets)
 
     def test_full_build_resolves_same_file_receiver_call(self, tmp_path):
         self._build(tmp_path)
         single = str(tmp_path / "Single.cs")
-        targets = self._call_targets_of(tmp_path, "Runner.Go")
-        assert f"{single}::Widget.Spin" in targets
+        targets = self._call_targets_of(tmp_path, "Acme.Single.Runner.Go")
+        assert f"{single}::Acme.Single.Widget.Spin" in targets
 
     def test_callers_of_returns_resolved_caller_after_full_build(self, tmp_path):
         from code_review_graph.tools.query import query_graph
@@ -1039,7 +1039,7 @@ class TestCSharpReceiverCallResolution:
         for method in ("StaticCall", "InstanceCall", "ConditionalCall"):
             result = query_graph(
                 "callers_of",
-                f"{service}::Service.{method}",
+                f"{service}::Acme.Services.Service.{method}",
                 repo_root=str(tmp_path),
             )
             assert result.get("status") == "ok"
@@ -1093,7 +1093,7 @@ class TestCSharpReceiverCallResolution:
         service = str(tmp_path / "Service.cs")
         result = query_graph(
             "tests_for",
-            f"{service}::Service.StaticCall",
+            f"{service}::Acme.Services.Service.StaticCall",
             repo_root=str(tmp_path),
         )
         assert result.get("status") == "ok"
@@ -1178,7 +1178,10 @@ class TestCSharpNamespaceImpactAndCoverage:
             for e in edges:
                 store.upsert_edge(e)
         store.commit()
-        # Same bare-endpoint resolution the build/postprocess pipeline runs.
+        # Same namespace binding and endpoint resolution as the build pipeline.
+        from code_review_graph.scoped_resolver import resolve_scoped_calls
+
+        resolve_scoped_calls(store, tmp_path)
         store.resolve_bare_call_targets()
         store.resolve_bare_tested_by_sources()
         return store, core, app, tests, unrelated
@@ -1231,8 +1234,8 @@ class TestCSharpNamespaceImpactAndCoverage:
     def test_bare_tested_by_source_resolves_via_namespace_evidence(self, tmp_path):
         store, core, _app, tests, _unrelated = self._build(tmp_path)
         try:
-            method_qn = f"{core}::TaskBoard.CountTasks"
-            test_qn = f"{tests}::TaskBoardTests.CountTasks_ReturnsZero"
+            method_qn = f"{core}::ACME.Core.TaskBoard.CountTasks"
+            test_qn = f"{tests}::ACME.Core.Tests.TaskBoardTests.CountTasks_ReturnsZero"
             tested_by = [
                 e for e in store.get_edges_by_source(method_qn)
                 if e.kind == "TESTED_BY"
@@ -1248,14 +1251,14 @@ class TestCSharpNamespaceImpactAndCoverage:
         store.close()
         result = query_graph(
             "tests_for",
-            f"{core}::TaskBoard.CountTasks",
+            f"{core}::ACME.Core.TaskBoard.CountTasks",
             repo_root=str(tmp_path),
         )
         assert result.get("status") == "ok"
         found = {
             r["qualified_name"]: r for r in result.get("results", [])
         }
-        test_qn = f"{tests}::TaskBoardTests.CountTasks_ReturnsZero"
+        test_qn = f"{tests}::ACME.Core.Tests.TaskBoardTests.CountTasks_ReturnsZero"
         assert test_qn in found
         # Must come from the resolved TESTED_BY edge, not name matching.
         assert found[test_qn].get("inferred_by") != "naming_convention"


### PR DESCRIPTION
C# declarations in different namespaces can collapse into the same graph node, and call resolution can select types the caller cannot name. This change stores the namespace and complete containing-type path in C# qualified names and resolves calls using the declaration and lexical using scope.

Fixes #946. Includes the nested-type identity needed by #934/#937; it does not change inheritance target spelling or implement #943.

- Preserve namespace-body identity for ordinary usings, including reopened and file-scoped namespaces; collect explicit global usings across files in the same inferred project.
- Retain raw call references, re-evaluate bindings on incremental updates, and keep `TESTED_BY` mirrors aligned when bindings change or declarations are deleted. Persist flow invalidation when a binding changes, and reuse full tracing so unchanged callers and old/new entry points stay consistent, including after deferred postprocessing.
- Preserve each call's lexical containing type and byte offset, including initializers and same-line receivers; bind nullable receivers while retaining their raw annotations.
- Resolve `Alias::Type` through namespace aliases only, and allow unqualified calls to enclosing static methods while respecting nearer method groups and recorded callable shadowing. `this.Run()` stays within the immediate type.
- Reparse legacy C# identities through a version gate, retrying failed files individually instead of repeating a full rebuild. No new dependency or schema migration.

Project ownership uses the nearest unambiguous `.csproj`; loose C# files share the review root. MSBuild compile-item evaluation, generated/implicit usings, generic binding, overload selection, and inherited-member resolution remain outside this change. The data model and boundaries are documented in `docs/architecture.md`.

Validation: `uv run pytest --tb=short -q` — 3,048 passed, 9 skipped, 2 xpassed. Ruff, the CI mypy command, and wheel build passed. The 63 C# namespace tests and three real-observer watcher tests also pass in an isolated Python 3.11 environment.

A temporary 2,000-caller smoke check changed only a global alias: all callers rebound in 1.085 seconds, the full flow refresh took 0.104 seconds, and all 2,001 stored flows matched a fresh trace. A repeated binding pass made no changes. These are local smoke timings, not a performance guarantee.

All 13 GitHub checks passed for the `ced4f45` code state, including Python 3.10–3.13 and Windows daemon/file-handle tests; `b7e713d` adds only the changelog entry.


`CHANGELOG.md` records the change under `[Unreleased]`. Graphs that carry embeddings should re-run `code-review-graph embed` after the identity upgrade: the renamed C# nodes leave their previous vectors orphaned until a refresh purges them.

Two known gaps are left as follow-ups rather than widened into this change. Same-named types declared in several projects stay unresolved even where the caller's own `.csproj` owns exactly one of them, so a repository holding many copies of one namespace binds fewer calls than before. And a file whose grammar parse fails yields no type node, which now leaves it unbindable in both directions where bare-name matching previously guessed.

Local measurement on two real corpora, not a guarantee: serilog, 216 files, 1389 bound C# calls before and 1352 after; dotnet/samples, 3042 files, 7110 before and 4572 after. In a sample of the differences most were references this change declines to guess — `XElement.Load`, `Stopwatch.GetTimestamp` and `((ICollection)x).CopyTo` each previously bound to a same-named declaration in the repository — alongside the two gaps above. A 1500-file and a 6000-file synthetic C# repository showed single-file `update` at 1.5s and 3.2s against 1.8s and 3.0s on `main`, with the full build faster in both.

