### PR TITLE
fix(query): caveat ambiguous bare-name inheritor candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,13 @@
 
 ### Fixed
 
-- `inheritors_of` no longer reports a same-named class from another namespace
-  as an inheritor. `INHERITS`/`IMPLEMENTS` targets are bare base names, so the
-  fallback that matches them by name could not tell two declarations of
-  `PlainBase` apart and asserted the wrong one with no caveat. A name carried
-  by exactly one declaration is unambiguous and behaves as before; where
-  several share it, each match is judged on its own visibility — the same
-  file, an import of the declaring file, or a namespace that file declares,
-  walking outwards so a class in `A.Sub` still sees a base in `A`. A
-  match is excluded only when both files name a namespace and they disagree.
-  One the graph cannot place — Java package declarations are not stored — is
-  still returned rather than dropped, marked `inferred_by: "bare_name"`, so
-  nothing is asserted that was not established and no correct answer
-  disappears because a sibling carried stronger evidence (#940).
+- `inheritors_of` marks bare-name fallback candidates with
+  `inferred_by: "bare_name"` when multiple indexed `Class`/`Type` declarations
+  share the name within the compatible language family. The marker survives
+  both standard and minimal output. Candidates are streamed with existing
+  result limits and counts. This mitigates #940 without resolving namespace,
+  package, or import binding; ambiguous candidates are retained for verification.
+  Exact-target matches and the existing single-declaration fallback are unchanged.
 
 ## [2.3.8] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `inheritors_of` no longer reports a same-named class from another namespace
+  as an inheritor. `INHERITS`/`IMPLEMENTS` targets are bare base names, so the
+  fallback that matches them by name could not tell two declarations of
+  `PlainBase` apart and asserted the wrong one with no caveat. A name carried
+  by exactly one declaration is unambiguous and behaves as before; where
+  several share it, each match is judged on its own visibility — the same
+  file, an import of the declaring file, or a namespace that file declares,
+  walking outwards so a class in `A.Sub` still sees a base in `A`. A
+  match is excluded only when both files name a namespace and they disagree.
+  One the graph cannot place — Java package declarations are not stored — is
+  still returned rather than dropped, marked `inferred_by: "bare_name"`, so
+  nothing is asserted that was not established and no correct answer
+  disappears because a sibling carried stronger evidence (#940).
+
 ## [2.3.8] - 2026-08-21
 
 ### Added

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -604,8 +604,10 @@ def query_graph(
             # (e.g. "Animal") while qn is fully qualified
             # (e.g. "sample.dart::Animal"). Search by plain name too. See: #87
             if total_results == 0 and node:
-                # ponytail: indexed-name ambiguity only; binding belongs in #943.
-                # File namespaces/imports cannot prove which declaration a base names.
+                # Ambiguity is measured on the indexed name alone: several
+                # declarations answer to this bare base name. Which one it
+                # binds to is #943's work — file namespaces and imports cannot
+                # prove it — so caveat the matches instead of guessing.
                 languages = (
                     _compatible_edge_languages(node.language) if node.language else (None,)
                 )

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -116,103 +116,6 @@ def _rank_disambiguation_candidates(
     return [node_to_dict(node) for node in sorted(candidates, key=score)]
 
 
-def _declared_namespaces(store: GraphStore, file_path: str) -> set[str]:
-    """Return the namespaces a file declares, when the parser records them."""
-    file_node = store.get_node(file_path) if file_path else None
-    extra = getattr(file_node, "extra", None)
-    declared = extra.get("csharp_namespaces") if isinstance(extra, dict) else None
-    if not isinstance(declared, list):
-        return set()
-    return {namespace for namespace in declared if isinstance(namespace, str)}
-
-
-def _namespace_scope(namespaces: set[str]) -> set[str]:
-    """Return *namespaces* plus the enclosing namespaces they can see into.
-
-    A declaration in ``A.Sub`` names a type in ``A`` without a using
-    directive, so lookup has to walk outwards. The reverse does not hold:
-    ``A`` cannot see ``A.Sub`` unqualified.
-    """
-    scope = set()
-    for namespace in namespaces:
-        while namespace:
-            scope.add(namespace)
-            namespace = namespace.rpartition(".")[0]
-    return scope
-
-
-def _declaration_visibility(
-    store: GraphStore, node: GraphNode, child: GraphNode, declared: set[str],
-) -> str:
-    """Return whether *child* can name the declaration in *node*.
-
-    ``"visible"`` on evidence, never proximity: the same file, an import of
-    the declaring file, or — for C#, whose ``using`` imports a namespace
-    rather than a file — a namespace the declaring file declares.
-
-    ``"hidden"`` only when both files name a namespace and they disagree,
-    which is positive evidence that this declaration is out of reach.
-    Everything else is ``"unknown"``: absent evidence is not counter-evidence,
-    and a language whose packages the graph does not record must not have its
-    correct answers deleted on that silence.
-    """
-    if not node.file_path or not child.file_path:
-        return "unknown"
-    if node.file_path == child.file_path:
-        return "visible"
-    imported = {
-        edge.target_qualified
-        for edge in store.iter_edges_by_source(child.file_path)
-        if edge.kind == "IMPORTS_FROM"
-    }
-    if node.file_path in imported:
-        return "visible"
-    if not declared:
-        return "unknown"
-    child_namespaces = _declared_namespaces(store, child.file_path)
-    if declared & (imported | _namespace_scope(child_namespaces)):
-        return "visible"
-    return "hidden" if child_namespaces else "unknown"
-
-
-def _resolve_bare_inheritors(
-    store: GraphStore, node: GraphNode, candidates: list[tuple[GraphNode, Any]],
-) -> list[tuple[GraphNode, Any, bool]]:
-    """Attach identity to bare-name inheritor matches. See: #940.
-
-    ``INHERITS``/``IMPLEMENTS`` targets are bare base names, so the fallback
-    that matches them by name cannot tell two same-named declarations apart
-    and would report a class from another namespace as an inheritor without
-    any caveat. One declaration of the name is unambiguous and stays exactly
-    as before; several means each match is judged on its own visibility. A
-    match the graph cannot place is kept and flagged as inferred from the bare
-    name — dropping it would delete the correct answer whenever a sibling
-    happens to carry stronger evidence.
-
-    Returns ``(child, edge, inferred)`` triples.
-    """
-    languages = _compatible_edge_languages(node.language) if node.language else (None,)
-    declarations = sum(
-        store.count_nodes_by_name(node.name, language=language, kinds=("Class", "Type"))
-        for language in languages
-    )
-    if declarations <= 1:
-        return [(child, edge, False) for child, edge in candidates]
-    declared = _declared_namespaces(store, node.file_path)
-    # Visibility depends only on the child's file, and one file commonly holds
-    # several inheritors, so each file is placed once per query.
-    by_file: dict[str, str] = {}
-    resolved = []
-    for child, edge in candidates:
-        visibility = by_file.get(child.file_path)
-        if visibility is None:
-            visibility = _declaration_visibility(store, node, child, declared)
-            by_file[child.file_path] = visibility
-        if visibility != "hidden":
-            resolved.append((child, edge, visibility == "unknown"))
-    return resolved
-
-
 def get_impact_radius(
     changed_files: list[str] | None = None,
     max_depth: int = 2,
@@ -701,21 +604,25 @@ def query_graph(
             # (e.g. "Animal") while qn is fully qualified
             # (e.g. "sample.dart::Animal"). Search by plain name too. See: #87
             if total_results == 0 and node:
-                bare_matches: list[tuple[GraphNode, Any]] = []
+                # ponytail: indexed-name ambiguity only; binding belongs in #943.
+                # File namespaces/imports cannot prove which declaration a base names.
+                languages = (
+                    _compatible_edge_languages(node.language) if node.language else (None,)
+                )
+                ambiguous_base = sum(
+                    store.count_nodes_by_name(node.name, language=language, kinds=("Class", "Type"))
+                    for language in languages
+                ) > 1
                 for kind in ("INHERITS", "IMPLEMENTS"):
                     for e in store.iter_edges_by_target_name(
                         node.name, kind=kind, language=node.language or None,
                     ):
                         child = store.get_node(e.source_qualified)
                         if child:
-                            bare_matches.append((child, e))
-                for child, e, inferred in _resolve_bare_inheritors(
-                    store, node, bare_matches,
-                ):
-                    child_result = node_to_dict(child)
-                    if inferred:
-                        child_result["inferred_by"] = "bare_name"
-                    add_result(child_result, e)
+                            child_result = node_to_dict(child)
+                            if ambiguous_base:
+                                child_result["inferred_by"] = "bare_name"
+                            add_result(child_result, e)
 
         elif pattern == "triggers_of":
             for edge in store.get_edges_by_source(qn):
@@ -806,10 +713,13 @@ def query_graph(
         )
 
         if detail_level == "minimal":
+            result_fields: tuple[str, ...] = ("name", "kind", "file_path", "indirect")
+            if pattern == "inheritors_of":
+                result_fields += ("inferred_by",)
             minimal_results = [
                 {
                     k: r[k]
-                    for k in ("name", "kind", "file_path", "indirect")
+                    for k in result_fields
                     if k in r
                 }
                 for r in results

--- a/code_review_graph/tools/query.py
+++ b/code_review_graph/tools/query.py
@@ -10,7 +10,14 @@ from typing import Any
 from ..config_keys import normalize_spring_config_key
 from ..context_savings import attach_context_savings, estimate_file_tokens
 from ..embeddings import EmbeddingStore
-from ..graph import GraphNode, GraphStore, _sanitize_name, edge_to_dict, node_to_dict
+from ..graph import (
+    GraphNode,
+    GraphStore,
+    _compatible_edge_languages,
+    _sanitize_name,
+    edge_to_dict,
+    node_to_dict,
+)
 from ..hints import generate_hints, get_session
 from ..incremental import get_changed_files, get_db_path, get_staged_and_unstaged
 from ..parser import normalize_file_path
@@ -107,6 +114,103 @@ def _rank_disambiguation_candidates(
         return rank, node.qualified_name
 
     return [node_to_dict(node) for node in sorted(candidates, key=score)]
+
+
+def _declared_namespaces(store: GraphStore, file_path: str) -> set[str]:
+    """Return the namespaces a file declares, when the parser records them."""
+    file_node = store.get_node(file_path) if file_path else None
+    extra = getattr(file_node, "extra", None)
+    declared = extra.get("csharp_namespaces") if isinstance(extra, dict) else None
+    if not isinstance(declared, list):
+        return set()
+    return {namespace for namespace in declared if isinstance(namespace, str)}
+
+
+def _namespace_scope(namespaces: set[str]) -> set[str]:
+    """Return *namespaces* plus the enclosing namespaces they can see into.
+
+    A declaration in ``A.Sub`` names a type in ``A`` without a using
+    directive, so lookup has to walk outwards. The reverse does not hold:
+    ``A`` cannot see ``A.Sub`` unqualified.
+    """
+    scope = set()
+    for namespace in namespaces:
+        while namespace:
+            scope.add(namespace)
+            namespace = namespace.rpartition(".")[0]
+    return scope
+
+
+def _declaration_visibility(
+    store: GraphStore, node: GraphNode, child: GraphNode, declared: set[str],
+) -> str:
+    """Return whether *child* can name the declaration in *node*.
+
+    ``"visible"`` on evidence, never proximity: the same file, an import of
+    the declaring file, or — for C#, whose ``using`` imports a namespace
+    rather than a file — a namespace the declaring file declares.
+
+    ``"hidden"`` only when both files name a namespace and they disagree,
+    which is positive evidence that this declaration is out of reach.
+    Everything else is ``"unknown"``: absent evidence is not counter-evidence,
+    and a language whose packages the graph does not record must not have its
+    correct answers deleted on that silence.
+    """
+    if not node.file_path or not child.file_path:
+        return "unknown"
+    if node.file_path == child.file_path:
+        return "visible"
+    imported = {
+        edge.target_qualified
+        for edge in store.iter_edges_by_source(child.file_path)
+        if edge.kind == "IMPORTS_FROM"
+    }
+    if node.file_path in imported:
+        return "visible"
+    if not declared:
+        return "unknown"
+    child_namespaces = _declared_namespaces(store, child.file_path)
+    if declared & (imported | _namespace_scope(child_namespaces)):
+        return "visible"
+    return "hidden" if child_namespaces else "unknown"
+
+
+def _resolve_bare_inheritors(
+    store: GraphStore, node: GraphNode, candidates: list[tuple[GraphNode, Any]],
+) -> list[tuple[GraphNode, Any, bool]]:
+    """Attach identity to bare-name inheritor matches. See: #940.
+
+    ``INHERITS``/``IMPLEMENTS`` targets are bare base names, so the fallback
+    that matches them by name cannot tell two same-named declarations apart
+    and would report a class from another namespace as an inheritor without
+    any caveat. One declaration of the name is unambiguous and stays exactly
+    as before; several means each match is judged on its own visibility. A
+    match the graph cannot place is kept and flagged as inferred from the bare
+    name — dropping it would delete the correct answer whenever a sibling
+    happens to carry stronger evidence.
+
+    Returns ``(child, edge, inferred)`` triples.
+    """
+    languages = _compatible_edge_languages(node.language) if node.language else (None,)
+    declarations = sum(
+        store.count_nodes_by_name(node.name, language=language, kinds=("Class", "Type"))
+        for language in languages
+    )
+    if declarations <= 1:
+        return [(child, edge, False) for child, edge in candidates]
+    declared = _declared_namespaces(store, node.file_path)
+    # Visibility depends only on the child's file, and one file commonly holds
+    # several inheritors, so each file is placed once per query.
+    by_file: dict[str, str] = {}
+    resolved = []
+    for child, edge in candidates:
+        visibility = by_file.get(child.file_path)
+        if visibility is None:
+            visibility = _declaration_visibility(store, node, child, declared)
+            by_file[child.file_path] = visibility
+        if visibility != "hidden":
+            resolved.append((child, edge, visibility == "unknown"))
+    return resolved
 
 
 def get_impact_radius(
@@ -597,13 +701,21 @@ def query_graph(
             # (e.g. "Animal") while qn is fully qualified
             # (e.g. "sample.dart::Animal"). Search by plain name too. See: #87
             if total_results == 0 and node:
+                bare_matches: list[tuple[GraphNode, Any]] = []
                 for kind in ("INHERITS", "IMPLEMENTS"):
                     for e in store.iter_edges_by_target_name(
                         node.name, kind=kind, language=node.language or None,
                     ):
                         child = store.get_node(e.source_qualified)
                         if child:
-                            add_result(node_to_dict(child), e)
+                            bare_matches.append((child, e))
+                for child, e, inferred in _resolve_bare_inheritors(
+                    store, node, bare_matches,
+                ):
+                    child_result = node_to_dict(child)
+                    if inferred:
+                        child_result["inferred_by"] = "bare_name"
+                    add_result(child_result, e)
 
         elif pattern == "triggers_of":
             for edge in store.get_edges_by_source(qn):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -520,6 +520,165 @@ class TestQueryGraphCallTargetFallbacks:
         assert result["status"] == "ok"
         assert {item["name"] for item in result["results"]} == {"Dog"}
 
+    @staticmethod
+    def _build_repo(tmp_path, monkeypatch, files):
+        for relative, source in files.items():
+            path = tmp_path / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(source, encoding="utf-8")
+        (tmp_path / ".code-review-graph").mkdir()
+        monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
+        with GraphStore(tmp_path / ".code-review-graph" / "graph.db") as store:
+            full_build(tmp_path, store)
+
+    def test_inheritors_of_excludes_same_named_base_in_another_namespace(
+        self, tmp_path, monkeypatch,
+    ):
+        """Issue #940: a bare base name must not cross a namespace boundary."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
+            "A/Child.cs": "namespace A;\npublic class Sub : PlainBase { }\n",
+            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
+            "B/Child.cs": "namespace B;\npublic class FarSub : PlainBase { }\n",
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
+            repo_root=str(tmp_path),
+        )
+
+        assert result["status"] == "ok"
+        assert {item["name"] for item in result["results"]} == {"Sub"}
+        # Namespace evidence resolved it, so the match is asserted, not hedged.
+        assert all("inferred_by" not in item for item in result["results"])
+
+    def test_inheritors_of_uses_a_using_directive_as_namespace_evidence(
+        self, tmp_path, monkeypatch,
+    ):
+        """A child in a third namespace is visible through its own using."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
+            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
+            "C/Child.cs": (
+                "namespace C;\nusing A;\npublic class Imported : PlainBase { }\n"
+            ),
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
+            repo_root=str(tmp_path),
+        )
+
+        assert {item["name"] for item in result["results"]} == {"Imported"}
+
+    def test_inheritors_of_sees_an_enclosing_namespace_declaration(
+        self, tmp_path, monkeypatch,
+    ):
+        """A class in A.Sub names a type in A without a using directive."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
+            "A/Sub/Child.cs": (
+                "namespace A.Sub;\npublic class Nested : PlainBase { }\n"
+            ),
+            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
+            repo_root=str(tmp_path),
+        )
+
+        assert {item["name"] for item in result["results"]} == {"Nested"}
+        assert all("inferred_by" not in item for item in result["results"])
+
+    def test_inheritors_of_does_not_look_into_a_nested_namespace(
+        self, tmp_path, monkeypatch,
+    ):
+        """The walk is outwards only: A cannot name A.Sub.PlainBase bare."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "A/Sub/Base.cs": "namespace A.Sub;\npublic class PlainBase { }\n",
+            "A/Child.cs": "namespace A;\npublic class Outer : PlainBase { }\n",
+            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'A' / 'Sub' / 'Base.cs').as_posix()}::PlainBase",
+            repo_root=str(tmp_path),
+        )
+
+        assert result["results"] == []
+
+    def test_inheritors_of_marks_bare_matches_when_identity_is_unavailable(
+        self, tmp_path, monkeypatch,
+    ):
+        """Java packages are not stored, so ambiguous matches stay unasserted."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "ja/JBase.java": "package ja;\npublic class JBase {}\n",
+            "ja/JSub.java": "package ja;\npublic class JSub extends JBase {}\n",
+            "jb/JBase.java": "package jb;\npublic class JBase {}\n",
+            "jb/JFar.java": "package jb;\npublic class JFar extends JBase {}\n",
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'ja' / 'JBase.java').as_posix()}::JBase",
+            repo_root=str(tmp_path),
+        )
+
+        # Dropping them would lose the correct same-package answer, so they are
+        # returned; every one is flagged because none of them is established.
+        assert {item["name"] for item in result["results"]} == {"JSub", "JFar"}
+        assert all(
+            item["inferred_by"] == "bare_name" for item in result["results"]
+        )
+
+    def test_inheritors_of_keeps_an_unplaceable_sibling_of_an_evidenced_match(
+        self, tmp_path, monkeypatch,
+    ):
+        """Stronger evidence on one match must not delete an unplaceable one."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "ja/JBase.java": "package ja;\npublic class JBase {}\n",
+            "ja/SamePkg.java": "package ja;\npublic class SamePkg extends JBase {}\n",
+            "jb/JBase.java": "package jb;\npublic class JBase {}\n",
+            "jc/Importer.java": (
+                "package jc;\nimport ja.JBase;\n"
+                "public class Importer extends JBase {}\n"
+            ),
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'ja' / 'JBase.java').as_posix()}::JBase",
+            repo_root=str(tmp_path),
+        )
+
+        placed = {item["name"]: item.get("inferred_by") for item in result["results"]}
+        # SamePkg is the correct answer and the graph cannot prove it; Importer
+        # is proven by its import. Judging per match keeps both.
+        assert placed == {"SamePkg": "bare_name", "Importer": None}
+
+    def test_inheritors_of_leaves_an_unambiguous_bare_match_asserted(
+        self, tmp_path, monkeypatch,
+    ):
+        """One declaration of the name needs no evidence and gains no caveat."""
+        self._build_repo(tmp_path, monkeypatch, {
+            "Solo.java": "public class Solo {}\n",
+            "SoloChild.java": "public class SoloChild extends Solo {}\n",
+        })
+
+        result = query_graph(
+            pattern="inheritors_of",
+            target=f"{(tmp_path / 'Solo.java').as_posix()}::Solo",
+            repo_root=str(tmp_path),
+        )
+
+        assert {item["name"] for item in result["results"]} == {"SoloChild"}
+        assert all("inferred_by" not in item for item in result["results"])
+
 
 def _seed_repo_relative_graph(root: Path) -> None:
     """Seed graph data with cwd-relative paths, as eval repos currently do."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -430,7 +430,8 @@ class TestQueryGraphCallTargetFallbacks:
         assert "tsxCaller" in names
         assert "apexCaller" not in names
 
-    def test_inheritors_of_bare_fallback_uses_js_family_without_apex(self):
+    @pytest.mark.parametrize("ambiguous", [False, True])
+    def test_inheritors_of_bare_fallback_uses_js_family_without_apex(self, ambiguous):
         """Bare INHERITS/IMPLEMENTS edges stay inside the JS language family."""
         base_file = (self.root / "base.js").as_posix()
         ts_file = (self.root / "child.ts").as_posix()
@@ -440,6 +441,15 @@ class TestQueryGraphCallTargetFallbacks:
             store.upsert_node(NodeInfo(
                 kind="Class", name="BaseWidget", file_path=base_file,
                 line_start=1, line_end=8, language="javascript",
+            ))
+            # Only a compatible type declaration should cause an ambiguity marker.
+            store.upsert_node(NodeInfo(
+                kind="Class", name="BaseWidget", file_path=apex_file,
+                line_start=1, line_end=8, language="apex",
+            ))
+            store.upsert_node(NodeInfo(
+                kind="Type" if ambiguous else "Function", name="BaseWidget", file_path=ts_file,
+                line_start=1, line_end=8, language="typescript",
             ))
             store.upsert_node(NodeInfo(
                 kind="Class", name="TsChild", file_path=ts_file,
@@ -487,6 +497,10 @@ class TestQueryGraphCallTargetFallbacks:
             "TsChild",
             "JsxImplementer",
         }
+        assert all(
+            item.get("inferred_by") == ("bare_name" if ambiguous else None)
+            for item in result["results"]
+        )
 
     def test_inheritors_of_bare_dart_class_ignores_member_matches(
         self,
@@ -519,6 +533,7 @@ class TestQueryGraphCallTargetFallbacks:
 
         assert result["status"] == "ok"
         assert {item["name"] for item in result["results"]} == {"Dog"}
+        assert all("inferred_by" not in item for item in result["results"])
 
     @staticmethod
     def _build_repo(tmp_path, monkeypatch, files):
@@ -529,150 +544,200 @@ class TestQueryGraphCallTargetFallbacks:
         (tmp_path / ".code-review-graph").mkdir()
         monkeypatch.setenv("CRG_SERIAL_PARSE", "1")
         with GraphStore(tmp_path / ".code-review-graph" / "graph.db") as store:
-            full_build(tmp_path, store)
+            assert full_build(tmp_path, store)["errors"] == []
 
-    def test_inheritors_of_excludes_same_named_base_in_another_namespace(
-        self, tmp_path, monkeypatch,
+    @pytest.mark.parametrize(
+        "base_source,other_source,child_source,extra_files",
+        [
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace B; public class Child : PlainBase {}",
+                {}, id="different-namespace",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace C; using A; public class Child : PlainBase {}",
+                {}, id="ordinary-using",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace C; public class Child : PlainBase {}",
+                {"Usings.cs": "global using A;"}, id="global-using",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "using PlainBase = A.PlainBase; namespace C; "
+                "public class Child : PlainBase {}",
+                {}, id="type-alias",
+            ),
+            pytest.param(
+                "namespace A.Models; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace A.C { using Models; public class Child : PlainBase {} }",
+                {}, id="relative-using",
+            ),
+            pytest.param(
+                "public class PlainBase {} namespace Unrelated { class Marker {} }",
+                "namespace B; public class PlainBase {}",
+                "namespace C; public class Child : PlainBase {}",
+                {}, id="global-base-with-unrelated-namespace",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace A.Sub; public class Child : PlainBase {}",
+                {}, id="enclosing-namespace",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace A.Sub; public class PlainBase {}",
+                "namespace A.Sub; public class Child : PlainBase {}",
+                {}, id="nearer-base-shadows-outer-base",
+            ),
+            pytest.param(
+                "namespace A; public class PlainBase {}",
+                "namespace B; public class PlainBase {}",
+                "namespace A { class Marker {} } "
+                "namespace B { public class Child : PlainBase {} }",
+                {}, id="unrelated-namespace-in-child-file",
+            ),
+            pytest.param(
+                "namespace A { public class PlainBase {} } "
+                "namespace B { public class Child : PlainBase {} }",
+                "namespace B; public class PlainBase {}",
+                "", {}, id="same-file-does-not-prove-binding",
+            ),
+        ],
+    )
+    def test_inheritors_of_caveats_ambiguous_bases_without_guessing_visibility(
+        self, tmp_path, monkeypatch, base_source, other_source, child_source, extra_files,
     ):
-        """Issue #940: a bare base name must not cross a namespace boundary."""
+        """#940: file namespaces/imports prove neither binding nor absence."""
         self._build_repo(tmp_path, monkeypatch, {
-            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
-            "A/Child.cs": "namespace A;\npublic class Sub : PlainBase { }\n",
-            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
-            "B/Child.cs": "namespace B;\npublic class FarSub : PlainBase { }\n",
+            "Base.cs": base_source,
+            "Other.cs": other_source,
+            "Child.cs": child_source,
+            **extra_files,
         })
+        for detail_level in ("standard", "minimal"):
+            result = query_graph(
+                "inheritors_of", f"{(tmp_path / 'Base.cs').as_posix()}::PlainBase",
+                str(tmp_path), detail_level=detail_level,
+            )
+            assert result["status"] == "ok"
+            assert result["result_count"] == 1
+            assert result["results_omitted"] == 0
+            assert {item["name"]: item.get("inferred_by") for item in result["results"]} == {
+                "Child": "bare_name",
+            }
 
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
-            repo_root=str(tmp_path),
-        )
-
-        assert result["status"] == "ok"
-        assert {item["name"] for item in result["results"]} == {"Sub"}
-        # Namespace evidence resolved it, so the match is asserted, not hedged.
-        assert all("inferred_by" not in item for item in result["results"])
-
-    def test_inheritors_of_uses_a_using_directive_as_namespace_evidence(
-        self, tmp_path, monkeypatch,
+    @pytest.mark.parametrize("with_import", [False, True])
+    def test_inheritors_of_caveats_java_package_matches_even_with_an_import(
+        self, tmp_path, monkeypatch, with_import,
     ):
-        """A child in a third namespace is visible through its own using."""
+        """Retain both candidates; an imported file does not prove type binding."""
         self._build_repo(tmp_path, monkeypatch, {
-            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
-            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
-            "C/Child.cs": (
-                "namespace C;\nusing A;\npublic class Imported : PlainBase { }\n"
+            "ja/JBase.java": "package ja; public class JBase {}",
+            "ja/JSub.java": "package ja; public class JSub extends JBase {}",
+            "jb/JBase.java": "package jb; public class JBase {}",
+            "jc/Child.java": (
+                "package jc; " + ("import ja.JBase; " if with_import else "import jb.JBase; ")
+                + "public class Child extends JBase {}"
             ),
         })
+        for detail_level in ("standard", "minimal"):
+            result = query_graph(
+                "inheritors_of", f"{(tmp_path / 'ja' / 'JBase.java').as_posix()}::JBase",
+                str(tmp_path), detail_level=detail_level,
+            )
+            assert {item["name"]: item.get("inferred_by") for item in result["results"]} == {
+                "JSub": "bare_name", "Child": "bare_name",
+            }
 
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
-            repo_root=str(tmp_path),
-        )
-
-        assert {item["name"] for item in result["results"]} == {"Imported"}
-
-    def test_inheritors_of_sees_an_enclosing_namespace_declaration(
-        self, tmp_path, monkeypatch,
+    @pytest.mark.parametrize("ambiguous", [False, True])
+    def test_inheritors_of_streams_bare_matches_and_keeps_counts(
+        self, monkeypatch, ambiguous,
     ):
-        """A class in A.Sub names a type in A without a using directive."""
-        self._build_repo(tmp_path, monkeypatch, {
-            "A/Base.cs": "namespace A;\npublic class PlainBase { }\n",
-            "A/Sub/Child.cs": (
-                "namespace A.Sub;\npublic class Nested : PlainBase { }\n"
-            ),
-            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
-        })
+        """The result cap must also bound live edges, for either declaration count."""
+        import weakref
 
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'A' / 'Base.cs').as_posix()}::PlainBase",
-            repo_root=str(tmp_path),
-        )
+        with GraphStore(self.db_path) as store:
+            for name in ("Base", "Other.Base") if ambiguous else ("Base",):
+                store.upsert_node(NodeInfo(
+                    kind="Class", name="Base", file_path=self.target_file,
+                    parent_name="Other" if name == "Other.Base" else None,
+                    language="objc", line_start=1, line_end=2,
+                ))
+            for index in range(6):
+                name = f"Child{index}"
+                store.upsert_node(NodeInfo(
+                    kind="Class", name=name, file_path=self.cross_file,
+                    language="objc", line_start=1, line_end=2,
+                ))
+                store.upsert_edge(EdgeInfo(
+                    kind="INHERITS" if index < 3 else "IMPLEMENTS",
+                    source=f"{self.cross_file}::{name}", target="Base",
+                    file_path=self.cross_file, line=1,
+                ))
+            store.commit()
 
-        assert {item["name"] for item in result["results"]} == {"Nested"}
-        assert all("inferred_by" not in item for item in result["results"])
+        original = GraphStore.iter_edges_by_target_name
 
-    def test_inheritors_of_does_not_look_into_a_nested_namespace(
-        self, tmp_path, monkeypatch,
+        def bounded_edges(store, *args, **kwargs):
+            previous = None
+            for edge in original(store, *args, **kwargs):
+                yield edge
+                # The consumer may hold the current edge, but must release its predecessor.
+                if previous is not None:
+                    assert previous() is None, "bare matches are being retained"
+                previous = weakref.ref(edge)
+
+        monkeypatch.setattr(GraphStore, "iter_edges_by_target_name", bounded_edges)
+        for detail_level in ("standard", "minimal"):
+            result = query_graph(
+                "inheritors_of", f"{self.target_file}::Base", str(self.root),
+                detail_level=detail_level, max_results=1,
+            )
+            assert result["result_count"] == 6
+            assert result["results_omitted"] == 5
+            assert len(result["results"]) == 1
+            assert result["results"][0].get("inferred_by") == (
+                "bare_name" if ambiguous else None
+            )
+            if detail_level == "standard":
+                assert len(result["edges"]) == 1
+                assert result["edges"][0]["source"] == result["results"][0]["qualified_name"]
+
+    @pytest.mark.parametrize("resolved", [False, True])
+    def test_inheritors_of_preserves_exact_and_single_declaration_matches(
+        self, tmp_path, monkeypatch, resolved,
     ):
-        """The walk is outwards only: A cannot name A.Sub.PlainBase bare."""
-        self._build_repo(tmp_path, monkeypatch, {
-            "A/Sub/Base.cs": "namespace A.Sub;\npublic class PlainBase { }\n",
-            "A/Child.cs": "namespace A;\npublic class Outer : PlainBase { }\n",
-            "B/Base.cs": "namespace B;\npublic class PlainBase { }\n",
-        })
-
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'A' / 'Sub' / 'Base.cs').as_posix()}::PlainBase",
-            repo_root=str(tmp_path),
-        )
-
-        assert result["results"] == []
-
-    def test_inheritors_of_marks_bare_matches_when_identity_is_unavailable(
-        self, tmp_path, monkeypatch,
-    ):
-        """Java packages are not stored, so ambiguous matches stay unasserted."""
-        self._build_repo(tmp_path, monkeypatch, {
-            "ja/JBase.java": "package ja;\npublic class JBase {}\n",
-            "ja/JSub.java": "package ja;\npublic class JSub extends JBase {}\n",
-            "jb/JBase.java": "package jb;\npublic class JBase {}\n",
-            "jb/JFar.java": "package jb;\npublic class JFar extends JBase {}\n",
-        })
-
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'ja' / 'JBase.java').as_posix()}::JBase",
-            repo_root=str(tmp_path),
-        )
-
-        # Dropping them would lose the correct same-package answer, so they are
-        # returned; every one is flagged because none of them is established.
-        assert {item["name"] for item in result["results"]} == {"JSub", "JFar"}
-        assert all(
-            item["inferred_by"] == "bare_name" for item in result["results"]
-        )
-
-    def test_inheritors_of_keeps_an_unplaceable_sibling_of_an_evidenced_match(
-        self, tmp_path, monkeypatch,
-    ):
-        """Stronger evidence on one match must not delete an unplaceable one."""
-        self._build_repo(tmp_path, monkeypatch, {
-            "ja/JBase.java": "package ja;\npublic class JBase {}\n",
-            "ja/SamePkg.java": "package ja;\npublic class SamePkg extends JBase {}\n",
-            "jb/JBase.java": "package jb;\npublic class JBase {}\n",
-            "jc/Importer.java": (
-                "package jc;\nimport ja.JBase;\n"
-                "public class Importer extends JBase {}\n"
-            ),
-        })
-
-        result = query_graph(
-            pattern="inheritors_of",
-            target=f"{(tmp_path / 'ja' / 'JBase.java').as_posix()}::JBase",
-            repo_root=str(tmp_path),
-        )
-
-        placed = {item["name"]: item.get("inferred_by") for item in result["results"]}
-        # SamePkg is the correct answer and the graph cannot prove it; Importer
-        # is proven by its import. Judging per match keeps both.
-        assert placed == {"SamePkg": "bare_name", "Importer": None}
-
-    def test_inheritors_of_leaves_an_unambiguous_bare_match_asserted(
-        self, tmp_path, monkeypatch,
-    ):
-        """One declaration of the name needs no evidence and gains no caveat."""
+        """The mitigation changes only ambiguous bare-name fallback responses."""
         self._build_repo(tmp_path, monkeypatch, {
             "Solo.java": "public class Solo {}\n",
             "SoloChild.java": "public class SoloChild extends Solo {}\n",
         })
+        target = f"{(tmp_path / 'Solo.java').as_posix()}::Solo"
+        if resolved:
+            with GraphStore(tmp_path / ".code-review-graph" / "graph.db") as store:
+                store.upsert_node(NodeInfo(
+                    kind="Class", name="Solo", file_path=(tmp_path / "Other.java").as_posix(),
+                    language="java", line_start=1, line_end=1,
+                ))
+                store.upsert_edge(EdgeInfo(
+                    kind="INHERITS",
+                    source=f"{(tmp_path / 'SoloChild.java').as_posix()}::SoloChild",
+                    target=target, file_path=(tmp_path / "SoloChild.java").as_posix(), line=1,
+                ))
+                store.commit()
 
         result = query_graph(
             pattern="inheritors_of",
-            target=f"{(tmp_path / 'Solo.java').as_posix()}::Solo",
+            target=target,
             repo_root=str(tmp_path),
         )
 


### PR DESCRIPTION
When several indexed declarations share a base name, `inheritors_of` can return a child of another declaration without a caveat. For example, querying `A/Base.cs::PlainBase` can return `B.Child` through a bare `PlainBase` edge. This change retains those candidates and marks them with `inferred_by: "bare_name"` in both standard and minimal output.

This is the query-side mitigation described in #940. Full declaration binding remains tracked by #943; #940 should remain open for that work.

- Count exact-name `Class`/`Type` declarations within the same language family used by the existing bare-edge lookup. Methods and unrelated languages do not create ambiguity; JavaScript, TypeScript, and TSX share the count.
- Stream candidates through the existing bounded result collector, preserving result counts, omitted counts, and aligned edges.
- Preserve the marker in compact inheritance results. Other query projections retain their current behavior.

File-level namespaces, imports, and same-file placement cannot establish lexical binding or prove that a base is inaccessible. This query therefore keeps every ambiguous bare-name candidate marked for verification. Exact-target lookup and the existing single-indexed-declaration fallback retain their current behavior; the latter remains a heuristic. Parser output, stored edge targets, generic handling, and resolvers are outside this change.

Regression coverage includes C# global/relative usings, type aliases, global bases, enclosing namespaces and shadowing, multiple namespaces in one file, Java package/import candidates, compact output, bounded edge retention, exact targets, Dart member names, and JS-family declaration counts. Fourteen regression cases fail against the original PR implementation and pass with this version.

A local `tracemalloc` smoke check with 10,000 inheritors and `max_results=1` measured about 43 KB peak Python allocation, versus 12.7 MB with the original PR and 42 KB on the base commit. Both single- and multiple-declaration cases retained all 10,000 in the total count while returning one result.

Validation: `uv run pytest --tb=short -q --cov=code_review_graph --cov-report=term --cov-fail-under=65` — 3,002 passed, 9 skipped, 2 xpassed; 85.04% coverage. Ruff, the CI mypy command, Bandit, and `uv build --wheel` passed locally.
